### PR TITLE
Add pre-commit support to garage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+fail_fast: false # set to true to have pre-commit stop running hooks after the first failure.
+repos:
+-   repo: local
+    hooks:
+    -   id: check-commit-message
+        name: Check commit message
+        language: script
+        entry: scripts/check_commit_message
+        stages: [commit-msg]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.3.0
+    # https://github.com/pre-commit/pre-commit-hooks/blob/master/README.md
+    hooks:
+    -   id: autopep8-wrapper            # Runs autopep8 over python source.
+    -   id: check-added-large-files     # Prevent giant files from being committed.
+    -   id: check-ast                   # Simply check whether files parse as valid python.
+    # -   id: check-builtin-literals      # Require literal syntax when initializing empty or zero Python builtin types.
+    # -   id: check-byte-order-marker     # Forbid files which have a UTF-8 byte-order marker
+    # -   id: check-case-conflict         # Check for files with names that would conflict on a case-insensitive filesystem
+    # -   id: check-docstring-first       # Checks for a common error of placing code before the docstring.
+    # -   id: check-executables-have-shebangs # Checks that non-binary executables have a proper shebang.
+    # -   id: check-json                  # Attempts to load all json files to verify syntax.
+    -   id: check-merge-conflict        # Check for files that contain merge conflict strings.
+    # -   id: check-symlinks              # Checks for symlinks which do not point to anything.
+    # -   id: check-vcs-permalinks        # Ensures that links to vcs websites are permalinks.
+    -   id: check-xml                   # Attempts to load all xml files to verify syntax.
+    -   id: check-yaml                  # Attempts to load all yaml files to verify syntax.
+    -   id: debug-statements            # Check for debugger imports and py37+ breakpoint() calls in python source.
+    # -   id: detect-aws-credentials      # Checks for the existence of AWS secrets that you have set up with the AWS CLI
+    # -   id: detect-private-key          # Checks for the existence of private keys.
+    # -   id: double-quote-string-fixer   # This hook replaces double quoted strings with single quoted strings.
+    -   id: end-of-file-fixer           # Makes sure files end in a newline and only a newline.
+    # -   id: fix-encoding-pragma         # Add # -*- coding: utf-8 -*- to the top of python files.
+    # -   id: file-contents-sorter        # Sort the lines in specified files (defaults to alphabetical). You must provide list of target files as input to it.
+    -   id: flake8                      # Run flake8 on your python files.
+    -   id: forbid-new-submodules       # Prevent addition of new git submodules.
+    # -   id: mixed-line-ending           # Replaces or checks mixed line ending.
+    # -   id: name-tests-test             # Assert that files in tests/ end in _test.py
+    # -   id: no-commit-to-branch         # Protect specific branches from direct checkins.
+    # -   id: pyflakes                    # Run pyflakes on your python files.
+    # -   id: pretty-format-json          # Checks that all your JSON files have keys that are sorted and indented.
+    # -   id: requirements-txt-fixer      # Sorts entries in requirements.txt, removes 0.0.0 entries
+    # -   id: sort-simple-yaml            # Sorts simple YAML files which consist only of top-level keys, preserving comments and blocks.
+    -   id: trailing-whitespace         # Trims trailing whitespace.

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - scripts/travisci/check_yapf.sh
   - scripts/travisci/check_pylint.sh
   - scripts/travisci/check_imports.sh
+  - scripts/travisci/check_precommit.sh
 
 notifications:
   email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,15 @@ In short:
 * A newline between the subject and the body
 * If relevant, an informative body which is wrapped to 72 characters
 
+garage currently uses [pre-commit](https://pre-commit.com/#usage), a multi-language package manager for pre-commit hooks, and its out-of-the-box [hooks](https://github.com/pre-commit/pre-commit-hooks).
+To setup pre-commit on your local machine:
+* `pre-commit install` to install pre-commit into your .git/hooks/ directory
+* `pre-commit autoupdate` to update the hooks to the latest version
+
+To run pre-commit:
+* `pre-commit run --files *file_name*` to run pre-commit on the specified file.
+* `pre-commit run --files *file_name1* *file_name2*` to run on multiple files.
+
 ### Git recipes
 
 These recipes assume you are working out of a private GitHub fork.

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: garage
 channels:
+    - https://conda.anaconda.org/conda-forge
     - https://conda.anaconda.org/kne
     - https://conda.anaconda.org/menpo
 dependencies:
@@ -18,6 +19,7 @@ dependencies:
     - pandas
     - mkl-service=1.1.2
     - absl-py==0.2.2
+    - pre_commit
     - pip:
         - pyprind
         - ipdb

--- a/scripts/check_commit_message
+++ b/scripts/check_commit_message
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+import sys
+
+# Get the commit message location
+commit_msg_filepath = sys.argv[1]
+
+# Extract the message lines into a list
+lines = list((line.rstrip() for line in open(commit_msg_filepath, 'r')))
+
+# Remove all commented lines
+lines = [line for line in lines if len(line) == 0 or line[0] != '#']
+
+exit_code = 0
+
+# Error: no commit message
+if len(lines) == 0 or len(lines[0]) == 0:
+    print('Error: commit message cannot be blank.')
+    sys.exit(1)
+
+# Error: invalid subject line length
+if len(lines[0]) > 50:
+    print('Error: your subject line must be within 50 characters.')
+    exit_code = 1
+
+# Error: subject line not capitalized
+if lines[0][0].isalpha() and not lines[0][0].isupper():
+    print('Error: your subject line must be capitalized.')
+    exit_code = 1
+
+# Error: subject line ends with period
+if lines[0].endswith('.'):
+    print('Error: your subject line cannot end with a period.')
+    exit_code = 1
+
+# No body paragraph
+if len(lines) == 1:
+    sys.exit(exit_code)
+
+# Error: subject and body not separated by newline
+if len(lines[1]) != 0:
+    print('Error: you must separate your subject '
+          'and body paragraph with a newline.')
+    exit_code = 1
+
+lines = lines[2:]
+
+count = 0
+for line in lines:
+    count += 1
+    # Ignore newline
+    if len(line) == 0:
+        continue
+
+    # Error: invalid body paragraph length
+    if len(line) > 72:
+        print('Error: line {} of your body paragraph '
+              'must be wrapped to 72 characters:'.format(count))
+        print('>> ' + line)
+        exit_code = 1
+
+sys.exit(exit_code)

--- a/scripts/travisci/check_precommit.sh
+++ b/scripts/travisci/check_precommit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
+  files_changed=$(git diff "${TRAVIS_COMMIT_RANGE}" --name-only \
+    | grep ".*\.py")
+  if [[ ! -z "${files_changed}" ]]; then
+    pre-commit run --files  ${files_changed}
+  fi
+else
+  git remote set-branches --add origin master
+  git fetch
+  files_changed=$(git diff origin/master --name-only | grep ".*\.py")
+  if [[ ! -z "${files_changed}" ]]; then
+    pre-commit run --files ${files_changed}
+  fi
+fi


### PR DESCRIPTION
This PR adds `pre-commit` support to garage, a multi-language package manager for pre-commit hooks. pre-commit helps you adhere to the git commit message guidelines, such as reminding you to keep your subject line to 50 characters and to wrap your body to 72 characters. 

This also adds automatic integration with Travis CI.

Note: you must update your conda environment once this PR is merged: 
`conda env update --name="garage"`

Ref: #7 