### PR TITLE
Add PPO to garage/tf

### DIFF
--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -1,0 +1,55 @@
+"""
+This is an example to train a task with PPO algorithm.
+
+Here it creates InvertedDoublePendulum using gym. And uses a PPO with 1M
+steps.
+
+Results:
+    AverageReturn: 526.092
+    RiseTime: itr 488
+"""
+import gym
+
+from garage.envs import normalize
+from garage.misc.instrument import run_experiment
+from garage.tf.algos import PPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicy
+
+
+def run_task(*_):
+    """
+    Wrap PPO training task in the run_task function.
+
+    :param _:
+    :return:
+    """
+    env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
+
+    policy = GaussianMLPPolicy(
+        name="policy", env_spec=env.spec, hidden_sizes=(64, 64))
+
+    baseline = GaussianMLPBaseline(env_spec=env.spec)
+
+    algo = PPO(
+        env=env,
+        policy=policy,
+        baseline=baseline,
+        batch_size=2048,
+        max_path_length=100,
+        n_itr=488,
+        discount=0.99,
+        step_size=0.01,
+        optimizer_args=dict(batch_size=32, max_epochs=10),
+        plot=False)
+    algo.train()
+
+
+run_experiment(
+    run_task,
+    n_parallel=1,
+    snapshot_mode="last",
+    seed=1,
+    plot=False,
+)

--- a/garage/tf/algos/__init__.py
+++ b/garage/tf/algos/__init__.py
@@ -1,5 +1,6 @@
 from garage.tf.algos.batch_polopt import BatchPolopt
 from garage.tf.algos.ddpg import DDPG
 from garage.tf.algos.npo import NPO
+from garage.tf.algos.ppo import PPO
 from garage.tf.algos.trpo import TRPO
 from garage.tf.algos.vpg import VPG

--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -115,6 +115,7 @@ class BatchPolopt(RLAlgorithm):
         sess.run(tf.global_variables_initializer())
         self.start_worker(sess)
         start_time = time.time()
+        last_average_return = None
         for itr in range(self.start_itr, self.n_itr):
             itr_start_time = time.time()
             with logger.prefix('itr #%d | ' % itr):
@@ -122,6 +123,7 @@ class BatchPolopt(RLAlgorithm):
                 paths = self.obtain_samples(itr)
                 logger.log("Processing samples...")
                 samples_data = self.process_samples(itr, paths)
+                last_average_return = samples_data["average_return"]
                 logger.log("Logging diagnostics...")
                 self.log_diagnostics(paths)
                 logger.log("Optimizing policy...")
@@ -144,6 +146,7 @@ class BatchPolopt(RLAlgorithm):
         self.shutdown_worker()
         if created_session:
             sess.close()
+        return last_average_return
 
     def log_diagnostics(self, paths):
         self.env.log_diagnostics(paths)

--- a/garage/tf/algos/ppo.py
+++ b/garage/tf/algos/ppo.py
@@ -1,0 +1,30 @@
+"""This module implements a PPO algorithm."""
+from garage.tf.algos import NPO
+from garage.tf.algos.npo import PGLoss
+from garage.tf.optimizers import FirstOrderOptimizer
+
+
+class PPO(NPO):
+    """
+    Proximal Policy Optimization.
+
+    See https://arxiv.org/abs/1707.06347.
+    """
+
+    def __init__(self, optimizer=None, optimizer_args=None, **kwargs):
+        """
+        Construct class.
+
+        :param optimizer: Optimizer.
+        :param optimizer_args: Optimizer args.
+        :param kwargs:
+        """
+        if optimizer is None:
+            optimizer = FirstOrderOptimizer
+            if optimizer_args is None:
+                optimizer_args = dict()
+        super(PPO, self).__init__(
+            pg_loss=PGLoss.CLIP,
+            optimizer=optimizer,
+            optimizer_args=optimizer_args,
+            **kwargs)

--- a/garage/tf/misc/tensor_utils.py
+++ b/garage/tf/misc/tensor_utils.py
@@ -1,3 +1,6 @@
+from collections import Iterable
+from collections import namedtuple
+
 import numpy as np
 import tensorflow as tf
 
@@ -8,6 +11,41 @@ def compile_function(inputs, outputs, log_name=None):
         return sess.run(outputs, feed_dict=dict(list(zip(inputs, input_vals))))
 
     return run
+
+
+def flatten_batch(t, name="flatten_batch"):
+    return tf.reshape(t, [-1] + list(t.shape[2:]), name=name)
+
+
+def flatten_batch_dict(d, name=None):
+    with tf.name_scope(name, "flatten_batch_dict", [d]):
+        return {k: flatten_batch(v) for k, v in d.items()}
+
+
+def filter_valids(t, valid, name="filter_valids"):
+    return tf.boolean_mask(t, valid, name=name)
+
+
+def filter_valids_dict(d, valid, name=None):
+    with tf.name_scope(name, "filter_valids_dict", [d, valid]):
+        return {k: filter_valids(v, valid) for k, v in d.items()}
+
+
+def graph_inputs(name, **kwargs):
+    Singleton = namedtuple(name, kwargs.keys())
+    return Singleton(**kwargs)
+
+
+def flatten_inputs(deep):
+    def flatten(deep):
+        for d in deep:
+            if isinstance(d, Iterable) and not isinstance(
+                    d, (str, bytes, tf.Tensor, np.ndarray)):
+                yield from flatten(d)
+            else:
+                yield d
+
+    return list(flatten(deep))
 
 
 def flatten_tensor_variables(ts):
@@ -124,3 +162,65 @@ def pad_tensor_dict(tensor_dict, max_len):
         else:
             ret[k] = pad_tensor(tensor_dict[k], max_len)
     return ret
+
+
+def compute_adv(discount, gae_lambda, max_len, baselines, rewards):
+    with tf.name_scope("advantage"):
+        # Calculate advantages
+        #
+        # Advantages are a discounted cumulative sum.
+        #
+        # The discount cumulative sum can be represented as an IIR
+        # filter ob the reversed input vectors, i.e.
+        #    y[t] - discount*y[t+1] = x[t]
+        #        or
+        #    rev(y)[t] - discount*rev(y)[t-1] = rev(x)[t]
+        #
+        # Given the time-domain IIR filter step response, we can
+        # calculate the filter response to our signal by convolving the
+        # signal with the filter response function. The time-domain IIR
+        # step response is calculated below as discount_filter:
+        #     discount_filter =
+        #         [1, discount, discount^2, ..., discount^N-1]
+        #         where the epsiode length is N.
+        #
+        # We convolve discount_filter with the reversed time-domain
+        # signal deltas to calculate the reversed advantages:
+        #     rev(advantages) = discount_filter (X) rev(deltas)
+        #
+        # TensorFlow's tf.nn.conv1d op is not a true convolution, but
+        # actually a cross-correlation, so its input and output are
+        # already implicitly reversed for us.
+        #    advantages = discount_filter (tf.nn.conv1d) deltas
+
+        # Prepare convolutional IIR filter to calculate advantages
+        gamma_lambda = tf.constant(
+            float(discount) * float(gae_lambda),
+            dtype=tf.float32,
+            shape=[max_len, 1, 1])
+        advantage_filter = tf.cumprod(gamma_lambda, exclusive=True)
+
+        # Calculate deltas
+        pad = tf.zeros_like(baselines[:, :1])
+        baseline_shift = tf.concat([baselines[:, 1:], pad], 1)
+        deltas = rewards + discount * baseline_shift - baselines
+        # Convolve deltas with the discount filter to get advantages
+        deltas_pad = tf.expand_dims(
+            tf.concat([deltas, tf.zeros_like(deltas[:, :-1])], axis=1), axis=2)
+        adv = tf.nn.conv1d(
+            deltas_pad, advantage_filter, stride=1, padding='VALID')
+        advantages = tf.reshape(adv, [-1])
+    return advantages
+
+
+def compute_ret(discount, max_len, rewards):
+    with tf.name_scope("returns"):
+        gamma = tf.constant(
+            float(discount), dtype=tf.float32, shape=[max_len, 1, 1])
+        return_filter = tf.cumprod(gamma, exclusive=True)
+        rewards_pad = tf.expand_dims(
+            tf.concat([rewards, tf.zeros_like(rewards[:, :-1])], axis=1),
+            axis=2)
+        returns = tf.nn.conv1d(
+            rewards_pad, return_filter, stride=1, padding='VALID')
+    return returns

--- a/garage/tf/samplers/batch_sampler.py
+++ b/garage/tf/samplers/batch_sampler.py
@@ -1,17 +1,20 @@
+import numpy as np
 import tensorflow as tf
 
+from garage.misc import logger, special
 from garage.sampler import parallel_sampler
 from garage.sampler import singleton_pool
 from garage.sampler.base import BaseSampler
+from garage.tf.misc import tensor_utils
 
 
-def worker_init_tf(G):
-    G.sess = tf.Session()
-    G.sess.__enter__()
+def worker_init_tf(g):
+    g.sess = tf.Session()
+    g.sess.__enter__()
 
 
-def worker_init_tf_vars(G):
-    G.sess.run(tf.global_variables_initializer())
+def worker_init_tf_vars(g):
+    g.sess.run(tf.global_variables_initializer())
 
 
 class BatchSampler(BaseSampler):
@@ -41,3 +44,103 @@ class BatchSampler(BaseSampler):
             paths_truncated = parallel_sampler.truncate_paths(
                 paths, self.algo.batch_size)
             return paths_truncated
+
+    def process_samples(self, itr, paths):
+        baselines = []
+        returns = []
+
+        max_path_length = self.algo.max_path_length
+
+        if hasattr(self.algo.baseline, "predict_n"):
+            all_path_baselines = self.algo.baseline.predict_n(paths)
+        else:
+            all_path_baselines = [
+                self.algo.baseline.predict(path) for path in paths
+            ]
+
+        for idx, path in enumerate(paths):
+            path_baselines = np.append(all_path_baselines[idx], 0)
+            deltas = path["rewards"] + \
+                     self.algo.discount * path_baselines[1:] - \
+                     path_baselines[:-1]
+            path["advantages"] = special.discount_cumsum(
+                deltas, self.algo.discount * self.algo.gae_lambda)
+            path["deltas"] = deltas
+
+        for idx, path in enumerate(paths):
+            # baselines
+            path['baselines'] = all_path_baselines[idx]
+            baselines.append(path['baselines'])
+
+            # returns
+            path["returns"] = special.discount_cumsum(path["rewards"],
+                                                      self.algo.discount)
+            returns.append(path["returns"])
+
+        # make all paths the same length
+        obs = [path["observations"] for path in paths]
+        obs = tensor_utils.pad_tensor_n(obs, max_path_length)
+
+        actions = [path["actions"] for path in paths]
+        actions = tensor_utils.pad_tensor_n(actions, max_path_length)
+
+        rewards = [path["rewards"] for path in paths]
+        rewards = tensor_utils.pad_tensor_n(rewards, max_path_length)
+
+        returns = [path["returns"] for path in paths]
+        returns = tensor_utils.pad_tensor_n(returns, max_path_length)
+
+        advantages = [path["advantages"] for path in paths]
+        advantages = tensor_utils.pad_tensor_n(advantages, max_path_length)
+
+        baselines = tensor_utils.pad_tensor_n(baselines, max_path_length)
+
+        agent_infos = [path["agent_infos"] for path in paths]
+        agent_infos = tensor_utils.stack_tensor_dict_list([
+            tensor_utils.pad_tensor_dict(p, max_path_length)
+            for p in agent_infos
+        ])
+
+        env_infos = [path["env_infos"] for path in paths]
+        env_infos = tensor_utils.stack_tensor_dict_list([
+            tensor_utils.pad_tensor_dict(p, max_path_length) for p in env_infos
+        ])
+
+        valids = [np.ones_like(path["returns"]) for path in paths]
+        valids = tensor_utils.pad_tensor_n(valids, max_path_length)
+
+        average_discounted_return = (np.mean(
+            [path["returns"][0] for path in paths]))
+
+        undiscounted_returns = [sum(path["rewards"]) for path in paths]
+
+        ent = np.sum(
+            self.algo.policy.distribution.entropy(agent_infos) *
+            valids) / np.sum(valids)
+
+        samples_data = dict(
+            observations=obs,
+            actions=actions,
+            rewards=rewards,
+            advantages=advantages,
+            baselines=baselines,
+            returns=returns,
+            valids=valids,
+            agent_infos=agent_infos,
+            env_infos=env_infos,
+            paths=paths,
+            average_return=np.mean(undiscounted_returns),
+        )
+
+        logger.record_tabular('Iteration', itr)
+        logger.record_tabular('AverageDiscountedReturn',
+                              average_discounted_return)
+        logger.record_tabular('AverageReturn', np.mean(undiscounted_returns))
+        logger.record_tabular('NumTrajs', len(paths))
+        logger.record_tabular('Entropy', ent)
+        logger.record_tabular('Perplexity', np.exp(ent))
+        logger.record_tabular('StdReturn', np.std(undiscounted_returns))
+        logger.record_tabular('MaxReturn', np.max(undiscounted_returns))
+        logger.record_tabular('MinReturn', np.min(undiscounted_returns))
+
+        return samples_data

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -1,0 +1,246 @@
+"""
+This script creates a regression test over garage-PPO and baselines-PPO.
+
+Unlike garage, baselines doesn't set max_path_length. It keeps steps the action
+until it's done. So you need to change the baselines source code to make it
+stops at length 100.
+"""
+import datetime
+import multiprocessing
+import os.path as osp
+import random
+import unittest
+
+from baselines import bench
+from baselines import logger as baselines_logger
+from baselines.bench import benchmarks
+from baselines.common import set_global_seeds
+from baselines.common.vec_env.dummy_vec_env import DummyVecEnv
+from baselines.common.vec_env.vec_normalize import VecNormalize
+from baselines.logger import configure
+from baselines.ppo2 import ppo2
+from baselines.ppo2.policies import MlpPolicy
+import gym
+import matplotlib.pyplot as plt
+import pandas as pd
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.misc import ext
+from garage.misc import logger as garage_logger
+from garage.tf.algos import PPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicy
+
+
+class TestBenchmarkPPO(unittest.TestCase):
+    def test_benchmark_ppo(self):
+        """
+        Compare benchmarks between garage and baselines.
+
+        :return:
+        """
+        mujoco1m = benchmarks.get_benchmark("Mujoco1M")
+
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+        benchmark_dir = "./benchmark_ppo/%s/" % timestamp
+        for task in mujoco1m["tasks"]:
+            env_id = task["env_id"]
+            env = gym.make(env_id)
+            seeds = random.sample(range(100), task["trials"])
+
+            task_dir = osp.join(benchmark_dir, env_id)
+            plt_file = osp.join(benchmark_dir,
+                                "{}_benchmark.png".format(env_id))
+            baselines_csvs = []
+            garage_csvs = []
+
+            for trail in range(task["trials"]):
+                env.reset()
+                seed = seeds[trail]
+
+                trail_dir = task_dir + "/trail_%d_seed_%d" % (trail + 1, seed)
+                garage_dir = trail_dir + "/garage"
+                baselines_dir = trail_dir + "/baselines"
+
+                # Run garage algorithms
+                garage_csv = run_garage(env, seed, garage_dir)
+
+                # Run baselines algorithms
+                env.reset()
+                baselines_csv = run_baselines(env, seed, baselines_dir)
+
+                garage_csvs.append(garage_csv)
+                baselines_csvs.append(baselines_csv)
+
+            plot(
+                b_csvs=baselines_csvs,
+                g_csvs=garage_csvs,
+                g_x="Iteration",
+                g_y="AverageReturn",
+                b_x="nupdates",
+                b_y="eprewmean",
+                trails=task["trials"],
+                seeds=seeds,
+                plt_file=plt_file,
+                env_id=env_id)
+
+
+def run_garage(env, seed, log_dir):
+    """
+    Create garage model and training.
+
+    Replace the ppo with the algorithm you want to run.
+
+    :param env: Environment of the task.
+    :param seed: Random seed for the trail.
+    :param log_dir: Log dir path.
+    :return:
+    """
+    ext.set_seed(seed)
+
+    with tf.Graph().as_default():
+        env = TfEnv(normalize(env))
+
+        policy = GaussianMLPPolicy(
+            name="policy",
+            env_spec=env.spec,
+            hidden_sizes=(64, 64),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(
+                hidden_sizes=(64, 64),
+                use_trust_region=True,
+            ),
+        )
+
+        algo = PPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=2048,
+            max_path_length=100,
+            n_itr=488,
+            discount=0.99,
+            gae_lambda=0.95,
+            clip_range=0.1,
+            policy_ent_coeff=0.0,
+            optimizer_args=dict(
+                batch_size=32,
+                max_epochs=10,
+                tf_optimizer_args=dict(
+                    learning_rate=3e-4,
+                    epsilon=1e-5,
+                ),
+            ),
+            plot=False,
+        )
+
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, "progress.csv")
+        garage_logger.add_tabular_output(tabular_log_file)
+        garage_logger.set_tensorboard_dir(log_dir)
+
+        algo.train()
+
+        garage_logger.remove_tabular_output(tabular_log_file)
+
+        return tabular_log_file
+
+
+def run_baselines(env, seed, log_dir):
+    """
+    Create baselines model and training.
+
+    Replace the ppo and its training with the algorithm you want to run.
+
+    :param env: Environment of the task.
+    :param seed: Random seed for the trail.
+    :param log_dir: Log dir path.
+    :return
+    """
+    ncpu = max(multiprocessing.cpu_count() // 2, 1)
+    config = tf.ConfigProto(
+        allow_soft_placement=True,
+        intra_op_parallelism_threads=ncpu,
+        inter_op_parallelism_threads=ncpu)
+    tf.Session(config=config).__enter__()
+
+    # Set up logger for baselines
+    configure(dir=log_dir)
+    baselines_logger.info('rank {}: seed={}, logdir={}'.format(
+        0, seed, baselines_logger.get_dir()))
+
+    def make_env():
+        monitor = bench.Monitor(
+            env, baselines_logger.get_dir(), allow_early_resets=True)
+        return monitor
+
+    env = DummyVecEnv([make_env])
+    env = VecNormalize(env)
+
+    set_global_seeds(seed)
+    policy = MlpPolicy
+    ppo2.learn(
+        policy=policy,
+        env=env,
+        nsteps=2048,
+        nminibatches=32,
+        lam=0.95,
+        gamma=0.99,
+        noptepochs=10,
+        log_interval=1,
+        ent_coef=0.0,
+        lr=3e-4,
+        vf_coef=0.5,
+        max_grad_norm=0.5,
+        cliprange=0.1,
+        total_timesteps=int(1e6))
+
+    return osp.join(log_dir, "progress.csv")
+
+
+def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
+    """
+    Plot benchmark from csv files of garage and baselines.
+
+    :param b_csvs: A list contains all csv files in the task.
+    :param g_csvs: A list contains all csv files in the task.
+    :param g_x: X column names of garage csv.
+    :param g_y: Y column names of garage csv.
+    :param b_x: X column names of baselines csv.
+    :param b_y: Y column names of baselines csv.
+    :param trails: Number of trails in the task.
+    :param seeds: A list contains all the seeds in the task.
+    :param plt_file: Path of the plot png file.
+    :param env_id: String contains the id of the environment.
+    :return:
+    """
+    assert len(b_csvs) == len(g_csvs)
+    for trail in range(trails):
+        seed = seeds[trail]
+
+        df_g = pd.read_csv(g_csvs[trail])
+        df_b = pd.read_csv(b_csvs[trail])
+
+        plt.plot(
+            df_g[g_x],
+            df_g[g_y],
+            label="garage_trail%d_seed%d" % (trail + 1, seed))
+        plt.plot(
+            df_b[b_x],
+            df_b[b_y],
+            label="baselines_trail%d_seed%d" % (trail + 1, seed))
+
+    plt.legend()
+    plt.xlabel("Iteration")
+    plt.ylabel("AverageReturn")
+    plt.title(env_id)
+
+    plt.savefig(plt_file)
+    plt.close()

--- a/tests/benchmarks/test_benchmark_trpo.py
+++ b/tests/benchmarks/test_benchmark_trpo.py
@@ -1,0 +1,225 @@
+"""
+This script creates a regression test over garage-TRPO and baselines-TRPO.
+
+Unlike garage, baselines doesn't set max_path_length. It keeps steps the action
+until it's done. So you need to change the baselines source code to make it
+stops at length 100. You also need to change the
+garage.tf.samplers.BatchSampler to smooth the reward curve.
+"""
+import datetime
+import os.path as osp
+import random
+import unittest
+
+from baselines import logger as baselines_logger
+from baselines.bench import benchmarks
+from baselines.common.cmd_util import make_mujoco_env
+from baselines.common.tf_util import _PLACEHOLDER_CACHE
+from baselines.ppo1.mlp_policy import MlpPolicy
+from baselines.trpo_mpi import trpo_mpi
+import gym
+import matplotlib.pyplot as plt
+import pandas as pd
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.misc import ext
+from garage.misc import logger as garage_logger
+from garage.tf.algos import TRPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicy
+
+
+class TestBenchmarkPPO(unittest.TestCase):
+    def test_benchmark_trpo(self):
+        """
+        Compare benchmarks between garage and baselines.
+
+        :return:
+        """
+
+        mujoco1m = benchmarks.get_benchmark("Mujoco1M")
+
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+        benchmark_dir = "./benchmark_trpo/%s/" % timestamp
+        for task in mujoco1m["tasks"]:
+            env_id = task["env_id"]
+            env = gym.make(env_id)
+            seeds = random.sample(range(100), task["trials"])
+
+            task_dir = osp.join(benchmark_dir, env_id)
+            plt_file = osp.join(benchmark_dir,
+                                "{}_benchmark.png".format(env_id))
+            baselines_csvs = []
+            garage_csvs = []
+
+            for trail in range(task["trials"]):
+                _PLACEHOLDER_CACHE.clear()
+                env.reset()
+                seed = seeds[trail]
+
+                trail_dir = task_dir + "/trail_%d_seed_%d" % (trail + 1, seed)
+                garage_dir = trail_dir + "/garage"
+                baselines_dir = trail_dir + "/baselines"
+
+                baselines_csv = run_baselines(env_id, seed, baselines_dir)
+
+                # Run garage algorithms
+                env.reset()
+                garage_csv = run_garage(env, seed, garage_dir)
+
+                garage_csvs.append(garage_csv)
+                baselines_csvs.append(baselines_csv)
+
+            plot(
+                b_csvs=baselines_csvs,
+                g_csvs=garage_csvs,
+                g_x="Iteration",
+                g_y="AverageReturn",
+                b_x="Iter",
+                b_y="EpRewMean",
+                trails=task["trials"],
+                seeds=seeds,
+                plt_file=plt_file,
+                env_id=env_id)
+
+
+def run_garage(env, seed, log_dir):
+    """
+    Create garage model and training.
+
+    Replace the trpo with the algorithm you want to run.
+
+    :param env: Environment of the task.
+    :param seed: Random seed for the trail.
+    :param log_dir: Log dir path.
+    :return:import baselines.common.tf_util as U
+    """
+    ext.set_seed(seed)
+
+    with tf.Graph().as_default():
+        env = TfEnv(normalize(env))
+
+        policy = GaussianMLPPolicy(
+            name="policy",
+            env_spec=env.spec,
+            hidden_sizes=(32, 32),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(
+                hidden_sizes=(32, 32),
+                use_trust_region=True,
+            ),
+        )
+
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=1024,
+            max_path_length=100,
+            n_itr=976,
+            discount=0.99,
+            gae_lambda=0.98,
+            clip_range=0.1,
+            policy_ent_coeff=0.0,
+            plot=False,
+        )
+
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, "progress.csv")
+        garage_logger.add_tabular_output(tabular_log_file)
+        garage_logger.set_tensorboard_dir(log_dir)
+
+        algo.train()
+
+        garage_logger.remove_tabular_output(tabular_log_file)
+
+        return tabular_log_file
+
+
+def run_baselines(env_id, seed, log_dir):
+    """
+    Create baselines model and training.
+
+    Replace the trpo and its training with the algorithm you want to run.
+
+    :param env: Environment of the task.
+    :param seed: Random seed for the trail.
+    :param log_dir: Log dir path.
+    :return
+    """
+
+    with tf.Session().as_default():
+        baselines_logger.configure(log_dir)
+
+        def policy_fn(name, ob_space, ac_space):
+            return MlpPolicy(
+                name=name,
+                ob_space=ob_space,
+                ac_space=ac_space,
+                hid_size=32,
+                num_hid_layers=2)
+
+        env = make_mujoco_env(env_id, seed)
+        trpo_mpi.learn(
+            env,
+            policy_fn,
+            timesteps_per_batch=1024,
+            max_kl=0.01,
+            cg_iters=10,
+            cg_damping=0.1,
+            max_timesteps=int(1e6),
+            gamma=0.99,
+            lam=0.98,
+            vf_iters=5,
+            vf_stepsize=1e-3)
+        env.close()
+
+    return osp.join(log_dir, "progress.csv")
+
+
+def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
+    """
+    Plot benchmark from csv files of garage and baselines.
+
+    :param b_csvs: A list contains all csv files in the task.
+    :param g_csvs: A list contains all csv files in the task.
+    :param g_x: X column names of garage csv.
+    :param g_y: Y column names of garage csv.
+    :param b_x: X column names of baselines csv.
+    :param b_y: Y column names of baselines csv.
+    :param trails: Number of trails in the task.
+    :param seeds: A list contains all the seeds in the task.
+    :param plt_file: Path of the plot png file.
+    :param env_id: String contains the id of the environment.
+    :return:
+    """
+    assert len(b_csvs) == len(g_csvs)
+    for trail in range(trails):
+        seed = seeds[trail]
+
+        df_g = pd.read_csv(g_csvs[trail])
+        df_b = pd.read_csv(b_csvs[trail])
+
+        plt.plot(
+            df_g[g_x],
+            df_g[g_y],
+            label="garage_trail%d_seed%d" % (trail + 1, seed))
+        plt.plot(
+            df_b[b_x],
+            df_b[b_y],
+            label="baselines_trail%d_seed%d" % (trail + 1, seed))
+
+    plt.legend()
+    plt.xlabel("Iteration")
+    plt.ylabel("AverageReturn")
+    plt.title(env_id)
+
+    plt.savefig(plt_file)
+    plt.close()

--- a/tests/tf/algos/test_ppo.py
+++ b/tests/tf/algos/test_ppo.py
@@ -1,0 +1,45 @@
+"""
+This script creates a test that fails when garage.tf.algos.PPO performance is
+too low.
+"""
+import unittest
+
+import gym
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.tf.algos import PPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicy
+
+
+class TestTRPO(unittest.TestCase):
+    def test_trpo_pendulum(self):
+        """Test PPO with Pendulum environment."""
+        env = TfEnv(normalize(gym.make("Pendulum-v0")))
+        policy = GaussianMLPPolicy(
+            name="policy",
+            env_spec=env.spec,
+            hidden_sizes=(32, 32),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(hidden_sizes=(32, 32)),
+        )
+        algo = PPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=1024,
+            max_path_length=100,
+            n_itr=10,
+            discount=0.99,
+            gae_lambda=0.98,
+            policy_ent_coeff=0.0,
+            plot=False,
+        )
+        last_avg_ret = algo.train()
+        assert last_avg_ret > -400

--- a/tests/tf/algos/test_trpo.py
+++ b/tests/tf/algos/test_trpo.py
@@ -1,0 +1,45 @@
+"""
+This script creates a test that fails when garage.tf.algos.TRPO performance is
+too low.
+"""
+import unittest
+
+import gym
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.tf.algos import TRPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicy
+
+
+class TestTRPO(unittest.TestCase):
+    def test_trpo_pendulum(self):
+        """Test TRPO with Pendulum environment."""
+        env = TfEnv(normalize(gym.make("Pendulum-v0")))
+        policy = GaussianMLPPolicy(
+            name="policy",
+            env_spec=env.spec,
+            hidden_sizes=(32, 32),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(hidden_sizes=(32, 32)),
+        )
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=1024,
+            max_path_length=100,
+            n_itr=10,
+            discount=0.99,
+            gae_lambda=0.98,
+            policy_ent_coeff=0.0,
+            plot=False,
+        )
+        last_avg_ret = algo.train()
+        assert last_avg_ret > -400

--- a/tests/tf/misc/test_tensor_utils.py
+++ b/tests/tf/misc/test_tensor_utils.py
@@ -1,0 +1,37 @@
+"""
+This script creates a test that tests functions in garage.tf.misc.tensor_utils.
+"""
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.misc.tensor_utils import compute_adv
+
+
+class TestTensorUtil(unittest.TestCase):
+    def test_compute_adv(self):
+        """Tests compute_adv function in utils."""
+        discount = 1
+        gae_lambda = 1
+        max_len = 1
+        rewards = tf.placeholder(
+            dtype=tf.float32, name="reward", shape=[None, None])
+        baselines = tf.placeholder(
+            dtype=tf.float32, name="baseline", shape=[None, None])
+        adv = compute_adv(discount, gae_lambda, max_len, baselines, rewards)
+
+        # Set up inputs and outputs
+        rewards_val = np.ones(shape=[2, 1])
+        baselines_val = np.zeros(shape=[2, 1])
+        desired_val = np.array([1., 1.])
+
+        with tf.Session() as sess:
+            adv = sess.run(
+                adv,
+                feed_dict={
+                    rewards: rewards_val,
+                    baselines: baselines_val,
+                })
+
+        assert np.array_equal(adv, desired_val)


### PR DESCRIPTION
Add Proximal Policy Optimization algorithm into garage TensorFlow tree.
PPO can be inherited from NPO. The difference among PPO, NPO and TRPO is
the constraint of the surrogate objective. This commit rewrites the
current NPO in garage tf so that it can run in GPU.

The policy, baseline and optimizer that PPO needs are already
implemented in the primitives of garage.

The process_samples function in garage.samplers.BaseSampler only
produces dense trajectories for RNN implementation. But it is faster if
we always produce dense trajs and flatten them in GPU. This commit adds
a process_samples function in garage.tf.samplers.BatchSampler and make
it the default sampler for TF tree. The VectorizedSampler inherites it.

Also rewrites the TRPO in garage/tf since the NPO implementation has
changed.

Adds flatten functions into garage/tf/misc/tensor_urils.py.

Refer to: #113 