### PR TITLE
Reraise exceptions caught in run_experiment.py

### DIFF
--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -178,6 +178,7 @@ def run_experiment(argv):
             except BaseException:
                 if args.n_parallel > 0:
                     parallel_sampler.terminate()
+                raise
         else:
             data = pickle.loads(base64.b64decode(args.args_data))
             maybe_iter = concretize(data)


### PR DESCRIPTION
We catch BaseException in run_experiment so that we can cleanly
terminate all of the worker processes when an interrupt occurs. If we
don't re-raise the exception after cleaning up, all exceptions which
end the program are silently supressed.

This change re-raises the caught exception after clean-up so that it
propagates to the user.