### PR TITLE
Set up mujoco in setup_linux.sh and setup_osx.sh

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")/.."
 echo "Setting up MuJoCo..."
 /bin/bash ./scripts/setup_mujoco.sh
 if [[ "${?}" -ne 0 ]]; then
-  echo -e "\e[0;31mError: mujoco couldn't be set up\e[0m"
+  echo -e "\e[0;31mError: MuJoCo couldn't be set up\e[0m"
   exit 1
 fi
 

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -2,48 +2,60 @@
 # Make sure that conda is available
 
 hash conda 2>/dev/null || {
-    echo "Please install anaconda before continuing. You can download it at https://www.continuum.io/downloads. Please use the Python 2.7 installer."
-    exit 0
+  echo "Please install anaconda before continuing. You can download it at" \
+    "https://www.continuum.io/downloads. Please use the Python 2.7" \
+    "installer."
+  exit 0
 }
 
 echo "Installing system dependencies"
 echo "You will probably be asked for your sudo password."
 sudo apt-get update
-sudo apt-get install -y python-pip python-dev swig cmake build-essential zlib1g-dev
+sudo apt-get install -y python-pip python-dev swig cmake build-essential \
+  zlib1g-dev
 sudo apt-get build-dep -y python-pygame
 sudo apt-get build-dep -y python-scipy
 
 # Make sure that we're under the directory of the project
 cd "$(dirname "$0")/.."
 
+echo "Setting up MuJoCo..."
+/bin/bash ./scripts/setup_mujoco.sh
+if [[ "${?}" -ne 0 ]]; then
+  echo -e "\e[0;31mError: mujoco couldn't be set up\e[0m"
+  exit 1
+fi
+
 echo "Creating conda environment..."
 conda env create -f environment.yml
-if [ $? -ne 0 ]; then
-   echo -e "\e[0;31mError: conda environment could not be created\e[0m"
-   exit 1
+if [[ "${?}" -ne 0 ]]; then
+  echo -e "\e[0;31mError: conda environment could not be created\e[0m"
+  exit 1
 fi
 
 env_name="garage"
 tf_version="1.8"
-read -r -p "Install tensorflow-gpu instead of regular tensorflow [y/N]: " response
-case "$response" in
+read -r -p "Install tensorflow-gpu instead of regular tensorflow [y/N]: " \
+  response
+case "${response}" in
   [yY])
-     source activate $env_name
-     pip install tensorflow-gpu==$tf_version
-     source deactivate
-     ;;
+    source activate "${env_name}"
+    pip install tensorflow-gpu=="${tf_version}"
+    source deactivate
+    ;;
   *)
-     source activate $env_name
-     pip install tensorflow==$tf_version
-     source deactivate
-     ;;
+    source activate "${env_name}"
+    pip install tensorflow=="${tf_version}"
+    source deactivate
+    ;;
 esac
 
 echo "Updating conda environment..."
 conda env update
-if [ $? -ne 0 ]; then
-   echo -e "\e[0;31mError: conda environment could not be updated\e[0m"
-   exit 1
+if [[ "${?}" -ne 0 ]]; then
+  echo -e "\e[0;31mError: conda environment could not be updated\e[0m"
+  exit 1
 fi
 
-echo "Conda environment created! Make sure to run \`source activate garage\` whenever you open a new terminal and want to run programs under garage."
+echo "Conda environment created! Make sure to run \`source activate garage\`" \
+  "whenever you open a new terminal and want to run programs under garage."

--- a/scripts/setup_mujoco.sh
+++ b/scripts/setup_mujoco.sh
@@ -1,57 +1,52 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
-    mujoco_file="libmujoco150.dylib"
-    glfw_file="libglfw.3.dylib"
-    zip_file="mjpro150_osx.zip"
-    mktemp_cmd="mktemp -d /tmp/mujoco"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    mujoco_file="libmujoco150.so"
-    glfw_file="libglfw.so.3"
-    zip_file="mjpro150_linux.zip"
-    mktemp_cmd="mktemp -d"
+if [[ "$(uname)" == "Darwin" ]]; then
+  mujoco_file="libmujoco150.dylib"
+  glfw_file="libglfw.3.dylib"
+  zip_file="mjpro150_osx.zip"
+  mktemp_cmd="mktemp -d /tmp/mujoco"
+elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
+  mujoco_file="libmujoco150.so"
+  glfw_file="libglfw.so.3"
+  zip_file="mjpro150_linux.zip"
+  mktemp_cmd="mktemp -d"
 fi
 
-if [ ! -f vendor/mujoco/$mujoco_file ]; then
-    read -e -p "Please enter the path to the mujoco zip file [$zip_file]:" path
-    path=${path:-$zip_file}
-    eval path=\"$path\"
-    if [ ! -f $path ]; then
-        echo "No file found at $path"
-        exit 0
-    fi
-    rm -r /tmp/mujoco
-    dir=`$mktemp_cmd`
-    unzip $path -d $dir
-    if [ ! -f $dir/mjpro150/bin/$mujoco_file ]; then
-        echo "mjpro/$mujoco_file not found. Make sure you have the correct file (most likely named $zip_file)"
-        exit 0
-    fi
-    if [ ! -f $dir/mjpro150/bin/$glfw_file ]; then
-        echo "mjpro/$glfw_file not found. Make sure you have the correct file (most likely named $zip_file)"
-        exit 0
-    fi
+if [[ ! -f "vendor/mujoco/${mujoco_file}" ]]; then
+  read -e -p "Please enter the path to the mujoco zip file [${zip_file}]:" path
+  path="${path:-$zip_file}"
+  eval path=\"${path}\"
+  if [[ ! -f "${path}" ]]; then
+    echo "No file found at $path"
+    exit 1
+  fi
+  rm -r /tmp/mujoco
+  dir=`$mktemp_cmd`
+  unzip "${path}" -d "${dir}"
+  if [[ ! -f "${dir}/mjpro150/bin/${mujoco_file}" ]]; then
+    echo "mjpro/${mujoco_file} not found. Make sure you have the correct" \
+      "file (most likely named ${zip_file})"
+    exit 1
+  fi
+  if [[ ! -f "${dir}/mjpro150/bin/${glfw_file}" ]]; then
+    echo "mjpro/${glfw_file} not found. Make sure you have the correct file" \
+      "(most likely named ${zip_file})"
+    exit 1
+  fi
 
-    mkdir -p vendor/mujoco
-    cp $dir/mjpro150/bin/$mujoco_file vendor/mujoco/
-    cp $dir/mjpro150/bin/$glfw_file vendor/mujoco/
+  mkdir -p vendor/mujoco
+  cp "${dir}/mjpro150/bin/${mujoco_file}" vendor/mujoco/
+  cp "${dir}/mjpro150/bin/${glfw_file}" vendor/mujoco/
 fi
 
-if [ ! -f vendor/mujoco/mjkey.txt ]; then
-    read -e -p "Please enter the path to the mujoco license file [mjkey.txt]:" path
-    path=${path:-mjkey.txt}
-    eval path=$path
-    if [ ! -f $path ]; then
-        echo "No file found at $path"
-        exit 0
-    fi
-    cp $path vendor/mujoco/mjkey.txt
+if [[ ! -f vendor/mujoco/mjkey.txt ]]; then
+  read -e -p "Please enter the path to the mujoco license file [mjkey.txt]:" \
+    path
+  path="${path:-mjkey.txt}"
+  eval path="${path}"
+  if [[ ! -f "${path}" ]]; then
+    echo "No file found at ${path}"
+    exit 1
+  fi
+  cp "${path}" vendor/mujoco/mjkey.txt
 fi
-
-if [ "$(conda info --envs | grep -c garage)" -eq "1" ]; then
-    /bin/bash -c "source activate garage; pip3 install -U 'mujoco-py<1.50.2,>=1.50.1'; source deactivate"
-else
-    echo "Installation of mujoco_py skipped, since the conda environment garage was not found."
-fi
-
-echo "Mujoco has been set up!"

--- a/scripts/setup_osx.sh
+++ b/scripts/setup_osx.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # Make sure that pip is available
 hash brew 2>/dev/null || {
-    echo "Please install homebrew before continuing. You can use the following command to install:"
-    echo "/usr/bin/ruby -e \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""
-    exit 0
+  echo "Please install homebrew before continuing. You can use the" \
+    "following command to install:"
+  echo "/usr/bin/ruby -e \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""
+  exit 0
 }
 
 hash conda 2>/dev/null || {
-    echo "Please install anaconda before continuing. You can download it at https://www.continuum.io/downloads. Please use the Python 2.7 installer."
-    exit 0
+  echo "Please install anaconda before continuing. You can download" \
+    "it at https://www.continuum.io/downloads. Please use the Python 2.7" \
+    " installer."
+  exit 0
 }
 
 
@@ -19,8 +22,17 @@ brew install swig sdl sdl_image sdl_mixer sdl_ttf portmidi
 
 # Make sure that we're under the directory of the project
 cd "$(dirname "$0")/.."
+
+echo "Setting up MuJoCo..."
+/bin/bash ./scripts/setup_mujoco.sh
+if [[ "${?}" -ne 0 ]]; then
+  echo -e "\e[0;31mError: mujoco couldn't be set up\e[0m"
+  exit 1
+fi
+
 echo "Creating conda environment..."
 conda env create -f environment.yml
 conda env update
 
-echo "Conda environment created! Make sure to run \`source activate garage\` whenever you open a new terminal and want to run programs under garage."
+echo "Conda environment created! Make sure to run \`source activate garage\`" \
+  "whenever you open a new terminal and want to run programs under garage."

--- a/scripts/setup_osx.sh
+++ b/scripts/setup_osx.sh
@@ -26,7 +26,7 @@ cd "$(dirname "$0")/.."
 echo "Setting up MuJoCo..."
 /bin/bash ./scripts/setup_mujoco.sh
 if [[ "${?}" -ne 0 ]]; then
-  echo -e "\e[0;31mError: mujoco couldn't be set up\e[0m"
+  echo -e "\e[0;31mError: MuJoCo couldn't be set up\e[0m"
   exit 1
 fi
 


### PR DESCRIPTION
The script setup_mujoco.sh is called now from the scripts to install
garage in Linux and OS X, since it's required by the packages installed
by conda.
Also, the three scripts were formatted with the style defined by Google.