### PR TITLE
Remove quotes in filename variables in pep8 checks

### DIFF
--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -94,28 +94,30 @@ errors_change="${errors_change[@]}"
 ignored_errors_change="${ignored_errors_change[@]}"
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
   files_changed="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=M \
-    --name-only)"
+                     --name-only | grep ".*.py")"
   files_added="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=A \
-    --name-only)"
+                   --name-only | grep ".*.py")"
   flake8 --isolated --import-order-style=google \
     --application-import-names=sandbox,garage,examples,contrib \
     --select="${errors_change// /,}" \
-    --ignore="${ignored_errors_change// /,}" "${files_changed}"
+    --ignore="${ignored_errors_change// /,}" ${files_changed}
   flake8 --isolated --import-order-style=google \
     --application-import-names=sandbox,garage,examples,contrib \
     --select="${erros_add// /,}" \
-    --ignore="${ignored_errors_change// /,}" "${files_added}"
+    --ignore="${ignored_errors_change// /,}" ${files_added}
 else
   git remote set-branches --add origin master
   git fetch
-  files_changed="$(git diff origin/master --diff-filter=M --name-only)"
-  files_added="$(git diff origin/master --diff-filter=A --name-only)"
+  files_changed="$(git diff origin/master --diff-filter=M --name-only \
+                     | grep ".*.py")"
+  files_added="$(git diff origin/master --diff-filter=A --name-only \
+                   | grep ".*.py")"
   flake8 --isolated --import-order-style=google \
     --application-import-names=sandbox,garage,examples,contrib \
     --select="${errors_change// /,}" \
-    --ignore="${ignored_errors_change// /,}" "${files_changed}"
+    --ignore="${ignored_errors_change// /,}" ${files_changed}
   flake8 --isolated --import-order-style=google \
     --application-import-names=sandbox,garage,examples,contrib \
     --select="${erros_add// /,}" \
-    --ignore="${ignored_errors_change// /,}" "${files_added}"
+    --ignore="${ignored_errors_change// /,}" ${files_added}
 fi

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -33,7 +33,7 @@ exclude_all=(
 )
 
 
-### CHANGED_FILES ###
+### CHANGED FILES ###
 
 # Error codes applied to changed files
 errors_changed=(
@@ -161,15 +161,12 @@ test_exclude_added=(
 
 
 ################################################################################
-
-# DOCSTRING
-# The following error code enables all the error codes for docstring defined
-# here:
-# http://pep257.readthedocs.io/en/latest/error_codes.html
-# If one of the errors needs to be ignored, just add it to the ignore array.
-#erros_add="${errors_changed[@]} D"
-
-if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
+# If Travis CI is running this script and there's a valid pull request,
+# use the commits defined by TRAVIS_COMMIT_RANGE to get a list of changed
+# and added files introduced in the feature branch,
+# Otherwise, obtain the lists by comparing against the master branch in the
+# repository.
+if [[ "${TRAVIS}" == "true" && "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
   files_changed="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=M \
                      --name-only | grep ".*\.py")"
   files_added="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=A \
@@ -183,6 +180,8 @@ else
                    | grep ".*\.py")"
 fi
 
+# Obtain the files that have been added or modified in the repository that
+# exist inside the tests folder.
 test_files_changed="$(echo "${files_changed}" |  grep "tests/*")"
 test_files_added="$(echo "${files_added}" |  grep "tests/*")"
 

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -29,6 +29,7 @@ ignored_errors_all=(
 
 # Files or directories to exclude from checks applied to all files.
 exclude_all=(
+./tests/'*'
 )
 
 
@@ -88,6 +89,7 @@ ignored_errors_changed=(
 
 # Files or directories to exclude from checks applied to changed files.
 exclude_changed=(
+./tests/'*'
 )
 
 ### ADDED FILES ###
@@ -112,6 +114,52 @@ exclude_added=(
 ./tests/'*'
 )
 
+### ALL TEST FILES ###
+
+# Error codes applied to all test files
+test_errors_all=(
+${errors_all[@]}
+)
+
+# Error codes ignored for all test files
+test_ignored_errors_all=(
+)
+
+# Files or directories to exclude from checks applied to all files.
+test_exclude_all=(
+)
+
+### CHANGED TEST FILES ###
+
+# Error codes applied to changed test files
+test_errors_changed=(
+${errors_changed[@]}
+)
+
+# Error codes ignored to changed test files
+test_ignored_errors_changed=(
+)
+
+# Files or directories to exclude from checks applied to changed test files.
+test_exclude_changed=(
+)
+
+### ADDED TEST FILES ###
+
+# Error codes applied to added test files
+test_errors_added=(
+${errors_changed[@]}
+)
+
+# Error codes ignored to added test files
+test_ignored_errors_added=(
+)
+
+# Files or directories to exclude from checks applied to added test files.
+test_exclude_added=(
+)
+
+
 ################################################################################
 
 # DOCSTRING
@@ -134,6 +182,9 @@ else
   files_added="$(git diff origin/master --diff-filter=A --name-only \
                    | grep ".*\.py")"
 fi
+
+test_files_changed="$(echo "${files_changed}" |  grep "tests/*")"
+test_files_added="$(echo "${files_added}" |  grep "tests/*")"
 
 # Check rules with flake8
 check_flake8() {
@@ -171,4 +222,35 @@ if [[ ! -z "${files_added}" ]]; then
                --ignore="${ignored_errors_added// /,}" \
                --exclude="${exclude_added// /,}" \
                ${files_added}
+fi
+
+# All test files
+test_errors_all="${test_errors_all[@]}"
+test_ignored_errors_all="${test_ignored_errors_all[@]}"
+test_exclude_all="${test_exclude_all[@]}"
+check_flake8 --select="${test_errors_all// /,}" \
+             --ignore="${test_ignored_errors_all// /,}" \
+             --exclude="${test_exclude_all// /,}" \
+             --filename="./tests/*"
+
+# Changed test files
+test_errors_changed="${test_errors_changed[@]}"
+test_ignored_errors_changed="${test_ignored_errors_changed[@]}"
+test_exclude_changed="${test_exclude_changed[@]}"
+if [[ ! -z "${test_files_changed}" ]]; then
+  check_flake8 --select="${test_errors_changed// /,}" \
+               --ignore="${test_ignored_errors_changed// /,}" \
+               --exclude="${test_exclude_changed// /,}" \
+               ${test_files_changed}
+fi
+
+# Added test files
+test_errors_added="${test_errors_added[@]}"
+test_ignored_errors_added="${test_ignored_errors_added[@]}"
+test_exclude_added="${test_exclude_added[@]}"
+if [[ ! -z "${test_files_added}" ]]; then
+  check_flake8 --select="${test_errors_added// /,}" \
+               --ignore="${test_ignored_errors_added// /,}" \
+               --exclude="${test_exclude_added// /,}" \
+               ${test_files_added}
 fi

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -27,10 +27,9 @@ E714 # use is not operator rather than not ... is
 ignored_errors_all=(
 )
 
-#errors_all="${errors_all[@]}"
-#ignored_errors_all="${ignored_errors_all[@]}"
-#flake8 --isolated --select="${errors_all// /,}" \
-#  --ignore="${ignored_errors_all// /,}"
+# Files or directories to exclude from checks applied to all files.
+exclude_all=(
+)
 
 
 ### CHANGED_FILES ###
@@ -83,11 +82,13 @@ E722 # do not use bare except, specify exception instead
 E731 # do not assign a lambda expression, use a def
 )
 
-# Add the codes of the errors to be ignored for the absolute verification in
-# this array.
+# Error codes ignored for changed files
 ignored_errors_changed=(
 )
 
+# Files or directories to exclude from checks applied to changed files.
+exclude_changed=(
+)
 
 ### ADDED FILES ###
 
@@ -104,6 +105,11 @@ D
 
 # Error codes applied to added files
 ignored_errors_added=(
+)
+
+# Files or directories to exclude from checks applied to added files.
+exclude_added=(
+./tests/'*'
 )
 
 ################################################################################
@@ -140,21 +146,29 @@ check_flake8() {
 # All files
 errors_all="${errors_all[@]}"
 ignored_errors_all="${ignored_errors_all[@]}"
+exclude_all="${exclude_all[@]}"
 check_flake8 --select="${errors_all// /,}" \
-             --ignore="${ignored_errors_all// /,}"
+             --ignore="${ignored_errors_all// /,}" \
+             --exclude="${exclude_all// /,}"
 
 # Changed files
 errors_changed="${errors_changed[@]}"
 ignored_errors_changed="${ignored_errors_changed[@]}"
+exclude_changed="${exclude_changed[@]}"
 if [[ ! -z "${files_changed}" ]]; then
   check_flake8 --select="${errors_changed// /,}" \
-               --ignore="${ignored_errors_changed// /,}" ${files_changed}
+               --ignore="${ignored_errors_changed// /,}" \
+               --exclude="${exclude_changed// /,}" \
+               ${files_changed}
 fi
 
 # Added files
 errors_added="${errors_added[@]}"
 ignored_errors_added="${ignored_errors_added[@]}"
+exclude_added="${exclude_added[@]}"
 if [[ ! -z "${files_added}" ]]; then
   check_flake8 --select="${errors_added// /,}" \
-               --ignore="${ignored_errors_added// /,}" ${files_added}
+               --ignore="${ignored_errors_added// /,}" \
+               --exclude="${exclude_added// /,}" \
+               ${files_added}
 fi

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# ABSOLUTE VERIFICATION:
-# The following errors are analyzed in all python files across the repository.
-errors_absolute=(
+
+# Python packages considered local to the project, for the purposes of import
+# order checking. Comma-delimited.
+garage_packages="garage,sandbox,examples,contrib"
+
+### ALL FILES ###
+
+# Error codes applied to all files
+errors_all=(
 # TABS
 E101 # indentation contains mixed spaces and tabs
 W191 # indentation contains tabs
@@ -17,21 +23,20 @@ E702 # multiple statements on one line (semicolon)
 E714 # use is not operator rather than not ... is
 )
 
-# Add the codes of the errors to be ignored for the absolute verification in
-# this array.
-ignored_errors_absolute=(
+# Error codes ignored for all files
+ignored_errors_all=(
 )
 
-errors_absolute="${errors_absolute[@]}"
-ignored_errors_absolute="${ignored_errors_absolute[@]}"
-flake8 --isolated --select="${errors_absolute// /,}" \
-  --ignore="${ignored_errors_absolute// /,}"
+#errors_all="${errors_all[@]}"
+#ignored_errors_all="${ignored_errors_all[@]}"
+#flake8 --isolated --select="${errors_all// /,}" \
+#  --ignore="${ignored_errors_all// /,}"
 
 
-# INCREMENTAL VERIFICATION:
-# The following errors are analyzed only in the modified code in the pull
-# request branch.
-errors_change=(
+### CHANGED_FILES ###
+
+# Error codes applied to changed files
+errors_changed=(
 # INDENTATION
 E125 # continuation line with same indent as next logical line
 E128 # continuation line under-indented for visual indent
@@ -80,44 +85,76 @@ E731 # do not assign a lambda expression, use a def
 
 # Add the codes of the errors to be ignored for the absolute verification in
 # this array.
-ignored_errors_change=(
+ignored_errors_changed=(
 )
+
+
+### ADDED FILES ###
+
+# Error codes for added files
+errors_added=(
+${errors_changed[@]}
+# DOCSTRING
+# The following error code enables all the error codes for docstring defined
+# here:
+# http://pep257.readthedocs.io/en/latest/error_codes.html
+# If one of the errors needs to be ignored, just add it to the ignore array.
+D
+)
+
+# Error codes applied to added files
+ignored_errors_added=(
+)
+
+################################################################################
 
 # DOCSTRING
 # The following error code enables all the error codes for docstring defined
 # here:
 # http://pep257.readthedocs.io/en/latest/error_codes.html
 # If one of the errors needs to be ignored, just add it to the ignore array.
-erros_add="${errors_change[@]} D"
+#erros_add="${errors_changed[@]} D"
 
-errors_change="${errors_change[@]}"
-ignored_errors_change="${ignored_errors_change[@]}"
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
   files_changed="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=M \
-                     --name-only | grep ".*.py")"
+                     --name-only | grep ".*\.py")"
   files_added="$(git diff "${TRAVIS_COMMIT_RANGE}" --diff-filter=A \
-                   --name-only | grep ".*.py")"
-  flake8 --isolated --import-order-style=google \
-    --application-import-names=sandbox,garage,examples,contrib \
-    --select="${errors_change// /,}" \
-    --ignore="${ignored_errors_change// /,}" ${files_changed}
-  flake8 --isolated --import-order-style=google \
-    --application-import-names=sandbox,garage,examples,contrib \
-    --select="${erros_add// /,}" \
-    --ignore="${ignored_errors_change// /,}" ${files_added}
+                   --name-only | grep ".*\.py")"
 else
   git remote set-branches --add origin master
   git fetch
   files_changed="$(git diff origin/master --diff-filter=M --name-only \
-                     | grep ".*.py")"
+                     | grep ".*\.py")"
   files_added="$(git diff origin/master --diff-filter=A --name-only \
-                   | grep ".*.py")"
-  flake8 --isolated --import-order-style=google \
-    --application-import-names=sandbox,garage,examples,contrib \
-    --select="${errors_change// /,}" \
-    --ignore="${ignored_errors_change// /,}" ${files_changed}
-  flake8 --isolated --import-order-style=google \
-    --application-import-names=sandbox,garage,examples,contrib \
-    --select="${erros_add// /,}" \
-    --ignore="${ignored_errors_change// /,}" ${files_added}
+                   | grep ".*\.py")"
+fi
+
+# Check rules with flake8
+check_flake8() {
+  flake8 --isolated \
+         --import-order-style=google \
+         --application-import-names="${garage_packages}" \
+         "$@"
+}
+
+# All files
+errors_all="${errors_all[@]}"
+ignored_errors_all="${ignored_errors_all[@]}"
+check_flake8 --select="${errors_all// /,}" \
+             --ignore="${ignored_errors_all// /,}"
+
+# Changed files
+errors_changed="${errors_changed[@]}"
+ignored_errors_changed="${ignored_errors_changed[@]}"
+if [[ ! -z "${files_changed}" ]]; then
+  check_flake8 --select="${errors_changed// /,}" \
+               --ignore="${ignored_errors_changed// /,}" ${files_changed}
+fi
+
+# Added files
+errors_added="${errors_added[@]}"
+ignored_errors_added="${ignored_errors_added[@]}"
+if [[ ! -z "${files_added}" ]]; then
+  check_flake8 --select="${errors_added// /,}" \
+               --ignore="${ignored_errors_added// /,}" ${files_added}
 fi

--- a/scripts/travisci/check_pylint.sh
+++ b/scripts/travisci/check_pylint.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
   files_changed=$(git diff "${TRAVIS_COMMIT_RANGE}" --name-only \
-    | grep ".*.py")
+    | grep ".*\.py")
   if [[ ! -z "${files_changed}" ]]; then
     pylint ${files_changed} --rcfile=setup.cfg
   fi
 else
   git remote set-branches --add origin master
   git fetch
-  files_changed=$(git diff origin/master --name-only | grep ".*.py")
+  files_changed=$(git diff origin/master --name-only | grep ".*\.py")
   if [[ ! -z "${files_changed}" ]]; then
     pylint ${files_changed} --rcfile=setup.cfg
   fi

--- a/scripts/travisci/check_pylint.sh
+++ b/scripts/travisci/check_pylint.sh
@@ -3,13 +3,13 @@ if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
   files_changed=$(git diff "${TRAVIS_COMMIT_RANGE}" --name-only \
     | grep ".*.py")
   if [[ ! -z "${files_changed}" ]]; then
-    pylint "${files_changed}" --rcfile=setup.cfg
+    pylint ${files_changed} --rcfile=setup.cfg
   fi
 else
   git remote set-branches --add origin master
   git fetch
   files_changed=$(git diff origin/master --name-only | grep ".*.py")
   if [[ ! -z "${files_changed}" ]]; then
-    pylint "${files_changed}" --rcfile=setup.cfg
+    pylint ${files_changed} --rcfile=setup.cfg
   fi
 fi


### PR DESCRIPTION
Both the scripts for pylint and flake8 were doing the correct filename
subtitution but with added quotes that were passed to corresponding
command for pylint and flake8, not checking any file at all. For
example, the bad command produced was:
pylint 'garage/algos/cma_es_lib.py garage/envs/dm_control_env.py'
Instead of:
pylint garage/algos/cma_es_lib.py garage/envs/dm_control_env.py
This commit fixes the problem. Also the grep command is used to filter
the python files, because flake8 and pylint may check on all the files
passed to them.