### PR TITLE
Override plot parameter of algorithm constructor

### DIFF
--- a/examples/trpo_gym_cartpole.py
+++ b/examples/trpo_gym_cartpole.py
@@ -1,3 +1,5 @@
+import gym
+
 from garage.algos import TRPO
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
@@ -22,7 +24,6 @@ def run_task(*_):
         policy=policy,
         baseline=baseline,
         batch_size=4000,
-        max_path_length=env.horizon,
         n_itr=50,
         discount=0.99,
         step_size=0.01,

--- a/examples/trpo_gym_cartpole.py
+++ b/examples/trpo_gym_cartpole.py
@@ -5,6 +5,7 @@ from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.util import spec
 from garage.misc.instrument import run_experiment
+from garage.envs.util import horizon
 from garage.policies import CategoricalMLPPolicy
 
 
@@ -24,6 +25,7 @@ def run_task(*_):
         policy=policy,
         baseline=baseline,
         batch_size=4000,
+        max_path_length=horizon(env),
         n_itr=50,
         discount=0.99,
         step_size=0.01,

--- a/examples/trpo_gym_cartpole.py
+++ b/examples/trpo_gym_cartpole.py
@@ -3,9 +3,9 @@ import gym
 from garage.algos import TRPO
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
+from garage.envs.util import horizon
 from garage.envs.util import spec
 from garage.misc.instrument import run_experiment
-from garage.envs.util import horizon
 from garage.policies import CategoricalMLPPolicy
 
 

--- a/examples/trpo_gym_pendulum.py
+++ b/examples/trpo_gym_pendulum.py
@@ -3,6 +3,7 @@ import gym
 from garage.algos import TRPO
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
+from garage.envs.util import horizon
 from garage.envs.util import spec
 from garage.misc.instrument import run_experiment
 from garage.policies import GaussianMLPPolicy
@@ -11,8 +12,8 @@ from garage.policies import GaussianMLPPolicy
 def run_task(*_):
     # Please note that different environments with different action spaces may
     # require different policies. For example with a Box action space, a
-    # GaussianMLPPolicy works, but for a Discrete action space may need to use a
-    # CategoricalMLPPolicy (see the trpo_gym_cartpole.py example)
+    # GaussianMLPPolicy works, but for a Discrete action space may need to use
+    # a CategoricalMLPPolicy (see the trpo_gym_cartpole.py example)
     env = normalize(gym.make("Pendulum-v0"))
 
     policy = GaussianMLPPolicy(env_spec=spec(env), hidden_sizes=(32, 32))
@@ -24,7 +25,7 @@ def run_task(*_):
         policy=policy,
         baseline=baseline,
         batch_size=4000,
-        max_path_length=env.horizon,
+        max_path_length=horizon(env),
         n_itr=50,
         discount=0.99,
         step_size=0.01,

--- a/garage/algos/batch_polopt.py
+++ b/garage/algos/batch_polopt.py
@@ -96,7 +96,7 @@ class BatchPolopt(RLAlgorithm):
         self.max_path_length = max_path_length
         self.discount = discount
         self.gae_lambda = gae_lambda
-        self.plot = plot
+        self.plot = plot or Plotter.enable
         self.pause_for_plot = pause_for_plot
         self.center_adv = center_adv
         self.positive_adv = positive_adv
@@ -116,7 +116,7 @@ class BatchPolopt(RLAlgorithm):
 
     def train(self):
         plotter = Plotter()
-        if plotter.status(self.plot):
+        if self.plot:
             plotter.init_plot(self.env, self.policy)
         self.start_worker()
         self.init_opt()
@@ -135,7 +135,7 @@ class BatchPolopt(RLAlgorithm):
                 logger.save_itr_params(itr, params)
                 logger.log("saved")
                 logger.dump_tabular(with_prefix=False)
-                if plotter.status(self.plot):
+                if self.plot:
                     plotter.update_plot(self.policy, self.max_path_length)
                     if self.pause_for_plot:
                         input("Plotting evaluation run: Press Enter to "

--- a/garage/algos/batch_polopt.py
+++ b/garage/algos/batch_polopt.py
@@ -96,7 +96,7 @@ class BatchPolopt(RLAlgorithm):
         self.max_path_length = max_path_length
         self.discount = discount
         self.gae_lambda = gae_lambda
-        self.plot = plot or Plotter.enable
+        self.plot = plot
         self.pause_for_plot = pause_for_plot
         self.center_adv = center_adv
         self.positive_adv = positive_adv

--- a/garage/algos/cem.py
+++ b/garage/algos/cem.py
@@ -97,7 +97,7 @@ class CEM(RLAlgorithm, Serializable):
         self.env = env
         self.policy = policy
         self.batch_size = batch_size
-        self.plot = plot
+        self.plot = plot or Plotter.enable
         self.extra_decay_time = extra_decay_time
         self.extra_std = extra_std
         self.best_frac = best_frac
@@ -111,7 +111,7 @@ class CEM(RLAlgorithm, Serializable):
 
     def train(self):
         parallel_sampler.populate_task(self.env, self.policy)
-        if self.plotter.status(self.plot):
+        if self.plot:
             self.plotter.init_plot(self.env, self.policy)
 
         cur_std = self.init_std
@@ -184,7 +184,7 @@ class CEM(RLAlgorithm, Serializable):
                 ))
             logger.dump_tabular(with_prefix=False)
             logger.pop_prefix()
-            if self.plotter.status(self.plot):
+            if self.plot:
                 self.plotter.update_plot(self.policy, self.max_path_length)
         parallel_sampler.terminate_task()
         self.plotter.shutdown()

--- a/garage/algos/cem.py
+++ b/garage/algos/cem.py
@@ -97,7 +97,7 @@ class CEM(RLAlgorithm, Serializable):
         self.env = env
         self.policy = policy
         self.batch_size = batch_size
-        self.plot = plot or Plotter.enable
+        self.plot = plot
         self.extra_decay_time = extra_decay_time
         self.extra_std = extra_std
         self.best_frac = best_frac

--- a/garage/algos/cem.py
+++ b/garage/algos/cem.py
@@ -7,7 +7,7 @@ from garage.algos import RLAlgorithm
 from garage.core import Serializable
 import garage.misc.logger as logger
 from garage.misc.special import discount_cumsum
-import garage.plotter as plotter
+from garage.plotter import Plotter
 from garage.sampler.utils import rollout
 
 
@@ -105,11 +105,12 @@ class CEM(RLAlgorithm, Serializable):
         self.max_path_length = max_path_length
         self.n_itr = n_itr
         self.n_evals = n_evals
+        self.plotter = Plotter()
 
     def train(self):
         parallel_sampler.populate_task(self.env, self.policy)
-        if self.plot:
-            plotter.init_plot(self.env, self.policy)
+        if self.plotter.status(self.plot):
+            self.plotter.init_plot(self.env, self.policy)
 
         cur_std = self.init_std
         cur_mean = self.policy.get_param_values()
@@ -181,6 +182,7 @@ class CEM(RLAlgorithm, Serializable):
                 ))
             logger.dump_tabular(with_prefix=False)
             logger.pop_prefix()
-            if self.plot:
-                plotter.update_plot(self.policy, self.max_path_length)
+            if self.plotter.status(self.plot):
+                self.plotter.update_plot(self.policy, self.max_path_length)
         parallel_sampler.terminate_task()
+        self.plotter.shutdown()

--- a/garage/algos/cma_es.py
+++ b/garage/algos/cma_es.py
@@ -49,7 +49,7 @@ class CMAES(RLAlgorithm, Serializable):
         Serializable.quick_init(self, locals())
         self.env = env
         self.policy = policy
-        self.plot = plot or Plotter.enable
+        self.plot = plot
         self.sigma0 = sigma0
         self.discount = discount
         self.max_path_length = max_path_length

--- a/garage/algos/cma_es.py
+++ b/garage/algos/cma_es.py
@@ -49,7 +49,7 @@ class CMAES(RLAlgorithm, Serializable):
         Serializable.quick_init(self, locals())
         self.env = env
         self.policy = policy
-        self.plot = plot
+        self.plot = plot or Plotter.enable
         self.sigma0 = sigma0
         self.discount = discount
         self.max_path_length = max_path_length
@@ -64,7 +64,7 @@ class CMAES(RLAlgorithm, Serializable):
         es = cma_es_lib.CMAEvolutionStrategy(cur_mean, cur_std)
 
         parallel_sampler.populate_task(self.env, self.policy)
-        if self.plotter.status(self.plot):
+        if self.plot:
             self.plotter.init_plot(self.env, self.policy)
 
         cur_std = self.sigma0
@@ -138,7 +138,7 @@ class CMAES(RLAlgorithm, Serializable):
                     env=self.env,
                 ))
             logger.dump_tabular(with_prefix=False)
-            if self.plotter.status(self.plot):
+            if self.plot:
                 self.plotter.update_plot(self.policy, self.max_path_length)
             logger.pop_prefix()
             # Update iteration.

--- a/garage/algos/cma_es.py
+++ b/garage/algos/cma_es.py
@@ -1,10 +1,8 @@
 import numpy as np
-import theano.tensor as TT
 
 from garage.algos import cma_es_lib
 from garage.algos import RLAlgorithm
 from garage.core import Serializable
-from garage.misc import ext
 import garage.misc.logger as logger
 from garage.misc.special import discount_cumsum
 from garage.plotter import Plotter
@@ -13,13 +11,13 @@ from garage.sampler import stateful_pool
 from garage.sampler.utils import rollout
 
 
-def sample_return(G, params, max_path_length, discount):
+def sample_return(g, params, max_path_length, discount):
     # env, policy, params, max_path_length, discount = args
     # of course we make the strong assumption that there is no race condition
-    G.policy.set_param_values(params)
+    g.policy.set_param_values(params)
     path = rollout(
-        G.env,
-        G.policy,
+        g.env,
+        g.policy,
         max_path_length,
     )
     path["returns"] = discount_cumsum(path["rewards"], discount)
@@ -41,8 +39,8 @@ class CMAES(RLAlgorithm, Serializable):
         """
         :param n_itr: Number of iterations.
         :param max_path_length: Maximum length of a single rollout.
-        :param batch_size: # of samples from trajs from param distribution, when
-         this is set, n_samples is ignored
+        :param batch_size: # of samples from trajs from param distribution,
+         when this is set, n_samples is ignored
         :param discount: Discount.
         :param plot: Plot evaluation run after each iteration.
         :param sigma0: Initial std for param dist

--- a/garage/algos/ddpg.py
+++ b/garage/algos/ddpg.py
@@ -126,7 +126,7 @@ class DDPG(RLAlgorithm):
         self.n_updates_per_sample = n_updates_per_sample
         self.include_horizon_terminal_transitions = \
             include_horizon_terminal_transitions
-        self.plot = plot or Plotter.enable
+        self.plot = plot
         self.pause_for_plot = pause_for_plot
 
         self.qf_loss_averages = []

--- a/garage/algos/ddpg.py
+++ b/garage/algos/ddpg.py
@@ -126,7 +126,7 @@ class DDPG(RLAlgorithm):
         self.n_updates_per_sample = n_updates_per_sample
         self.include_horizon_terminal_transitions = \
             include_horizon_terminal_transitions
-        self.plot = plot
+        self.plot = plot or Plotter.enable
         self.pause_for_plot = pause_for_plot
 
         self.qf_loss_averages = []
@@ -144,7 +144,7 @@ class DDPG(RLAlgorithm):
 
     def start_worker(self):
         parallel_sampler.populate_task(self.env, self.policy)
-        if self.plotter.status(self.plot):
+        if self.plot:
             self.plotter.init_plot(self.env, self.policy)
 
     @overrides
@@ -389,7 +389,7 @@ class DDPG(RLAlgorithm):
         self.es_path_returns = []
 
     def update_plot(self):
-        if self.plotter.status(self.plot):
+        if self.plot:
             self.plotter.update_plot(self.policy, self.max_path_length)
 
     def get_epoch_snapshot(self, epoch):

--- a/garage/algos/ddpg.py
+++ b/garage/algos/ddpg.py
@@ -12,7 +12,7 @@ from garage.misc import ext
 from garage.misc import special
 import garage.misc.logger as logger
 from garage.misc.overrides import overrides
-from garage.plotter import plotter
+from garage.plotter import Plotter
 from garage.replay_buffer import ReplayBuffer
 from garage.sampler import parallel_sampler
 
@@ -141,10 +141,11 @@ class DDPG(RLAlgorithm):
         self.scale_reward = scale_reward
 
         self.opt_info = None
+        self.plotter = Plotter()
 
     def start_worker(self):
         parallel_sampler.populate_task(self.env, self.policy)
-        if self.plot:
+        if plotter.status(self.plot):
             plotter.init_plot(self.env, self.policy)
 
     @overrides
@@ -227,6 +228,7 @@ class DDPG(RLAlgorithm):
                           "continue...")
         self.env.close()
         self.policy.terminate()
+        self.plotter.shutdown()
 
     def init_opt(self):
 
@@ -388,8 +390,8 @@ class DDPG(RLAlgorithm):
         self.es_path_returns = []
 
     def update_plot(self):
-        if self.plot:
-            plotter.update_plot(self.policy, self.max_path_length)
+        if self.plotter.status(self.plot):
+            self.plotter.update_plot(self.policy, self.max_path_length)
 
     def get_epoch_snapshot(self, epoch):
         return dict(

--- a/garage/algos/ddpg.py
+++ b/garage/algos/ddpg.py
@@ -145,7 +145,7 @@ class DDPG(RLAlgorithm):
 
     def start_worker(self):
         parallel_sampler.populate_task(self.env, self.policy)
-        if plotter.status(self.plot):
+        if self.plotter.status(self.plot):
             plotter.init_plot(self.env, self.policy)
 
     @overrides

--- a/garage/algos/ddpg.py
+++ b/garage/algos/ddpg.py
@@ -89,12 +89,11 @@ class DDPG(RLAlgorithm):
         :param scale_reward: The scaling factor applied to the rewards when
          training
         :param include_horizon_terminal_transitions: whether to include
-         transitions with terminal=True because the horizon was reached.
-         This might make the Q value back up less stable for certain tasks.
+         transitions with terminal=True because the horizon was reached. This
+         might make the Q value back up less stable for certain tasks.
         :param plot: Whether to visualize the policy performance after each
          eval_interval.
-        :param pause_for_plot: Whether to pause before continuing when
-         plotting.
+        :param pause_for_plot: Whether to pause before continuing when plotting
         :return:
         """
         self.env = env
@@ -146,7 +145,7 @@ class DDPG(RLAlgorithm):
     def start_worker(self):
         parallel_sampler.populate_task(self.env, self.policy)
         if self.plotter.status(self.plot):
-            plotter.init_plot(self.env, self.policy)
+            self.plotter.init_plot(self.env, self.policy)
 
     @overrides
     def train(self):

--- a/garage/plotter/__init__.py
+++ b/garage/plotter/__init__.py
@@ -1,3 +1,1 @@
-from garage.plotter.plotter import init_plot
-from garage.plotter.plotter import init_worker
-from garage.plotter.plotter import update_plot
+from garage.plotter.plotter import Plotter

--- a/garage/plotter/plotter.py
+++ b/garage/plotter/plotter.py
@@ -26,7 +26,7 @@ class Plotter():
 
     # Static variable used along with function run_experiment to enable or
     # disable the plotter
-    enable = None
+    enable = True
 
     def __init__(self):
         self._process = None
@@ -82,42 +82,19 @@ class Plotter():
             pass
 
     def shutdown(self):
-        if self._process.is_alive():
+        if Plotter.enable and self._process.is_alive():
             self._queue.put(Message(op=Op.STOP, args=None, kwargs=None))
             self._queue.close()
             self._process.join()
 
     @staticmethod
-    def set_enable(enable):
+    def disable():
         """Set the plot enabling according to the run_experiment function.
         """
-        Plotter.enable = enable
-
-    @staticmethod
-    def status(plot_algo_status):
-        """Use this method as a guard for plot enabling.
-
-        This guard method considers the plot enabling defined in the
-        function run_experiment.
-
-        Parameters
-        ----------
-        plot_algo_status : boolean
-            The plot enabling defined in the algorithm class.
-
-        Returns
-        -------
-            The plot enabling of the algorithm if the run_experiment was not
-            called, and the plot enabling of the run_experiment otherwise.
-
-        """
-        if Plotter.enable is None:
-            return plot_algo_status
-        else:
-            return Plotter.enable
+        Plotter.enable = False
 
     def init_worker(self):
-        if Plotter.enable is None or Plotter.enable:
+        if Plotter.enable:
             self._queue = Queue()
             if ('Darwin' in platform.platform()):
                 self._process = Thread(target=self._worker_start)
@@ -128,7 +105,7 @@ class Plotter():
             atexit.register(self.shutdown)
 
     def init_plot(self, env, policy):
-        if Plotter.enable is None or Plotter.enable:
+        if Plotter.enable:
             if not (self._process and self._queue):
                 self.init_worker()
 
@@ -145,7 +122,7 @@ class Plotter():
                 Message(op=Op.UPDATE, args=(env, policy), kwargs=None))
 
     def update_plot(self, policy, max_length=np.inf):
-        if Plotter.enable is None or Plotter.enable:
+        if Plotter.enable:
             self._queue.put(
                 Message(
                     op=Op.DEMO,

--- a/garage/plotter/plotter.py
+++ b/garage/plotter/plotter.py
@@ -1,88 +1,150 @@
 import atexit
+from collections import namedtuple
+from enum import Enum
 from multiprocessing import Process
 from multiprocessing import Queue
 import platform
-from queue import Empty
 from threading import Thread
 
 import numpy as np
 
 from garage.sampler.utils import rollout
 
-__all__ = ['init_worker', 'init_plot', 'update_plot']
-
-process = None
-queue = None
+__all__ = ['Plotter']
 
 
-def _worker_start():
-    env = None
-    policy = None
-    max_length = None
-    try:
-        while True:
-            msgs = {}
-            # Only fetch the last message of each type
+class Op(Enum):
+    STOP = 0
+    UPDATE = 1
+    DEMO = 2
+
+
+Message = namedtuple("Message", ["op", "args", "kwargs"])
+
+
+class Plotter():
+
+    # Static variable used along with function run_experiment to enable or
+    # disable the plotter
+    enable = None
+
+    def __init__(self):
+        self._process = None
+        self._queue = None
+
+    def _worker_start(self):
+        env = None
+        policy = None
+        max_length = None
+        initial_rollout = True
+        try:
+            # Each iteration will process ALL messages currently in the
+            # queue
             while True:
-                try:
-                    msg = queue.get_nowait()
-                    msgs[msg[0]] = msg[1:]
-                except Empty:
+                msgs = {}
+                # If true, block and yield processor
+                if initial_rollout:
+                    msg = self._queue.get()
+                    msgs[msg.op] = msg
+                    # Only fetch the last message of each type
+                    while not self._queue.empty():
+                        msg = self._queue.get()
+                        msgs[msg.op] = msg
+                else:
+                    # Only fetch the last message of each type
+                    while not self._queue.empty():
+                        msg = self._queue.get_nowait()
+                        msgs[msg.op] = msg
+
+                if Op.STOP in msgs:
                     break
-            if 'stop' in msgs:
-                break
-            elif 'update' in msgs:
-                env, policy = msgs['update']
-                # env.start_viewer()
-            elif 'demo' in msgs:
-                param_values, max_length = msgs['demo']
-                policy.set_param_values(param_values)
-                rollout(
-                    env,
-                    policy,
-                    max_path_length=max_length,
-                    animated=True,
-                    speedup=5)
-            else:
-                if max_length:
+                elif Op.UPDATE in msgs:
+                    env, policy = msgs[Op.UPDATE].args
+                elif Op.DEMO in msgs:
+                    param_values, max_length = msgs[Op.DEMO].args
+                    policy.set_param_values(param_values)
+                    initial_rollout = False
                     rollout(
                         env,
                         policy,
                         max_path_length=max_length,
                         animated=True,
                         speedup=5)
-    except KeyboardInterrupt:
-        pass
+                else:
+                    if max_length:
+                        rollout(
+                            env,
+                            policy,
+                            max_path_length=max_length,
+                            animated=True,
+                            speedup=5)
+        except KeyboardInterrupt:
+            pass
 
+    def shutdown(self):
+        if self._process.is_alive():
+            self._queue.put(Message(op=Op.STOP, args=None, kwargs=None))
+            self._queue.close()
+            self._process.join()
 
-def _shutdown_worker():
-    if process:
-        queue.put(['stop'])
-        queue.close()
-        process.join()
+    @staticmethod
+    def set_enable(enable):
+        """Set the plot enabling according to the run_experiment function.
+        """
+        Plotter.enable = enable
 
+    @staticmethod
+    def status(plot_algo_status):
+        """Use this method as a guard for plot enabling.
 
-def init_worker():
-    global process, queue
-    queue = Queue()
-    process = Thread(target=_worker_start) if (
-        'Darwin' in platform.platform()) else Process(target=_worker_start)
-    process.daemon = True
-    process.start()
-    atexit.register(_shutdown_worker)
+        This guard method considers the plot enabling defined in the
+        function run_experiment.
 
+        Parameters
+        ----------
+        plot_algo_status : boolean
+            The plot enabling defined in the algorithm class.
 
-def init_plot(env, policy):
-    global process, queue
-    if not (process and queue):
-        init_worker()
+        Returns
+        -------
+            The plot enabling of the algorithm if the run_experiment was not
+            called, and the plot enabling of the run_experiment otherwise.
 
-    # Needed in order to draw glfw window on the main thread
-    if ('Darwin' in platform.platform()):
-        rollout(env, policy, max_path_length=np.inf, animated=True, speedup=5)
+        """
+        if Plotter.enable is None:
+            return plot_algo_status
+        else:
+            return Plotter.enable
 
-    queue.put(['update', env, policy])
+    def init_worker(self):
+        if Plotter.enable is None or Plotter.enable:
+            self._queue = Queue()
+            if ('Darwin' in platform.platform()):
+                self._process = Thread(target=self._worker_start)
+            else:
+                self._process = Process(target=self._worker_start)
+            self._process.daemon = True
+            self._process.start()
+            atexit.register(self.shutdown)
 
+    def init_plot(self, env, policy):
+        if Plotter.enable is None or Plotter.enable:
+            if not (self._process and self._queue):
+                self.init_worker()
 
-def update_plot(policy, max_length=np.inf):
-    queue.put(['demo', policy.get_param_values(), max_length])
+            # Needed in order to draw glfw window on the main thread
+            if ('Darwin' in platform.platform()):
+                rollout(env, policy, max_path_length=np.inf, animated=True,
+                        speedup=5)
+
+            self._queue.put(
+                Message(
+                    op=Op.UPDATE, args=(env, policy), kwargs=None))
+
+    def update_plot(self, policy, max_length=np.inf):
+        if Plotter.enable is None or Plotter.enable:
+            self._queue.put(
+                Message(
+                    op=Op.DEMO,
+                    args=(policy.get_param_values(), max_length),
+                    kwargs=None))

--- a/garage/plotter/plotter.py
+++ b/garage/plotter/plotter.py
@@ -134,12 +134,14 @@ class Plotter():
 
             # Needed in order to draw glfw window on the main thread
             if ('Darwin' in platform.platform()):
-                rollout(env, policy, max_path_length=np.inf, animated=True,
+                rollout(env,
+                        policy,
+                        max_path_length=np.inf,
+                        animated=True,
                         speedup=5)
 
             self._queue.put(
-                Message(
-                    op=Op.UPDATE, args=(env, policy), kwargs=None))
+                Message(op=Op.UPDATE, args=(env, policy), kwargs=None))
 
     def update_plot(self, policy, max_length=np.inf):
         if Plotter.enable is None or Plotter.enable:

--- a/garage/plotter/plotter.py
+++ b/garage/plotter/plotter.py
@@ -134,11 +134,12 @@ class Plotter():
 
             # Needed in order to draw glfw window on the main thread
             if ('Darwin' in platform.platform()):
-                rollout(env,
-                        policy,
-                        max_path_length=np.inf,
-                        animated=True,
-                        speedup=5)
+                rollout(
+                    env,
+                    policy,
+                    max_path_length=np.inf,
+                    animated=True,
+                    speedup=5)
 
             self._queue.put(
                 Message(op=Op.UPDATE, args=(env, policy), kwargs=None))

--- a/garage/plotter/plotter.py
+++ b/garage/plotter/plotter.py
@@ -114,14 +114,9 @@ class Plotter:
         # Needed in order to draw glfw window on the main thread
         if ('Darwin' in platform.platform()):
             rollout(
-                env,
-                policy,
-                max_path_length=np.inf,
-                animated=True,
-                speedup=5)
+                env, policy, max_path_length=np.inf, animated=True, speedup=5)
 
-        self._queue.put(
-            Message(op=Op.UPDATE, args=(env, policy), kwargs=None))
+        self._queue.put(Message(op=Op.UPDATE, args=(env, policy), kwargs=None))
 
     def update_plot(self, policy, max_length=np.inf):
         if not Plotter.enable:

--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -72,7 +72,7 @@ class BatchPolopt(RLAlgorithm):
         self.max_path_length = max_path_length
         self.discount = discount
         self.gae_lambda = gae_lambda
-        self.plot = plot
+        self.plot = plot or Plotter.enable
         self.pause_for_plot = pause_for_plot
         self.center_adv = center_adv
         self.positive_adv = positive_adv
@@ -91,13 +91,13 @@ class BatchPolopt(RLAlgorithm):
 
     def start_worker(self, sess):
         self.sampler.start_worker()
-        if Plotter.status(self.plot):
+        if self.plot:
             self.plotter = Plotter(self.env, self.policy, sess)
             self.plotter.start()
 
     def shutdown_worker(self):
         self.sampler.shutdown_worker()
-        if Plotter.status(self.plot):
+        if self.plot:
             self.plotter.shutdown()
 
     def obtain_samples(self, itr):
@@ -135,7 +135,7 @@ class BatchPolopt(RLAlgorithm):
                 logger.record_tabular('Time', time.time() - start_time)
                 logger.record_tabular('ItrTime', time.time() - itr_start_time)
                 logger.dump_tabular(with_prefix=False)
-                if Plotter.status(self.plot):
+                if self.plot:
                     self.plotter.update_plot(self.policy, self.max_path_length)
                     if self.pause_for_plot:
                         input("Plotting evaluation run: Press Enter to "

--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -72,7 +72,7 @@ class BatchPolopt(RLAlgorithm):
         self.max_path_length = max_path_length
         self.discount = discount
         self.gae_lambda = gae_lambda
-        self.plot = plot or Plotter.enable
+        self.plot = plot
         self.pause_for_plot = pause_for_plot
         self.center_adv = center_adv
         self.positive_adv = positive_adv

--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -4,9 +4,7 @@ import tensorflow as tf
 
 from garage.algos import RLAlgorithm
 import garage.misc.logger as logger
-from garage.sampler.utils import rollout
 from garage.tf.plotter import Plotter
-from garage.tf.policies.base import Policy
 from garage.tf.samplers import BatchSampler
 from garage.tf.samplers import VectorizedSampler
 
@@ -14,7 +12,8 @@ from garage.tf.samplers import VectorizedSampler
 class BatchPolopt(RLAlgorithm):
     """
     Base class for batch sampling-based policy optimization methods.
-    This includes various policy gradient methods like vpg, npg, ppo, trpo, etc.
+    This includes various policy gradient methods like vpg, npg, ppo, trpo,
+    etc.
     """
 
     def __init__(self,

--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -92,13 +92,13 @@ class BatchPolopt(RLAlgorithm):
 
     def start_worker(self, sess):
         self.sampler.start_worker()
-        if self.plot:
+        if Plotter.status(self.plot):
             self.plotter = Plotter(self.env, self.policy, sess)
             self.plotter.start()
 
     def shutdown_worker(self):
         self.sampler.shutdown_worker()
-        if self.plot:
+        if Plotter.status(self.plot):
             self.plotter.shutdown()
 
     def obtain_samples(self, itr):
@@ -136,7 +136,7 @@ class BatchPolopt(RLAlgorithm):
                 logger.record_tabular('Time', time.time() - start_time)
                 logger.record_tabular('ItrTime', time.time() - itr_start_time)
                 logger.dump_tabular(with_prefix=False)
-                if self.plot:
+                if Plotter.status(self.plot):
                     self.plotter.update_plot(self.policy, self.max_path_length)
                     if self.pause_for_plot:
                         input("Plotting evaluation run: Press Enter to "

--- a/garage/tf/plotter/plotter.py
+++ b/garage/tf/plotter/plotter.py
@@ -25,7 +25,7 @@ class Plotter(object):
 
     # Static variable used along with function run_experiment to enable or
     # disable the plotter
-    enable = None
+    enable = True
 
     def __init__(self,
                  env,
@@ -99,36 +99,13 @@ class Plotter(object):
             self.worker_thread.join()
 
     @staticmethod
-    def set_enable(enable):
+    def disable():
         """Set the plot enabling according to the run_experiment function.
         """
-        Plotter.enable = enable
-
-    @staticmethod
-    def status(plot_algo_status):
-        """Use this method as a guard for plot enabling.
-
-        This guard method considers the plot enabling defined in the
-        function run_experiment.
-
-        Parameters
-        ----------
-        plot_algo_status : boolean
-            The plot enabling defined in the algorithm class.
-
-        Returns
-        -------
-            The plot enabling of the algorithm if the run_experiment was not
-            called, and the plot enabling of the run_experiment otherwise.
-
-        """
-        if Plotter.enable is None:
-            return plot_algo_status
-        else:
-            return Plotter.enable
+        Plotter.enable = False
 
     def start(self):
-        if Plotter.enable is None or Plotter.enable:
+        if Plotter.enable:
             if not self.worker_thread.is_alive():
                 tf.get_variable_scope().reuse_variables()
                 self.worker_thread.start()
@@ -141,7 +118,7 @@ class Plotter(object):
                 atexit.register(self.shutdown)
 
     def update_plot(self, policy, max_length=np.inf):
-        if Plotter.enable is None or Plotter.enable:
+        if Plotter.enable:
             if self.worker_thread.is_alive():
                 self.queue.put(
                     Message(

--- a/garage/tf/plotter/plotter.py
+++ b/garage/tf/plotter/plotter.py
@@ -134,7 +134,8 @@ class Plotter(object):
                 self.worker_thread.start()
                 self.queue.put(
                     Message(
-                        op=Op.UPDATE, args=(self.env, self.policy),
+                        op=Op.UPDATE,
+                        args=(self.env, self.policy),
                         kwargs=None))
                 self.queue.task_done()
                 atexit.register(self.shutdown)

--- a/garage/tf/plotter/plotter.py
+++ b/garage/tf/plotter/plotter.py
@@ -110,9 +110,7 @@ class Plotter:
             self.worker_thread.start()
             self.queue.put(
                 Message(
-                    op=Op.UPDATE,
-                    args=(self.env, self.policy),
-                    kwargs=None))
+                    op=Op.UPDATE, args=(self.env, self.policy), kwargs=None))
             self.queue.task_done()
             atexit.register(self.shutdown)
 

--- a/garage/tf/plotter/plotter.py
+++ b/garage/tf/plotter/plotter.py
@@ -22,6 +22,11 @@ Message = namedtuple("Message", ["op", "args", "kwargs"])
 
 
 class Plotter(object):
+
+    # Static variable used along with function run_experiment to enable or
+    # disable the plotter
+    enable = None
+
     def __init__(self,
                  env,
                  policy,

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -17,6 +17,7 @@ from garage.misc.ext import is_iterable
 from garage.misc.ext import set_seed
 from garage.misc.instrument import concretize
 import garage.misc.logger as logger
+from garage.plotter import Plotter
 
 
 def run_experiment(argv):
@@ -126,9 +127,7 @@ def run_experiment(argv):
         if args.seed is not None:
             parallel_sampler.set_seed(args.seed)
 
-    if args.plot:
-        from garage.plotter import plotter
-        plotter.init_worker()
+    Plotter.set_enable(args.plot)
 
     if args.log_dir is None:
         log_dir = osp.join(default_log_dir, args.exp_name)

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -128,8 +128,9 @@ def run_experiment(argv):
         if args.seed is not None:
             parallel_sampler.set_seed(args.seed)
 
-    garage.plotter.Plotter.set_enable(args.plot)
-    garage.tf.plotter.Plotter.set_enable(args.plot)
+    if not args.plot:
+        garage.plotter.Plotter.disable()
+        garage.tf.plotter.Plotter.disable()
 
     if args.log_dir is None:
         log_dir = osp.join(default_log_dir, args.exp_name)

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -17,7 +17,8 @@ from garage.misc.ext import is_iterable
 from garage.misc.ext import set_seed
 from garage.misc.instrument import concretize
 import garage.misc.logger as logger
-from garage.plotter import Plotter
+import garage.plotter
+import garage.tf.plotter
 
 
 def run_experiment(argv):
@@ -127,7 +128,8 @@ def run_experiment(argv):
         if args.seed is not None:
             parallel_sampler.set_seed(args.seed)
 
-    Plotter.set_enable(args.plot)
+    garage.plotter.Plotter.set_enable(args.plot)
+    garage.tf.plotter.Plotter.set_enable(args.plot)
 
     if args.log_dir is None:
         log_dir = osp.join(default_log_dir, args.exp_name)


### PR DESCRIPTION
When running a training session, there's two places to enable the
plotter: the algorithm constructor or the function run_experiment.
However, the latter must override the parameter set in the former.
The algorithm contains the plotter object, so it would be sufficient to
set the value of its plot parameter to the value set in the
run_experiment, but the constructor of the algorithm is passed within an
anonymous function to run_experiment and it's not possible to modify the
bytecode to change the plot parameter directly or to access the objects
after the anonymous function is called from run_experiment.
Instead, static methods were implemented in both the plotter of the
Theano and TF branch to disable or enable the plotter from
run_experiment.
Also, a cleanup of the plotter in the Theano branch was performed, and
the corresponding algorithm classes were modified to consider the new
guards and cleanup changes.
Finally, there's some legacy PEP8 style errors that where fixed.