### PR TITLE
Missing changes to cleanly exit worker processes

### DIFF
--- a/garage/sampler/parallel_sampler.py
+++ b/garage/sampler/parallel_sampler.py
@@ -59,7 +59,7 @@ def populate_task(env, policy, scope=None):
         ] * singleton_pool.n_parallel)
     else:
         # avoid unnecessary copying
-        g = _get_scoped_g(singleton_pool.g, scope)
+        g = _get_scoped_g(singleton_pool.G, scope)
         g.env = env
         g.policy = policy
     logger.log("Populated")

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -72,8 +72,8 @@ class StatefulPool(object):
         Run the method on each worker process, and collect the result of
         execution.
 
-        The runner method will receive 'G' as its first argument, followed by
-        the arguments in the args_list, if any
+        The runner method will receive 'G' as its first argument, followed
+        by the arguments in the args_list, if any
         :return:
         """
         assert not inspect.ismethod(runner), (

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -64,7 +64,8 @@ class StatefulPool(object):
             )
 
     def terminate(self):
-        self.pool.terminate()
+        if self.pool:
+            self.pool.terminate()
 
     def run_each(self, runner, args_list=None):
         """

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -72,13 +72,13 @@ class StatefulPool(object):
         Run the method on each worker process, and collect the result of
         execution.
 
-        The runner method will receive 'G' as its first argument, followed
+        The runner method will receive 'g' as its first argument, followed
         by the arguments in the args_list, if any
         :return:
         """
         assert not inspect.ismethod(runner), (
             "run_each() cannot run a class method. Please ensure that runner "
-            "is a function with the prototype def foo(G, ...), where G is an "
+            "is a function with the prototype def foo(g, ...), where g is an "
             "object of type garage.sampler.stateful_pool.SharedGlobal")
 
         if args_list is None:
@@ -97,7 +97,7 @@ class StatefulPool(object):
     def run_map(self, runner, args_list):
         assert not inspect.ismethod(runner), (
             "run_map() cannot run a class method. Please ensure that runner "
-            "is a function with the prototype 'def foo(G, ...)', where G is "
+            "is a function with the prototype 'def foo(g, ...)', where g is "
             "an object of type garage.sampler.stateful_pool.SharedGlobal")
 
         if self.n_parallel > 1:
@@ -112,8 +112,8 @@ class StatefulPool(object):
     def run_imap_unordered(self, runner, args_list):
         assert not inspect.ismethod(runner), (
             "run_imap_unordered() cannot run a class method. Please ensure "
-            "that runner is a function with the prototype 'def foo(G, ...)', "
-            "where G is an object of type "
+            "that runner is a function with the prototype 'def foo(g, ...)', "
+            "where g is an object of type "
             "garage.sampler.stateful_pool.SharedGlobal")
 
         if self.n_parallel > 1:
@@ -131,7 +131,7 @@ class StatefulPool(object):
                     show_prog_bar=True):
         """
         Run the collector method using the worker pool. The collect_once method
-        will receive 'G' as its first argument, followed by the provided args,
+        will receive 'g' as its first argument, followed by the provided args,
         if any. The method should return a pair of values. The first should be
         the object to be collected, and the second is the increment to be
         added.
@@ -140,7 +140,7 @@ class StatefulPool(object):
 
         Sample script:
 
-        def collect_once(G):
+        def collect_once(g):
             return 'a', 1
 
         stateful_pool.run_collect(collect_once, threshold=3)
@@ -152,8 +152,8 @@ class StatefulPool(object):
         """
         assert not inspect.ismethod(collect_once), (
             "run_collect() cannot run a class method. Please ensure that "
-            "collect_once is a function with the prototype 'def foo(G, ...)', "
-            "where G is an object of type "
+            "collect_once is a function with the prototype 'def foo(g, ...)', "
+            "where g is an object of type "
             "garage.sampler.stateful_pool.SharedGlobal")
 
         if args is None:


### PR DESCRIPTION
These are changes that are required for the following commit to work:
dcdc6b4e29edf22a1df9a0b4a708e7d9b6d447de
The worker processes pool is only created when n_parallel is bigger than
1, so n_parallel=1 was creating null exceptions when terminate was
called. This is solved by adding a guard to check if the pool was
instantiated.
Another fix that is required is to rename back the member g in
singleton_pool to G. This was done in a previous change to enforce PEP8
style of having non-capital variables/parameters, but the member has to
keep the same name as defined in singleton_pool.