### PR TITLE
Fix check_imports CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   # get mujoco key
   - mkdir $HOME/.mujoco
   - echo "$MJKEY" > $HOME/.mujoco/mjkey.txt
-  #- openssl aes-256-cbc -K $encrypted_df93cb1b6551_key -iv $encrypted_df93cb1b6551_iv -in scripts/travisci/mjkey.txt.enc -out $HOME/.mujoco/mjkey.txt -d
 
 install:
   # mujoco deps
@@ -39,17 +38,13 @@ install:
   # it's not included in environment.yml because of CPU vs GPU
   - pip install tensorflow==1.8
 
-  # other stuff
-  - pip install yapf
-  - pip install flake8
-  - pip install flake8-import-order
-
   # prevent rllab from exiting on config
   - cp rllab/config.py rllab/config_personal.py
 
+  # --- uncomment if you add a test which actually uses mujoco_py ---
   # trigger compilation of mujoco_py bindings to catch problems early
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.mujoco/mjpro150/bin
-  - python -c "import mujoco_py"
+  # - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.mujoco/mjpro150/bin
+  # - python -c "import mujoco_py"
 
 git:
   depth: false

--- a/environment.yml
+++ b/environment.yml
@@ -42,3 +42,6 @@ dependencies:
         - jsonmerge
         - protobuf
         - memory_profiler
+        - flake8
+        - flake8-import-order
+        - yapf

--- a/examples/cluster_gym_mujoco_demo.py
+++ b/examples/cluster_gym_mujoco_demo.py
@@ -3,8 +3,9 @@ import sys
 from rllab.baselines import LinearFeatureBaseline
 from rllab.envs import GymEnv
 from rllab.envs import normalize
-from rllab.misc import run_experiment_lite
-from rllab.misc import variant, VariantGenerator
+from rllab.misc.instrument import run_experiment_lite
+from rllab.misc.instrument import variant
+from rllab.misc.instrument import VariantGenerator
 from rllab.tf.algos import TRPO
 from rllab.tf.envs import TfEnv
 from rllab.tf.policies import GaussianMLPPolicy

--- a/examples/trpo_gym_tf_cartpole.py
+++ b/examples/trpo_gym_tf_cartpole.py
@@ -1,7 +1,8 @@
 from rllab.baselines import LinearFeatureBaseline
 from rllab.envs import GymEnv
 from rllab.envs import normalize
-from rllab.misc import run_experiment_lite, stub
+from rllab.misc.instrument import run_experiment_lite
+from rllab.misc.instrument import stub
 from rllab.tf.algos import TRPO
 from rllab.tf.envs import TfEnv
 from rllab.tf.policies import CategoricalMLPPolicy

--- a/rllab/tf/algos/npo.py
+++ b/rllab/tf/algos/npo.py
@@ -2,6 +2,7 @@ import tensorflow as tf
 
 from rllab.misc import ext
 import rllab.misc.logger as logger
+from rllab.misc.overrides import overrides
 from rllab.tf.algos import BatchPolopt
 from rllab.tf.misc import tensor_utils
 from rllab.tf.misc.tensor_utils import enclosing_scope

--- a/rllab/tf/core/__init__.py
+++ b/rllab/tf/core/__init__.py
@@ -1,8 +1,8 @@
 from rllab.tf.core import layers
-from rllab.tf.core.layers_powered import LayersPowered
+from rllab.tf.core.parameterized import Parameterized
+from rllab.tf.core.layers_powered import LayersPowered  # noqa: I100
 from rllab.tf.core.network import ConvNetwork
 from rllab.tf.core.network import GRUNetwork
 from rllab.tf.core.network import LSTMNetwork
 from rllab.tf.core.network import MLP
 from rllab.tf.core.parameterized import JointParameterized
-from rllab.tf.core.parameterized import Parameterized

--- a/scripts/travisci/check_imports.py
+++ b/scripts/travisci/check_imports.py
@@ -3,6 +3,7 @@ import ast
 import glob
 import logging
 import sys
+from unittest import mock
 import warnings
 
 warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -14,11 +15,42 @@ IGNORE_PATHS = [
     "dist/",
     "docs/",
     "contrib/",
+    "sandbox/",
 ]
 
 IGNORE_MODULES = [
     "__future__",
 ]
+
+# Mock out some modules because they are slow or error-prone
+MOCK_MODULES = [
+    # "dm_control",
+    # "dm_control.rl",
+    # "dm_control.rl.control",
+    # "dm_control.rl.environment",
+    "ipdb",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "matplotlib.ticker",
+    "mujoco_py",
+    "mujoco_py.builder",
+    "mujoco_py.generated",
+    "mujoco_py.generated.const",
+    # "tensorflow",
+    # "tensorflow.python",
+    # "tensorflow.python.training",
+    # "theano",
+    # "theano.gradient",
+    # "theano.tensor",
+    # "theano.tensor.extra_ops",
+    # "theano.tensor.nnet",
+    # "theano.tensor.signal",
+    # "theano.tensor.signal.pool",
+    # "theano.sandbox",
+    # "theano.sandbox.rng_mrg",
+]
+for m in MOCK_MODULES:
+    sys.modules[m] = mock.MagicMock()
 
 # Passing flag
 passed = True
@@ -48,35 +80,31 @@ for fn in filenames:
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 line = lines[node.lineno - 1].strip()
 
-                # Disabling the clever exec-based tester for now
-                # try:
-                #     exec(line, {})
-                # except TypeError:
-                #     pass
-                # except AttributeError:
-                #     logging.error(("{filename}:{line_num} - \"{line}\" "
-                #                    "failed with an AttributeError.").format(
-                #                        filename=fn,
-                #                        line_num=node.lineno,
-                #                        line=line))
-                #     passed = False
-                # except SyntaxError:
-                #     logging.error(("{filename}:{line_num} - \"{line}\" "
-                #                    "failed with a SyntaxError.").format(
-                #                        filename=fn,
-                #                        line_num=node.lineno,
-                #                        line=line))
-                #     passed = False
-                #
-                # except ImportError:
-                #     logging.error(
-                #         "{filename}:{line_num} - \"{line}\" failed.".format(
-                #             filename=fn, line_num=node.lineno, line=line))
-                #     passed = False
+                try:
+                    if not [True for i in IGNORE_MODULES if i in line]:
+                        exec(line, {})
+                except TypeError:
+                    pass
+                except AttributeError:
+                    logging.error(("{filename}:{line_num} - \"{line}\" "
+                                   "failed with an AttributeError.").format(
+                                       filename=fn,
+                                       line_num=node.lineno,
+                                       line=line))
+                    passed = False
+                except SyntaxError:
+                    logging.error(("{filename}:{line_num} - \"{line}\" "
+                                   "failed with a SyntaxError.").format(
+                                       filename=fn,
+                                       line_num=node.lineno,
+                                       line=line))
+                    passed = False
 
-                # Send it back to bash, instead of using exec
-                if not [True for i in IGNORE_MODULES if i in line]:
-                    print(line)
+                except ImportError:
+                    logging.error(
+                        "{filename}:{line_num} - \"{line}\" failed.".format(
+                            filename=fn, line_num=node.lineno, line=line))
+                    passed = False
 
 # exit code is non-zero if the script finished without error
 sys.exit(not passed)

--- a/scripts/travisci/check_imports.sh
+++ b/scripts/travisci/check_imports.sh
@@ -4,8 +4,4 @@ export TF_CPP_MIN_LOG_LEVEL=3      # shut TensorFlow up
 export DISABLE_MUJOCO_RENDERING=1  # silence glfw
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOME}/.mujoco/mjpro150/bin"
 
-imports=$(python scripts/travisci/check_imports.py \
-           | sort \
-           | uniq \
-           | paste -sd ";" -)
-python -c "${imports}"
+python scripts/travisci/check_imports.py


### PR DESCRIPTION
The check_imports CI script was not detecting all broken imports, and
some snuck in.

This change makes the check_imports script more strict, and fixes the
problems detected by the stricter check.