### PR TITLE
Fix tensorboard creates another TF device issue

### DIFF
--- a/garage/misc/logger.py
+++ b/garage/misc/logger.py
@@ -85,6 +85,7 @@ def remove_tabular_output(file_name):
 
 def set_tensorboard_dir(dir_name):
     _tensorboard.set_dir(dir_name)
+    log("tensorboard data will be logged into:" + dir_name)
 
 
 def set_snapshot_dir(dir_name):

--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -14,6 +14,7 @@ import tensorflow as tf
 
 from garage.misc.console import mkdir_p
 
+
 class TensorBoardOutput:
     def __init__(self):
         self._scalars = tf.Summary()

--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -13,8 +13,6 @@ from tensorboard.plugins.custom_scalar import metadata
 import tensorflow as tf
 
 from garage.misc.console import mkdir_p
-import garage.misc.logger
-
 
 class TensorBoardOutput:
     def __init__(self):
@@ -25,7 +23,6 @@ class TensorBoardOutput:
 
         self._histogram_ds = {}
         self._histogram_summary_op = []
-        self._session = tf.Session()
         self._histogram_distribute_list = [
             'normal', 'gamma', 'poisson', 'uniform'
         ]
@@ -53,8 +50,6 @@ class TensorBoardOutput:
 
             self._default_step = 0
             assert self._writer is not None
-            garage.misc.logger.log("tensorboard data will be logged into:" +
-                                   dir_name)
 
     def dump_tensorboard(self, step=None):
         if not self._writer:
@@ -181,8 +176,9 @@ class TensorBoardOutput:
         del self._scalars.value[:]
 
     def _dump_histogram(self, step):
+        self.session = tf.get_default_session()
         if len(self._histogram_summary_op):
-            summary_str = self._session.run(
+            summary_str = self.session.run(
                 self._histogram_summary_op_merge, feed_dict=self._feed)
             self._writer.add_summary(summary_str, global_step=step)
             self._writer.flush()


### PR DESCRIPTION
Class TensorBoardOutput used to create tf.Session in its constructor.
But the session seems to launch a TF device. Since the only use of the
session is to dump histogram, and usually there is a session created as
default when dump histograms into tensorboard. So I deleted it in the
constructor and moved it into method _dump_histogram.

There is also a circular import in TensorBoardOutput, deleted it.

Refer to: #72 