### PR TITLE
Remove /progress from Tensorboard output paths

### DIFF
--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -49,7 +49,6 @@ class TensorBoardOutput:
 
             self._layout_writer_dir = dirname(dirname(
                 abspath(dir_name))) + '/custom_scalar_config'
-            mkdir_p(self._layout_writer_dir)
 
             self._default_step = 0
             assert self._writer is not None

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -72,11 +72,6 @@ def run_experiment(argv):
         default='debug.log',
         help='Name of the text log file (in pure text).')
     parser.add_argument(
-        '--tensorboard_log_dir',
-        type=str,
-        default='progress',
-        help='Name of the folder for tensorboard_summary.')
-    parser.add_argument(
         '--tensorboard_step_key',
         type=str,
         default=None,
@@ -139,7 +134,6 @@ def run_experiment(argv):
     tabular_log_file = osp.join(log_dir, args.tabular_log_file)
     text_log_file = osp.join(log_dir, args.text_log_file)
     params_log_file = osp.join(log_dir, args.params_log_file)
-    tensorboard_log_dir = osp.join(log_dir, args.tensorboard_log_dir)
 
     if args.variant_data is not None:
         variant_data = pickle.loads(base64.b64decode(args.variant_data))
@@ -153,7 +147,7 @@ def run_experiment(argv):
 
     logger.add_text_output(text_log_file)
     logger.add_tabular_output(tabular_log_file)
-    logger.set_tensorboard_dir(tensorboard_log_dir)
+    logger.set_tensorboard_dir(log_dir)
     prev_snapshot_dir = logger.get_snapshot_dir()
     prev_mode = logger.get_snapshot_mode()
     logger.set_snapshot_dir(log_dir)


### PR DESCRIPTION
There is an argument in scripts/run_experiment that sets
log_dir/progress as the tensorboard output dir. Delete it and set the
tensorboard dir same as log_dir removes `/progress` in the end of every
run.

Also, mkdir_p in TensorboradOutput is useless and it creates an empty
dir every run when rencord_tensor is not called. Delete it.

Fixes: #177 