### PR TITLE
allow_multiline_lambdas in YAPF

### DIFF
--- a/garage/algos/cma_es_lib.py
+++ b/garage/algos/cma_es_lib.py
@@ -3352,7 +3352,11 @@ class CMAEvolutionStrategy(OOOptimizer):
                     boundary_repair = self.boundary_handler.repair
                 elif isinstance(self.boundary_handler, BoundPenalty):
                     fpenalty = lambda x: self.boundary_handler.__call__(
-                        x, SolutionDict({tuple(x): {'geno': x}}), self.gp)
+                        x, SolutionDict({
+                            tuple(x): {
+                                'geno': x
+                            }
+                        }), self.gp)
                     gradpen = grad_numerical_sym(xmean, fpenalty)
                 elif self.boundary_handler is None or \
                         isinstance(self.boundary_handler, BoundNone):
@@ -3362,9 +3366,8 @@ class CMAEvolutionStrategy(OOOptimizer):
                         "unknown boundary handling method" +
                         str(self.boundary_handler) + " when using gradf")
                 gradgp = grad_numerical_of_coordinate_map(
-                    xmean,
-                    lambda x: self.gp.pheno(x, copy=True,
-                            into_bounds=boundary_repair))
+                    xmean, lambda x: self.gp.pheno(
+                        x, copy=True, into_bounds=boundary_repair))
                 grad_at_mean = grad_at_mean * gradgp + gradpen
 
             # TODO: frozen variables brake the code (e.g. at grad of map)
@@ -4503,7 +4506,8 @@ class CMAEvolutionStrategy(OOOptimizer):
             self.gp._tf_matrix_inv = (
                 dot(self.B / self.D, self.B.T).T / self.sigma_vec).T
             self.gp.tf_pheno = lambda x: dot(self.gp._tf_matrix, x)
-            self.gp.tf_geno = lambda x: dot(self.gp._tf_matrix_inv, x)  # not really necessary
+            self.gp.tf_geno = lambda x: dot(self.gp._tf_matrix_inv, x
+                                            )  # not really necessary
             self.gp.isidentity = False
             assert self.mean is not self.mean_old
             self.mean = self.gp.geno(self.mean)  # same as tf_geno

--- a/garage/misc/ext.py
+++ b/garage/misc/ext.py
@@ -287,13 +287,14 @@ def flatten_hessian(cost,
         # It is possible that the inputs are disconnected from expr,
         # even if they are connected to cost.
         # This should not be an error.
-        hess, updates = theano.scan(lambda i, y, x: grad(
-            y[i],
-            x,
-            consider_constant=consider_constant,
-            disconnected_inputs='ignore').flatten(),
-                                    sequences=arange(expr.shape[0]),
-                                    non_sequences=[expr, input])
+        hess, updates = theano.scan(
+            lambda i, y, x: grad(
+                y[i],
+                x,
+                consider_constant=consider_constant,
+                disconnected_inputs='ignore').flatten(),
+            sequences=arange(expr.shape[0]),
+            non_sequences=[expr, input])
         assert not updates, \
             ("Scan has returned a list of updates. This should not "
              "happen! Report this to theano-users (also include the "

--- a/garage/optimizers/conjugate_gradient_optimizer.py
+++ b/garage/optimizers/conjugate_gradient_optimizer.py
@@ -41,8 +41,7 @@ class PerlmutterHvp(Serializable):
                 inputs=inputs + xs,
                 outputs=Hx_plain(),
                 log_name="f_Hx_plain",
-            ),
-        )
+            ), )
 
     def build_eval(self, inputs):
         def eval(x):

--- a/garage/optimizers/first_order_optimizer.py
+++ b/garage/optimizers/first_order_optimizer.py
@@ -88,8 +88,7 @@ class FirstOrderOptimizer(Serializable):
                 inputs=inputs + extra_inputs,
                 outputs=loss,
                 updates=updates,
-            )
-        )
+            ))
 
     def loss(self, inputs, extra_inputs=None):
         if extra_inputs is None:

--- a/garage/optimizers/lbfgs_optimizer.py
+++ b/garage/optimizers/lbfgs_optimizer.py
@@ -60,8 +60,7 @@ class LbfgsOptimizer(Serializable):
             f_opt=lambda: compile_function(
                 inputs=inputs + extra_inputs,
                 outputs=get_opt_output(gradients),
-            )
-        )
+            ))
 
     def loss(self, inputs, extra_inputs=None):
         if extra_inputs is None:

--- a/garage/optimizers/penalty_lbfgs_optimizer.py
+++ b/garage/optimizers/penalty_lbfgs_optimizer.py
@@ -90,9 +90,7 @@ class PenaltyLbfgsOptimizer(Serializable):
             f_opt=lambda: compile_function(
                 inputs=inputs + [penalty_var],
                 outputs=get_opt_output(),
-                log_name="f_opt"
-            )
-        )
+                log_name="f_opt"))
 
     def loss(self, inputs):
         return self._opt_fun["f_loss"](*inputs)

--- a/garage/policies/categorical_gru_policy.py
+++ b/garage/policies/categorical_gru_policy.py
@@ -56,11 +56,9 @@ class CategoricalGRUPolicy(StochasticPolicy, LasagnePowered):
                 name="reshape_feature",
                 op=lambda flat_feature, input: TT.reshape(
                     flat_feature,
-                    [input.shape[0], input.shape[1], feature_dim]
-                ),
-                shape_op=lambda _, input_shape: (
-                    input_shape[0], input_shape[1], feature_dim)
-            )
+                    [input.shape[0], input.shape[1], feature_dim]),
+                shape_op=lambda _, input_shape: (input_shape[0],
+                                                 input_shape[1], feature_dim))
 
         prob_network = GRUNetwork(
             input_shape=(feature_dim, ),

--- a/garage/tf/core/network.py
+++ b/garage/tf/core/network.py
@@ -268,14 +268,14 @@ class GRUNetwork(object):
                 name="output_flat")
             l_output = L.OpLayer(
                 l_output_flat,
-                op=lambda flat_output, l_input:
-                tf.reshape(flat_output,
-                    tf.stack((tf.shape(l_input)[0], tf.shape(l_input)[1], -1))),
-                shape_op=lambda flat_output_shape, l_input_shape:
-                (l_input_shape[0], l_input_shape[1], flat_output_shape[-1]),
+                op=lambda flat_output, l_input: tf.reshape(
+                    flat_output,
+                    tf.stack((tf.shape(l_input)[0], tf.shape(l_input)[1], -1))
+                ),
+                shape_op=lambda flat_output_shape, l_input_shape: (
+                    l_input_shape[0], l_input_shape[1], flat_output_shape[-1]),
                 extras=[l_in],
-                name="output"
-            )
+                name="output")
             l_step_state = l_gru.get_step_layer(
                 l_step_input, l_step_prev_state, name="step_state")
             l_step_hidden = l_step_state
@@ -399,14 +399,14 @@ class LSTMNetwork(object):
                 name="output_flat")
             l_output = L.OpLayer(
                 l_output_flat,
-                op=lambda flat_output, l_input:
-                tf.reshape(flat_output,
-                    tf.stack((tf.shape(l_input)[0], tf.shape(l_input)[1], -1))),
-                shape_op=lambda flat_output_shape, l_input_shape:
-                (l_input_shape[0], l_input_shape[1], flat_output_shape[-1]),
+                op=lambda flat_output, l_input: tf.reshape(
+                    flat_output,
+                    tf.stack((tf.shape(l_input)[0], tf.shape(l_input)[1], -1))
+                ),
+                shape_op=lambda flat_output_shape, l_input_shape: (
+                    l_input_shape[0], l_input_shape[1], flat_output_shape[-1]),
                 extras=[l_in],
-                name="output"
-            )
+                name="output")
             l_step_state = l_lstm.get_step_layer(
                 l_step_input, l_step_prev_state, name="step_state")
             l_step_hidden = L.SliceLayer(

--- a/garage/tf/optimizers/conjugate_gradient_optimizer.py
+++ b/garage/tf/optimizers/conjugate_gradient_optimizer.py
@@ -60,8 +60,7 @@ class PerlmutterHvp(object):
                     inputs=inputs + xs,
                     outputs=Hx_plain(),
                     log_name="f_Hx_plain",
-                ),
-            )
+                ), )
 
     def build_eval(self, inputs):
         def eval(x):

--- a/garage/tf/optimizers/first_order_optimizer.py
+++ b/garage/tf/optimizers/first_order_optimizer.py
@@ -86,9 +86,8 @@ class FirstOrderOptimizer(Serializable):
                 extra_inputs = list()
             self._input_vars = inputs + extra_inputs
             self._opt_fun = ext.lazydict(
-                f_loss=
-                lambda: tensor_utils.compile_function(inputs + extra_inputs, loss),
-            )
+                f_loss=lambda: tensor_utils.compile_function(
+                    inputs + extra_inputs, loss), )
 
     def loss(self, inputs, extra_inputs=None):
         if extra_inputs is None:

--- a/garage/tf/optimizers/lbfgs_optimizer.py
+++ b/garage/tf/optimizers/lbfgs_optimizer.py
@@ -60,8 +60,7 @@ class LbfgsOptimizer(Serializable):
                 f_opt=lambda: tensor_utils.compile_function(
                     inputs=inputs + extra_inputs,
                     outputs=get_opt_output(),
-                )
-            )
+                ))
 
     def loss(self, inputs, extra_inputs=None):
         if extra_inputs is None:

--- a/garage/tf/optimizers/penalty_lbfgs_optimizer.py
+++ b/garage/tf/optimizers/penalty_lbfgs_optimizer.py
@@ -94,8 +94,7 @@ class PenaltyLbfgsOptimizer(Serializable):
                 f_opt=lambda: tensor_utils.compile_function(
                     inputs=inputs + [penalty_var],
                     outputs=get_opt_output(),
-                )
-            )
+                ))
 
     def loss(self, inputs):
         return self._opt_fun["f_loss"](*inputs)

--- a/garage/tf/policies/categorical_gru_policy.py
+++ b/garage/tf/policies/categorical_gru_policy.py
@@ -61,16 +61,10 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                         flat_feature,
                         tf.stack([
                             tf.shape(input)[0],
-                            tf.shape(input)[1],
-                            feature_dim
-                        ])
-                    ),
+                            tf.shape(input)[1], feature_dim
+                        ])),
                     shape_op=lambda _, input_shape: (
-                        input_shape[0],
-                        input_shape[1],
-                        feature_dim
-                    )
-                )
+                        input_shape[0], input_shape[1], feature_dim))
 
             prob_network = GRUNetwork(
                 input_shape=(feature_dim, ),

--- a/garage/tf/policies/categorical_lstm_policy.py
+++ b/garage/tf/policies/categorical_lstm_policy.py
@@ -62,13 +62,10 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
                         flat_feature,
                         tf.stack([
                             tf.shape(input)[0],
-                            tf.shape(input)[1],
-                            feature_dim
-                        ])
-                    ),
+                            tf.shape(input)[1], feature_dim
+                        ])),
                     shape_op=lambda _, input_shape: (
-                        input_shape[0], input_shape[1], feature_dim)
-                )
+                        input_shape[0], input_shape[1], feature_dim))
 
             if prob_network is None:
                 prob_network = LSTMNetwork(

--- a/garage/tf/policies/gaussian_gru_policy.py
+++ b/garage/tf/policies/gaussian_gru_policy.py
@@ -63,13 +63,10 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                         flat_feature,
                         tf.stack([
                             tf.shape(input)[0],
-                            tf.shape(input)[1],
-                            feature_dim
-                        ])
-                    ),
+                            tf.shape(input)[1], feature_dim
+                        ])),
                     shape_op=lambda _, input_shape: (
-                        input_shape[0], input_shape[1], feature_dim)
-                )
+                        input_shape[0], input_shape[1], feature_dim))
 
             if std_share_network:
                 mean_network = GRUNetwork(

--- a/garage/tf/policies/gaussian_lstm_policy.py
+++ b/garage/tf/policies/gaussian_lstm_policy.py
@@ -63,12 +63,10 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
                         flat_feature,
                         tf.stack([
                             tf.shape(input)[0],
-                            tf.shape(input)[1],
-                            feature_dim])
-                    ),
+                            tf.shape(input)[1], feature_dim
+                        ])),
                     shape_op=lambda _, input_shape: (
-                        input_shape[0], input_shape[1], feature_dim)
-                )
+                        input_shape[0], input_shape[1], feature_dim))
 
             if std_share_network:
                 mean_network = LSTMNetwork(

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,3 +86,4 @@ enable = C0326,C1801,E0602,E0603,W0601,W0611,R1710
 
 [yapf]
 based_on_style = pep8
+allow_multiline_lambdas = true


### PR DESCRIPTION
Otherwise YAPF will fail to wrap lines with lambdas, leading to
conflicts with flake8. Despite not being the default, this setting
does not appear to conflict with PEP8.