### PR TITLE
Fix baselines installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -53,4 +53,4 @@ dependencies:
         - pep8-naming==0.7.0
         - pylint==1.9.2
         - yapf
-        - baselines
+        - git+https://github.com/openai/baselines.git@f2729693253c0ef4d4086231d36e0a4307ec1cb3#egg=baselines

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -12,7 +12,7 @@ echo "Installing system dependencies"
 echo "You will probably be asked for your sudo password."
 sudo apt-get update
 sudo apt-get install -y python-pip python-dev swig cmake build-essential \
-  zlib1g-dev
+  zlib1g-dev libopenmpi-dev
 sudo apt-get build-dep -y python-pygame
 sudo apt-get build-dep -y python-scipy
 

--- a/scripts/setup_osx.sh
+++ b/scripts/setup_osx.sh
@@ -18,7 +18,7 @@ hash conda 2>/dev/null || {
 echo "Installing system dependencies"
 echo "You will probably be asked for your sudo password."
 
-brew install swig sdl sdl_image sdl_mixer sdl_ttf portmidi
+brew install swig sdl sdl_image sdl_mixer sdl_ttf portmidi openmpi
 
 # Make sure that we're under the directory of the project
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
Fix baselines installation in environments.yml. Using `pip install
baselines` installs the wrong version of baselines. Change it to install
using git.

Add mpi dependency in setup_linux.sh and setup_osx.sh.

Fixes: #169, #166 