### PR TITLE
Ignore PEP8 rule W503 for flake8

### DIFF
--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -42,8 +42,6 @@ E125 # continuation line with same indent as next logical line
 E128 # continuation line under-indented for visual indent
 # MAXIMUM LINE LENGTH
 E501 # line too long
-# BREAK BEFORE BINARY OPERATOR
-W503 # line break before binary operator
 # BLANK LINE
 E301 # expected 1 blank line, found 0
 E302 # expected 2 blank lines, found 0
@@ -85,6 +83,11 @@ E731 # do not assign a lambda expression, use a def
 
 # Error codes ignored for changed files
 ignored_errors_changed=(
+# BREAK BEFORE BINARY OPERATOR
+# It enforces the break after the operator, which is acceptable, but it's
+# preferred to do it before the operator. Since YAPF enforces the preferred
+# style, this rule is ignored.
+W503 # line break before binary operator
 )
 
 # Files or directories to exclude from checks applied to changed files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,6 @@
 # W191 indentation contains tabs
 # MAXIMUM LINE LENGTH
 # E501 line too long
-# BREAK BEFORE BINARY OPERATOR
-# W503 line break before binary operator
 # BLANK LINE
 # E301 expected 1 blank line, found 0
 # E302 expected 2 blank lines, found 0
@@ -62,8 +60,13 @@
 # E722 do not use bare except, specify exception instead.
 # E731 do not assign a lambda expression, use a def.
 select = E101,W191,E201,E202,E241,E211,E221,W291,E702,E714,E125,E128,E501,
-         W503,E301,E302,E303,E401,I100,I101,I201,I202,E203,E225,E226,E251,
-         E231,E701,E261,E262,E741,E742,E743,N,D,E711,E712,E721,E722,E731
+         E301,E302,E303,E401,I100,I101,I201,I202,E203,E225,E226,E251,E231,
+         E701,E261,E262,E741,E742,E743,N,D,E711,E712,E721,E722,E731
+# BREAK BEFORE BINARY OPERATOR
+# W503 enforces the break after the operator, which is acceptable, but it's
+# preferred to do it before the operator. Since YAPF enforces the preferred
+# style, this rule is ignored.
+ignore = W503
 import-order-style = google
 application-import-names = sandbox,garage,examples,contrib
 


### PR DESCRIPTION
W503 enforces the break after the operator, which is acceptable by PEP8,
but it's preferred to do it before the operator. Since YAPF enforces the
preferred style, this rule is ignored to avoid conflicts between both
lint tools.