### PR TITLE
Cleanly terminate all worker processes on an interrupt

### DIFF
--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -846,12 +846,14 @@ def launch_ec2(params_list,
     if config.LABEL:
         sio.write("""
             aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=owner,Value={label} --region {aws_region}
-        """.format(label=config.LABEL,  # noqa: E501
-                   aws_region=config.AWS_REGION_NAME))
+        """.format(  # noqa: E501
+            label=config.LABEL,
+            aws_region=config.AWS_REGION_NAME))
     sio.write("""
         aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=exp_prefix,Value={exp_prefix} --region {aws_region}
-    """.format(exp_prefix=exp_prefix,  # noqa: E501
-               aws_region=config.AWS_REGION_NAME))
+    """.format(  # noqa: E501
+        exp_prefix=exp_prefix,
+        aws_region=config.AWS_REGION_NAME))
     sio.write("""
         service docker start
     """)
@@ -969,8 +971,9 @@ def launch_ec2(params_list,
                             sleep 5
                         fi
                     done & echo log sync initiated
-                """.format(log_dir=log_dir,  # noqa: E501
-                           remote_log_dir=remote_log_dir))
+                """.format(  # noqa: E501
+                    log_dir=log_dir,
+                    remote_log_dir=remote_log_dir))
         if use_gpu:
             sio.write("""
                 for i in {1..800}; do su -c "nvidia-modprobe -u -c=0" ubuntu && break || sleep 3; done
@@ -1037,8 +1040,8 @@ def launch_ec2(params_list,
         aws s3 cp {s3_path} /home/ubuntu/remote_script.sh --region {aws_region} && \\
         chmod +x /home/ubuntu/remote_script.sh && \\
         bash /home/ubuntu/remote_script.sh
-        """.format(s3_path=s3_path,  # noqa: E501
-                   aws_region=config.AWS_REGION_NAME))
+        """.format(  # noqa: E501
+            s3_path=s3_path, aws_region=config.AWS_REGION_NAME))
         user_data = dedent(sio.getvalue())
     else:
         user_data = full_script

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -846,10 +846,12 @@ def launch_ec2(params_list,
     if config.LABEL:
         sio.write("""
             aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=owner,Value={label} --region {aws_region}
-        """.format(label=config.LABEL, aws_region=config.AWS_REGION_NAME))  # noqa: E501
+        """.format(label=config.LABEL,  # noqa: E501
+                   aws_region=config.AWS_REGION_NAME))
     sio.write("""
         aws ec2 create-tags --resources $EC2_INSTANCE_ID --tags Key=exp_prefix,Value={exp_prefix} --region {aws_region}
-    """.format(exp_prefix=exp_prefix, aws_region=config.AWS_REGION_NAME))  # noqa: E501
+    """.format(exp_prefix=exp_prefix,  # noqa: E501
+               aws_region=config.AWS_REGION_NAME))
     sio.write("""
         service docker start
     """)
@@ -942,18 +944,18 @@ def launch_ec2(params_list,
             if sync_log_on_termination:
                 # sio.write("""
                 #     while /bin/true; do
-                #         if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
+                #         if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]  # noqa: E501
                 #           then
                 #             logger "Running shutdown hook."
-                #             aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log --region {aws_region}
-                #             aws s3 cp --recursive {log_dir} {remote_log_dir} --region {aws_region}
+                #             aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log --region {aws_region}  # noqa: E501
+                #             aws s3 cp --recursive {log_dir} {remote_log_dir} --region {aws_region}  # noqa: E501
                 #             break
                 #           else
                 #             # Spot instance not yet marked for termination.
                 #             sleep 5
                 #         fi
                 #     done & echo log sync initiated
-                # """.format(log_dir=log_dir, remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))
+                # """.format(log_dir=log_dir, remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))  # noqa: E501
                 sio.write("""
                     while /bin/true; do
                         if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
@@ -967,12 +969,13 @@ def launch_ec2(params_list,
                             sleep 5
                         fi
                     done & echo log sync initiated
-                """.format(log_dir=log_dir, remote_log_dir=remote_log_dir))
+                """.format(log_dir=log_dir,  # noqa: E501
+                           remote_log_dir=remote_log_dir))
         if use_gpu:
             sio.write("""
                 for i in {1..800}; do su -c "nvidia-modprobe -u -c=0" ubuntu && break || sleep 3; done
                 systemctl start nvidia-docker
-            """)
+            """)  # noqa: E501
         sio.write("""
             {command}
         """.format(
@@ -985,14 +988,14 @@ def launch_ec2(params_list,
                 env=env,
                 local_code_dir=config.DOCKER_CODE_DIR)))
         # sio.write("""
-        #     aws s3 cp --recursive {log_dir} {remote_log_dir} --region {aws_region}
-        # """.format(log_dir=log_dir, remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))
+        #     aws s3 cp --recursive {log_dir} {remote_log_dir} --region {aws_region}  # noqa: E501
+        # """.format(log_dir=log_dir, remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))  # noqa: E501
         sio.write("""
             aws s3 cp --recursive {log_dir} {remote_log_dir}
         """.format(log_dir=log_dir, remote_log_dir=remote_log_dir))
         # sio.write("""
-        #     aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log --region {aws_region}
-        # """.format(remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))
+        #     aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log --region {aws_region}  # noqa: E501
+        # """.format(remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))  # noqa: E501
         sio.write("""
             aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log
         """.format(remote_log_dir=remote_log_dir))
@@ -1001,7 +1004,7 @@ def launch_ec2(params_list,
         sio.write("""
             EC2_INSTANCE_ID="`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id || die \"wget instance-id has failed: $?\"`"
             aws ec2 terminate-instances --instance-ids $EC2_INSTANCE_ID --region {aws_region}
-        """.format(aws_region=config.AWS_REGION_NAME))
+        """.format(aws_region=config.AWS_REGION_NAME))  # noqa: E501
     sio.write("} >> /home/ubuntu/user_data.log 2>&1\n")
 
     full_script = dedent(sio.getvalue())
@@ -1034,7 +1037,8 @@ def launch_ec2(params_list,
         aws s3 cp {s3_path} /home/ubuntu/remote_script.sh --region {aws_region} && \\
         chmod +x /home/ubuntu/remote_script.sh && \\
         bash /home/ubuntu/remote_script.sh
-        """.format(s3_path=s3_path, aws_region=config.AWS_REGION_NAME))
+        """.format(s3_path=s3_path,  # noqa: E501
+                   aws_region=config.AWS_REGION_NAME))
         user_data = dedent(sio.getvalue())
     else:
         user_data = full_script
@@ -1057,7 +1061,7 @@ def launch_ec2(params_list,
 
     if instance_args["NetworkInterfaces"]:
         # disable_security_group = query_yes_no(
-        #     "Cannot provide both network interfaces and security groups info. Do you want to disable security group settings?",
+        #     "Cannot provide both network interfaces and security groups info. Do you want to disable security group settings?",  # noqa: E501
         #     default="yes",
         # )
         disable_security_group = True
@@ -1170,8 +1174,8 @@ def s3_sync_code(config, dry=False, added_project_directories=[]):
         try:
             current_commit = subprocess.check_output(
                 ["git", "rev-parse", "HEAD"]).strip().decode("utf-8")
-            clean_state = not subprocess.check_output(["git", "status",
-                                                       "--porcelain"])
+            clean_state = not subprocess.check_output(
+                ["git", "status", "--porcelain"])
         except subprocess.CalledProcessError as _:
             print("Warning: failed to execute git commands")
             has_git = False
@@ -1184,13 +1188,16 @@ def s3_sync_code(config, dry=False, added_project_directories=[]):
         full_path = "%s/%s" % (base, code_path)
         cache_path = "%s/%s" % (base, dir_hash)
         cache_cmds = ["aws", "s3", "cp", "--recursive"] + \
-                     flatten(["--exclude", "%s" % pattern] for pattern in config.CODE_SYNC_IGNORES) + \
+                     flatten(["--exclude", "%s" % pattern]
+                             for pattern in config.CODE_SYNC_IGNORES) + \
                      [cache_path, full_path]
         cmds = ["aws", "s3", "cp", "--recursive"] + \
-               flatten(["--exclude", "%s" % pattern] for pattern in config.CODE_SYNC_IGNORES) + \
+               flatten(["--exclude", "%s" % pattern]
+                       for pattern in config.CODE_SYNC_IGNORES) + \
                [".", full_path]
         caching_cmds = ["aws", "s3", "cp", "--recursive"] + \
-                       flatten(["--exclude", "%s" % pattern] for pattern in config.CODE_SYNC_IGNORES) + \
+                       flatten(["--exclude", "%s" % pattern]
+                               for pattern in config.CODE_SYNC_IGNORES) + \
                        [full_path, cache_path]
         mujoco_key_cmd = [
             "aws", "s3", "sync", config.MUJOCO_KEY_PATH,
@@ -1234,8 +1241,9 @@ def to_lab_kube_pod(params,
                     sync_all_data_node_to_s3=False,
                     terminate_machine=True):
     """
-    :param params: The parameters for the experiment. If logging directory parameters are provided, we will create
-    docker volume mapping to make sure that the logging files are created at the correct locations
+    :param params: The parameters for the experiment. If logging directory
+    parameters are provided, we will create docker volume mapping to make sure
+    that the logging files are created at the correct locations
     :param docker_image: docker image to run the command on
     :param script: script command for running experiment
     :return:
@@ -1285,7 +1293,7 @@ def to_lab_kube_pod(params,
                             while /bin/true; do
                                 aws s3 sync {log_dir} {remote_log_dir} --region {aws_region} --quiet
                                 sleep {periodic_sync_interval}
-                            done & echo sync initiated""".format(
+                            done & echo sync initiated""".format(  # noqa: E501
                     log_dir=log_dir,
                     remote_log_dir=remote_log_dir,
                     aws_region=config.AWS_REGION_NAME,
@@ -1295,7 +1303,7 @@ def to_lab_kube_pod(params,
                             while /bin/true; do
                                 aws s3 sync {log_dir} {remote_log_dir} --region {aws_region} --quiet
                                 sleep {periodic_sync_interval}
-                            done & echo sync initiated""".format(
+                            done & echo sync initiated""".format(  # noqa: E501
                     log_dir=log_dir,
                     remote_log_dir=remote_log_dir,
                     aws_region=config.AWS_REGION_NAME,
@@ -1307,7 +1315,7 @@ def to_lab_kube_pod(params,
                     while /bin/true; do
                         aws s3 sync --exclude '*' --include '*.csv' --include '*.json' --include '*.pkl' {log_dir} {remote_log_dir} --region {aws_region} --quiet
                         sleep {periodic_sync_interval}
-                    done & echo sync initiated""".format(
+                    done & echo sync initiated""".format(  # noqa: E501
                     log_dir=log_dir,
                     remote_log_dir=remote_log_dir,
                     aws_region=config.AWS_REGION_NAME,
@@ -1317,7 +1325,7 @@ def to_lab_kube_pod(params,
                     while /bin/true; do
                         aws s3 sync --exclude '*' --include '*.csv' --include '*.json' {log_dir} {remote_log_dir} --region {aws_region} --quiet
                         sleep {periodic_sync_interval}
-                    done & echo sync initiated""".format(
+                    done & echo sync initiated""".format(  # noqa: E501
                     log_dir=log_dir,
                     remote_log_dir=remote_log_dir,
                     aws_region=config.AWS_REGION_NAME,

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -443,6 +443,8 @@ def run_experiment(stub_method_call=None,
     config.USE_GPU = use_gpu
     config.USE_TF = use_tf
 
+    os.environ["JOBLIB_START_METHOD"] = "forkserver"
+
     if use_tf:
         if not use_gpu:
             os.environ['CUDA_VISIBLE_DEVICES'] = ""

--- a/garage/sampler/parallel_sampler.py
+++ b/garage/sampler/parallel_sampler.py
@@ -69,6 +69,8 @@ def terminate_task(scope=None):
     singleton_pool.run_each(_worker_terminate_task,
                             [(scope, )] * singleton_pool.n_parallel)
 
+def terminate():
+    singleton_pool.terminate()
 
 def _worker_set_seed(_, seed):
     logger.log("Setting seed to %d" % seed)

--- a/garage/sampler/parallel_sampler.py
+++ b/garage/sampler/parallel_sampler.py
@@ -146,7 +146,7 @@ def truncate_paths(paths, max_samples):
     total_n_samples = sum(len(path["rewards"]) for path in paths)
     while paths and total_n_samples - len(paths[-1]["rewards"]) >= max_samples:
         total_n_samples -= len(paths.pop(-1)["rewards"])
-    if paths > 0:
+    if paths:
         last_path = paths.pop(-1)
         truncated_last_path = dict()
         truncated_len = len(

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -24,7 +24,8 @@ class ProgBarCounter(object):
     def inc(self, increment):
         if not logger.get_log_tabular_only():
             self.cur_count += increment
-            new_progress = self.cur_count * self.max_progress / self.total_count
+            new_progress = (
+                self.cur_count * self.max_progress / self.total_count)
             if new_progress < self.max_progress:
                 self.pbar.update(new_progress - self.cur_progress)
             self.cur_progress = new_progress
@@ -75,8 +76,8 @@ class StatefulPool(object):
         :return:
         """
         assert not inspect.ismethod(runner), (
-            "run_each() cannot run a class method. Please ensure that runner is"
-            " a function with the prototype def foo(G, ...), where G is an "
+            "run_each() cannot run a class method. Please ensure that runner "
+            "is a function with the prototype def foo(G, ...), where G is an "
             "object of type garage.sampler.stateful_pool.SharedGlobal")
 
         if args_list is None:
@@ -94,9 +95,9 @@ class StatefulPool(object):
 
     def run_map(self, runner, args_list):
         assert not inspect.ismethod(runner), (
-            "run_map() cannot run a class method. Please ensure that runner is "
-            "a function with the prototype 'def foo(G, ...)', where G is an "
-            "object of type garage.sampler.stateful_pool.SharedGlobal")
+            "run_map() cannot run a class method. Please ensure that runner "
+            "is a function with the prototype 'def foo(G, ...)', where G is "
+            "an object of type garage.sampler.stateful_pool.SharedGlobal")
 
         if self.n_parallel > 1:
             return self.pool.map(_worker_run_map,
@@ -109,9 +110,10 @@ class StatefulPool(object):
 
     def run_imap_unordered(self, runner, args_list):
         assert not inspect.ismethod(runner), (
-            "run_imap_unordered() cannot run a class method. Please ensure that"
-            "runner is a function with the prototype 'def foo(G, ...)', where "
-            "G is an object of type garage.sampler.stateful_pool.SharedGlobal")
+            "run_imap_unordered() cannot run a class method. Please ensure "
+            "that runner is a function with the prototype 'def foo(G, ...)', "
+            "where G is an object of type "
+            "garage.sampler.stateful_pool.SharedGlobal")
 
         if self.n_parallel > 1:
             for x in self.pool.imap_unordered(
@@ -130,7 +132,8 @@ class StatefulPool(object):
         Run the collector method using the worker pool. The collect_once method
         will receive 'G' as its first argument, followed by the provided args,
         if any. The method should return a pair of values. The first should be
-        the object to be collected, and the second is the increment to be added.
+        the object to be collected, and the second is the increment to be
+        added.
         This will continue until the total increment reaches or exceeds the
         given threshold.
 
@@ -189,6 +192,7 @@ class StatefulPool(object):
             if show_prog_bar:
                 pbar.stop()
             return results
+        return []
 
 
 singleton_pool = StatefulPool()

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -62,6 +62,9 @@ class StatefulPool(object):
                 temp_folder="/tmp",
             )
 
+    def terminate(self):
+        self.pool.terminate()
+
     def run_each(self, runner, args_list=None):
         """
         Run the method on each worker process, and collect the result of

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import os.path as osp
 import pickle as pickle
-import signal
 import sys
 sys.path.append(".")
 import uuid
@@ -123,13 +122,11 @@ def run_experiment(argv):
 
     # Fork the work processes with SIGINT blocked so they don't get
     # finished when they own locks
-    signal.pthread_sigmask(signal.SIG_BLOCK, [signal.SIGINT])
     if args.n_parallel > 0:
         from garage.sampler import parallel_sampler
         parallel_sampler.initialize(n_parallel=args.n_parallel)
         if args.seed is not None:
             parallel_sampler.set_seed(args.seed)
-    signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGINT])
 
     if args.plot:
         from garage.plotter import plotter
@@ -178,7 +175,7 @@ def run_experiment(argv):
             method_call = cloudpickle.loads(base64.b64decode(args.args_data))
             try:
                 method_call(variant_data)
-            except KeyboardInterrupt:
+            except BaseException:
                 if args.n_parallel > 0:
                     parallel_sampler.terminate()
         else:

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -120,8 +120,6 @@ def run_experiment(argv):
     if args.seed is not None:
         set_seed(args.seed)
 
-    # Fork the work processes with SIGINT blocked so they don't get
-    # finished when they own locks
     if args.n_parallel > 0:
         from garage.sampler import parallel_sampler
         parallel_sampler.initialize(n_parallel=args.n_parallel)

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2,7 +2,6 @@ import argparse
 import ast
 import base64
 import datetime
-import logging
 import os.path as osp
 import pickle as pickle
 import signal

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -2,6 +2,7 @@ import argparse
 import ast
 import base64
 import datetime
+import os
 import os.path as osp
 import pickle as pickle
 import signal
@@ -116,6 +117,7 @@ def run_experiment(argv):
 
     args = parser.parse_args(argv[1:])
 
+    assert(os.environ.get("JOBLIB_START_METHOD", None) == "forkserver")
     if args.seed is not None:
         set_seed(args.seed)
 

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -117,7 +117,7 @@ def run_experiment(argv):
 
     args = parser.parse_args(argv[1:])
 
-    assert(os.environ.get("JOBLIB_START_METHOD", None) == "forkserver")
+    assert (os.environ.get("JOBLIB_START_METHOD", None) == "forkserver")
     if args.seed is not None:
         set_seed(args.seed)
 


### PR DESCRIPTION
When calling function run_experiment and the parameter n_parallel is
bigger than zero, worker processes are created to do parallel sampling
during the training. However, when there's a keyboard interrupt, there
are certain occasions when processes are not completely killed after the
execution has finished.
By checking the PID of these processes using the command "ps -fu | grep
run_experiment", we noticed they had the status code "Sl", where S means
interruptible sleep, so the processes are waiting for a signal to wake
up and continue their execution.
When executing the command "kill -SIGINT <pid>" with the PID of the
sleeping process, we got the python trace back and found that the
processes were sleeping trying to acquire the lock of the inqueue inside
the pool of python multiprocessing.
By default, when a keyboard interruption occurs all processes get
notified, but the notifications are not sent in any order. This could
produce an issue when a process is interrupted and finished without
releasing the lock that other process are waiting for as it's in this
case.
To avoid this problem, the worker processes are forked with SIGINT
blocked, so only their parent will be notified, taking care of
terminating the pool of workers once the keyboard interrupt is caught.