### PR TITLE
Mock out dm_control in check_imports.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   # mujoco deps
   - sudo add-apt-repository --yes ppa:flixr/backports # for patchelf
   - sudo apt-get update
-  - sudo apt-get install libglfw2 libglew-dev libosmesa6-dev patchelf libopenmpi-dev openmpi-bin
+  - sudo apt-get install -y libglfw2 libglew-dev libosmesa6-dev patchelf libopenmpi-dev openmpi-bin
 
   # mujoco installation
   - wget https://www.roboti.us/download/mjpro150_linux.zip

--- a/scripts/travisci/check_imports.py
+++ b/scripts/travisci/check_imports.py
@@ -42,10 +42,10 @@ IGNORE_MODULES = [
 
 # Mock out some modules because they are slow or error-prone
 MOCK_MODULES = [
-    # "dm_control",
-    # "dm_control.rl",
-    # "dm_control.rl.control",
-    # "dm_control.rl.environment",
+    "dm_control",
+    "dm_control.rl",
+    "dm_control.rl.control",
+    "dm_control.rl.environment",
     "ipdb",
     "matplotlib",
     "matplotlib.pyplot",
@@ -54,6 +54,8 @@ MOCK_MODULES = [
     "mujoco_py.builder",
     "mujoco_py.generated",
     "mujoco_py.generated.const",
+    "OpenGL",
+    "OpenGL.GL",
     # "tensorflow",
     # "tensorflow.python",
     # "tensorflow.python.training",


### PR DESCRIPTION
Some import tests have been failing because dm_control is having
trouble finding glew libraries in TravisCI (even though we install
them).

The best solution to this problem is to control our CI environment
more closely using Docker (See #159). In the meantime, I am mocking
dm_control imports out of the check_imports.py script, so that
dm_control can't break the build.