### PR TITLE
Fix render() in mujoco envs

### DIFF
--- a/garage/envs/grid_world_env.py
+++ b/garage/envs/grid_world_env.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from garage.core import Serializable
 from garage.envs import Step
+from garage.misc.overrides import overrides
 
 MAPS = {
     "chain": ["GFFFFFFFFFFFFFSFFFFFFFFFFFFFG"],
@@ -28,7 +29,7 @@ MAPS = {
         "FHFFHFHF",
         "FFFHFFFG"
     ],
-} # yapf: disable
+}   # yapf: disable
 
 
 class GridWorldEnv(gym.Env, Serializable):
@@ -64,8 +65,8 @@ class GridWorldEnv(gym.Env, Serializable):
     @staticmethod
     def action_from_direction(d):
         """
-        Return the action corresponding to the given direction. This is a helper
-        method for debugging and testing purposes.
+        Return the action corresponding to the given direction. This is a
+        helper method for debugging and testing purposes.
         :return: the action index corresponding to the given direction
         """
         return dict(left=0, down=1, right=2, up=3)[d]
@@ -108,8 +109,8 @@ class GridWorldEnv(gym.Env, Serializable):
     def get_possible_next_states(self, state, action):
         """
         Given the state and action, return a list of possible next states and
-        their probabilities. Only next states with nonzero probabilities will be
-        returned
+        their probabilities. Only next states with nonzero probabilities will
+        be returned
         :param state: start state
         :param action: action
         :return: a list of pairs (s', p(s'|s,a))
@@ -139,3 +140,7 @@ class GridWorldEnv(gym.Env, Serializable):
     @property
     def observation_space(self):
         return gym.spaces.Discrete(self.n_row * self.n_col)
+
+    @overrides
+    def render(self, mode='human'):
+        pass

--- a/garage/envs/mujoco/sawyer/bin_sorting_env.py
+++ b/garage/envs/mujoco/sawyer/bin_sorting_env.py
@@ -3,7 +3,7 @@ import numpy as np
 from garage.core import Serializable
 from garage.envs import Step
 from garage.envs.mujoco import MujocoEnv
-from garage.misc import overrides
+from garage.misc.overrides import overrides
 
 
 class BinSortingEnv(MujocoEnv, Serializable):

--- a/garage/envs/mujoco/sawyer/block_stacking_env.py
+++ b/garage/envs/mujoco/sawyer/block_stacking_env.py
@@ -3,7 +3,7 @@ import numpy as np
 from garage.core import Serializable
 from garage.envs import Step
 from garage.envs.mujoco import MujocoEnv
-from garage.misc import overrides
+from garage.misc.overrides import overrides
 
 
 class BlockStackingEnv(MujocoEnv, Serializable):

--- a/garage/envs/mujoco/sawyer/pick_and_place_env.py
+++ b/garage/envs/mujoco/sawyer/pick_and_place_env.py
@@ -5,7 +5,7 @@ import numpy as np
 from garage.core import Serializable
 from garage.envs import Step
 from garage.envs.mujoco import MujocoEnv
-from garage.misc import overrides
+from garage.misc.overrides import overrides
 
 
 class PickAndPlaceEnv(MujocoEnv, Serializable):

--- a/garage/envs/normalized_env.py
+++ b/garage/envs/normalized_env.py
@@ -106,5 +106,8 @@ class NormalizedEnv(gym.Wrapper, Serializable):
     def log_diagnostics(self, paths):
         pass
 
+    def render(self, *args, **kwargs):
+        return self.env.render(*args, **kwargs)
+
 
 normalize = NormalizedEnv

--- a/tests/envs/test_sawyer_envs.py
+++ b/tests/envs/test_sawyer_envs.py
@@ -2,7 +2,9 @@ import numpy as np
 
 from garage.algos import TRPO
 from garage.baselines import LinearFeatureBaseline
-from garage.envs.mujoco.sawyer import BinSortingEnv, BlockStackingEnv, PickAndPlaceEnv
+from garage.envs.mujoco.sawyer import BinSortingEnv
+from garage.envs.mujoco.sawyer import BlockStackingEnv
+from garage.envs.mujoco.sawyer import PickAndPlaceEnv
 from garage.envs.util import spec
 from garage.misc.instrument import run_experiment
 from garage.policies import GaussianMLPPolicy
@@ -78,7 +80,7 @@ def test_env():
 
 
 test_env()
-run_experiment_lite(
+run_experiment(
     run_bin_sorting,
     n_parallel=2,
     plot=True,


### PR DESCRIPTION
 - There were missing overrides imports in mujoco/sawyer. Add them.
 - NormalizedEnv didn't implement render(), therefore caused
   NotImplementError. Add render() in NormalizedEnv. Same with
GridWorldEnv.
 - Fix multiple errors in EmbeddedViwer. There were wrong params
   assignments and missing interaction setting such as set default
camera.
 - Fix multiple errors in GatherEnv and GatherViewer.

Fixes: #93 