### PR TITLE
Added log_diagnostics to normalized_env

### DIFF
--- a/garage/envs/normalized_env.py
+++ b/garage/envs/normalized_env.py
@@ -103,5 +103,8 @@ class NormalizedEnv(gym.Wrapper, Serializable):
 
         return next_obs, reward * self._scale_reward, done, info
 
+    def log_diagnostics(self, paths):
+        pass
+
 
 normalize = NormalizedEnv


### PR DESCRIPTION
Running examples such as `examples/ddpg_cartpole.py` will throw `AttributeError: 'NormalizedEnv' object has no attribute 'log_diagnostics'`. This PR will fix that issue by adding the log_diagnostics function to NormalizedEnv.