### PR TITLE
Fix spec(env) implementation

### DIFF
--- a/examples/vpg_1.py
+++ b/examples/vpg_1.py
@@ -5,7 +5,7 @@ import theano.tensor as TT
 
 from garage.envs import normalize
 from garage.envs.box2d import CartpoleEnv
-from garage.envs.util import new_tensor_variable
+from garage.envs.util import new_tensor_variable, spec
 from garage.policies import GaussianMLPPolicy
 
 # normalize() makes sure that the actions for the environment lies within the
@@ -13,7 +13,7 @@ from garage.policies import GaussianMLPPolicy
 env = normalize(CartpoleEnv())
 # Initialize a neural network policy with a single hidden layer of 8 hidden
 # units
-policy = GaussianMLPPolicy(env.spec, hidden_sizes=(8, ))
+policy = GaussianMLPPolicy(spec(env), hidden_sizes=(8, ))
 
 # We will collect 100 trajectories per iteration
 N = 100
@@ -33,8 +33,8 @@ learning_rate = 0.01
 # example. However, doing it in a slightly more abstract way allows us to
 # delegate to the environment for handling the correct data type for the
 # variable. For instance, for an environment with discrete observations, we
-# might want to use integer types if the observations are represented as one-hot
-# vectors.
+# might want to use integer types if the observations are represented
+# as one-hot vectors.
 observations_var = new_tensor_variable(
     env.observation_space,
     'observations',
@@ -54,11 +54,11 @@ dist_info_vars = policy.dist_info_sym(observations_var)
 # It contains many utilities for computing distribution-related quantities,
 # given the computed dist_info_vars. Below we use dist.log_likelihood_sym to
 # compute the symbolic log-likelihood. For this example, the corresponding
-# distribution is an instance of the class garage.distributions.DiagonalGaussian
+# distribution is an instance of garage.distributions.DiagonalGaussian
 dist = policy.distribution
 
-# Note that we negate the objective, since most optimizers assume a minimization
-# problem
+# Note that we negate the objective, since most optimizers assume a
+# minimization problem
 surr = -TT.mean(
     dist.log_likelihood_sym(actions_var, dist_info_vars) * returns_var)
 
@@ -87,10 +87,10 @@ for _ in range(n_itr):
             # policy.get_action() returns a pair of values. The second one
             # returns a dictionary, whose values contains sufficient statistics
             # for the action distribution. It should at least contain entries
-            # that would be returned by calling policy.dist_info(), which is the
-            # non-symbolic analog of policy.dist_info_sym(). Storing these
-            # statistics is useful, e.g., when forming importance sampling
-            # ratios. In our case it is not needed.
+            # that would be returned by calling policy.dist_info(), which is
+            # the non-symbolic analog of policy.dist_info_sym(). Storing
+            # these statistics is useful, e.g., when forming importance
+            # sampling ratios. In our case it is not needed.
             action, _ = policy.get_action(observation)
             # Recall that the last entry of the tuple stores diagnostic
             # information about the environment. In our case it is not needed.

--- a/garage/envs/util.py
+++ b/garage/envs/util.py
@@ -10,8 +10,8 @@ from garage.spaces import Discrete as GarageDiscrete
 from garage.spaces import Product as GarageProduct
 
 __all__ = [
-    'bounds', 'default_value', 'flat_dim', 'flatten', 'flatten_n', 'sample',
-    'spec', 'unflatten', 'unflatten_n', 'weighted_sample',
+    'bounds', 'default_value', 'flat_dim', 'flatten', 'flatten_n', 'horizon',
+    'sample', 'spec', 'unflatten', 'unflatten_n', 'weighted_sample',
     'new_tensor_variable'
 ]
 
@@ -115,8 +115,8 @@ def sample(space):
 
 def spec(env):
     return EnvSpec(
-        observation_space=env.observation_space,
-        action_space=env.action_space,
+        observation_space=_to_garage_space(env.observation_space),
+        action_space=_to_garage_space(env.action_space),
     )
 
 

--- a/garage/exploration_strategies/ou_strategy.py
+++ b/garage/exploration_strategies/ou_strategy.py
@@ -3,10 +3,10 @@ import numpy as np
 import numpy.random as nr
 
 from garage.core import Serializable
-from garage.envs.util import flat_dim
 from garage.exploration_strategies import ExplorationStrategy
 from garage.misc.ext import AttrDict
 from garage.misc.overrides import overrides
+from garage.spaces import Box
 
 
 class OUStrategy(ExplorationStrategy, Serializable):
@@ -19,14 +19,14 @@ class OUStrategy(ExplorationStrategy, Serializable):
     """
 
     def __init__(self, env_spec, mu=0, theta=0.15, sigma=0.3, **kwargs):
-        assert isinstance(env_spec.action_space, gym.spaces.Box)
+        assert isinstance(env_spec.action_space, Box)
         assert len(env_spec.action_space.shape) == 1
         Serializable.quick_init(self, locals())
         self.mu = mu
         self.theta = theta
         self.sigma = sigma
         self.action_space = env_spec.action_space
-        self.state = np.ones(flat_dim(self.action_space)) * self.mu
+        self.state = np.ones(self.action_space.flat_dim) * self.mu
         self.reset()
 
     def __getstate__(self):
@@ -40,7 +40,7 @@ class OUStrategy(ExplorationStrategy, Serializable):
 
     @overrides
     def reset(self):
-        self.state = np.ones(flat_dim(self.action_space)) * self.mu
+        self.state = np.ones(self.action_space.flat_dim) * self.mu
 
     def evolve_state(self):
         x = self.state

--- a/garage/policies/deterministic_mlp_policy.py
+++ b/garage/policies/deterministic_mlp_policy.py
@@ -1,4 +1,3 @@
-import lasagne
 import lasagne.init as LI
 import lasagne.layers as L
 import lasagne.nonlinearities as NL
@@ -6,7 +5,6 @@ import lasagne.nonlinearities as NL
 from garage.core import batch_norm
 from garage.core import LasagnePowered
 from garage.core import Serializable
-from garage.envs.util import flat_dim
 from garage.misc import ext
 from garage.policies import Policy
 
@@ -16,16 +14,15 @@ class DeterministicMLPPolicy(Policy, LasagnePowered):
                  env_spec,
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=NL.rectify,
-                 hidden_W_init=LI.HeUniform(),
+                 hidden_w_init=LI.HeUniform(),
                  hidden_b_init=LI.Constant(0.),
                  output_nonlinearity=NL.tanh,
-                 output_W_init=LI.Uniform(-3e-3, 3e-3),
+                 output_w_init=LI.Uniform(-3e-3, 3e-3),
                  output_b_init=LI.Uniform(-3e-3, 3e-3),
                  bn=False):
         Serializable.quick_init(self, locals())
 
-        l_obs = L.InputLayer(
-            shape=(None, flat_dim(env_spec.observation_space)))
+        l_obs = L.InputLayer(shape=(None, env_spec.observation_space.flat_dim))
 
         l_hidden = l_obs
         if bn:
@@ -35,7 +32,7 @@ class DeterministicMLPPolicy(Policy, LasagnePowered):
             l_hidden = L.DenseLayer(
                 l_hidden,
                 num_units=size,
-                W=hidden_W_init,
+                W=hidden_w_init,
                 b=hidden_b_init,
                 nonlinearity=hidden_nonlinearity,
                 name="h%d" % idx)
@@ -44,8 +41,8 @@ class DeterministicMLPPolicy(Policy, LasagnePowered):
 
         l_output = L.DenseLayer(
             l_hidden,
-            num_units=flat_dim(env_spec.action_space),
-            W=output_W_init,
+            num_units=env_spec.action_space.flat_dim,
+            W=output_w_init,
             b=output_b_init,
             nonlinearity=output_nonlinearity,
             name="output")

--- a/garage/policies/gaussian_gru_policy.py
+++ b/garage/policies/gaussian_gru_policy.py
@@ -9,7 +9,6 @@ from garage.core import LasagnePowered
 from garage.core import ParamLayer
 from garage.core import Serializable
 from garage.distributions import RecurrentDiagonalGaussian
-from garage.envs.util import flat_dim, flatten
 from garage.misc import ext
 from garage.misc.overrides import overrides
 from garage.policies import StochasticPolicy
@@ -28,7 +27,7 @@ class GaussianGRUPolicy(StochasticPolicy, LasagnePowered):
     ):
         """
         :param env_spec: A spec for the env.
-        :param hidden_sizes: list of sizes for the fully connected hidden layers
+        :param hidden_sizes: sizes list for the fully connected hidden layers
         :param hidden_nonlinearity: nonlinearity used for each hidden layer
         :return:
         """
@@ -38,11 +37,11 @@ class GaussianGRUPolicy(StochasticPolicy, LasagnePowered):
         assert len(hidden_sizes) == 1
 
         if state_include_action:
-            obs_dim = flat_dim(env_spec.observation_space) + flat_dim(
-                env_spec.action_space)
+            obs_dim = env_spec.observation_space.flat_dim +\
+                env_spec.action_space.flat_dim
         else:
-            obs_dim = flat_dim(env_spec.observation_space)
-        action_flat_dim = flat_dim(env_spec.action_space)
+            obs_dim = env_spec.observation_space.flat_dim
+        action_flat_dim = env_spec.action_space.flat_dim
 
         mean_network = GRUNetwork(
             input_shape=(obs_dim, ),
@@ -119,13 +118,13 @@ class GaussianGRUPolicy(StochasticPolicy, LasagnePowered):
     def get_action(self, observation):
         if self._state_include_action:
             if self._prev_action is None:
-                prev_action = np.zeros((flat_dim(self.action_space), ))
+                prev_action = np.zeros((self.action_space.flat_dim, ))
             else:
-                prev_action = flatten(self.action_space, self._prev_action)
+                prev_action = self.action_space.flatten(self._prev_action)
             all_input = np.concatenate(
-                [flatten(self.observation_space, observation), prev_action])
+                [self.observation_space.flatten(observation), prev_action])
         else:
-            all_input = flatten(self.observation_space, observation)
+            all_input = self.observation_space.flatten(observation)
             # should not be used
             prev_action = np.nan
         mean, log_std, hidden_vec = [

--- a/garage/q_functions/continuous_mlp_q_function.py
+++ b/garage/q_functions/continuous_mlp_q_function.py
@@ -7,7 +7,6 @@ import theano.tensor as TT
 from garage.core import batch_norm
 from garage.core import LasagnePowered
 from garage.core import Serializable
-from garage.envs.util import flat_dim
 from garage.misc import ext
 from garage.q_functions import QFunction
 
@@ -17,19 +16,19 @@ class ContinuousMLPQFunction(QFunction, LasagnePowered):
                  env_spec,
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=NL.rectify,
-                 hidden_W_init=lasagne.init.HeUniform(),
+                 hidden_w_init=lasagne.init.HeUniform(),
                  hidden_b_init=lasagne.init.Constant(0.),
                  action_merge_layer=-2,
                  output_nonlinearity=None,
-                 output_W_init=lasagne.init.Uniform(-3e-3, 3e-3),
+                 output_w_init=lasagne.init.Uniform(-3e-3, 3e-3),
                  output_b_init=lasagne.init.Uniform(-3e-3, 3e-3),
                  bn=False):
         Serializable.quick_init(self, locals())
 
         l_obs = L.InputLayer(
-            shape=(None, flat_dim(env_spec.observation_space)), name="obs")
+            shape=(None, env_spec.observation_space.flat_dim), name="obs")
         l_action = L.InputLayer(
-            shape=(None, flat_dim(env_spec.action_space)), name="actions")
+            shape=(None, env_spec.action_space.flat_dim), name="actions")
 
         n_layers = len(hidden_sizes) + 1
 
@@ -51,7 +50,7 @@ class ContinuousMLPQFunction(QFunction, LasagnePowered):
             l_hidden = L.DenseLayer(
                 l_hidden,
                 num_units=size,
-                W=hidden_W_init,
+                W=hidden_w_init,
                 b=hidden_b_init,
                 nonlinearity=hidden_nonlinearity,
                 name="h%d" % (idx + 1))
@@ -62,7 +61,7 @@ class ContinuousMLPQFunction(QFunction, LasagnePowered):
         l_output = L.DenseLayer(
             l_hidden,
             num_units=1,
-            W=output_W_init,
+            W=output_w_init,
             b=output_b_init,
             nonlinearity=output_nonlinearity,
             name="output")


### PR DESCRIPTION
spec(env) now returns garage.Spaces, and the algorithms using env_spec are updated accordingly to treat them as garage.Spaces.

Ref: #133 