### PR TITLE
Fixes GLEW import issue

### DIFF
--- a/garage/envs/mujoco/point_env.py
+++ b/garage/envs/mujoco/point_env.py
@@ -1,6 +1,7 @@
 import math
 
-import glfw
+import mujoco_py  # pylint: disable=unused-import
+import glfw  # noqa: I100
 import numpy as np
 
 from garage.core import Serializable


### PR DESCRIPTION
In order to correctly import glfw, we must first import mujoco_py.