### PR TITLE
Remove enclosing scope

### DIFF
--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -13,7 +13,6 @@ from tensorboard.plugins.custom_scalar import metadata
 import tensorflow as tf
 
 from garage.misc.console import mkdir_p
-from garage.tf.misc.tensor_utils import enclosing_scope
 
 
 class TensorBoardOutput:
@@ -29,7 +28,6 @@ class TensorBoardOutput:
             'normal', 'gamma', 'poisson', 'uniform'
         ]
         self._feed = {}
-        self._name = "TensorBoardOutput/"
 
         self._default_step = 0
         self._writer = None
@@ -67,9 +65,9 @@ class TensorBoardOutput:
         self._dump_histogram(run_step)
         self._dump_tensors()
 
-    def record_histogram(self, key, val):
+    def record_histogram(self, key, val, name=None):
         if str(key) not in self._histogram_ds:
-            with enclosing_scope(self._name, "record_hist"):
+            with tf.name_scope(name, "record_hist"):
                 self._histogram_ds[str(key)] = tf.Variable(val)
             self._histogram_summary_op.append(
                 tf.summary.histogram(str(key), self._histogram_ds[str(key)]))
@@ -82,6 +80,7 @@ class TensorBoardOutput:
                                  histogram_type,
                                  key=None,
                                  shape=[1000],
+                                 name=None,
                                  **kwargs):
         '''
         distribution type and args:
@@ -99,7 +98,7 @@ class TensorBoardOutput:
 
         if str(key) not in self._histogram_ds:
             self._histogram_ds[str(key)] = self._get_histogram_var_by_type(
-                histogram_type, shape, **kwargs)
+                histogram_type, shape, name, **kwargs)
             self._histogram_summary_op.append(
                 tf.summary.histogram(
                     str(key), self._histogram_ds[str(key)][0]))
@@ -128,8 +127,12 @@ class TensorBoardOutput:
             self._scalars.value.add(
                 tag=key + '/' + str(idx).strip('()'), simple_value=float(v))
 
-    def _get_histogram_var_by_type(self, histogram_type, shape, **kwargs):
-        with enclosing_scope(self._name, "get_hist_{}".format(histogram_type)):
+    def _get_histogram_var_by_type(self,
+                                   histogram_type,
+                                   shape,
+                                   name=None,
+                                   **kwargs):
+        with tf.name_scope(name, "get_hist_{}".format(histogram_type)):
             if histogram_type == "normal":
                 # Make a normal distribution, with a shifting mean
                 mean = tf.Variable(kwargs['mean'])

--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -66,15 +66,16 @@ class TensorBoardOutput:
         self._dump_tensors()
 
     def record_histogram(self, key, val, name=None):
-        if str(key) not in self._histogram_ds:
-            with tf.name_scope(name, "record_hist"):
+        with tf.name_scope(name, "record_histogram"):
+            if str(key) not in self._histogram_ds:
                 self._histogram_ds[str(key)] = tf.Variable(val)
-            self._histogram_summary_op.append(
-                tf.summary.histogram(str(key), self._histogram_ds[str(key)]))
-            self._histogram_summary_op_merge = tf.summary.merge(
-                self._histogram_summary_op)
+                self._histogram_summary_op.append(
+                    tf.summary.histogram(
+                        str(key), self._histogram_ds[str(key)]))
+                self._histogram_summary_op_merge = tf.summary.merge(
+                    self._histogram_summary_op)
 
-        self._feed[self._histogram_ds[str(key)]] = val
+            self._feed[self._histogram_ds[str(key)]] = val
 
     def record_histogram_by_type(self,
                                  histogram_type,

--- a/garage/tf/algos/ddpg.py
+++ b/garage/tf/algos/ddpg.py
@@ -242,20 +242,21 @@ class DDPG(RLAlgorithm):
 
     def _initialize(self):
         with tf.name_scope(self.name, "DDPG"):
-            """Set up the actor, critic and target network."""
-            # Set up the actor and critic network
-            self.actor._build_net(trainable=True)
-            self.critic._build_net(trainable=True)
+            with tf.name_scope("setup_networks"):
+                """Set up the actor, critic and target network."""
+                # Set up the actor and critic network
+                self.actor._build_net(trainable=True)
+                self.critic._build_net(trainable=True)
 
-            # Create target actor and critic network
-            target_actor = copy(self.actor)
-            target_critic = copy(self.critic)
+                # Create target actor and critic network
+                target_actor = copy(self.actor)
+                target_critic = copy(self.critic)
 
-            # Set up the target network
-            target_actor.name = "TargetActor"
-            target_actor._build_net(trainable=False)
-            target_critic.name = "TargetCritic"
-            target_critic._build_net(trainable=False)
+                # Set up the target network
+                target_actor.name = "TargetActor"
+                target_actor._build_net(trainable=False)
+                target_critic.name = "TargetCritic"
+                target_critic._build_net(trainable=False)
 
             # Initialize replay buffer
             replay_buffer = ReplayBuffer(self.replay_buffer_size,

--- a/garage/tf/algos/ddpg.py
+++ b/garage/tf/algos/ddpg.py
@@ -283,10 +283,8 @@ class DDPG(RLAlgorithm):
             actions = tf.placeholder(
                 tf.float32, shape=(None, self.action_dim), name="input_action")
 
-        #obs = tf.identity(obs, "obs")
         # Set up actor training function
         next_action = self.actor.get_action_sym(obs, name="actor_action")
-        #next_action = tf.identity(next_action, "next_action")
         next_qval = self.critic.get_qval_sym(
             obs, next_action, name="actor_qval")
         with tf.name_scope("action_loss"):

--- a/garage/tf/algos/vpg.py
+++ b/garage/tf/algos/vpg.py
@@ -90,10 +90,6 @@ class VPG(BatchPolopt, Serializable):
                                                        state_info_vars)
             logli = dist.log_likelihood_sym(action_var, dist_info_vars)
             kl = dist.kl_sym(old_dist_info_vars, dist_info_vars)
-            surr_obj_scope = tf.name_scope(
-                "surr_obj", values=[logli, advantage_var, valid_var])
-            mean_kl_scope = tf.name_scope("mean_kl", values=[kl, valid_var])
-            max_kl_scope = tf.name_scope("max_kl", values=[kl, valid_var])
 
             # formulate as a minimization problem
             # The gradient of the surrogate objective is the policy gradient
@@ -115,7 +111,7 @@ class VPG(BatchPolopt, Serializable):
                     mean_kl = tf.reduce_mean(kl)
                 tf.identity(mean_kl, name="mean_kl")
 
-            with tf.name_scope("mean_kl", values=[kl, valid_var]):
+            with tf.name_scope("max_kl", values=[kl, valid_var]):
                 if is_recurrent:
                     max_kl = tf.reduce_max(kl * valid_var)
                 else:

--- a/garage/tf/algos/vpg.py
+++ b/garage/tf/algos/vpg.py
@@ -19,119 +19,122 @@ class VPG(BatchPolopt, Serializable):
                  baseline,
                  optimizer=None,
                  optimizer_args=None,
-                 name="VPG",
+                 name=None,
                  **kwargs):
         Serializable.quick_init(self, locals())
-        with tf.name_scope(name):
-            if optimizer is None:
-                default_args = dict(
-                    batch_size=None,
-                    max_epochs=1,
-                )
-                if optimizer_args is None:
-                    optimizer_args = default_args
-                else:
-                    optimizer_args = dict(default_args, **optimizer_args)
-                optimizer = FirstOrderOptimizer(**optimizer_args)
-            self.optimizer = optimizer
-            self.opt_info = None
-            self.name = name
-            super(VPG, self).__init__(
-                env=env, policy=policy, baseline=baseline, **kwargs)
+        if optimizer is None:
+            default_args = dict(
+                batch_size=None,
+                max_epochs=1,
+            )
+            if optimizer_args is None:
+                optimizer_args = default_args
+            else:
+                optimizer_args = dict(default_args, **optimizer_args)
+            optimizer = FirstOrderOptimizer(**optimizer_args)
+        self.optimizer = optimizer
+        self.opt_info = None
+        self.name = name
+        super(VPG, self).__init__(
+            env=env, policy=policy, baseline=baseline, **kwargs)
 
     @overrides
     def init_opt(self):
-        is_recurrent = int(self.policy.recurrent)
-        with tf.name_scope("inputs"):
-            obs_var = self.env.observation_space.new_tensor_variable(
-                'obs',
-                extra_dims=1 + is_recurrent,
-            )
-            action_var = self.env.action_space.new_tensor_variable(
-                'action',
-                extra_dims=1 + is_recurrent,
-            )
-            advantage_var = tensor_utils.new_tensor(
-                name='advantage',
-                ndim=1 + is_recurrent,
-                dtype=tf.float32,
-            )
-            dist = self.policy.distribution
+        with tf.name_scope(self.name, "VPG"):
+            is_recurrent = int(self.policy.recurrent)
+            with tf.name_scope("inputs"):
+                obs_var = self.env.observation_space.new_tensor_variable(
+                    'obs',
+                    extra_dims=1 + is_recurrent,
+                )
+                action_var = self.env.action_space.new_tensor_variable(
+                    'action',
+                    extra_dims=1 + is_recurrent,
+                )
+                advantage_var = tensor_utils.new_tensor(
+                    name='advantage',
+                    ndim=1 + is_recurrent,
+                    dtype=tf.float32,
+                )
+                dist = self.policy.distribution
 
-            old_dist_info_vars = {
-                k: tf.placeholder(
-                    tf.float32,
-                    shape=[None] * (1 + is_recurrent) + list(shape),
-                    name='old_%s' % k)
-                for k, shape in dist.dist_info_specs
-            }
-            old_dist_info_vars_list = [
-                old_dist_info_vars[k] for k in dist.dist_info_keys
-            ]
+                old_dist_info_vars = {
+                    k: tf.placeholder(
+                        tf.float32,
+                        shape=[None] * (1 + is_recurrent) + list(shape),
+                        name='old_%s' % k)
+                    for k, shape in dist.dist_info_specs
+                }
+                old_dist_info_vars_list = [
+                    old_dist_info_vars[k] for k in dist.dist_info_keys
+                ]
 
-            state_info_vars = {
-                k: tf.placeholder(
-                    tf.float32,
-                    shape=[None] * (1 + is_recurrent) + list(shape),
-                    name=k)
-                for k, shape in self.policy.state_info_specs
-            }
-            state_info_vars_list = [
-                state_info_vars[k] for k in self.policy.state_info_keys
-            ]
+                state_info_vars = {
+                    k: tf.placeholder(
+                        tf.float32,
+                        shape=[None] * (1 + is_recurrent) + list(shape),
+                        name=k)
+                    for k, shape in self.policy.state_info_specs
+                }
+                state_info_vars_list = [
+                    state_info_vars[k] for k in self.policy.state_info_keys
+                ]
 
+                if is_recurrent:
+                    valid_var = tf.placeholder(
+                        tf.float32, shape=[None, None], name="valid")
+                else:
+                    valid_var = None
+
+            dist_info_vars = self.policy.dist_info_sym(obs_var,
+                                                       state_info_vars)
+            logli = dist.log_likelihood_sym(action_var, dist_info_vars)
+            kl = dist.kl_sym(old_dist_info_vars, dist_info_vars)
+            surr_obj_scope = tf.name_scope(
+                "surr_obj", values=[logli, advantage_var, valid_var])
+            mean_kl_scope = tf.name_scope("mean_kl", values=[kl, valid_var])
+            max_kl_scope = tf.name_scope("max_kl", values=[kl, valid_var])
+
+            # formulate as a minimization problem
+            # The gradient of the surrogate objective is the policy gradient
+            with tf.name_scope(
+                    "surr_obj", values=[logli, advantage_var, valid_var]):
+                if is_recurrent:
+                    surr_obj = (
+                        -tf.reduce_sum(logli * advantage_var * valid_var) /
+                        tf.reduce_sum(valid_var))
+                else:
+                    surr_obj = -tf.reduce_mean(logli * advantage_var)
+                tf.identity(surr_obj, name="surr_obj")
+
+            with tf.name_scope("mean_kl", values=[kl, valid_var]):
+                if is_recurrent:
+                    mean_kl = tf.reduce_sum(
+                        kl * valid_var) / tf.reduce_sum(valid_var)
+                else:
+                    mean_kl = tf.reduce_mean(kl)
+                tf.identity(mean_kl, name="mean_kl")
+
+            with tf.name_scope("mean_kl", values=[kl, valid_var]):
+                if is_recurrent:
+                    max_kl = tf.reduce_max(kl * valid_var)
+                else:
+                    max_kl = tf.reduce_max(kl)
+                tf.identity(max_kl, name="max_kl")
+
+            input_list = [obs_var, action_var, advantage_var
+                          ] + state_info_vars_list
             if is_recurrent:
-                valid_var = tf.placeholder(
-                    tf.float32, shape=[None, None], name="valid")
-            else:
-                valid_var = None
+                input_list.append(valid_var)
 
-        dist_info_vars = self.policy.dist_info_sym(obs_var, state_info_vars)
-        logli = dist.log_likelihood_sym(action_var, dist_info_vars)
-        kl = dist.kl_sym(old_dist_info_vars, dist_info_vars)
-        surr_obj_scope = tf.name_scope(
-            "surr_obj", values=[logli, advantage_var, valid_var])
-        mean_kl_scope = tf.name_scope("mean_kl", values=[kl, valid_var])
-        max_kl_scope = tf.name_scope("max_kl", values=[kl, valid_var])
+            self.optimizer.update_opt(
+                loss=surr_obj, target=self.policy, inputs=input_list)
 
-        # formulate as a minimization problem
-        # The gradient of the surrogate objective is the policy gradient
-        if is_recurrent:
-            with surr_obj_scope:
-                surr_obj = -tf.reduce_sum(logli * advantage_var *
-                                          valid_var) / tf.reduce_sum(valid_var)
-                tf.identity(surr_obj, name="surr_obj")
-            with mean_kl_scope:
-                mean_kl = tf.reduce_sum(
-                    kl * valid_var) / tf.reduce_sum(valid_var)
-                tf.identity(mean_kl, name="mean_kl")
-            with max_kl_scope:
-                max_kl = tf.reduce_max(kl * valid_var)
-                tf.identity(max_kl, name="max_kl")
-        else:
-            with surr_obj_scope:
-                surr_obj = -tf.reduce_mean(logli * advantage_var)
-                tf.identity(surr_obj, name="surr_obj")
-            with mean_kl_scope:
-                mean_kl = tf.reduce_mean(kl)
-                tf.identity(mean_kl, name="mean_kl")
-            with max_kl_scope:
-                max_kl = tf.reduce_max(kl)
-                tf.identity(max_kl, name="max_kl")
-
-        input_list = [obs_var, action_var, advantage_var
-                      ] + state_info_vars_list
-        if is_recurrent:
-            input_list.append(valid_var)
-
-        self.optimizer.update_opt(
-            loss=surr_obj, target=self.policy, inputs=input_list)
-
-        f_kl = tensor_utils.compile_function(
-            inputs=input_list + old_dist_info_vars_list,
-            outputs=[mean_kl, max_kl],
-        )
-        self.opt_info = dict(f_kl=f_kl, )
+            f_kl = tensor_utils.compile_function(
+                inputs=input_list + old_dist_info_vars_list,
+                outputs=[mean_kl, max_kl],
+            )
+            self.opt_info = dict(f_kl=f_kl, )
 
     @overrides
     def optimize_policy(self, itr, samples_data):

--- a/garage/tf/core/layers.py
+++ b/garage/tf/core/layers.py
@@ -29,7 +29,10 @@ def create_param(spec, shape, name, trainable=True, regularizable=True):
         regularizer = None
     else:
         # do not regularize this variable
-        regularizer = lambda _: tf.constant(0.)
+        def f(_):
+            return tf.constant(0.)
+
+        regularizer = f
     return tf.get_variable(
         name=name,
         shape=shape,
@@ -39,21 +42,21 @@ def create_param(spec, shape, name, trainable=True, regularizable=True):
         dtype=tf.float32)
 
 
-def as_tuple(x, N, t=None):
+def as_tuple(x, n, t=None):
     try:
-        X = tuple(x)
+        x = tuple(x)
     except TypeError:
-        X = (x, ) * N
+        x = (x, ) * n
 
-    if (t is not None) and not all(isinstance(v, t) for v in X):
+    if (t is not None) and not all(isinstance(v, t) for v in x):
         raise TypeError("expected a single value or an iterable "
                         "of {0}, got {1} instead".format(t.__name__, x))
 
-    if len(X) != N:
+    if len(x) != n:
         raise ValueError("expected a single value or an iterable "
-                         "with length {0}, got {1} instead".format(N, x))
+                         "with length {0}, got {1} instead".format(n, x))
 
-    return X
+    return x
 
 
 def conv_output_length(input_length, filter_size, stride, pad=0):
@@ -136,6 +139,8 @@ class Layer(object):
         self.name = name
         self.variable_reuse = variable_reuse
         self.get_output_kwargs = []
+        self.variable_scope = tf.variable_scope(
+            name, reuse=self.variable_reuse)
 
         if any(d is not None and d <= 0 for d in self.input_shape):
             raise ValueError(
@@ -161,7 +166,7 @@ class Layer(object):
         raise NotImplementedError
 
     def add_param_plain(self, spec, shape, name, **tags):
-        with tf.variable_scope(self.name, reuse=self.variable_reuse):
+        with self.variable_scope:
             tags['trainable'] = tags.get('trainable', True)
             tags['regularizable'] = tags.get('regularizable', True)
             param = create_param(spec, shape, name, **tags)
@@ -216,11 +221,7 @@ class InputLayer(Layer):
         super(InputLayer, self).__init__(shape, **kwargs)
         self.shape = shape
         if input_var is None:
-            if self.name is not None:
-                with tf.variable_scope(self.name):
-                    input_var = tf.placeholder(
-                        tf.float32, shape=shape, name="input")
-            else:
+            with tf.variable_scope(self.name):
                 input_var = tf.placeholder(
                     tf.float32, shape=shape, name="input")
         self.input_var = input_var
@@ -240,6 +241,9 @@ class MergeLayer(Layer):
             None if isinstance(incoming, tuple) else incoming
             for incoming in incomings
         ]
+        if name is None:
+            name = "%s_%d" % (type(self).__name__, G._n_layers)
+            G._n_layers += 1
         self.name = name
         self.params = OrderedDict()
         self.get_output_kwargs = []
@@ -303,19 +307,21 @@ class ConcatLayer(MergeLayer):
         return tuple(output_shape)
 
     def get_output_for(self, inputs, **kwargs):
-        dtypes = [x.dtype.as_numpy_dtype for x in inputs]
-        if len(set(dtypes)) > 1:
-            # need to convert to common data type
-            common_dtype = np.core.numerictypes.find_common_type([], dtypes)
-            inputs = [tf.cast(x, common_dtype) for x in inputs]
-        return tf.concat(axis=self.axis, values=inputs)
+        with tf.name_scope(self.name, values=[inputs]):
+            dtypes = [x.dtype.as_numpy_dtype for x in inputs]
+            if len(set(dtypes)) > 1:
+                # need to convert to common data type
+                common_dtype = np.core.numerictypes.find_common_type([],
+                                                                     dtypes)
+                inputs = [tf.cast(x, common_dtype) for x in inputs]
+            return tf.concat(axis=self.axis, values=inputs)
 
 
 concat = ConcatLayer  # shortcut
 
 
 class XavierUniformInitializer(object):
-    def __call__(self, shape, dtype=tf.float32, *args, **kwargs):
+    def __call__(self, shape, dtype=tf.float32, name=None, *args, **kwargs):
         if len(shape) == 2:
             n_inputs, n_outputs = shape
         else:
@@ -323,20 +329,22 @@ class XavierUniformInitializer(object):
             n_inputs = shape[-2] * receptive_field_size
             n_outputs = shape[-1] * receptive_field_size
         init_range = math.sqrt(6.0 / (n_inputs + n_outputs))
-        return tf.random_uniform_initializer(
-            -init_range, init_range, dtype=dtype)(shape)
+        with tf.name_scope(name, "XavierUniformInitializer"):
+            return tf.random_uniform_initializer(
+                -init_range, init_range, dtype=dtype)(shape)
 
 
 class HeUniformInitializer(object):
-    def __call__(self, shape, dtype=tf.float32, *args, **kwargs):
+    def __call__(self, shape, dtype=tf.float32, name=None, *args, **kwargs):
         if len(shape) == 2:
             n_inputs, _ = shape
         else:
             receptive_field_size = np.prod(shape[:2])
             n_inputs = shape[-2] * receptive_field_size
         init_range = math.sqrt(1.0 / n_inputs)
-        return tf.random_uniform_initializer(
-            -init_range, init_range, dtype=dtype)(shape)
+        with tf.name_scope(name, "HeUniformInitializer"):
+            return tf.random_uniform_initializer(
+                -init_range, init_range, dtype=dtype)(shape)
 
 
 def py_ortho_init(scale):
@@ -373,12 +381,14 @@ class ParamLayer(Layer):
         return input_shape[:-1] + (self.num_units, )
 
     def get_output_for(self, input, **kwargs):
-        ndim = input.get_shape().ndims
-        reshaped_param = tf.reshape(self.param,
-                                    (1, ) * (ndim - 1) + (self.num_units, ))
-        tile_arg = tf.concat(axis=0, values=[tf.shape(input)[:ndim - 1], [1]])
-        tiled = tf.tile(reshaped_param, tile_arg)
-        return tiled
+        with tf.name_scope(self.name, values=[input]):
+            ndim = input.get_shape().ndims
+            reshaped_param = tf.reshape(
+                self.param, (1, ) * (ndim - 1) + (self.num_units, ))
+            tile_arg = tf.concat(
+                axis=0, values=[tf.shape(input)[:ndim - 1], [1]])
+            tiled = tf.tile(reshaped_param, tile_arg)
+            return tiled
 
 
 class OpLayer(MergeLayer):
@@ -400,7 +410,8 @@ class OpLayer(MergeLayer):
         return self.shape_op(*input_shapes)
 
     def get_output_for(self, inputs, **kwargs):
-        return self.op(*inputs)
+        with tf.name_scope(self.name, values=[inputs]):
+            return self.op(*inputs)
 
 
 class DenseLayer(Layer):
@@ -408,7 +419,7 @@ class DenseLayer(Layer):
                  incoming,
                  num_units,
                  nonlinearity=None,
-                 W=XavierUniformInitializer(),
+                 w=XavierUniformInitializer(),
                  b=tf.zeros_initializer(),
                  **kwargs):
         super(DenseLayer, self).__init__(incoming, **kwargs)
@@ -421,7 +432,7 @@ class DenseLayer(Layer):
 
         num_inputs = int(np.prod(self.input_shape[1:]))
 
-        self.W = self.add_param(W, (num_inputs, num_units), name="W")
+        self.w = self.add_param(w, (num_inputs, num_units), name="W")
         if b is None:
             self.b = None
         else:
@@ -432,14 +443,15 @@ class DenseLayer(Layer):
         return (input_shape[0], self.num_units)
 
     def get_output_for(self, input, **kwargs):
-        if input.get_shape().ndims > 2:
-            # if the input has more than two dimensions, flatten it into a
-            # batch of feature vectors.
-            input = tf.reshape(input, tf.stack([tf.shape(input)[0], -1]))
-        activation = tf.matmul(input, self.W)
-        if self.b is not None:
-            activation = activation + tf.expand_dims(self.b, 0)
-        return self.nonlinearity(activation)
+        with tf.name_scope(self.name, values=[input]):
+            if input.get_shape().ndims > 2:
+                # if the input has more than two dimensions, flatten it into a
+                # batch of feature vectors.
+                input = tf.reshape(input, tf.stack([tf.shape(input)[0], -1]))
+            activation = tf.matmul(input, self.w)
+            if self.b is not None:
+                activation = activation + tf.expand_dims(self.b, 0)
+            return self.nonlinearity(activation)
 
 
 class BaseConvLayer(Layer):
@@ -450,7 +462,7 @@ class BaseConvLayer(Layer):
                  stride=1,
                  pad="VALID",
                  untie_biases=False,
-                 W=XavierUniformInitializer(),
+                 w=XavierUniformInitializer(),
                  b=tf.zeros_initializer(),
                  nonlinearity=tf.nn.relu,
                  n=None,
@@ -484,7 +496,7 @@ class BaseConvLayer(Layer):
                 raise NotImplementedError(
                     '`same` padding requires odd filter size.')
 
-        self.W = self.add_param(W, self.get_W_shape(), name="W")
+        self.w = self.add_param(w, self.get_w_shape(), name="W")
         if b is None:
             self.b = None
         else:
@@ -496,7 +508,7 @@ class BaseConvLayer(Layer):
             self.b = self.add_param(
                 b, biases_shape, name="b", regularizable=False)
 
-    def get_W_shape(self):
+    def get_w_shape(self):
         """Get the shape of the weight matrix `W`.
         Returns
         -------
@@ -528,22 +540,23 @@ class BaseConvLayer(Layer):
                     self.num_filters, )
 
     def get_output_for(self, input, **kwargs):
-        conved = self.convolve(input, **kwargs)
+        with tf.name_scope(self.name, values=[input]):
+            conved = self.convolve(input, **kwargs)
 
-        if self.b is None:
-            activation = conved
-        elif self.untie_biases:
-            # raise NotImplementedError
-            activation = conved + tf.expand_dims(self.b, 0)
-        else:
-            activation = conved + tf.reshape(self.b,
-                                             (1, 1, 1, self.num_filters))
+            if self.b is None:
+                activation = conved
+            elif self.untie_biases:
+                # raise NotImplementedError
+                activation = conved + tf.expand_dims(self.b, 0)
+            else:
+                activation = conved + tf.reshape(self.b,
+                                                 (1, 1, 1, self.num_filters))
 
-        return self.nonlinearity(activation)
+            return self.nonlinearity(activation)
 
-    def convolve(self, input, **kwargs):
+    def convolve(self, input, name=None, **kwargs):
         """
-        Symbolically convolves `input` with ``self.W``, producing an output of
+        Symbolically convolves `input` with ``self.w``, producing an output of
         shape ``self.output_shape``. To be implemented by subclasses.
         Parameters
         ----------
@@ -570,7 +583,7 @@ class Conv2DLayer(BaseConvLayer):
                  stride=(1, 1),
                  pad="VALID",
                  untie_biases=False,
-                 W=XavierUniformInitializer(),
+                 w=XavierUniformInitializer(),
                  b=tf.zeros_initializer(),
                  nonlinearity=tf.nn.relu,
                  convolution=tf.nn.conv2d,
@@ -582,20 +595,21 @@ class Conv2DLayer(BaseConvLayer):
             stride=stride,
             pad=pad,
             untie_biases=untie_biases,
-            W=W,
+            w=w,
             b=b,
             nonlinearity=nonlinearity,
             n=2,
             **kwargs)
         self.convolution = convolution
 
-    def convolve(self, input, **kwargs):
-        conved = self.convolution(
-            input,
-            self.W,
-            strides=(1, ) + self.stride + (1, ),
-            padding=self.pad)
-        return conved
+    def convolve(self, input, name=None, **kwargs):
+        with tf.name_scope(name, "convolve", values=[input]):
+            conved = self.convolution(
+                input,
+                self.w,
+                strides=(1, ) + self.stride + (1, ),
+                padding=self.pad)
+            return conved
 
 
 def pool_output_length(input_length, pool_size, stride, pad):
@@ -655,14 +669,15 @@ class Pool2DLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        assert self.mode == "max"
-        pooled = tf.nn.max_pool(
-            input,
-            ksize=(1, ) + self.pool_size + (1, ),
-            strides=(1, ) + self.stride + (1, ),
-            padding=self.pad,
-        )
-        return pooled
+        with tf.name_scope(self.name, values=[input]):
+            assert self.mode == "max"
+            pooled = tf.nn.max_pool(
+                input,
+                ksize=(1, ) + self.pool_size + (1, ),
+                strides=(1, ) + self.stride + (1, ),
+                padding=self.pad,
+            )
+            return pooled
 
 
 def spatial_expected_softmax(x, temp=1):
@@ -698,7 +713,8 @@ class SpatialExpectedSoftmaxLayer(Layer):
         return (input_shape[0], input_shape[-1] * 2)
 
     def get_output_for(self, input, **kwargs):
-        return spatial_expected_softmax(input)  #, self.temp)
+        with tf.name_scope(self.name, values=[input]):
+            return spatial_expected_softmax(input)  # , self.temp)
         # max_ = tf.reduce_max(input, reduction_indices=[1, 2], keep_dims=True)
         # exp = tf.exp(input - max_) + 1e-5
 
@@ -752,18 +768,19 @@ class DropoutLayer(Layer):
         deterministic : bool
             If true dropout and scaling is disabled, see notes
         """
-        if deterministic or self.p == 0:
-            return input
-        else:
-            # Using theano constant to prevent upcasting
-            # one = T.constant(1)
+        with tf.name_scope(self.name, values=[input]):
+            if deterministic or self.p == 0:
+                return input
+            else:
+                # Using theano constant to prevent upcasting
+                # one = T.constant(1)
 
-            retain_prob = 1. - self.p
-            if self.rescale:
-                input /= retain_prob
+                retain_prob = 1. - self.p
+                if self.rescale:
+                    input /= retain_prob
 
-            # use nonsymbolic shape for dropout mask if possible
-            return tf.nn.dropout(input, keep_prob=retain_prob)
+                # use nonsymbolic shape for dropout mask if possible
+                return tf.nn.dropout(input, keep_prob=retain_prob)
 
     def get_output_shape_for(self, input_shape):
         return input_shape
@@ -806,12 +823,14 @@ class FlattenLayer(Layer):
         return input_shape[:self.outdim - 1] + (flattened, )
 
     def get_output_for(self, input, **kwargs):
-        # total_entries = tf.reduce_prod(tf.shape(input))
-        pre_shape = tf.shape(input)[:self.outdim - 1]
-        to_flatten = tf.reduce_prod(tf.shape(input)[self.outdim - 1:])
-        return tf.reshape(
-            input, tf.concat(
-                axis=0, values=[pre_shape, tf.stack([to_flatten])]))
+        with tf.name_scope(self.name, values=[input]):
+            # total_entries = tf.reduce_prod(tf.shape(input))
+            pre_shape = tf.shape(input)[:self.outdim - 1]
+            to_flatten = tf.reduce_prod(tf.shape(input)[self.outdim - 1:])
+            return tf.reshape(
+                input,
+                tf.concat(axis=0, values=[pre_shape,
+                                          tf.stack([to_flatten])]))
 
 
 flatten = FlattenLayer  # shortcut
@@ -833,8 +852,8 @@ class ReshapeLayer(Layer):
                 raise NotImplementedError
                 # if s.ndim != 0:
                 #     raise ValueError(
-                #         "A symbolic variable in a shape specification must be "
-                #         "a scalar, but had %i dimensions" % s.ndim)
+                #         "A symbolic variable in a shape specification must "
+                #         "be a scalar, but had %i dimensions" % s.ndim)
             else:
                 raise ValueError("`shape` must be a tuple of int and/or [int]")
         if sum(s == -1 for s in shape) > 1:
@@ -898,13 +917,14 @@ class ReshapeLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        # Replace all `[i]` with the corresponding input dimension
-        output_shape = list(self.shape)
-        for dim, o in enumerate(output_shape):
-            if isinstance(o, list):
-                output_shape[dim] = tf.shape(input)[o[0]]
-        # Everything else is handled by Theano
-        return tf.reshape(input, tf.stack(output_shape))
+        with tf.name_scope(self.name, values=[input]):
+            # Replace all `[i]` with the corresponding input dimension
+            output_shape = list(self.shape)
+            for dim, o in enumerate(output_shape):
+                if isinstance(o, list):
+                    output_shape[dim] = tf.shape(input)[o[0]]
+            # Everything else is handled by Theano
+            return tf.reshape(input, tf.stack(output_shape))
 
 
 reshape = ReshapeLayer  # shortcut
@@ -928,18 +948,19 @@ class SliceLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        axis = self.axis
-        ndims = input.get_shape().ndims
-        if axis < 0:
-            axis += ndims
-        if isinstance(self.slice, int) and self.slice < 0:
-            return tf.reverse(
-                input,
-                [self.axis + 1])[(slice(None), ) * axis + (-1 - self.slice, ) +
-                                 (slice(None), ) * (ndims - axis - 1)]
-        # import ipdb; ipdb.set_trace()
-        return input[(slice(None), ) * axis + (self.slice, ) +
-                     (slice(None), ) * (ndims - axis - 1)]
+        with tf.name_scope(self.name, values=[input]):
+            axis = self.axis
+            ndims = input.get_shape().ndims
+            if axis < 0:
+                axis += ndims
+            if isinstance(self.slice, int) and self.slice < 0:
+                return tf.reverse(
+                    input, [self.axis + 1
+                            ])[(slice(None), ) * axis + (-1 - self.slice, ) +
+                               (slice(None), ) * (ndims - axis - 1)]
+            # import ipdb; ipdb.set_trace()
+            return input[(slice(None), ) * axis + (self.slice, ) +
+                         (slice(None), ) * (ndims - axis - 1)]
 
 
 class DimshuffleLayer(Layer):
@@ -997,36 +1018,39 @@ class DimshuffleLayer(Layer):
         return tuple(output_shape)
 
     def get_output_for(self, input, **kwargs):
-        return tf.transpose(input, self.pattern)
+        with tf.name_scope(self.name, values=[input]):
+            return tf.transpose(input, self.pattern)
 
 
 dimshuffle = DimshuffleLayer  # shortcut
 
 
 def apply_ln(layer):
-    def _normalize(x, prefix):
-        EPS = 1e-5
-        dim = x.get_shape()[-1].value
+    with tf.name_scope("apply_ln"):
 
-        bias_name = prefix + "_ln/bias"
-        scale_name = prefix + "_ln/scale"
+        def _normalize(x, prefix):
+            eps = 1e-5
+            dim = x.get_shape()[-1].value
 
-        if bias_name not in layer.norm_params:
-            layer.norm_params[bias_name] = layer.add_param(
-                tf.zeros_initializer(), (dim, ),
-                name=bias_name,
-                regularizable=False)
-        if scale_name not in layer.norm_params:
-            layer.norm_params[scale_name] = layer.add_param(
-                tf.ones_initializer(), (dim, ), name=scale_name)
+            bias_name = prefix + "_ln/bias"
+            scale_name = prefix + "_ln/scale"
 
-        bias = layer.norm_params[bias_name]
-        scale = layer.norm_params[scale_name]
-        mean, var = tf.nn.moments(x, axes=[1], keep_dims=True)
-        x_normed = (x - mean) / tf.sqrt(var + EPS)
-        return x_normed * scale + bias
+            if bias_name not in layer.norm_params:
+                layer.norm_params[bias_name] = layer.add_param(
+                    tf.zeros_initializer(), (dim, ),
+                    name=bias_name,
+                    regularizable=False)
+            if scale_name not in layer.norm_params:
+                layer.norm_params[scale_name] = layer.add_param(
+                    tf.ones_initializer(), (dim, ), name=scale_name)
 
-    return _normalize
+            bias = layer.norm_params[bias_name]
+            scale = layer.norm_params[scale_name]
+            mean, var = tf.nn.moments(x, axes=[1], keep_dims=True)
+            x_normed = (x - mean) / tf.sqrt(var + eps)
+            return x_normed * scale + bias
+
+        return _normalize
 
 
 class GRULayer(Layer):
@@ -1036,7 +1060,8 @@ class GRULayer(Layer):
     Update gate:       u(t) = f_u(x(t) @ W_xu + h(t-1) @ W_hu + b_u)
     Cell gate:         c(t) = f_c(x(t) @ W_xc + r(t) * (h(t-1) @ W_hc) + b_c)
     New hidden state:  h(t) = (1 - u(t)) * h(t-1) + u_t * c(t)
-    Note that the reset, update, and cell vectors must have the same dimension as the hidden state
+    Note that the reset, update, and cell vectors must have the same dimension
+    as the hidden state
     """
 
     def __init__(self,
@@ -1044,8 +1069,8 @@ class GRULayer(Layer):
                  num_units,
                  hidden_nonlinearity,
                  gate_nonlinearity=tf.nn.sigmoid,
-                 W_x_init=XavierUniformInitializer(),
-                 W_h_init=OrthogonalInitializer(),
+                 w_x_init=XavierUniformInitializer(),
+                 w_h_init=OrthogonalInitializer(),
                  b_init=tf.zeros_initializer(),
                  hidden_init=tf.zeros_initializer(),
                  hidden_init_trainable=False,
@@ -1060,86 +1085,97 @@ class GRULayer(Layer):
 
         super(GRULayer, self).__init__(incoming, **kwargs)
 
-        input_shape = self.input_shape[2:]
+        with tf.variable_scope("gru_layer_step"):
+            input_shape = self.input_shape[2:]
 
-        input_dim = np.prod(input_shape)
+            input_dim = np.prod(input_shape)
 
-        self.layer_normalization = layer_normalization
+            self.layer_normalization = layer_normalization
 
-        # Weights for the initial hidden state
-        self.h0 = self.add_param(
-            hidden_init, (num_units, ),
-            name="h0",
-            trainable=hidden_init_trainable,
-            regularizable=False)
-        # Weights for the reset gate
-        self.W_xr = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xr")
-        self.W_hr = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hr")
-        self.b_r = self.add_param(
-            b_init, (num_units, ), name="b_r", regularizable=False)
-        # Weights for the update gate
-        self.W_xu = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xu")
-        self.W_hu = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hu")
-        self.b_u = self.add_param(
-            b_init, (num_units, ), name="b_u", regularizable=False)
-        # Weights for the cell gate
-        self.W_xc = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xc")
-        self.W_hc = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hc")
-        self.b_c = self.add_param(
-            b_init, (num_units, ), name="b_c", regularizable=False)
+            # Weights for the initial hidden state
+            self.h0 = self.add_param(
+                hidden_init, (num_units, ),
+                name="h0",
+                trainable=hidden_init_trainable,
+                regularizable=False)
+            # Weights for the reset gate
+            self.W_xr = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xr")
+            self.W_hr = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hr")
+            self.b_r = self.add_param(
+                b_init, (num_units, ), name="b_r", regularizable=False)
+            # Weights for the update gate
+            self.W_xu = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xu")
+            self.W_hu = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hu")
+            self.b_u = self.add_param(
+                b_init, (num_units, ), name="b_u", regularizable=False)
+            # Weights for the cell gate
+            self.W_xc = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xc")
+            self.W_hc = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hc")
+            self.b_c = self.add_param(
+                b_init, (num_units, ), name="b_c", regularizable=False)
 
-        self.W_x_ruc = tf.concat(
-            axis=1, values=[self.W_xr, self.W_xu, self.W_xc])
-        self.W_h_ruc = tf.concat(
-            axis=1, values=[self.W_hr, self.W_hu, self.W_hc])
-        self.W_x_ru = tf.concat(axis=1, values=[self.W_xr, self.W_xu])
-        self.W_h_ru = tf.concat(axis=1, values=[self.W_hr, self.W_hu])
-        self.b_ruc = tf.concat(axis=0, values=[self.b_r, self.b_u, self.b_c])
+            self.W_x_ruc = tf.concat(
+                axis=1,
+                values=[self.W_xr, self.W_xu, self.W_xc],
+                name="W_x_ruc")
+            self.W_h_ruc = tf.concat(
+                axis=1,
+                values=[self.W_hr, self.W_hu, self.W_hc],
+                name="W_h_ruc")
+            self.W_x_ru = tf.concat(
+                axis=1, values=[self.W_xr, self.W_xu], name="W_x_ru")
+            self.W_h_ru = tf.concat(
+                axis=1, values=[self.W_hr, self.W_hu], name="W_h_ru")
+            self.b_ruc = tf.concat(
+                axis=0, values=[self.b_r, self.b_u, self.b_c], name="b_ruc")
 
-        self.gate_nonlinearity = gate_nonlinearity
-        self.num_units = num_units
-        self.nonlinearity = hidden_nonlinearity
-        self.norm_params = dict()
+            self.gate_nonlinearity = gate_nonlinearity
+            self.num_units = num_units
+            self.nonlinearity = hidden_nonlinearity
+            self.norm_params = dict()
 
-        # pre-run the step method to initialize the normalization parameters
-        h_dummy = tf.placeholder(
-            dtype=tf.float32, shape=(None, num_units), name="h_dummy")
-        x_dummy = tf.placeholder(
-            dtype=tf.float32, shape=(None, input_dim), name="x_dummy")
-        self.step(h_dummy, x_dummy)
+            # pre-run the step method to initialize the normalization
+            # parameters
+            h_dummy = tf.placeholder(
+                dtype=tf.float32, shape=(None, num_units), name="h_dummy")
+            x_dummy = tf.placeholder(
+                dtype=tf.float32, shape=(None, input_dim), name="x_dummy")
+            self.step(h_dummy, x_dummy)
 
-    def step(self, hprev, x):
-        if self.layer_normalization:
-            ln = apply_ln(self)
-            x_ru = ln(tf.matmul(x, self.W_x_ru), "x_ru")
-            h_ru = ln(tf.matmul(hprev, self.W_h_ru), "h_ru")
-            x_r, x_u = tf.split(axis=1, num_or_size_splits=2, value=x_ru)
-            h_r, h_u = tf.split(axis=1, num_or_size_splits=2, value=h_ru)
-            x_c = ln(tf.matmul(x, self.W_xc), "x_c")
-            h_c = ln(tf.matmul(hprev, self.W_hc), "h_c")
-            r = self.gate_nonlinearity(x_r + h_r)
-            u = self.gate_nonlinearity(x_u + h_u)
-            c = self.nonlinearity(x_c + r * h_c)
-            h = (1 - u) * hprev + u * c
-            return h
-        else:
-            xb_ruc = tf.matmul(x, self.W_x_ruc) + tf.reshape(
-                self.b_ruc, (1, -1))
-            h_ruc = tf.matmul(hprev, self.W_h_ruc)
-            xb_r, xb_u, xb_c = tf.split(
-                axis=1, num_or_size_splits=3, value=xb_ruc)
-            h_r, h_u, h_c = tf.split(axis=1, num_or_size_splits=3, value=h_ruc)
-            r = self.gate_nonlinearity(xb_r + h_r)
-            u = self.gate_nonlinearity(xb_u + h_u)
-            c = self.nonlinearity(xb_c + r * h_c)
-            h = (1 - u) * hprev + u * c
-            return h
+    def step(self, hprev, x, name=None):
+        with tf.name_scope(name, "step", values=[hprev, x]):
+            if self.layer_normalization:
+                ln = apply_ln(self)
+                x_ru = ln(tf.matmul(x, self.W_x_ru), "x_ru")
+                h_ru = ln(tf.matmul(hprev, self.W_h_ru), "h_ru")
+                x_r, x_u = tf.split(axis=1, num_or_size_splits=2, value=x_ru)
+                h_r, h_u = tf.split(axis=1, num_or_size_splits=2, value=h_ru)
+                x_c = ln(tf.matmul(x, self.W_xc), "x_c")
+                h_c = ln(tf.matmul(hprev, self.W_hc), "h_c")
+                r = self.gate_nonlinearity(x_r + h_r)
+                u = self.gate_nonlinearity(x_u + h_u)
+                c = self.nonlinearity(x_c + r * h_c)
+                h = (1 - u) * hprev + u * c
+                return h
+            else:
+                xb_ruc = tf.matmul(x, self.W_x_ruc) + tf.reshape(
+                    self.b_ruc, (1, -1))
+                h_ruc = tf.matmul(hprev, self.W_h_ruc)
+                xb_r, xb_u, xb_c = tf.split(
+                    axis=1, num_or_size_splits=3, value=xb_ruc)
+                h_r, h_u, h_c = tf.split(
+                    axis=1, num_or_size_splits=3, value=h_ruc)
+                r = self.gate_nonlinearity(xb_r + h_r)
+                u = self.gate_nonlinearity(xb_u + h_u)
+                c = self.nonlinearity(xb_c + r * h_c)
+                h = (1 - u) * hprev + u * c
+                return h
 
     def get_step_layer(self, l_in, l_prev_hidden, name=None):
         return GRUStepLayer(
@@ -1150,22 +1186,24 @@ class GRULayer(Layer):
         return n_batch, n_steps, self.num_units
 
     def get_output_for(self, input, **kwargs):
-        input_shape = tf.shape(input)
-        n_batches = input_shape[0]
-        n_steps = input_shape[1]
-        input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
-        if 'recurrent_state' in kwargs and self in kwargs['recurrent_state']:
-            h0s = kwargs['recurrent_state'][self]
-        else:
-            h0s = tf.tile(
-                tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
-        # flatten extra dimensions
-        shuffled_input = tf.transpose(input, (1, 0, 2))
-        hs = tf.scan(self.step, elems=shuffled_input, initializer=h0s)
-        shuffled_hs = tf.transpose(hs, (1, 0, 2))
-        if 'recurrent_state_output' in kwargs:
-            kwargs['recurrent_state_output'][self] = shuffled_hs
-        return shuffled_hs
+        with tf.name_scope(self.name, values=[input]):
+            input_shape = tf.shape(input)
+            n_batches = input_shape[0]
+            n_steps = input_shape[1]
+            input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
+            if ('recurrent_state' in kwargs
+                    and self in kwargs['recurrent_state']):
+                h0s = kwargs['recurrent_state'][self]
+            else:
+                h0s = tf.tile(
+                    tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
+            # flatten extra dimensions
+            shuffled_input = tf.transpose(input, (1, 0, 2))
+            hs = tf.scan(self.step, elems=shuffled_input, initializer=h0s)
+            shuffled_hs = tf.transpose(hs, (1, 0, 2))
+            if 'recurrent_state_output' in kwargs:
+                kwargs['recurrent_state_output'][self] = shuffled_hs
+            return shuffled_hs
 
 
 class GRUStepLayer(MergeLayer):
@@ -1181,11 +1219,12 @@ class GRUStepLayer(MergeLayer):
         return n_batch, self._gru_layer.num_units
 
     def get_output_for(self, inputs, **kwargs):
-        x, hprev = inputs
-        n_batch = tf.shape(x)[0]
-        x = tf.reshape(x, tf.stack([n_batch, -1]))
-        x.set_shape((None, self.input_shapes[0][1]))
-        return self._gru_layer.step(hprev, x)
+        with tf.name_scope(self.name, values=[inputs]):
+            x, hprev = inputs
+            n_batch = tf.shape(x)[0]
+            x = tf.reshape(x, tf.stack([n_batch, -1]))
+            x.set_shape((None, self.input_shapes[0][1]))
+            return self._gru_layer.step(hprev, x)
 
 
 class TfGRULayer(Layer):
@@ -1210,12 +1249,12 @@ class TfGRULayer(Layer):
         self.hidden_nonlinearity = hidden_nonlinearity
         Layer.__init__(self, incoming=incoming, **kwargs)
         # dummy input variable
-        input_dummy = tf.placeholder(tf.float32, (None, input_dim),
-                                     "input_dummy")
-        hidden_dummy = tf.placeholder(tf.float32, (None, num_units),
-                                      "hidden_dummy")
 
         with tf.variable_scope(self.name) as vs:
+            input_dummy = tf.placeholder(tf.float32, (None, input_dim),
+                                         "input_dummy")
+            hidden_dummy = tf.placeholder(tf.float32, (None, num_units),
+                                          "hidden_dummy")
             gru(input_dummy, hidden_dummy, scope=vs)
             vs.reuse_variables()
             self.scope = vs
@@ -1237,32 +1276,36 @@ class TfGRULayer(Layer):
             trainable=hidden_init_trainable,
             regularizable=False)
 
-    def step(self, hprev, x):
-        return self.gru(x, hprev, scope=self.scope)[1]
+    def step(self, hprev, x, name=None):
+        with tf.name_scope(name, "step", values=[hprev, x]):
+            return self.gru(x, hprev, scope=self.scope)[1]
 
     def get_output_for(self, input, **kwargs):
-        input_shape = tf.shape(input)
-        n_batches = input_shape[0]
-        state = tf.tile(
-            tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
-        state.set_shape((None, self.num_units))
-        if self.horizon is not None:
-            outputs = []
-            for idx in range(self.horizon):
-                output, state = self.gru(
-                    input[:, idx, :], state, scope=self.scope)  # self.name)
-                outputs.append(tf.expand_dims(output, 1))
-            outputs = tf.concat(axis=1, values=outputs)
-            return outputs
-        else:
-            n_steps = input_shape[1]
-            input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
-            # flatten extra dimensions
-            shuffled_input = tf.transpose(input, (1, 0, 2))
-            shuffled_input.set_shape((None, None, self.input_shape[-1]))
-            hs = tf.scan(self.step, elems=shuffled_input, initializer=state)
-            shuffled_hs = tf.transpose(hs, (1, 0, 2))
-            return shuffled_hs
+        with tf.name_scope(self.name, values=[input]):
+            input_shape = tf.shape(input)
+            n_batches = input_shape[0]
+            state = tf.tile(
+                tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
+            state.set_shape((None, self.num_units))
+            if self.horizon is not None:
+                outputs = []
+                for idx in range(self.horizon):
+                    output, state = self.gru(
+                        input[:, idx, :], state,
+                        scope=self.scope)  # self.name)
+                    outputs.append(tf.expand_dims(output, 1))
+                outputs = tf.concat(axis=1, values=outputs)
+                return outputs
+            else:
+                n_steps = input_shape[1]
+                input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
+                # flatten extra dimensions
+                shuffled_input = tf.transpose(input, (1, 0, 2))
+                shuffled_input.set_shape((None, None, self.input_shape[-1]))
+                hs = tf.scan(
+                    self.step, elems=shuffled_input, initializer=state)
+                shuffled_hs = tf.transpose(hs, (1, 0, 2))
+                return shuffled_hs
 
     def get_output_shape_for(self, input_shape):
         n_batch, n_steps = input_shape[:2]
@@ -1285,7 +1328,8 @@ class PseudoLSTMLayer(Layer):
     Hidden state:      h(t) = ϕ(c(t))
     Output:            out  = h(t)
 
-    If gate_squash_inputs is set to True, we have the following updates instead:
+    If gate_squash_inputs is set to True, we have the following updates
+    instead:
 
     Out gate:          o(t) = σ(W_ho @ h(t-1)) + W_xo @ x(t) + b_o)
     Incoming gate:     i(t) = σ(W_hi @ (o(t) * h(t-1)) + W_xi @ x(t) + b_i)
@@ -1310,8 +1354,8 @@ class PseudoLSTMLayer(Layer):
                  num_units,
                  hidden_nonlinearity=tf.tanh,
                  gate_nonlinearity=tf.nn.sigmoid,
-                 W_x_init=XavierUniformInitializer(),
-                 W_h_init=OrthogonalInitializer(),
+                 w_x_init=XavierUniformInitializer(),
+                 w_h_init=OrthogonalInitializer(),
                  forget_bias=1.0,
                  b_init=tf.zeros_initializer(),
                  hidden_init=tf.zeros_initializer(),
@@ -1330,139 +1374,149 @@ class PseudoLSTMLayer(Layer):
 
         super(PseudoLSTMLayer, self).__init__(incoming, **kwargs)
 
-        self.layer_normalization = layer_normalization
+        with tf.variable_scope("pseudo_lstm_layer"):
+            self.layer_normalization = layer_normalization
 
-        input_shape = self.input_shape[2:]
+            input_shape = self.input_shape[2:]
 
-        input_dim = np.prod(input_shape)
-        # Weights for the initial hidden state (this is actually not used, since
-        # the initial hidden state is determined by the initial cell state via
-        # h0 = self.nonlinearity(c0)). It is here merely for interface
-        # convenience
-        self.h0 = self.add_param(
-            hidden_init, (num_units, ),
-            name="h0",
-            trainable=hidden_init_trainable,
-            regularizable=False)
-        # Weights for the initial cell state
-        self.c0 = self.add_param(
-            cell_init, (num_units, ),
-            name="c0",
-            trainable=cell_init_trainable,
-            regularizable=False)
-        # Weights for the incoming gate
-        self.W_xi = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xi")
-        self.W_hi = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hi")
-        self.b_i = self.add_param(
-            b_init, (num_units, ), name="b_i", regularizable=False)
-        # Weights for the forget gate
-        self.W_xf = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xf")
-        self.W_hf = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hf")
-        self.b_f = self.add_param(
-            b_init, (num_units, ), name="b_f", regularizable=False)
-        # Weights for the out gate
-        self.W_xo = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xo")
-        self.W_ho = self.add_param(
-            W_h_init, (num_units, num_units), name="W_ho")
-        self.b_o = self.add_param(
-            b_init, (num_units, ), name="b_o", regularizable=False)
-        # Weights for the cell gate
-        self.W_xc = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xc")
-        self.W_hc = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hc")
-        self.b_c = self.add_param(
-            b_init, (num_units, ), name="b_c", regularizable=False)
+            input_dim = np.prod(input_shape)
+            # Weights for the initial hidden state (this is actually not used,
+            # since the initial hidden state is determined by the initial cell
+            # state via h0 = self.nonlinearity(c0)). It is here merely for
+            # interface convenience
+            self.h0 = self.add_param(
+                hidden_init, (num_units, ),
+                name="h0",
+                trainable=hidden_init_trainable,
+                regularizable=False)
+            # Weights for the initial cell state
+            self.c0 = self.add_param(
+                cell_init, (num_units, ),
+                name="c0",
+                trainable=cell_init_trainable,
+                regularizable=False)
+            # Weights for the incoming gate
+            self.W_xi = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xi")
+            self.W_hi = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hi")
+            self.b_i = self.add_param(
+                b_init, (num_units, ), name="b_i", regularizable=False)
+            # Weights for the forget gate
+            self.W_xf = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xf")
+            self.W_hf = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hf")
+            self.b_f = self.add_param(
+                b_init, (num_units, ), name="b_f", regularizable=False)
+            # Weights for the out gate
+            self.W_xo = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xo")
+            self.W_ho = self.add_param(
+                w_h_init, (num_units, num_units), name="W_ho")
+            self.b_o = self.add_param(
+                b_init, (num_units, ), name="b_o", regularizable=False)
+            # Weights for the cell gate
+            self.W_xc = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xc")
+            self.W_hc = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hc")
+            self.b_c = self.add_param(
+                b_init, (num_units, ), name="b_c", regularizable=False)
 
-        self.gate_nonlinearity = gate_nonlinearity
-        self.num_units = num_units
-        self.nonlinearity = hidden_nonlinearity
-        self.forget_bias = forget_bias
-        self.gate_squash_inputs = gate_squash_inputs
+            self.gate_nonlinearity = gate_nonlinearity
+            self.num_units = num_units
+            self.nonlinearity = hidden_nonlinearity
+            self.forget_bias = forget_bias
+            self.gate_squash_inputs = gate_squash_inputs
 
-        self.W_x_ifo = tf.concat(
-            axis=1, values=[self.W_xi, self.W_xf, self.W_xo])
-        self.W_h_ifo = tf.concat(
-            axis=1, values=[self.W_hi, self.W_hf, self.W_ho])
+            self.W_x_ifo = tf.concat(
+                axis=1, values=[self.W_xi, self.W_xf, self.W_xo])
+            self.W_h_ifo = tf.concat(
+                axis=1, values=[self.W_hi, self.W_hf, self.W_ho])
 
-        self.W_x_if = tf.concat(axis=1, values=[self.W_xi, self.W_xf])
-        self.W_h_if = tf.concat(axis=1, values=[self.W_hi, self.W_hf])
+            self.W_x_if = tf.concat(axis=1, values=[self.W_xi, self.W_xf])
+            self.W_h_if = tf.concat(axis=1, values=[self.W_hi, self.W_hf])
 
-        self.norm_params = dict()
+            self.norm_params = dict()
 
-    def step(self, hcprev, x):
-        hprev = hcprev[:, :self.num_units]
-        cprev = hcprev[:, self.num_units:]
+    def step(self, hcprev, x, name=None):
+        with tf.name_scope(name, "step", values=[hcprev, x]):
+            hprev = hcprev[:, :self.num_units]
+            cprev = hcprev[:, self.num_units:]
 
-        if self.layer_normalization:
-            ln = apply_ln(self)
-        else:
-            ln = lambda x, *args: x
+            if self.layer_normalization:
+                ln = apply_ln(self)
+            else:
 
-        if self.gate_squash_inputs:
-            """
-            Out gate:          o(t) = σ(W_ho @ h(t-1)) + W_xo @ x(t) + b_o)
-            Incoming gate:     i(t) = σ(W_hi @ (o(t) * h(t-1)) +
-                                        W_xi @ x(t) + b_i)
-            Forget gate:       f(t) = σ(W_hf @ (o(t) * h(t-1)) +
-                                        W_xf @ x(t) + b_f)
-            New cell gate:     c_new(t) = ϕ(W_hc @ (o(t) * h(t-1)) +
-                                            W_xc @ x(t) + b_c)
-            Cell state:        c(t) = f(t) * c(t-1) + i(t) * c_new(t)
-            Hidden state:      h(t) = ϕ(c(t))
-            Output:            out  = h(t)
-            """
+                def f(x, *args):
+                    return x
 
-            o = self.nonlinearity(
-                ln(tf.matmul(hprev, self.W_ho), "h_o") +
-                ln(tf.matmul(x, self.W_xo), "x_o") + self.b_o)
+                ln = f
 
-            x_if = ln(tf.matmul(x, self.W_x_if), "x_if")
-            h_if = ln(tf.matmul(o * hprev, self.W_h_if), "h_if")
+            if self.gate_squash_inputs:
+                """
+                Out gate:          o(t) = σ(W_ho @ h(t-1)) + W_xo @ x(t) + b_o)
+                Incoming gate:     i(t) = σ(W_hi @ (o(t) * h(t-1)) +
+                                            W_xi @ x(t) + b_i)
+                Forget gate:       f(t) = σ(W_hf @ (o(t) * h(t-1)) +
+                                            W_xf @ x(t) + b_f)
+                New cell gate:     c_new(t) = ϕ(W_hc @ (o(t) * h(t-1)) +
+                                                W_xc @ x(t) + b_c)
+                Cell state:        c(t) = f(t) * c(t-1) + i(t) * c_new(t)
+                Hidden state:      h(t) = ϕ(c(t))
+                Output:            out  = h(t)
+                """
 
-            x_i, x_f = tf.split(axis=1, num_or_size_splits=2, value=x_if)
-            h_i, h_f = tf.split(axis=1, num_or_size_splits=2, value=h_if)
+                o = self.nonlinearity(
+                    ln(tf.matmul(hprev, self.W_ho), "h_o") +
+                    ln(tf.matmul(x, self.W_xo), "x_o") + self.b_o)
 
-            i = self.gate_nonlinearity(x_i + h_i + self.b_i)
-            f = self.gate_nonlinearity(x_f + h_f + self.b_f + self.forget_bias)
-            c_new = self.nonlinearity(
-                ln(tf.matmul(o * hprev, self.W_hc), "h_c") +
-                ln(tf.matmul(x, self.W_xc), "x_c") + self.b_c)
-            c = f * cprev + i * c_new
-            h = self.nonlinearity(ln(c, "c"))
-            return tf.concat(axis=1, values=[h, c])
-        else:
-            """
-            Incoming gate:     i(t) = σ(W_hi @ h(t-1)) + W_xi @ x(t) + b_i)
-            Forget gate:       f(t) = σ(W_hf @ h(t-1)) + W_xf @ x(t) + b_f)
-            Out gate:          o(t) = σ(W_ho @ h(t-1)) + W_xo @ x(t) + b_o)
-            New cell gate:     c_new(t) = ϕ(W_hc @ (o(t) * h(t-1)) +
-                                            W_xc @ x(t) + b_c)
-            Cell gate:         c(t) = f(t) * c(t-1) + i(t) * c_new(t)
-            Hidden state:      h(t) = ϕ(c(t))
-            Output:            out  = h(t)
-            """
+                x_if = ln(tf.matmul(x, self.W_x_if), "x_if")
+                h_if = ln(tf.matmul(o * hprev, self.W_h_if), "h_if")
 
-            x_ifo = ln(tf.matmul(x, self.W_x_ifo), "x_ifo")
-            h_ifo = ln(tf.matmul(hprev, self.W_h_ifo), "h_ifo")
+                x_i, x_f = tf.split(axis=1, num_or_size_splits=2, value=x_if)
+                h_i, h_f = tf.split(axis=1, num_or_size_splits=2, value=h_if)
 
-            x_i, x_f, x_o = tf.split(axis=1, num_or_size_splits=3, value=x_ifo)
-            h_i, h_f, h_o = tf.split(axis=1, num_or_size_splits=3, value=h_ifo)
+                i = self.gate_nonlinearity(x_i + h_i + self.b_i)
+                f = self.gate_nonlinearity(x_f + h_f + self.b_f +
+                                           self.forget_bias)
+                c_new = self.nonlinearity(
+                    ln(tf.matmul(o * hprev, self.W_hc), "h_c") +
+                    ln(tf.matmul(x, self.W_xc), "x_c") + self.b_c)
+                c = f * cprev + i * c_new
+                h = self.nonlinearity(ln(c, "c"))
+                return tf.concat(axis=1, values=[h, c])
+            else:
+                """
+                Incoming gate:     i(t) = σ(W_hi @ h(t-1)) + W_xi @ x(t) + b_i)
+                Forget gate:       f(t) = σ(W_hf @ h(t-1)) + W_xf @ x(t) + b_f)
+                Out gate:          o(t) = σ(W_ho @ h(t-1)) + W_xo @ x(t) + b_o)
+                New cell gate:     c_new(t) = ϕ(W_hc @ (o(t) * h(t-1)) +
+                                                W_xc @ x(t) + b_c)
+                Cell gate:         c(t) = f(t) * c(t-1) + i(t) * c_new(t)
+                Hidden state:      h(t) = ϕ(c(t))
+                Output:            out  = h(t)
+                """
 
-            i = self.gate_nonlinearity(x_i + h_i + self.b_i)
-            f = self.gate_nonlinearity(x_f + h_f + self.b_f + self.forget_bias)
-            o = self.gate_nonlinearity(x_o + h_o + self.b_o)
-            c_new = self.nonlinearity(
-                ln(tf.matmul(o * hprev, self.W_hc), "h_c") +
-                ln(tf.matmul(x, self.W_xc), "x_c") + self.b_c)
-            c = f * cprev + i * c_new
-            h = self.nonlinearity(ln(c, "c"))
-            return tf.concat(axis=1, values=[h, c])
+                x_ifo = ln(tf.matmul(x, self.W_x_ifo), "x_ifo")
+                h_ifo = ln(tf.matmul(hprev, self.W_h_ifo), "h_ifo")
+
+                x_i, x_f, x_o = tf.split(
+                    axis=1, num_or_size_splits=3, value=x_ifo)
+                h_i, h_f, h_o = tf.split(
+                    axis=1, num_or_size_splits=3, value=h_ifo)
+
+                i = self.gate_nonlinearity(x_i + h_i + self.b_i)
+                f = self.gate_nonlinearity(x_f + h_f + self.b_f +
+                                           self.forget_bias)
+                o = self.gate_nonlinearity(x_o + h_o + self.b_o)
+                c_new = self.nonlinearity(
+                    ln(tf.matmul(o * hprev, self.W_hc), "h_c") +
+                    ln(tf.matmul(x, self.W_xc), "x_c") + self.b_c)
+                c = f * cprev + i * c_new
+                h = self.nonlinearity(ln(c, "c"))
+                return tf.concat(axis=1, values=[h, c])
 
     def get_step_layer(self, l_in, l_prev_state, name=None):
         return LSTMStepLayer(
@@ -1473,36 +1527,38 @@ class PseudoLSTMLayer(Layer):
         return n_batch, n_steps, self.num_units
 
     def get_output_for(self, input, **kwargs):
-        input_shape = tf.shape(input)
-        n_batches = input_shape[0]
-        n_steps = input_shape[1]
-        input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
-        c0s = tf.tile(tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
-        h0s = self.nonlinearity(c0s)
-        # flatten extra dimensions
-        shuffled_input = tf.transpose(input, (1, 0, 2))
-        hcs = tf.scan(
-            self.step,
-            elems=shuffled_input,
-            initializer=tf.concat(axis=1, values=[h0s, c0s]))
-        shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
-        shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-        shuffled_cs = shuffled_hcs[:, :, self.num_units:]
-        return shuffled_hs
+        with tf.name_scope(self.name, values=[input]):
+            input_shape = tf.shape(input)
+            n_batches = input_shape[0]
+            n_steps = input_shape[1]
+            input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
+            c0s = tf.tile(
+                tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
+            h0s = self.nonlinearity(c0s)
+            # flatten extra dimensions
+            shuffled_input = tf.transpose(input, (1, 0, 2))
+            hcs = tf.scan(
+                self.step,
+                elems=shuffled_input,
+                initializer=tf.concat(axis=1, values=[h0s, c0s]))
+            shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
+            shuffled_hs = shuffled_hcs[:, :, :self.num_units]
+            shuffled_cs = shuffled_hcs[:, :, self.num_units:]
+            return shuffled_hs
 
 
 class LSTMLayer(Layer):
     """
     A LSTM unit implements the following update mechanism:
 
-    Incoming gate:     i(t) = f_i(x(t) @ W_xi + h(t-1) @ W_hi +
-                                  w_ci * c(t-1) + b_i)
-    Forget gate:       f(t) = f_f(x(t) @ W_xf + h(t-1) @ W_hf +
-                                  w_cf * c(t-1) + b_f)
-    Cell gate:         c(t) = f(t) * c(t - 1) + i(t) * f_c(x(t) @ W_xc +
-                              h(t-1) @ W_hc + b_c)
-    Out gate:          o(t) = f_o(x(t) @ W_xo + h(t-1) W_ho + w_co * c(t) + b_o)
-    New hidden state:  h(t) = o(t) * f_h(c(t))
+    Incoming gate:    i(t) = f_i(x(t) @ W_xi + h(t-1) @ W_hi +
+                                 w_ci * c(t-1) + b_i)
+    Forget gate:      f(t) = f_f(x(t) @ W_xf + h(t-1) @ W_hf +
+                                 w_cf * c(t-1) + b_f)
+    Cell gate:        c(t) = f(t) * c(t - 1) + i(t) * f_c(x(t) @ W_xc +
+                             h(t-1) @ W_hc + b_c)
+    Out gate:         o(t) = f_o(x(t) @ W_xo + h(t-1) W_ho + w_co * c(t) + b_o)
+    New hidden state: h(t) = o(t) * f_h(c(t))
 
     Note that the incoming, forget, cell, and out vectors must have the same
     dimension as the hidden state
@@ -1513,8 +1569,8 @@ class LSTMLayer(Layer):
                  num_units,
                  hidden_nonlinearity=tf.tanh,
                  gate_nonlinearity=tf.nn.sigmoid,
-                 W_x_init=XavierUniformInitializer(),
-                 W_h_init=OrthogonalInitializer(),
+                 w_x_init=XavierUniformInitializer(),
+                 w_h_init=OrthogonalInitializer(),
                  forget_bias=1.0,
                  use_peepholes=False,
                  w_init=tf.random_normal_initializer(stddev=0.1),
@@ -1534,82 +1590,83 @@ class LSTMLayer(Layer):
 
         super(LSTMLayer, self).__init__(incoming, **kwargs)
 
-        self.layer_normalization = layer_normalization
+        with tf.variable_scope("lstm_layer"):
+            self.layer_normalization = layer_normalization
 
-        input_shape = self.input_shape[2:]
+            input_shape = self.input_shape[2:]
 
-        input_dim = np.prod(input_shape)
-        # Weights for the initial hidden state
-        self.h0 = self.add_param(
-            hidden_init, (num_units, ),
-            name="h0",
-            trainable=hidden_init_trainable,
-            regularizable=False)
-        # Weights for the initial cell state
-        self.c0 = self.add_param(
-            cell_init, (num_units, ),
-            name="c0",
-            trainable=cell_init_trainable,
-            regularizable=False)
-        # Weights for the incoming gate
-        self.W_xi = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xi")
-        self.W_hi = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hi")
-        if use_peepholes:
-            self.w_ci = self.add_param(w_init, (num_units, ), name="w_ci")
-        self.b_i = self.add_param(
-            b_init, (num_units, ), name="b_i", regularizable=False)
-        # Weights for the forget gate
-        self.W_xf = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xf")
-        self.W_hf = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hf")
-        if use_peepholes:
-            self.w_cf = self.add_param(w_init, (num_units, ), name="w_cf")
-        self.b_f = self.add_param(
-            b_init, (num_units, ), name="b_f", regularizable=False)
-        # Weights for the cell gate
-        self.W_xc = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xc")
-        self.W_hc = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hc")
-        self.b_c = self.add_param(
-            b_init, (num_units, ), name="b_c", regularizable=False)
-        # Weights for the reset gate
-        self.W_xr = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xr")
-        self.W_hr = self.add_param(
-            W_h_init, (num_units, num_units), name="W_hr")
-        self.b_r = self.add_param(
-            b_init, (num_units, ), name="b_r", regularizable=False)
-        # Weights for the out gate
-        self.W_xo = self.add_param(
-            W_x_init, (input_dim, num_units), name="W_xo")
-        self.W_ho = self.add_param(
-            W_h_init, (num_units, num_units), name="W_ho")
-        if use_peepholes:
-            self.w_co = self.add_param(w_init, (num_units, ), name="w_co")
-        self.b_o = self.add_param(
-            b_init, (num_units, ), name="b_o", regularizable=False)
-        self.gate_nonlinearity = gate_nonlinearity
-        self.num_units = num_units
-        self.nonlinearity = hidden_nonlinearity
-        self.forget_bias = forget_bias
-        self.use_peepholes = use_peepholes
+            input_dim = np.prod(input_shape)
+            # Weights for the initial hidden state
+            self.h0 = self.add_param(
+                hidden_init, (num_units, ),
+                name="h0",
+                trainable=hidden_init_trainable,
+                regularizable=False)
+            # Weights for the initial cell state
+            self.c0 = self.add_param(
+                cell_init, (num_units, ),
+                name="c0",
+                trainable=cell_init_trainable,
+                regularizable=False)
+            # Weights for the incoming gate
+            self.W_xi = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xi")
+            self.W_hi = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hi")
+            if use_peepholes:
+                self.w_ci = self.add_param(w_init, (num_units, ), name="w_ci")
+            self.b_i = self.add_param(
+                b_init, (num_units, ), name="b_i", regularizable=False)
+            # Weights for the forget gate
+            self.W_xf = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xf")
+            self.W_hf = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hf")
+            if use_peepholes:
+                self.w_cf = self.add_param(w_init, (num_units, ), name="w_cf")
+            self.b_f = self.add_param(
+                b_init, (num_units, ), name="b_f", regularizable=False)
+            # Weights for the cell gate
+            self.W_xc = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xc")
+            self.W_hc = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hc")
+            self.b_c = self.add_param(
+                b_init, (num_units, ), name="b_c", regularizable=False)
+            # Weights for the reset gate
+            self.W_xr = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xr")
+            self.W_hr = self.add_param(
+                w_h_init, (num_units, num_units), name="W_hr")
+            self.b_r = self.add_param(
+                b_init, (num_units, ), name="b_r", regularizable=False)
+            # Weights for the out gate
+            self.W_xo = self.add_param(
+                w_x_init, (input_dim, num_units), name="W_xo")
+            self.W_ho = self.add_param(
+                w_h_init, (num_units, num_units), name="W_ho")
+            if use_peepholes:
+                self.w_co = self.add_param(w_init, (num_units, ), name="w_co")
+            self.b_o = self.add_param(
+                b_init, (num_units, ), name="b_o", regularizable=False)
+            self.gate_nonlinearity = gate_nonlinearity
+            self.num_units = num_units
+            self.nonlinearity = hidden_nonlinearity
+            self.forget_bias = forget_bias
+            self.use_peepholes = use_peepholes
 
-        self.W_x_ifco = tf.concat(
-            axis=1, values=[self.W_xi, self.W_xf, self.W_xc, self.W_xo])
-        self.W_h_ifco = tf.concat(
-            axis=1, values=[self.W_hi, self.W_hf, self.W_hc, self.W_ho])
+            self.W_x_ifco = tf.concat(
+                axis=1, values=[self.W_xi, self.W_xf, self.W_xc, self.W_xo])
+            self.W_h_ifco = tf.concat(
+                axis=1, values=[self.W_hi, self.W_hf, self.W_hc, self.W_ho])
 
-        if use_peepholes:
-            self.w_c_ifo = tf.concat(
-                axis=0, values=[self.w_ci, self.w_cf, self.w_co])
+            if use_peepholes:
+                self.w_c_ifo = tf.concat(
+                    axis=0, values=[self.w_ci, self.w_cf, self.w_co])
 
-        self.norm_params = dict()
+            self.norm_params = dict()
 
-    def step(self, hcprev, x):
+    def step(self, hcprev, x, name=None):
         """
         Incoming gate:     i(t) = f_i(x(t) @ W_xi + h(t-1) @ W_hi +
                                       w_ci * c(t-1) + b_i)
@@ -1621,39 +1678,44 @@ class LSTMLayer(Layer):
                                       w_co * c(t) + b_o)
         New hidden state:  h(t) = o(t) * f_h(c(t))
         """
+        with tf.name_scope(name, "step", values=[hcprev, x]):
+            hprev = hcprev[:, :self.num_units]
+            cprev = hcprev[:, self.num_units:]
 
-        hprev = hcprev[:, :self.num_units]
-        cprev = hcprev[:, self.num_units:]
+            if self.layer_normalization:
+                ln = apply_ln(self)
+            else:
 
-        if self.layer_normalization:
-            ln = apply_ln(self)
-        else:
-            ln = lambda x, *args: x
+                def f(x, *args):
+                    return x
 
-        x_ifco = ln(tf.matmul(x, self.W_x_ifco), "x_ifco")
-        h_ifco = ln(tf.matmul(hprev, self.W_h_ifco), "h_ifco")
-        x_i, x_f, x_c, x_o = tf.split(
-            axis=1, num_or_size_splits=4, value=x_ifco)
-        h_i, h_f, h_c, h_o = tf.split(
-            axis=1, num_or_size_splits=4, value=h_ifco)
+                ln = f
 
-        if self.use_peepholes:
-            i = self.gate_nonlinearity(x_i + h_i + self.w_ci * cprev +
-                                       self.b_i)
-            f = self.gate_nonlinearity(x_f + h_f + self.w_cf * cprev +
-                                       self.b_f + self.forget_bias)
+            x_ifco = ln(tf.matmul(x, self.W_x_ifco), "x_ifco")
+            h_ifco = ln(tf.matmul(hprev, self.W_h_ifco), "h_ifco")
+            x_i, x_f, x_c, x_o = tf.split(
+                axis=1, num_or_size_splits=4, value=x_ifco)
+            h_i, h_f, h_c, h_o = tf.split(
+                axis=1, num_or_size_splits=4, value=h_ifco)
 
-            o = self.gate_nonlinearity(x_o + h_o + self.w_co * cprev +
-                                       self.b_o)
-        else:
-            i = self.gate_nonlinearity(x_i + h_i + self.b_i)
-            f = self.gate_nonlinearity(x_f + h_f + self.b_f + self.forget_bias)
-            o = self.gate_nonlinearity(x_o + h_o + self.b_o)
+            if self.use_peepholes:
+                i = self.gate_nonlinearity(x_i + h_i + self.w_ci * cprev +
+                                           self.b_i)
+                f = self.gate_nonlinearity(x_f + h_f + self.w_cf * cprev +
+                                           self.b_f + self.forget_bias)
 
-        c = f * cprev + i * self.nonlinearity(x_c + h_c + self.b_c)
-        h = o * self.nonlinearity(ln(c, "c"))
+                o = self.gate_nonlinearity(x_o + h_o + self.w_co * cprev +
+                                           self.b_o)
+            else:
+                i = self.gate_nonlinearity(x_i + h_i + self.b_i)
+                f = self.gate_nonlinearity(x_f + h_f + self.b_f +
+                                           self.forget_bias)
+                o = self.gate_nonlinearity(x_o + h_o + self.b_o)
 
-        return tf.concat(axis=1, values=[h, c])
+            c = f * cprev + i * self.nonlinearity(x_c + h_c + self.b_c)
+            h = o * self.nonlinearity(ln(c, "c"))
+
+            return tf.concat(axis=1, values=[h, c])
 
     def get_step_layer(self, l_in, l_prev_state, name=None):
         return LSTMStepLayer(
@@ -1664,24 +1726,27 @@ class LSTMLayer(Layer):
         return n_batch, n_steps, self.num_units
 
     def get_output_for(self, input, **kwargs):
-        input_shape = tf.shape(input)
-        n_batches = input_shape[0]
-        n_steps = input_shape[1]
-        input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
-        h0s = tf.tile(tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
-        c0s = tf.tile(tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
-        # flatten extra dimensions
-        shuffled_input = tf.transpose(input, (1, 0, 2))
-        hcs = tf.scan(
-            self.step,
-            elems=shuffled_input,
-            initializer=tf.concat(axis=1, values=[h0s, c0s]))
-        shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
-        shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-        shuffled_cs = shuffled_hcs[:, :, self.num_units:]
-        if 'recurrent_state_output' in kwargs:
-            kwargs['recurrent_state_output'][self] = shuffled_hcs
-        return shuffled_hs
+        with tf.name_scope(self.name, values=[input]):
+            input_shape = tf.shape(input)
+            n_batches = input_shape[0]
+            n_steps = input_shape[1]
+            input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
+            h0s = tf.tile(
+                tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
+            c0s = tf.tile(
+                tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
+            # flatten extra dimensions
+            shuffled_input = tf.transpose(input, (1, 0, 2))
+            hcs = tf.scan(
+                self.step,
+                elems=shuffled_input,
+                initializer=tf.concat(axis=1, values=[h0s, c0s]))
+            shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
+            shuffled_hs = shuffled_hcs[:, :, :self.num_units]
+            shuffled_cs = shuffled_hcs[:, :, self.num_units:]
+            if 'recurrent_state_output' in kwargs:
+                kwargs['recurrent_state_output'][self] = shuffled_hcs
+            return shuffled_hs
 
 
 class LSTMStepLayer(MergeLayer):
@@ -1697,11 +1762,12 @@ class LSTMStepLayer(MergeLayer):
         return n_batch, 2 * self._recurrent_layer.num_units
 
     def get_output_for(self, inputs, **kwargs):
-        x, hcprev = inputs
-        n_batch = tf.shape(x)[0]
-        x = tf.reshape(x, tf.stack([n_batch, -1]))
-        hc = self._recurrent_layer.step(hcprev, x)
-        return hc
+        with tf.name_scope(self.name, values=[inputs]):
+            x, hcprev = inputs
+            n_batch = tf.shape(x)[0]
+            x = tf.reshape(x, tf.stack([n_batch, -1]))
+            hc = self._recurrent_layer.step(hcprev, x)
+            return hc
 
 
 class TfBasicLSTMLayer(Layer):
@@ -1731,25 +1797,27 @@ class TfBasicLSTMLayer(Layer):
         self.lstm = lstm
         self.hidden_nonlinearity = hidden_nonlinearity
         Layer.__init__(self, incoming=incoming, **kwargs)
-        # dummy input variable
-        input_dummy = tf.placeholder(tf.float32, (None, input_dim),
-                                     "input_dummy")
-        hidden_dummy = tf.placeholder(tf.float32, (None, num_units),
-                                      "hidden_dummy")
-        cell_dummy = tf.placeholder(tf.float32, (None, num_units),
-                                    "cell_dummy")
 
-        with tf.variable_scope(self.name) as vs:
-            lstm(input_dummy, (cell_dummy, hidden_dummy), scope=vs)
-            vs.reuse_variables()
-            self.scope = vs
-            all_vars = [
-                v for v in tf.global_variables() if v.name.startswith(vs.name)
-            ]
-            trainable_vars = [
-                v for v in tf.trainable_variables()
-                if v.name.startswith(vs.name)
-            ]
+        with tf.variable_scope(self.name):
+            # dummy input variable
+            input_dummy = tf.placeholder(tf.float32, (None, input_dim),
+                                         "input_dummy")
+            hidden_dummy = tf.placeholder(tf.float32, (None, num_units),
+                                          "hidden_dummy")
+            cell_dummy = tf.placeholder(tf.float32, (None, num_units),
+                                        "cell_dummy")
+            with tf.variable_scope("lstm") as vs:
+                lstm(input_dummy, (cell_dummy, hidden_dummy), scope=vs)
+                vs.reuse_variables()
+                self.scope = vs
+                all_vars = [
+                    v for v in tf.global_variables()
+                    if v.name.startswith(vs.name)
+                ]
+                trainable_vars = [
+                    v for v in tf.trainable_variables()
+                    if v.name.startswith(vs.name)
+                ]
 
         for var in trainable_vars:
             self.add_param(spec=var, shape=None, name=None, trainable=True)
@@ -1767,44 +1835,49 @@ class TfBasicLSTMLayer(Layer):
             trainable=hidden_init_trainable,
             regularizable=False)
 
-    def step(self, hcprev, x):
-        hprev = hcprev[:, :self.num_units]
-        cprev = hcprev[:, self.num_units:]
-        x.set_shape((None, self.input_shape[-1]))
-        c, h = self.lstm(x, (cprev, hprev), scope=self.scope)[1]
-        return tf.concat(axis=1, values=[h, c])
+    def step(self, hcprev, x, name=None):
+        with tf.name_scope(name, "step", values=[hcprev, x]):
+            hprev = hcprev[:, :self.num_units]
+            cprev = hcprev[:, self.num_units:]
+            x.set_shape((None, self.input_shape[-1]))
+            c, h = self.lstm(x, (cprev, hprev), scope=self.scope)[1]
+            return tf.concat(axis=1, values=[h, c])
 
     def get_output_for(self, input, **kwargs):
-        input_shape = tf.shape(input)
-        n_batches = input_shape[0]
-        h0s = tf.tile(tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
-        h0s.set_shape((None, self.num_units))
-        c0s = tf.tile(tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
-        c0s.set_shape((None, self.num_units))
-        state = (c0s, h0s)
-        if self.horizon is not None:
-            outputs = []
-            for idx in range(self.horizon):
-                output, state = self.lstm(
-                    input[:, idx, :], state, scope=self.scope)  # self.name)
-                outputs.append(tf.expand_dims(output, 1))
-            outputs = tf.concat(axis=1, values=outputs)
-            return outputs
-        else:
-            n_steps = input_shape[1]
-            input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
-            # flatten extra dimensions
-            shuffled_input = tf.transpose(input, (1, 0, 2))
-            shuffled_input.set_shape((None, None, self.input_shape[-1]))
-            hcs = tf.scan(
-                self.step,
-                elems=shuffled_input,
-                initializer=tf.concat(axis=1, values=[h0s, c0s]),
-            )
-            shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
-            shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-            shuffled_cs = shuffled_hcs[:, :, self.num_units:]
-            return shuffled_hs
+        with tf.name_scope(self.name, values=[input]):
+            input_shape = tf.shape(input)
+            n_batches = input_shape[0]
+            h0s = tf.tile(
+                tf.reshape(self.h0, (1, self.num_units)), (n_batches, 1))
+            h0s.set_shape((None, self.num_units))
+            c0s = tf.tile(
+                tf.reshape(self.c0, (1, self.num_units)), (n_batches, 1))
+            c0s.set_shape((None, self.num_units))
+            state = (c0s, h0s)
+            if self.horizon is not None:
+                outputs = []
+                for idx in range(self.horizon):
+                    output, state = self.lstm(
+                        input[:, idx, :], state,
+                        scope=self.scope)  # self.name)
+                    outputs.append(tf.expand_dims(output, 1))
+                outputs = tf.concat(axis=1, values=outputs)
+                return outputs
+            else:
+                n_steps = input_shape[1]
+                input = tf.reshape(input, tf.stack([n_batches, n_steps, -1]))
+                # flatten extra dimensions
+                shuffled_input = tf.transpose(input, (1, 0, 2))
+                shuffled_input.set_shape((None, None, self.input_shape[-1]))
+                hcs = tf.scan(
+                    self.step,
+                    elems=shuffled_input,
+                    initializer=tf.concat(axis=1, values=[h0s, c0s]),
+                )
+                shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
+                shuffled_hs = shuffled_hcs[:, :, :self.num_units]
+                shuffled_cs = shuffled_hcs[:, :, self.num_units:]
+                return shuffled_hs
 
     def get_output_shape_for(self, input_shape):
         n_batch, n_steps = input_shape[:2]
@@ -1870,7 +1943,8 @@ class NonlinearityLayer(Layer):
                              if nonlinearity is None else nonlinearity)
 
     def get_output_for(self, input, **kwargs):
-        return self.nonlinearity(input)
+        with tf.name_scope(self.name, values=[input]):
+            return self.nonlinearity(input)
 
     def get_output_shape_for(self, input_shape):
         return input_shape
@@ -1933,26 +2007,29 @@ class BatchNormLayer(Layer):
         self.axis = axis
 
     def get_output_for(self, input, phase='train', **kwargs):
-        if phase == 'train':
-            # Calculate the moments based on the individual batch.
-            mean, variance = tf.nn.moments(
-                input, self.axis, shift=self.moving_mean)
-            # Update the moving_mean and moving_variance moments.
-            update_moving_mean = moving_averages.assign_moving_average(
-                self.moving_mean, mean, self.decay)
-            update_moving_variance = moving_averages.assign_moving_average(
-                self.moving_variance, variance, self.decay)
-            # Make sure the updates are computed here.
-            with tf.control_dependencies(
-                [update_moving_mean, update_moving_variance]):
+        with tf.name_scope(self.name, values=[input]):
+            if phase == 'train':
+                # Calculate the moments based on the individual batch.
+                mean, variance = tf.nn.moments(
+                    input, self.axis, shift=self.moving_mean)
+                # Update the moving_mean and moving_variance moments.
+                update_moving_mean = moving_averages.assign_moving_average(
+                    self.moving_mean, mean, self.decay)
+                update_moving_variance = moving_averages.assign_moving_average(
+                    self.moving_variance, variance, self.decay)
+                # Make sure the updates are computed here.
+                with tf.control_dependencies(
+                        [update_moving_mean,
+                         update_moving_variance]):  # yapf:disable
+                    output = tf.nn.batch_normalization(input, mean, variance,
+                                                       self.beta, self.gamma,
+                                                       self.epsilon)
+            else:
                 output = tf.nn.batch_normalization(
-                    input, mean, variance, self.beta, self.gamma, self.epsilon)
-        else:
-            output = tf.nn.batch_normalization(input, self.moving_mean,
-                                               self.moving_variance, self.beta,
-                                               self.gamma, self.epsilon)
-        output.set_shape(self.input_shape)
-        return output
+                    input, self.moving_mean, self.moving_variance, self.beta,
+                    self.gamma, self.epsilon)
+            output.set_shape(self.input_shape)
+            return output
 
     def get_output_shape_for(self, input_shape):
         return input_shape
@@ -1983,7 +2060,8 @@ class ElemwiseSumLayer(MergeLayer):
         super(ElemwiseSumLayer, self).__init__(incomings, **kwargs)
 
     def get_output_for(self, inputs, **kwargs):
-        return functools.reduce(tf.add, inputs)
+        with tf.name_scope(self.name, values=[inputs]):
+            return functools.reduce(tf.add, inputs)
 
     def get_output_shape_for(self, input_shapes):
         assert len(set(input_shapes)) == 1

--- a/garage/tf/core/layers.py
+++ b/garage/tf/core/layers.py
@@ -524,8 +524,6 @@ class BaseConvLayer(Layer):
         elif self.pad == 'VALID':
             pad = (0, ) * self.n
         else:
-            import ipdb
-            ipdb.set_trace()
             raise NotImplementedError
 
         # if isinstance(self.pad, tuple):

--- a/garage/tf/core/layers.py
+++ b/garage/tf/core/layers.py
@@ -848,10 +848,6 @@ class ReshapeLayer(Layer):
                                      "single-element lists of int >= 0")
             elif isinstance(s, (tf.Tensor, tf.Variable)):  # T.TensorVariable):
                 raise NotImplementedError
-                # if s.ndim != 0:
-                #     raise ValueError(
-                #         "A symbolic variable in a shape specification must "
-                #         "be a scalar, but had %i dimensions" % s.ndim)
             else:
                 raise ValueError("`shape` must be a tuple of int and/or [int]")
         if sum(s == -1 for s in shape) > 1:

--- a/garage/tf/core/parameterized.py
+++ b/garage/tf/core/parameterized.py
@@ -65,27 +65,29 @@ class Parameterized(object):
         param_values = tf.get_default_session().run(params)
         return flatten_tensors(param_values)
 
-    def set_param_values(self, flattened_params, **tags):
-        debug = tags.pop("debug", False)
-        param_values = unflatten_tensors(flattened_params,
-                                         self.get_param_shapes(**tags))
-        ops = []
-        feed_dict = dict()
-        for param, dtype, value in zip(
-                self.get_params(**tags), self.get_param_dtypes(**tags),
-                param_values):
-            if param not in self._cached_assign_ops:
-                assign_placeholder = tf.placeholder(
-                    dtype=param.dtype.base_dtype)
-                assign_op = tf.assign(param, assign_placeholder)
-                self._cached_assign_ops[param] = assign_op
-                self._cached_assign_placeholders[param] = assign_placeholder
-            ops.append(self._cached_assign_ops[param])
-            feed_dict[self._cached_assign_placeholders[param]] = value.astype(
-                dtype)
-            if debug:
-                print("setting value of %s" % param.name)
-        tf.get_default_session().run(ops, feed_dict=feed_dict)
+    def set_param_values(self, flattened_params, name=None, **tags):
+        with tf.name_scope(name, "set_param_values", [flattened_params]):
+            debug = tags.pop("debug", False)
+            param_values = unflatten_tensors(flattened_params,
+                                             self.get_param_shapes(**tags))
+            ops = []
+            feed_dict = dict()
+            for param, dtype, value in zip(
+                    self.get_params(**tags), self.get_param_dtypes(**tags),
+                    param_values):
+                if param not in self._cached_assign_ops:
+                    assign_placeholder = tf.placeholder(
+                        dtype=param.dtype.base_dtype)
+                    assign_op = tf.assign(param, assign_placeholder)
+                    self._cached_assign_ops[param] = assign_op
+                    self._cached_assign_placeholders[
+                        param] = assign_placeholder
+                ops.append(self._cached_assign_ops[param])
+                feed_dict[self._cached_assign_placeholders[
+                    param]] = value.astype(dtype)
+                if debug:
+                    print("setting value of %s" % param.name)
+            tf.get_default_session().run(ops, feed_dict=feed_dict)
 
     def flat_to_params(self, flattened_params, **tags):
         return unflatten_tensors(flattened_params, self.get_param_shapes(

--- a/garage/tf/distributions/bernoulli.py
+++ b/garage/tf/distributions/bernoulli.py
@@ -16,7 +16,7 @@ class Bernoulli(Distribution):
         return self._dim
 
     def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name=None):
-        with tf.name_scope(name, "kl",
+        with tf.name_scope(name, "kl_sym",
                            [old_dist_info_vars, new_dist_info_vars]):
             old_p = old_dist_info_vars["p"]
             new_p = new_dist_info_vars["p"]
@@ -44,7 +44,7 @@ class Bernoulli(Distribution):
                              old_dist_info_vars,
                              new_dist_info_vars,
                              name=None):
-        with tf.name_scope(name, "likelihood_ratio",
+        with tf.name_scope(name, "likelihood_ratio_sym",
                            [x_var, old_dist_info_vars, new_dist_info_vars]):
             old_p = old_dist_info_vars["p"]
             new_p = new_dist_info_vars["p"]
@@ -55,7 +55,8 @@ class Bernoulli(Distribution):
                 axis=ndims - 1)
 
     def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
-        with tf.name_scope(name, "log_likelihood", [x_var, dist_info_vars]):
+        with tf.name_scope(name, "log_likelihood_sym",
+                           [x_var, dist_info_vars]):
             p = dist_info_vars["p"]
             ndims = p.get_shape().ndims
             return tf.reduce_sum(

--- a/garage/tf/distributions/bernoulli.py
+++ b/garage/tf/distributions/bernoulli.py
@@ -2,7 +2,6 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.distributions import Distribution
-from garage.tf.misc.tensor_utils import enclosing_scope
 
 TINY = 1e-8
 
@@ -16,8 +15,9 @@ class Bernoulli(Distribution):
     def dim(self):
         return self._dim
 
-    def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name="kl_sym"):
-        with enclosing_scope(self._name, name):
+    def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name=None):
+        with tf.name_scope(name, "kl",
+                           [old_dist_info_vars, new_dist_info_vars]):
             old_p = old_dist_info_vars["p"]
             new_p = new_dist_info_vars["p"]
             kl = old_p * (tf.log(old_p + TINY) - tf.log(new_p + TINY)) \
@@ -30,7 +30,8 @@ class Bernoulli(Distribution):
         old_p = old_dist_info["p"]
         new_p = new_dist_info["p"]
         kl = old_p * (np.log(old_p + TINY) - np.log(new_p + TINY)) + \
-             (1 - old_p) * (np.log(1 - old_p + TINY) - np.log(1 - new_p + TINY))
+             (1 - old_p) * (np.log(1 - old_p + TINY)
+                            - np.log(1 - new_p + TINY))
         return np.sum(kl, axis=-1)
 
     def sample(self, dist_info):
@@ -42,8 +43,9 @@ class Bernoulli(Distribution):
                              x_var,
                              old_dist_info_vars,
                              new_dist_info_vars,
-                             name="likelihood_ratio_sym"):
-        with enclosing_scope(self._name, name):
+                             name=None):
+        with tf.name_scope(name, "likelihood_ratio",
+                           [x_var, old_dist_info_vars, new_dist_info_vars]):
             old_p = old_dist_info_vars["p"]
             new_p = new_dist_info_vars["p"]
             ndims = old_p.get_shape().ndims
@@ -52,11 +54,8 @@ class Bernoulli(Distribution):
                 (1 - x_var) * (1 - new_p) / (1 - old_p + TINY),
                 axis=ndims - 1)
 
-    def log_likelihood_sym(self,
-                           x_var,
-                           dist_info_vars,
-                           name="log_likelihood_sym"):
-        with enclosing_scope(self._name, name):
+    def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
+        with tf.name_scope(name, "log_likelihood", [x_var, dist_info_vars]):
             p = dist_info_vars["p"]
             ndims = p.get_shape().ndims
             return tf.reduce_sum(

--- a/garage/tf/distributions/categorical.py
+++ b/garage/tf/distributions/categorical.py
@@ -35,7 +35,7 @@ class Categorical(Distribution):
         """
         Compute the symbolic KL divergence of two categorical distributions
         """
-        with tf.name_scope(name, "kl",
+        with tf.name_scope(name, "kl_sym",
                            [old_dist_info_vars, new_dist_info_vars]):
             old_prob_var = old_dist_info_vars["prob"]
             new_prob_var = new_dist_info_vars["prob"]
@@ -61,7 +61,7 @@ class Categorical(Distribution):
                              old_dist_info_vars,
                              new_dist_info_vars,
                              name=None):
-        with tf.name_scope(name, "likelihood_ratio",
+        with tf.name_scope(name, "likelihood_ratio_sym",
                            [x_var, old_dist_info_vars, new_dist_info_vars]):
             old_prob_var = old_dist_info_vars["prob"]
             new_prob_var = new_dist_info_vars["prob"]
@@ -72,7 +72,7 @@ class Categorical(Distribution):
                    (tf.reduce_sum(old_prob_var * x_var, ndims - 1) + TINY)
 
     def entropy_sym(self, dist_info_vars, name=None):
-        with tf.name_scope(name, "entropy", [dist_info_vars]):
+        with tf.name_scope(name, "entropy_sym", [dist_info_vars]):
             probs = dist_info_vars["prob"]
             return -tf.reduce_sum(probs * tf.log(probs + TINY), axis=1)
 
@@ -80,7 +80,7 @@ class Categorical(Distribution):
                           old_dist_info_vars,
                           new_dist_info_vars,
                           name=None):
-        with tf.name_scope(name, "cross_entropy",
+        with tf.name_scope(name, "cross_entropy_sym",
                            [old_dist_info_vars, new_dist_info_vars]):
             old_prob_var = old_dist_info_vars["prob"]
             new_prob_var = new_dist_info_vars["prob"]
@@ -94,7 +94,8 @@ class Categorical(Distribution):
         return -np.sum(probs * np.log(probs + TINY), axis=1)
 
     def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
-        with tf.name_scope(name, "log_likelihood", [x_var, dist_info_vars]):
+        with tf.name_scope(name, "log_likelihood_sym",
+                           [x_var, dist_info_vars]):
             probs = dist_info_vars["prob"]
             ndims = probs.get_shape().ndims
             return tf.log(
@@ -114,7 +115,7 @@ class Categorical(Distribution):
         return self._f_sample(dist_info["prob"])
 
     def sample_sym(self, dist_info, name=None):
-        with tf.name_scope(name, "sample", [dist_info]):
+        with tf.name_scope(name, "sample_sym", [dist_info]):
             probs = dist_info["prob"]
             samples = tf.multinomial(tf.log(probs + 1e-8), num_samples=1)[:, 0]
             return tf.nn.embedding_lookup(

--- a/garage/tf/distributions/diagonal_gaussian.py
+++ b/garage/tf/distributions/diagonal_gaussian.py
@@ -40,7 +40,7 @@ class DiagonalGaussian(Distribution):
         #     axis=-1)
 
     def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name=None):
-        with tf.name_scope(name, "kl",
+        with tf.name_scope(name, "kl_sym",
                            [old_dist_info_vars, new_dist_info_vars]):
             old_means = old_dist_info_vars["mean"]
             old_log_stds = old_dist_info_vars["log_std"]
@@ -68,14 +68,15 @@ class DiagonalGaussian(Distribution):
                              old_dist_info_vars,
                              new_dist_info_vars,
                              name=None):
-        with tf.name_scope(name, "likelihood_ratio",
+        with tf.name_scope(name, "likelihood_ratio_sym",
                            [x_var, old_dist_info_vars, new_dist_info_vars]):
             logli_new = self.log_likelihood_sym(x_var, new_dist_info_vars)
             logli_old = self.log_likelihood_sym(x_var, old_dist_info_vars)
             return tf.exp(logli_new - logli_old)
 
     def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
-        with tf.name_scope(name, "log_likelihood", [x_var, dist_info_vars]):
+        with tf.name_scope(name, "log_likelihood_sym",
+                           [x_var, dist_info_vars]):
             means = dist_info_vars["mean"]
             log_stds = dist_info_vars["log_std"]
             zs = (x_var - means) / tf.exp(log_stds)
@@ -102,7 +103,7 @@ class DiagonalGaussian(Distribution):
         return np.sum(log_stds + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)
 
     def entropy_sym(self, dist_info_var, name=None):
-        with tf.name_scope(name, "entropy", [dist_info_var]):
+        with tf.name_scope(name, "entropy_sym", [dist_info_var]):
             log_std_var = dist_info_var["log_std"]
             return tf.reduce_sum(
                 log_std_var + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)

--- a/garage/tf/distributions/diagonal_gaussian.py
+++ b/garage/tf/distributions/diagonal_gaussian.py
@@ -20,8 +20,8 @@ class DiagonalGaussian(Distribution):
         new_means = new_dist_info["mean"]
         new_log_stds = new_dist_info["log_std"]
         """
-        Compute the KL divergence of two multivariate Gaussian distribution with
-        diagonal covariance matrices
+        Compute the KL divergence of two multivariate Gaussian distribution
+        with diagonal covariance matrices
         """
         old_std = np.exp(old_log_stds)
         new_std = np.exp(new_log_stds)

--- a/garage/tf/distributions/diagonal_gaussian.py
+++ b/garage/tf/distributions/diagonal_gaussian.py
@@ -2,7 +2,6 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.distributions import Distribution
-from garage.tf.misc.tensor_utils import enclosing_scope
 
 
 class DiagonalGaussian(Distribution):
@@ -40,8 +39,9 @@ class DiagonalGaussian(Distribution):
         #     numerator / denominator + TT.log(new_std) - TT.log(old_std),
         #     axis=-1)
 
-    def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name="kl_sym"):
-        with enclosing_scope(self._name, name):
+    def kl_sym(self, old_dist_info_vars, new_dist_info_vars, name=None):
+        with tf.name_scope(name, "kl",
+                           [old_dist_info_vars, new_dist_info_vars]):
             old_means = old_dist_info_vars["mean"]
             old_log_stds = old_dist_info_vars["log_std"]
             new_means = new_dist_info_vars["mean"]
@@ -67,17 +67,15 @@ class DiagonalGaussian(Distribution):
                              x_var,
                              old_dist_info_vars,
                              new_dist_info_vars,
-                             name="likelihood_ratio_sym"):
-        with enclosing_scope(self._name, name):
+                             name=None):
+        with tf.name_scope(name, "likelihood_ratio",
+                           [x_var, old_dist_info_vars, new_dist_info_vars]):
             logli_new = self.log_likelihood_sym(x_var, new_dist_info_vars)
             logli_old = self.log_likelihood_sym(x_var, old_dist_info_vars)
             return tf.exp(logli_new - logli_old)
 
-    def log_likelihood_sym(self,
-                           x_var,
-                           dist_info_vars,
-                           name="log_likelihood_sym"):
-        with enclosing_scope(self._name, name):
+    def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
+        with tf.name_scope(name, "log_likelihood", [x_var, dist_info_vars]):
             means = dist_info_vars["mean"]
             log_stds = dist_info_vars["log_std"]
             zs = (x_var - means) / tf.exp(log_stds)
@@ -103,8 +101,8 @@ class DiagonalGaussian(Distribution):
         log_stds = dist_info["log_std"]
         return np.sum(log_stds + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)
 
-    def entropy_sym(self, dist_info_var, name="entropy_sym"):
-        with enclosing_scope(self._name, name):
+    def entropy_sym(self, dist_info_var, name=None):
+        with tf.name_scope(name, "entropy", [dist_info_var]):
             log_std_var = dist_info_var["log_std"]
             return tf.reduce_sum(
                 log_std_var + np.log(np.sqrt(2 * np.pi * np.e)), axis=-1)

--- a/garage/tf/distributions/recurrent_categorical.py
+++ b/garage/tf/distributions/recurrent_categorical.py
@@ -21,7 +21,7 @@ class RecurrentCategorical(Distribution):
         """
         Compute the symbolic KL divergence of two categorical distributions
         """
-        with tf.name_scope(name, "kl",
+        with tf.name_scope(name, "kl_sym",
                            [old_dist_info_vars, new_dist_info_vars]):
             old_prob_var = old_dist_info_vars["prob"]
             new_prob_var = new_dist_info_vars["prob"]
@@ -46,7 +46,7 @@ class RecurrentCategorical(Distribution):
                              old_dist_info_vars,
                              new_dist_info_vars,
                              name=None):
-        with tf.name_scope(name, "likelihood_ratio",
+        with tf.name_scope(name, "likelihood_ratio_sym",
                            [x_var, old_dist_info_vars, new_dist_info_vars]):
             old_prob_var = old_dist_info_vars["prob"]
             new_prob_var = new_dist_info_vars["prob"]
@@ -63,12 +63,12 @@ class RecurrentCategorical(Distribution):
         return -np.sum(probs * np.log(probs + TINY), axis=2)
 
     def entropy_sym(self, dist_info_vars, name=None):
-        with tf.name_scope(name, "entropy", [dist_info_vars]):
+        with tf.name_scope(name, "entropy_sym", [dist_info_vars]):
             probs = dist_info_vars["prob"]
             return -tf.reduce_sum(probs * tf.log(probs + TINY), 2)
 
     def log_likelihood_sym(self, xs, dist_info_vars, name=None):
-        with tf.name_scope(name, "log_likelihood", [xs, dist_info_vars]):
+        with tf.name_scope(name, "log_likelihood_sym", [xs, dist_info_vars]):
             probs = dist_info_vars["prob"]
             # Assume layout is N * T * A
             a_dim = tf.shape(probs)[2]

--- a/garage/tf/misc/tensor_utils.py
+++ b/garage/tf/misc/tensor_utils.py
@@ -11,7 +11,10 @@ def compile_function(inputs, outputs, log_name=None):
 
 
 def flatten_tensor_variables(ts):
-    return tf.concat(axis=0, values=[tf.reshape(x, [-1]) for x in ts])
+    return tf.concat(
+        axis=0,
+        values=[tf.reshape(x, [-1]) for x in ts],
+        name="flatten_tensor_variables")
 
 
 def unflatten_tensor_variables(flatarr, shapes, symb_arrs):
@@ -121,25 +124,3 @@ def pad_tensor_dict(tensor_dict, max_len):
         else:
             ret[k] = pad_tensor(tensor_dict[k], max_len)
     return ret
-
-
-class enclosing_scope(object):
-    def __init__(self, enclosing_name, name, **kwargs):
-        self.enclosing_scope = None
-        self.scope = None
-        self.enclosing_name = enclosing_name
-        self.name = name
-        self.kwargs = kwargs
-
-    def __enter__(self):
-        if self.enclosing_name not in tf.get_variable_scope().name:
-            self.enclosing_scope = tf.variable_scope(self.enclosing_name,
-                                                     self.kwargs)
-            self.enclosing_scope.__enter__()
-        self.scope = tf.variable_scope(self.name, self.kwargs)
-        self.scope.__enter__()
-
-    def __exit__(self, *args):
-        self.scope.__exit__(*args)
-        if self.enclosing_scope is not None:
-            self.enclosing_scope.__exit__(*args)

--- a/garage/tf/optimizers/conjugate_gradient_optimizer.py
+++ b/garage/tf/optimizers/conjugate_gradient_optimizer.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy as np
 import tensorflow as tf
 
@@ -12,21 +10,19 @@ from garage.tf.misc import tensor_utils
 
 
 class PerlmutterHvp(object):
-    def __init__(self, num_slices=1, name="PerlmutterHvp"):
+    def __init__(self, num_slices=1):
         self.target = None
         self.reg_coeff = None
         self.opt_fun = None
         self._num_slices = num_slices
-        self._name = name
 
     def update_opt(self, f, target, inputs, reg_coeff, name=None):
-        with tf.name_scope(name, "PerlmutterHvp", [f, target, inputs]):
-            self.target = target
-            self.reg_coeff = reg_coeff
-            params = target.get_params(trainable=True)
-
+        self.target = target
+        self.reg_coeff = reg_coeff
+        params = target.get_params(trainable=True)
+        with tf.name_scope(name, "PerlmutterHvp", [f, inputs, params]):
             constraint_grads = tf.gradients(
-                f, xs=params, name="constraint_gradients")
+                f, xs=params, name="gradients_constraint")
             for idx, (grad, param) in enumerate(zip(constraint_grads, params)):
                 if grad is None:
                     constraint_grads[idx] = tf.zeros_like(param)
@@ -36,35 +32,36 @@ class PerlmutterHvp(object):
                 for p in params
             ])
 
-            def Hx_plain():
+            def hx_plain():
                 with tf.name_scope(
-                        "Hx_plain", values=[params, constraint_grads, xs]):
-                    Hx_plain_splits = tf.gradients(
-                        tf.reduce_sum(
+                        "hx_plain", values=[constraint_grads, params, xs]):
+                    with tf.name_scope(
+                            "hx_function", values=[constraint_grads, xs]):
+                        hx_f = tf.reduce_sum(
                             tf.stack([
                                 tf.reduce_sum(g * x)
                                 for g, x in zip(constraint_grads, xs)
                             ])),
-                        params,
-                        name="Hx_plain_gradients")
-                    for idx, (Hx, param) in enumerate(
-                            zip(Hx_plain_splits, params)):
-                        if Hx is None:
-                            Hx_plain_splits[idx] = tf.zeros_like(param)
+                    hx_plain_splits = tf.gradients(
+                        hx_f, params, name="gradients_hx_plain")
+                    for idx, (hx, param) in enumerate(
+                            zip(hx_plain_splits, params)):
+                        if hx is None:
+                            hx_plain_splits[idx] = tf.zeros_like(param)
                     return tensor_utils.flatten_tensor_variables(
-                        Hx_plain_splits)
+                        hx_plain_splits)
 
             self.opt_fun = ext.lazydict(
-                f_Hx_plain=lambda: tensor_utils.compile_function(
+                f_hx_plain=lambda: tensor_utils.compile_function(
                     inputs=inputs + xs,
-                    outputs=Hx_plain(),
-                    log_name="f_Hx_plain",
+                    outputs=hx_plain(),
+                    log_name="f_hx_plain",
                 ), )
 
     def build_eval(self, inputs):
         def eval(x):
             xs = tuple(self.target.flat_to_params(x, trainable=True))
-            ret = sliced_fun(self.opt_fun["f_Hx_plain"], self._num_slices)(
+            ret = sliced_fun(self.opt_fun["f_hx_plain"], self._num_slices)(
                 inputs, xs) + self.reg_coeff * x
             return ret
 
@@ -76,53 +73,50 @@ class FiniteDifferenceHvp(object):
                  base_eps=1e-8,
                  symmetric=True,
                  grad_clip=None,
-                 num_slices=1,
-                 name="FiniteDifferenceHvp"):
+                 num_slices=1):
         self.base_eps = base_eps
         self.symmetric = symmetric
         self.grad_clip = grad_clip
         self._num_slices = num_slices
-        self._name = name
 
     def update_opt(self, f, target, inputs, reg_coeff, name=None):
-        with tf.name_scope(
-                    name,
-                    "FiniteDifferenceHvp",
-                [f, target.get_params(trainable=True), inputs]):
-            self.target = target
-            self.reg_coeff = reg_coeff
+        self.target = target
+        self.reg_coeff = reg_coeff
+        params = target.get_params(trainable=True)
 
-            params = target.get_params(trainable=True)
-
+        with tf.name_scope(name, "FiniteDifferenceHvp",
+                           [f, inputs, params, target]):
             constraint_grads = tf.gradients(
-                f, xs=params, name="constraint_gradients")
+                f, xs=params, name="gradients_constraint")
             for idx, (grad, param) in enumerate(zip(constraint_grads, params)):
                 if grad is None:
                     constraint_grads[idx] = tf.zeros_like(param)
 
             flat_grad = tensor_utils.flatten_tensor_variables(constraint_grads)
 
-            def f_Hx_plain(*args):
-                inputs_ = args[:len(inputs)]
-                xs = args[len(inputs):]
-                flat_xs = np.concatenate([np.reshape(x, (-1, )) for x in xs])
-                param_val = self.target.get_param_values(trainable=True)
-                eps = np.cast['float32'](
-                    self.base_eps / (np.linalg.norm(param_val) + 1e-8))
-                self.target.set_param_values(
-                    param_val + eps * flat_xs, trainable=True)
-                flat_grad_dvplus = self.opt_fun["f_grad"](*inputs_)
-                self.target.set_param_values(param_val, trainable=True)
-                if self.symmetric:
+            def f_hx_plain(*args):
+                with tf.name_scope("f_hx_plain", values=[inputs, self.target]):
+                    inputs_ = args[:len(inputs)]
+                    xs = args[len(inputs):]
+                    flat_xs = np.concatenate(
+                        [np.reshape(x, (-1, )) for x in xs])
+                    param_val = self.target.get_param_values(trainable=True)
+                    eps = np.cast['float32'](
+                        self.base_eps / (np.linalg.norm(param_val) + 1e-8))
                     self.target.set_param_values(
-                        param_val - eps * flat_xs, trainable=True)
-                    flat_grad_dvminus = self.opt_fun["f_grad"](*inputs_)
-                    hx = (flat_grad_dvplus - flat_grad_dvminus) / (2 * eps)
+                        param_val + eps * flat_xs, trainable=True)
+                    flat_grad_dvplus = self.opt_fun["f_grad"](*inputs_)
                     self.target.set_param_values(param_val, trainable=True)
-                else:
-                    flat_grad = self.opt_fun["f_grad"](*inputs_)
-                    hx = (flat_grad_dvplus - flat_grad) / eps
-                return hx
+                    if self.symmetric:
+                        self.target.set_param_values(
+                            param_val - eps * flat_xs, trainable=True)
+                        flat_grad_dvminus = self.opt_fun["f_grad"](*inputs_)
+                        hx = (flat_grad_dvplus - flat_grad_dvminus) / (2 * eps)
+                        self.target.set_param_values(param_val, trainable=True)
+                    else:
+                        flat_grad = self.opt_fun["f_grad"](*inputs_)
+                        hx = (flat_grad_dvplus - flat_grad) / eps
+                    return hx
 
             self.opt_fun = ext.lazydict(
                 f_grad=lambda: tensor_utils.compile_function(
@@ -130,13 +124,13 @@ class FiniteDifferenceHvp(object):
                     outputs=flat_grad,
                     log_name="f_grad",
                 ),
-                f_Hx_plain=lambda: f_Hx_plain,
+                f_hx_plain=lambda: f_hx_plain,
             )
 
     def build_eval(self, inputs):
         def eval(x):
             xs = tuple(self.target.flat_to_params(x, trainable=True))
-            ret = sliced_fun(self.opt_fun["f_Hx_plain"], self._num_slices)(
+            ret = sliced_fun(self.opt_fun["f_hx_plain"], self._num_slices)(
                 inputs, xs) + self.reg_coeff * x
             return ret
 
@@ -144,11 +138,11 @@ class FiniteDifferenceHvp(object):
 
 
 class ConjugateGradientOptimizer(Serializable):
-    """
-    Performs constrained optimization via line search. The search direction is
-    computed using a conjugate gradient algorithm, which gives x = A^{-1}g,
-    where A is a second order approximation of the constraint and g is the
-    gradient of the loss function.
+    """Performs constrained optimization via line search.
+
+    The search direction is computed using a conjugate gradient algorithm,
+    which gives x = A^{-1}g, where A is a second order approximation of the
+    constraint and g is the gradient of the loss function.
     """
 
     def __init__(self,
@@ -163,11 +157,10 @@ class ConjugateGradientOptimizer(Serializable):
                  num_slices=1,
                  name="ConjugateGradientOptimizer"):
         """
-
         :param cg_iters: The number of CG iterations used to calculate A^-1 g
         :param reg_coeff: A small value so that A -> A + reg*I
-        :param subsample_factor: Subsampling factor to reduce samples when using
-         "conjugate gradient. Since the computation time for the descent
+        :param subsample_factor: Subsampling factor to reduce samples when
+         using "conjugate gradient. Since the computation time for the descent
          direction dominates, this can greatly reduce the overall computation
          time.
         :param debug_nan: if set to True, NanGuard will be added to the
@@ -209,10 +202,10 @@ class ConjugateGradientOptimizer(Serializable):
         """
         :param loss: Symbolic expression for the loss function.
         :param target: A parameterized object to optimize over. It should
-         implement methods of the :class:`garage.core.paramerized.Parameterized`
-         class.
-        :param leq_constraint: A constraint provided as a tuple (f, epsilon), of
-         the form f(*inputs) <= epsilon.
+         implement methods of the
+         the :class:`garage.core.paramerized.Parameterized` class.
+        :param leq_constraint: A constraint provided as a tuple (f, epsilon),
+         of the form f(*inputs) <= epsilon.
         :param inputs: A list of symbolic variables as inputs, which could be
          subsampled if needed. It is assumed that the first dimension of these
          inputs should correspond to the number of data points
@@ -220,12 +213,10 @@ class ConjugateGradientOptimizer(Serializable):
          should not be subsampled
         :return: No return value.
         """
+        params = target.get_params(trainable=True)
         with tf.name_scope(
-                name,
-                "ConjugateGradientOptimizer", [
-                    loss, inputs, extra_inputs, leq_constraint,
-                    target.get_params(trainable=True)
-                ]):
+                name, "ConjugateGradientOptimizer",
+            [loss, target, leq_constraint, inputs, extra_inputs, params]):
             inputs = tuple(inputs)
             if extra_inputs is None:
                 extra_inputs = tuple()
@@ -234,18 +225,19 @@ class ConjugateGradientOptimizer(Serializable):
 
             constraint_term, constraint_value = leq_constraint
 
-            params = target.get_params(trainable=True)
-            grads = tf.gradients(loss, xs=params)
-            for idx, (grad, param) in enumerate(zip(grads, params)):
-                if grad is None:
-                    grads[idx] = tf.zeros_like(param)
-            flat_grad = tensor_utils.flatten_tensor_variables(grads)
+            with tf.name_scope("loss_gradients", values=[loss, params]):
+                grads = tf.gradients(loss, xs=params)
+                for idx, (grad, param) in enumerate(zip(grads, params)):
+                    if grad is None:
+                        grads[idx] = tf.zeros_like(param)
+                flat_grad = tensor_utils.flatten_tensor_variables(grads)
 
             self._hvp_approach.update_opt(
                 f=constraint_term,
                 target=target,
                 inputs=inputs + extra_inputs,
-                reg_coeff=self._reg_coeff)
+                reg_coeff=self._reg_coeff,
+                name="update_opt_" + constraint_name)
 
             self._target = target
             self._max_constraint_val = constraint_value
@@ -291,84 +283,92 @@ class ConjugateGradientOptimizer(Serializable):
     def optimize(self,
                  inputs,
                  extra_inputs=None,
-                 subsample_grouped_inputs=None):
-        prev_param = np.copy(self._target.get_param_values(trainable=True))
-        inputs = tuple(inputs)
-        if extra_inputs is None:
-            extra_inputs = tuple()
+                 subsample_grouped_inputs=None,
+                 name=None):
+        with tf.name_scope(
+                name,
+                "optimize",
+                values=[inputs, extra_inputs, subsample_grouped_inputs]):
+            prev_param = np.copy(self._target.get_param_values(trainable=True))
+            inputs = tuple(inputs)
+            if extra_inputs is None:
+                extra_inputs = tuple()
 
-        if self._subsample_factor < 1:
-            if subsample_grouped_inputs is None:
-                subsample_grouped_inputs = [inputs]
-            subsample_inputs = tuple()
-            for inputs_grouped in subsample_grouped_inputs:
-                n_samples = len(inputs_grouped[0])
-                inds = np.random.choice(
-                    n_samples,
-                    int(n_samples * self._subsample_factor),
-                    replace=False)
-                subsample_inputs += tuple([x[inds] for x in inputs_grouped])
-        else:
-            subsample_inputs = inputs
+            if self._subsample_factor < 1:
+                if subsample_grouped_inputs is None:
+                    subsample_grouped_inputs = [inputs]
+                subsample_inputs = tuple()
+                for inputs_grouped in subsample_grouped_inputs:
+                    n_samples = len(inputs_grouped[0])
+                    inds = np.random.choice(
+                        n_samples,
+                        int(n_samples * self._subsample_factor),
+                        replace=False)
+                    subsample_inputs += tuple(
+                        [x[inds] for x in inputs_grouped])
+            else:
+                subsample_inputs = inputs
 
-        logger.log(("Start CG optimization: "
-                    "#parameters: %d, #inputs: %d, #subsample_inputs: %d") %
-                   (len(prev_param), len(inputs[0]), len(subsample_inputs[0])))
+            logger.log(
+                ("Start CG optimization: "
+                 "#parameters: %d, #inputs: %d, #subsample_inputs: %d") %
+                (len(prev_param), len(inputs[0]), len(subsample_inputs[0])))
 
-        logger.log("computing loss before")
-        loss_before = sliced_fun(self._opt_fun["f_loss"],
-                                 self._num_slices)(inputs, extra_inputs)
-        logger.log("performing update")
+            logger.log("computing loss before")
+            loss_before = sliced_fun(self._opt_fun["f_loss"],
+                                     self._num_slices)(inputs, extra_inputs)
+            logger.log("performing update")
 
-        logger.log("computing gradient")
-        flat_g = sliced_fun(self._opt_fun["f_grad"],
-                            self._num_slices)(inputs, extra_inputs)
-        logger.log("gradient computed")
+            logger.log("computing gradient")
+            flat_g = sliced_fun(self._opt_fun["f_grad"],
+                                self._num_slices)(inputs, extra_inputs)
+            logger.log("gradient computed")
 
-        logger.log("computing descent direction")
-        Hx = self._hvp_approach.build_eval(subsample_inputs + extra_inputs)
+            logger.log("computing descent direction")
+            hx = self._hvp_approach.build_eval(subsample_inputs + extra_inputs)
 
-        descent_direction = krylov.cg(Hx, flat_g, cg_iters=self._cg_iters)
+            descent_direction = krylov.cg(hx, flat_g, cg_iters=self._cg_iters)
 
-        initial_step_size = np.sqrt(
-            2.0 * self._max_constraint_val *
-            (1. / (descent_direction.dot(Hx(descent_direction)) + 1e-8)))
-        if np.isnan(initial_step_size):
-            initial_step_size = 1.
-        flat_descent_step = initial_step_size * descent_direction
+            initial_step_size = np.sqrt(
+                2.0 * self._max_constraint_val *
+                (1. / (descent_direction.dot(hx(descent_direction)) + 1e-8)))
+            if np.isnan(initial_step_size):
+                initial_step_size = 1.
+            flat_descent_step = initial_step_size * descent_direction
 
-        logger.log("descent direction computed")
+            logger.log("descent direction computed")
 
-        n_iter = 0
-        for n_iter, ratio in enumerate(self._backtrack_ratio
-                                       ** np.arange(self._max_backtracks)):
-            cur_step = ratio * flat_descent_step
-            cur_param = prev_param - cur_step
-            self._target.set_param_values(cur_param, trainable=True)
-            loss, constraint_val = sliced_fun(
-                self._opt_fun["f_loss_constraint"],
-                self._num_slices)(inputs, extra_inputs)
-            if self._debug_nan and np.isnan(constraint_val):
-                import ipdb
-                ipdb.set_trace()
-            if loss < loss_before and \
-               constraint_val <= self._max_constraint_val:
-                break
-        if (np.isnan(loss) or np.isnan(constraint_val) or loss >= loss_before
-                    or constraint_val >= self._max_constraint_val
-                ) and not self._accept_violation:
-            logger.log("Line search condition violated. Rejecting the step!")
-            if np.isnan(loss):
-                logger.log("Violated because loss is NaN")
-            if np.isnan(constraint_val):
-                logger.log("Violated because constraint %s is NaN" %
-                           self._constraint_name)
-            if loss >= loss_before:
-                logger.log("Violated because loss not improving")
-            if constraint_val >= self._max_constraint_val:
-                logger.log("Violated because constraint %s is violated" %
-                           self._constraint_name)
-            self._target.set_param_values(prev_param, trainable=True)
-        logger.log("backtrack iters: %d" % n_iter)
-        logger.log("computing loss after")
-        logger.log("optimization finished")
+            n_iter = 0
+            for n_iter, ratio in enumerate(self._backtrack_ratio**np.arange(
+                    self._max_backtracks)):  # yapf: disable
+                cur_step = ratio * flat_descent_step
+                cur_param = prev_param - cur_step
+                self._target.set_param_values(cur_param, trainable=True)
+                loss, constraint_val = sliced_fun(
+                    self._opt_fun["f_loss_constraint"],
+                    self._num_slices)(inputs, extra_inputs)
+                if self._debug_nan and np.isnan(constraint_val):
+                    import ipdb
+                    ipdb.set_trace()
+                if loss < loss_before and \
+                   constraint_val <= self._max_constraint_val:
+                    break
+            if (np.isnan(loss) or np.isnan(constraint_val)
+                    or loss >= loss_before or constraint_val >=
+                    self._max_constraint_val) and not self._accept_violation:
+                logger.log(
+                    "Line search condition violated. Rejecting the step!")
+                if np.isnan(loss):
+                    logger.log("Violated because loss is NaN")
+                if np.isnan(constraint_val):
+                    logger.log("Violated because constraint %s is NaN" %
+                               self._constraint_name)
+                if loss >= loss_before:
+                    logger.log("Violated because loss not improving")
+                if constraint_val >= self._max_constraint_val:
+                    logger.log("Violated because constraint %s is violated" %
+                               self._constraint_name)
+                self._target.set_param_values(prev_param, trainable=True)
+            logger.log("backtrack iters: %d" % n_iter)
+            logger.log("computing loss after")
+            logger.log("optimization finished")

--- a/garage/tf/optimizers/conjugate_gradient_optimizer.py
+++ b/garage/tf/optimizers/conjugate_gradient_optimizer.py
@@ -216,7 +216,8 @@ class ConjugateGradientOptimizer(Serializable):
         params = target.get_params(trainable=True)
         with tf.name_scope(
                 name, "ConjugateGradientOptimizer",
-            [loss, target, leq_constraint, inputs, extra_inputs, params]):
+                [loss, target, leq_constraint, inputs, extra_inputs,
+                 params]):  # yapf: disable
             inputs = tuple(inputs)
             if extra_inputs is None:
                 extra_inputs = tuple()
@@ -348,8 +349,7 @@ class ConjugateGradientOptimizer(Serializable):
                     self._opt_fun["f_loss_constraint"],
                     self._num_slices)(inputs, extra_inputs)
                 if self._debug_nan and np.isnan(constraint_val):
-                    import ipdb
-                    ipdb.set_trace()
+                    break
                 if loss < loss_before and \
                    constraint_val <= self._max_constraint_val:
                     break

--- a/garage/tf/optimizers/first_order_optimizer.py
+++ b/garage/tf/optimizers/first_order_optimizer.py
@@ -26,7 +26,7 @@ class FirstOrderOptimizer(Serializable):
             batch_size=32,
             callback=None,
             verbose=False,
-            name="FirstOrderOptimizer",
+            name=None,
             **kwargs):
         """
         :param max_epochs:
@@ -55,7 +55,13 @@ class FirstOrderOptimizer(Serializable):
         self._train_op = None
         self._name = name
 
-    def update_opt(self, loss, target, inputs, extra_inputs=None, **kwargs):
+    def update_opt(self,
+                   loss,
+                   target,
+                   inputs,
+                   extra_inputs=None,
+                   name=None,
+                   **kwargs):
         """
         :param loss: Symbolic expression for the loss function.
         :param target: A parameterized object to optimize over. It should
@@ -66,17 +72,12 @@ class FirstOrderOptimizer(Serializable):
         :param inputs: A list of symbolic variables as inputs
         :return: No return value.
         """
-        with tf.variable_scope(
-                self._name,
-                values=[
-                    loss,
-                    target.get_params(trainable=True), inputs, extra_inputs
-                ]):
-
+        params = target.get_params(trainable=True)
+        with tf.name_scope(name, "update_opt",
+                           [loss, params, inputs, extra_inputs]):
             self._target = target
 
-            self._train_op = self._tf_optimizer.minimize(
-                loss, var_list=target.get_params(trainable=True))
+            self._train_op = self._tf_optimizer.minimize(loss, var_list=params)
 
             # updates = OrderedDict(
             #     [(k, v.astype(k.dtype)) for k, v in updates.iteritems()])
@@ -93,59 +94,60 @@ class FirstOrderOptimizer(Serializable):
             extra_inputs = tuple()
         return self._opt_fun["f_loss"](*(tuple(inputs) + extra_inputs))
 
-    def optimize(self, inputs, extra_inputs=None, callback=None):
+    def optimize(self, inputs, extra_inputs=None, callback=None, name=None):
+        with tf.name_scope(name, "optimize", values=[inputs, extra_inputs]):
 
-        if not inputs:
-            # Assumes that we should always sample mini-batches
-            raise NotImplementedError
+            if not inputs:
+                # Assumes that we should always sample mini-batches
+                raise NotImplementedError
 
-        f_loss = self._opt_fun["f_loss"]
+            f_loss = self._opt_fun["f_loss"]
 
-        if extra_inputs is None:
-            extra_inputs = tuple()
+            if extra_inputs is None:
+                extra_inputs = tuple()
 
-        last_loss = f_loss(*(tuple(inputs) + extra_inputs))
+            last_loss = f_loss(*(tuple(inputs) + extra_inputs))
 
-        start_time = time.time()
+            start_time = time.time()
 
-        dataset = BatchDataset(
-            inputs, self._batch_size, extra_inputs=extra_inputs)
+            dataset = BatchDataset(
+                inputs, self._batch_size, extra_inputs=extra_inputs)
 
-        sess = tf.get_default_session()
+            sess = tf.get_default_session()
 
-        for epoch in range(self._max_epochs):
-            if self._verbose:
-                logger.log("Epoch %d" % (epoch))
-                progbar = pyprind.ProgBar(len(inputs[0]))
-
-            for batch in dataset.iterate(update=True):
-                sess.run(self._train_op,
-                         dict(list(zip(self._input_vars, batch))))
+            for epoch in range(self._max_epochs):
                 if self._verbose:
-                    progbar.update(len(batch[0]))
+                    logger.log("Epoch %d" % (epoch))
+                    progbar = pyprind.ProgBar(len(inputs[0]))
 
-            if self._verbose:
-                if progbar.active:
-                    progbar.stop()
+                for batch in dataset.iterate(update=True):
+                    sess.run(self._train_op,
+                             dict(list(zip(self._input_vars, batch))))
+                    if self._verbose:
+                        progbar.update(len(batch[0]))
 
-            new_loss = f_loss(*(tuple(inputs) + extra_inputs))
+                if self._verbose:
+                    if progbar.active:
+                        progbar.stop()
 
-            if self._verbose:
-                logger.log("Epoch: %d | Loss: %f" % (epoch, new_loss))
-            if self._callback or callback:
-                elapsed = time.time() - start_time
-                callback_args = dict(
-                    loss=new_loss,
-                    params=self._target.get_param_values(trainable=True)
-                    if self._target else None,
-                    itr=epoch,
-                    elapsed=elapsed,
-                )
-                if self._callback:
-                    self._callback(callback_args)
-                if callback:
-                    callback(**callback_args)
+                new_loss = f_loss(*(tuple(inputs) + extra_inputs))
 
-            if abs(last_loss - new_loss) < self._tolerance:
-                break
-            last_loss = new_loss
+                if self._verbose:
+                    logger.log("Epoch: %d | Loss: %f" % (epoch, new_loss))
+                if self._callback or callback:
+                    elapsed = time.time() - start_time
+                    callback_args = dict(
+                        loss=new_loss,
+                        params=self._target.get_param_values(trainable=True)
+                        if self._target else None,
+                        itr=epoch,
+                        elapsed=elapsed,
+                    )
+                    if self._callback:
+                        self._callback(callback_args)
+                    if callback:
+                        callback(**callback_args)
+
+                if abs(last_loss - new_loss) < self._tolerance:
+                    break
+                last_loss = new_loss

--- a/garage/tf/optimizers/lbfgs_optimizer.py
+++ b/garage/tf/optimizers/lbfgs_optimizer.py
@@ -6,7 +6,6 @@ import tensorflow as tf
 from garage.core import Serializable
 from garage.misc import ext
 from garage.tf.misc import tensor_utils
-from garage.tf.misc.tensor_utils import enclosing_scope
 
 
 class LbfgsOptimizer(Serializable):
@@ -27,7 +26,7 @@ class LbfgsOptimizer(Serializable):
                    target,
                    inputs,
                    extra_inputs=None,
-                   name="update_opt",
+                   name=None,
                    *args,
                    **kwargs):
         """
@@ -40,7 +39,11 @@ class LbfgsOptimizer(Serializable):
         :param inputs: A list of symbolic variables as inputs
         :return: No return value.
         """
-        with enclosing_scope(self._name, name):
+        with tf.name_scope(
+                name,
+                "LbfgsOptimizer",
+            [loss,
+             target.get_params(trainable=True), inputs, extra_inputs]):
             self._target = target
 
             def get_opt_output():

--- a/garage/tf/optimizers/penalty_lbfgs_optimizer.py
+++ b/garage/tf/optimizers/penalty_lbfgs_optimizer.py
@@ -21,10 +21,8 @@ class PenaltyLbfgsOptimizer(Serializable):
                  increase_penalty_factor=2,
                  decrease_penalty_factor=0.5,
                  max_penalty_itr=10,
-                 adapt_penalty=True,
-                 name="PenaltyLbfgsOptimizer"):
+                 adapt_penalty=True):
         Serializable.quick_init(self, locals())
-        self._name = name
         self._max_opt_itr = max_opt_itr
         self._penalty = initial_penalty
         self._initial_penalty = initial_penalty
@@ -52,36 +50,35 @@ class PenaltyLbfgsOptimizer(Serializable):
         """
         :param loss: Symbolic expression for the loss function.
         :param target: A parameterized object to optimize over. It should
-         implement methods of the :class:`garage.core.paramerized.Parameterized`
-         class.
+         implement methods of the
+         :class:`garage.core.paramerized.Parameterized` class.
         :param leq_constraint: A constraint provided as a tuple (f, epsilon),
          of the form f(*inputs) <= epsilon.
         :param inputs: A list of symbolic variables as inputs
         :return: No return value.
         """
-        with tf.name_scope(
-                name,
-                "PenaltyLbfgsOptimizer",
-                [loss, target.get_params(trainable=True), leq_constraint]):
+        self._target = target
+        self._max_constraint_val = constraint_value
+        self._constraint_name = constraint_name
+        params = target.get_params(trainable=True)
+        with tf.name_scope(name, "PenaltyLbfgsOptimizer",
+                           [leq_constraint, loss, params]):
             constraint_term, constraint_value = leq_constraint
             penalty_var = tf.placeholder(tf.float32, tuple(), name="penalty")
             penalized_loss = loss + penalty_var * constraint_term
 
-            self._target = target
-            self._max_constraint_val = constraint_value
-            self._constraint_name = constraint_name
-
             def get_opt_output():
-                params = target.get_params(trainable=True)
-                grads = tf.gradients(penalized_loss, params)
-                for idx, (grad, param) in enumerate(zip(grads, params)):
-                    if grad is None:
-                        grads[idx] = tf.zeros_like(param)
-                flat_grad = tensor_utils.flatten_tensor_variables(grads)
-                return [
-                    tf.cast(penalized_loss, tf.float64),
-                    tf.cast(flat_grad, tf.float64),
-                ]
+                with tf.name_scope(
+                        "get_opt_output", values=[params, penalized_loss]):
+                    grads = tf.gradients(penalized_loss, params)
+                    for idx, (grad, param) in enumerate(zip(grads, params)):
+                        if grad is None:
+                            grads[idx] = tf.zeros_like(param)
+                    flat_grad = tensor_utils.flatten_tensor_variables(grads)
+                    return [
+                        tf.cast(penalized_loss, tf.float64),
+                        tf.cast(flat_grad, tf.float64),
+                    ]
 
             self._opt_fun = ext.lazydict(
                 f_loss=lambda: tensor_utils.compile_function(
@@ -104,75 +101,77 @@ class PenaltyLbfgsOptimizer(Serializable):
     def constraint_val(self, inputs):
         return self._opt_fun["f_constraint"](*inputs)
 
-    def optimize(self, inputs):
+    def optimize(self, inputs, name=None):
+        with tf.name_scope(name, "optimize", values=[inputs]):
 
-        inputs = tuple(inputs)
+            inputs = tuple(inputs)
 
-        try_penalty = np.clip(self._penalty, self._min_penalty,
-                              self._max_penalty)
-
-        penalty_scale_factor = None
-        f_opt = self._opt_fun["f_opt"]
-        f_penalized_loss = self._opt_fun["f_penalized_loss"]
-
-        def gen_f_opt(penalty):
-            def f(flat_params):
-                self._target.set_param_values(flat_params, trainable=True)
-                return f_opt(*(inputs + (penalty, )))
-
-            return f
-
-        cur_params = self._target.get_param_values(
-            trainable=True).astype('float64')
-        opt_params = cur_params
-
-        for penalty_itr in range(self._max_penalty_itr):
-            logger.log('trying penalty=%.3f...' % try_penalty)
-
-            itr_opt_params, _, _ = scipy.optimize.fmin_l_bfgs_b(
-                func=gen_f_opt(try_penalty),
-                x0=cur_params,
-                maxiter=self._max_opt_itr)
-
-            _, try_loss, try_constraint_val = f_penalized_loss(
-                *(inputs + (try_penalty, )))
-
-            logger.log('penalty %f => loss %f, %s %f' %
-                       (try_penalty, try_loss, self._constraint_name,
-                        try_constraint_val))
-
-            # Either constraint satisfied, or we are at the last iteration
-            # already and no alternative parameter satisfies the constraint
-            if try_constraint_val < self._max_constraint_val or \
-                    (penalty_itr == self._max_penalty_itr - 1 and \
-                     opt_params is None):
-                opt_params = itr_opt_params
-
-            if not self._adapt_penalty:
-                break
-
-            # Decide scale factor on the first iteration, or if constraint
-            # violation yields numerical error
-            if penalty_scale_factor is None or np.isnan(try_constraint_val):
-                # Increase penalty if constraint violated, or if constraint term
-                # is NAN
-                if try_constraint_val > self._max_constraint_val or np.isnan(
-                        try_constraint_val):
-                    penalty_scale_factor = self._increase_penalty_factor
-                else:
-                    # Otherwise (i.e. constraint satisfied), shrink penalty
-                    penalty_scale_factor = self._decrease_penalty_factor
-                    opt_params = itr_opt_params
-            else:
-                if penalty_scale_factor > 1 and \
-                                try_constraint_val <= self._max_constraint_val:
-                    break
-                elif penalty_scale_factor < 1 and \
-                                try_constraint_val >= self._max_constraint_val:
-                    break
-            try_penalty *= penalty_scale_factor
-            try_penalty = np.clip(try_penalty, self._min_penalty,
+            try_penalty = np.clip(self._penalty, self._min_penalty,
                                   self._max_penalty)
-            self._penalty = try_penalty
 
-        self._target.set_param_values(opt_params, trainable=True)
+            penalty_scale_factor = None
+            f_opt = self._opt_fun["f_opt"]
+            f_penalized_loss = self._opt_fun["f_penalized_loss"]
+
+            def gen_f_opt(penalty):
+                def f(flat_params):
+                    self._target.set_param_values(flat_params, trainable=True)
+                    return f_opt(*(inputs + (penalty, )))
+
+                return f
+
+            cur_params = self._target.get_param_values(
+                trainable=True).astype('float64')
+            opt_params = cur_params
+
+            for penalty_itr in range(self._max_penalty_itr):
+                logger.log('trying penalty=%.3f...' % try_penalty)
+
+                itr_opt_params, _, _ = scipy.optimize.fmin_l_bfgs_b(
+                    func=gen_f_opt(try_penalty),
+                    x0=cur_params,
+                    maxiter=self._max_opt_itr)
+
+                _, try_loss, try_constraint_val = f_penalized_loss(
+                    *(inputs + (try_penalty, )))
+
+                logger.log('penalty %f => loss %f, %s %f' %
+                           (try_penalty, try_loss, self._constraint_name,
+                            try_constraint_val))
+
+                # Either constraint satisfied, or we are at the last iteration
+                # already and no alternative parameter satisfies the constraint
+                if try_constraint_val < self._max_constraint_val or \
+                        (penalty_itr == self._max_penalty_itr - 1 and \
+                            opt_params is None):
+                    opt_params = itr_opt_params
+
+                if not self._adapt_penalty:
+                    break
+
+                # Decide scale factor on the first iteration, or if constraint
+                # violation yields numerical error
+                if (penalty_scale_factor is None
+                        or np.isnan(try_constraint_val)):
+                    # Increase penalty if constraint violated, or if constraint
+                    # term is NAN
+                    if (try_constraint_val > self._max_constraint_val
+                            or np.isnan(try_constraint_val)):
+                        penalty_scale_factor = self._increase_penalty_factor
+                    else:
+                        # Otherwise (i.e. constraint satisfied), shrink penalty
+                        penalty_scale_factor = self._decrease_penalty_factor
+                        opt_params = itr_opt_params
+                else:
+                    if (penalty_scale_factor > 1 and
+                            try_constraint_val <= self._max_constraint_val):
+                        break
+                    elif (penalty_scale_factor < 1
+                          and try_constraint_val >= self._max_constraint_val):
+                        break
+                try_penalty *= penalty_scale_factor
+                try_penalty = np.clip(try_penalty, self._min_penalty,
+                                      self._max_penalty)
+                self._penalty = try_penalty
+
+            self._target.set_param_values(opt_params, trainable=True)

--- a/garage/tf/policies/categorical_conv_policy.py
+++ b/garage/tf/policies/categorical_conv_policy.py
@@ -77,7 +77,7 @@ class CategoricalConvPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var]):
             with tf.name_scope(self._prob_network_name, [obs_var]):
                 prob = L.get_output(
                     self._l_prob, {self._l_obs: tf.cast(obs_var, tf.float32)})

--- a/garage/tf/policies/categorical_conv_policy.py
+++ b/garage/tf/policies/categorical_conv_policy.py
@@ -7,7 +7,6 @@ from garage.tf.core import LayersPowered
 import garage.tf.core.layers as L
 from garage.tf.distributions import Categorical
 from garage.tf.misc import tensor_utils
-from garage.tf.misc.tensor_utils import enclosing_scope
 from garage.tf.policies import StochasticPolicy
 from garage.tf.spaces import Discrete
 
@@ -24,7 +23,7 @@ class CategoricalConvPolicy(StochasticPolicy, LayersPowered, Serializable):
             hidden_nonlinearity=tf.nn.relu,
             output_nonlinearity=tf.nn.softmax,
             prob_network=None,
-            name="CategoricalConvPolicy",
+            name=None,
     ):
         """
         :param env_spec: A spec for the mdp.
@@ -42,44 +41,47 @@ class CategoricalConvPolicy(StochasticPolicy, LayersPowered, Serializable):
 
         self._name = name
         self._env_spec = env_spec
-        if prob_network is None:
-            prob_network = ConvNetwork(
-                input_shape=env_spec.observation_space.shape,
-                output_dim=env_spec.action_space.n,
-                conv_filters=conv_filters,
-                conv_filter_sizes=conv_filter_sizes,
-                conv_strides=conv_strides,
-                conv_pads=conv_pads,
-                hidden_sizes=hidden_sizes,
-                hidden_nonlinearity=hidden_nonlinearity,
-                output_nonlinearity=output_nonlinearity,
-                name="prob_network",
-            )
+        self._prob_network_name = "prob_network"
 
-        self._l_prob = prob_network.output_layer
-        self._l_obs = prob_network.input_layer
-        self._f_prob = tensor_utils.compile_function(
-            [prob_network.input_layer.input_var],
-            L.get_output(prob_network.output_layer))
+        with tf.variable_scope(name, "CategoricalConvPolicy"):
+            if prob_network is None:
+                prob_network = ConvNetwork(
+                    input_shape=env_spec.observation_space.shape,
+                    output_dim=env_spec.action_space.n,
+                    conv_filters=conv_filters,
+                    conv_filter_sizes=conv_filter_sizes,
+                    conv_strides=conv_strides,
+                    conv_pads=conv_pads,
+                    hidden_sizes=hidden_sizes,
+                    hidden_nonlinearity=hidden_nonlinearity,
+                    output_nonlinearity=output_nonlinearity,
+                    name="conv_prob_network",
+                )
 
-        self._dist = Categorical(env_spec.action_space.n)
+            with tf.name_scope(self._prob_network_name):
+                out_prob = L.get_output(prob_network.output_layer)
 
-        super(CategoricalConvPolicy, self).__init__(env_spec)
-        LayersPowered.__init__(self, [prob_network.output_layer])
+            self._l_prob = prob_network.output_layer
+            self._l_obs = prob_network.input_layer
+            self._f_prob = tensor_utils.compile_function(
+                [prob_network.input_layer.input_var], [out_prob])
+
+            self._dist = Categorical(env_spec.action_space.n)
+
+            super(CategoricalConvPolicy, self).__init__(env_spec)
+            LayersPowered.__init__(self, [prob_network.output_layer])
 
     @property
     def vectorized(self):
         return True
 
     @overrides
-    def dist_info_sym(self,
-                      obs_var,
-                      state_info_vars=None,
-                      name="dist_info_sym"):
-        with enclosing_scope(self._name, name):
-            return dict(
-                prob=L.get_output(self._l_prob,
-                                  {self._l_obs: tf.cast(obs_var, tf.float32)}))
+    def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
+        with tf.name_scope(name, "dist_info", [obs_var]):
+            with tf.name_scope(self._prob_network_name, [obs_var]):
+                prob = L.get_output(
+                    self._l_prob, {self._l_obs: tf.cast(obs_var, tf.float32)})
+            return dict(prob)
 
     @overrides
     def dist_info(self, obs, state_infos=None):

--- a/garage/tf/policies/categorical_gru_policy.py
+++ b/garage/tf/policies/categorical_gru_policy.py
@@ -122,7 +122,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var, state_info_vars]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var, state_info_vars]):
             n_batches = tf.shape(obs_var)[0]
             n_steps = tf.shape(obs_var)[1]
             obs_var = tf.reshape(obs_var, tf.stack([n_batches, n_steps, -1]))

--- a/garage/tf/policies/categorical_lstm_policy.py
+++ b/garage/tf/policies/categorical_lstm_policy.py
@@ -126,7 +126,7 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var, state_info_vars]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var, state_info_vars]):
             n_batches = tf.shape(obs_var)[0]
             n_steps = tf.shape(obs_var)[1]
             obs_var = tf.reshape(obs_var, tf.stack([n_batches, n_steps, -1]))

--- a/garage/tf/policies/categorical_lstm_policy.py
+++ b/garage/tf/policies/categorical_lstm_policy.py
@@ -9,7 +9,6 @@ from garage.tf.core import LSTMNetwork
 import garage.tf.core.layers as L
 from garage.tf.distributions import RecurrentCategorical
 from garage.tf.misc import tensor_utils
-from garage.tf.misc.tensor_utils import enclosing_scope
 from garage.tf.policies import StochasticPolicy
 from garage.tf.spaces import Discrete
 
@@ -17,7 +16,7 @@ from garage.tf.spaces import Discrete
 class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(self,
                  env_spec,
-                 name="CategoricalLSTMPolicy",
+                 name=None,
                  hidden_dim=32,
                  feature_network=None,
                  prob_network=None,
@@ -32,7 +31,8 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
         :param hidden_nonlinearity: nonlinearity used for each hidden layer
         :return:
         """
-        with tf.variable_scope(name):
+        self._prob_network_name = "prob_network"
+        with tf.variable_scope(name, "CategoricalLSTMPolicy"):
             assert isinstance(env_spec.action_space, Discrete)
             Serializable.quick_init(self, locals())
             super(CategoricalLSTMPolicy, self).__init__(env_spec)
@@ -78,7 +78,7 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
                     forget_bias=forget_bias,
                     use_peepholes=use_peepholes,
                     lstm_layer_cls=lstm_layer_cls,
-                    name="prob_network")
+                    name=self._prob_network_name)
 
             self.prob_network = prob_network
             self.feature_network = feature_network
@@ -90,21 +90,23 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
             if feature_network is None:
                 feature_var = flat_input_var
             else:
-                feature_var = L.get_output(
-                    l_flat_feature,
-                    {feature_network.input_layer: flat_input_var})
+                with tf.name_scope("feature_network", values=[flat_input_var]):
+                    feature_var = L.get_output(
+                        l_flat_feature,
+                        {feature_network.input_layer: flat_input_var})
 
-            self.f_step_prob = tensor_utils.compile_function(
-                [
-                    flat_input_var,
-                    prob_network.step_prev_hidden_layer.input_var,
-                    prob_network.step_prev_cell_layer.input_var
-                ],
-                L.get_output([
-                    prob_network.step_output_layer,
-                    prob_network.step_hidden_layer,
-                    prob_network.step_cell_layer
-                ], {prob_network.step_input_layer: feature_var}))
+            with tf.name_scope(self._prob_network_name, values=[feature_var]):
+                out_prob_step, out_prob_hidden, out_step_cell = L.get_output(
+                    [
+                        prob_network.step_output_layer,
+                        prob_network.step_hidden_layer,
+                        prob_network.step_cell_layer
+                    ], {prob_network.step_input_layer: feature_var})
+
+            self.f_step_prob = tensor_utils.compile_function([
+                flat_input_var, prob_network.step_prev_hidden_layer.input_var,
+                prob_network.step_prev_cell_layer.input_var
+            ], [out_prob_step, out_prob_hidden, out_step_cell])
 
             self.input_dim = input_dim
             self.action_dim = action_dim
@@ -123,8 +125,8 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
             LayersPowered.__init__(self, out_layers)
 
     @overrides
-    def dist_info_sym(self, obs_var, state_info_vars, name="dist_info_sym"):
-        with enclosing_scope(self.name, name):
+    def dist_info_sym(self, obs_var, state_info_vars, name=None):
+        with tf.name_scope(name, "dist_info", [obs_var, state_info_vars]):
             n_batches = tf.shape(obs_var)[0]
             n_steps = tf.shape(obs_var)[1]
             obs_var = tf.reshape(obs_var, tf.stack([n_batches, n_steps, -1]))
@@ -137,18 +139,23 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
             else:
                 all_input_var = obs_var
             if self.feature_network is None:
-                return dict(
-                    prob=L.get_output(self.prob_network.output_layer,
-                                      {self.l_input: all_input_var}))
+                with tf.name_scope(
+                        self._prob_network_name, values=[all_input_var]):
+                    prob = L.get_output(self.prob_network.output_layer,
+                                        {self.l_input: all_input_var})
+                return dict(prob)
             else:
                 flat_input_var = tf.reshape(all_input_var,
                                             (-1, self.input_dim))
-                return dict(
-                    prob=L.get_output(
+                with tf.name_scope(
+                        self._prob_network_name,
+                        values=[all_input_var, flat_input_var]):
+                    prob = L.get_output(
                         self.prob_network.output_layer, {
                             self.l_input: all_input_var,
                             self.feature_network.input_layer: flat_input_var
-                        }))
+                        })
+                return dict(prob)
 
     @property
     def vectorized(self):

--- a/garage/tf/policies/categorical_mlp_policy.py
+++ b/garage/tf/policies/categorical_mlp_policy.py
@@ -64,7 +64,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var, state_info_vars]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var, state_info_vars]):
             with tf.name_scope(self._prob_network_name, values=[obs_var]):
                 prob = L.get_output(
                     self._l_prob, {self._l_obs: tf.cast(obs_var, tf.float32)})

--- a/garage/tf/policies/continuous_mlp_policy.py
+++ b/garage/tf/policies/continuous_mlp_policy.py
@@ -60,7 +60,7 @@ class ContinuousMLPPolicy(Policy, Serializable, LayersPowered):
         self._hidden_nonlinearity = hidden_nonlinearity
         self._output_nonlinearity = output_nonlinearity
         self._batch_norm = bn
-        self._q_network_name = "q_network"
+        self._policy_network_name = "policy_network"
 
     def _build_net(self, reuse=None, custom_getter=None, trainable=None):
         """
@@ -96,7 +96,7 @@ class ContinuousMLPPolicy(Policy, Serializable, LayersPowered):
                 trainable=trainable,
                 name="output")
 
-            with tf.name_scope(self._q_network_name):
+            with tf.name_scope(self._policy_network_name):
                 action = layers.get_output(l_output)
                 scaled_action = tf.multiply(
                     action, self._action_bound, name="scaled_action")
@@ -111,7 +111,7 @@ class ContinuousMLPPolicy(Policy, Serializable, LayersPowered):
     def get_action_sym(self, obs_var, name=None, **kwargs):
         """Return action sym according to obs_var."""
         with tf.name_scope(name, "get_action_sym", [obs_var]):
-            with tf.name_scope(self._q_network_name):
+            with tf.name_scope(self._policy_network_name):
                 actions = layers.get_output(
                     self._output_layer, {self._obs_layer: obs_var}, **kwargs)
             return tf.multiply(actions, self._action_bound)

--- a/garage/tf/policies/deterministic_mlp_policy.py
+++ b/garage/tf/policies/deterministic_mlp_policy.py
@@ -68,6 +68,6 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
         return actions, dict()
 
     def get_action_sym(self, obs_var, name=None):
-        with tf.name_scope(name, "get_action", values=[obs_var]):
+        with tf.name_scope(name, "get_action_sym", values=[obs_var]):
             with tf.name_scope(self._prob_network_name, values=[obs_var]):
                 return L.get_output(self.prob_network.output_layer, obs_var)

--- a/garage/tf/policies/gaussian_gru_policy.py
+++ b/garage/tf/policies/gaussian_gru_policy.py
@@ -185,7 +185,7 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var, state_info_vars]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var, state_info_vars]):
             n_batches = tf.shape(obs_var)[0]
             n_steps = tf.shape(obs_var)[1]
             obs_var = tf.reshape(obs_var, tf.stack([n_batches, n_steps, -1]))

--- a/garage/tf/policies/gaussian_lstm_policy.py
+++ b/garage/tf/policies/gaussian_lstm_policy.py
@@ -15,7 +15,7 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name="GaussianLSTMPolicy",
+            name=None,
             hidden_dim=32,
             feature_network=None,
             state_include_action=True,
@@ -35,7 +35,7 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
         """
         self._mean_network_name = "mean_network"
         self._std_network_name = "std_network"
-        with tf.variable_scope(name):
+        with tf.variable_scope(name, "GaussianLSTMPolicy"):
             Serializable.quick_init(self, locals())
             super(GaussianLSTMPolicy, self).__init__(env_spec)
 

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -183,7 +183,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         return True
 
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
-        with tf.name_scope(name, "dist_info", [obs_var]):
+        with tf.name_scope(name, "dist_info_sym", [obs_var]):
             with tf.name_scope(self._mean_network_name, values=[obs_var]):
                 mean_var = L.get_output(self._l_mean, obs_var)
             with tf.name_scope(self._std_network_name, values=[obs_var]):
@@ -227,7 +227,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         :param old_dist_info_vars:
         :return:
         """
-        with tf.name_scope(name, "get_reparam_action",
+        with tf.name_scope(name, "get_reparam_action_sym",
                            [obs_var, action_var, old_dist_info_vars]):
             new_dist_info_vars = self.dist_info_sym(obs_var, action_var)
             new_mean_var, new_log_std_var = new_dist_info_vars[

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -9,7 +9,6 @@ from garage.tf.core import MLP
 import garage.tf.core.layers as L
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.misc import tensor_utils
-from garage.tf.misc.tensor_utils import enclosing_scope
 from garage.tf.policies import StochasticPolicy
 from garage.tf.spaces import Box
 
@@ -17,7 +16,7 @@ from garage.tf.spaces import Box
 class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(self,
                  env_spec,
-                 name="GaussianMLPPolicy",
+                 name=None,
                  hidden_sizes=(32, 32),
                  learn_std=True,
                  init_std=1.0,
@@ -58,8 +57,10 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         Serializable.quick_init(self, locals())
         assert isinstance(env_spec.action_space, Box)
         self.name = name
+        self._mean_network_name = "mean_network"
+        self._std_network_name = "std_network"
 
-        with tf.variable_scope(name):
+        with tf.variable_scope(name, "GaussianMLPPolicy"):
 
             obs_dim = env_spec.observation_space.flat_dim
             action_dim = env_spec.action_space.flat_dim
@@ -74,23 +75,24 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                     else:
                         raise NotImplementedError
                     init_b = tf.constant_initializer(init_std_param)
-                    mean_network = MLP(
-                        name="mean_network",
-                        input_shape=(obs_dim, ),
-                        output_dim=2 * action_dim,
-                        hidden_sizes=hidden_sizes,
-                        hidden_nonlinearity=hidden_nonlinearity,
-                        output_nonlinearity=output_nonlinearity,
-                        output_b_init=init_b,
-                    )
-                    l_mean = L.SliceLayer(
-                        mean_network.output_layer,
-                        slice(action_dim),
-                        name="mean_slice",
-                    )
+                    with tf.variable_scope(self._mean_network_name):
+                        mean_network = MLP(
+                            name="mlp",
+                            input_shape=(obs_dim, ),
+                            output_dim=2 * action_dim,
+                            hidden_sizes=hidden_sizes,
+                            hidden_nonlinearity=hidden_nonlinearity,
+                            output_nonlinearity=output_nonlinearity,
+                            output_b_init=init_b,
+                        )
+                        l_mean = L.SliceLayer(
+                            mean_network.output_layer,
+                            slice(action_dim),
+                            name="mean_slice",
+                        )
                 else:
                     mean_network = MLP(
-                        name="mean_network",
+                        name=self._mean_network_name,
                         input_shape=(obs_dim, ),
                         output_dim=action_dim,
                         hidden_sizes=hidden_sizes,
@@ -107,7 +109,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
             else:
                 if adaptive_std:
                     std_network = MLP(
-                        name="std_network",
+                        name=self._std_network_name,
                         input_shape=(obs_dim, ),
                         input_layer=mean_network.input_layer,
                         output_dim=action_dim,
@@ -117,11 +119,12 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                     )
                     l_std_param = std_network.output_layer
                 elif std_share_network:
-                    l_std_param = L.SliceLayer(
-                        mean_network.output_layer,
-                        slice(action_dim, 2 * action_dim),
-                        name="std_slice",
-                    )
+                    with tf.variable_scope(self._std_network_name):
+                        l_std_param = L.SliceLayer(
+                            mean_network.output_layer,
+                            slice(action_dim, 2 * action_dim),
+                            name="std_slice",
+                        )
                 else:
                     if std_parametrization == 'exp':
                         init_std_param = np.log(init_std)
@@ -129,13 +132,14 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                         init_std_param = np.log(np.exp(init_std) - 1)
                     else:
                         raise NotImplementedError
-                    l_std_param = L.ParamLayer(
-                        mean_network.input_layer,
-                        num_units=action_dim,
-                        param=tf.constant_initializer(init_std_param),
-                        name="output_std_param",
-                        trainable=learn_std,
-                    )
+                    with tf.variable_scope(self._std_network_name):
+                        l_std_param = L.ParamLayer(
+                            mean_network.input_layer,
+                            num_units=action_dim,
+                            param=tf.constant_initializer(init_std_param),
+                            name="output_std_param",
+                            trainable=learn_std,
+                        )
 
             self.std_parametrization = std_parametrization
 
@@ -165,8 +169,9 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
 
             dist_info_sym = self.dist_info_sym(
                 mean_network.input_layer.input_var, dict())
-            mean_var = dist_info_sym["mean"]
-            log_std_var = dist_info_sym["log_std"]
+            mean_var = tf.identity(dist_info_sym["mean"], name="mean")
+            log_std_var = tf.identity(
+                dist_info_sym["log_std"], name="standard_dev")
 
             self._f_dist = tensor_utils.compile_function(
                 inputs=[obs_var],
@@ -177,13 +182,12 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
     def vectorized(self):
         return True
 
-    def dist_info_sym(self,
-                      obs_var,
-                      state_info_vars=None,
-                      name="dist_info_sym"):
-        with enclosing_scope(self.name, name):
-            mean_var, std_param_var = L.get_output(
-                [self._l_mean, self._l_std_param], obs_var)
+    def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
+        with tf.name_scope(name, "dist_info", [obs_var]):
+            with tf.name_scope(self._mean_network_name, values=[obs_var]):
+                mean_var = L.get_output(self._l_mean, obs_var)
+            with tf.name_scope(self._std_network_name, values=[obs_var]):
+                std_param_var = L.get_output(self._l_std_param, obs_var)
             if self.min_std_param is not None:
                 std_param_var = tf.maximum(std_param_var, self.min_std_param)
             if self.std_parametrization == 'exp':
@@ -213,7 +217,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                                obs_var,
                                action_var,
                                old_dist_info_vars,
-                               name="get_reparam_action_sym"):
+                               name=None):
         """
         Given observations, old actions, and distribution of old actions,
         return a symbolically reparameterized representation of the actions in
@@ -223,7 +227,8 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         :param old_dist_info_vars:
         :return:
         """
-        with enclosing_scope(self.name, name):
+        with tf.name_scope(name, "get_reparam_action",
+                           [obs_var, action_var, old_dist_info_vars]):
             new_dist_info_vars = self.dist_info_sym(obs_var, action_var)
             new_mean_var, new_log_std_var = new_dist_info_vars[
                 "mean"], new_dist_info_vars["log_std"]

--- a/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -6,7 +6,6 @@ from garage.tf.core import LayersPowered
 import garage.tf.core.layers as L
 from garage.tf.core.layers import batch_norm
 from garage.tf.misc import tensor_utils
-from garage.tf.misc.tensor_utils import enclosing_scope
 from garage.tf.q_functions import QFunction
 
 
@@ -118,7 +117,7 @@ class ContinuousMLPQFunction(QFunction, Serializable, LayersPowered):
         return self._f_qval(observations, actions)
 
     def get_qval_sym(self, obs_var, action_var, name="get_qval_sym", **kwargs):
-        with enclosing_scope(self.name, name):
+        with tf.name_scope(name, values=[obs_var, action_var]):
             qvals = L.get_output(self._output_layer, {
                 self._obs_layer: obs_var,
                 self._action_layer: action_var

--- a/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -116,8 +116,8 @@ class ContinuousMLPQFunction(QFunction, Serializable, LayersPowered):
     def get_qval(self, observations, actions):
         return self._f_qval(observations, actions)
 
-    def get_qval_sym(self, obs_var, action_var, name="get_qval_sym", **kwargs):
-        with tf.name_scope(name, values=[obs_var, action_var]):
+    def get_qval_sym(self, obs_var, action_var, name=None, **kwargs):
+        with tf.name_scope(name, "get_qval_sym", values=[obs_var, action_var]):
             qvals = L.get_output(self._output_layer, {
                 self._obs_layer: obs_var,
                 self._action_layer: action_var

--- a/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/garage/tf/regressors/categorical_mlp_regressor.py
@@ -2,7 +2,6 @@ import numpy as np
 import tensorflow as tf
 
 from garage.core import Serializable
-from garage.misc import ext
 from garage.misc import logger
 from garage.tf.core import LayersPowered
 from garage.tf.core import MLP
@@ -11,7 +10,6 @@ from garage.tf.distributions import Categorical
 from garage.tf.misc import tensor_utils
 from garage.tf.optimizers import ConjugateGradientOptimizer
 from garage.tf.optimizers import LbfgsOptimizer
-from garage.tf.optimizers import PenaltyLbfgsOptimizer
 
 NONE = list()
 
@@ -27,7 +25,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
             self,
             input_shape,
             output_dim,
-            name="CategoricalMLPRegressor",
+            name=None,
             prob_network=None,
             hidden_sizes=(32, 32),
             hidden_nonlinearity=tf.nn.tanh,
@@ -51,7 +49,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
         """
         Serializable.quick_init(self, locals())
 
-        with tf.variable_scope(name):
+        with tf.variable_scope(name, "CategoricalMLPRegressor"):
             if optimizer is None:
                 optimizer = LbfgsOptimizer(name="optimizer")
             if tr_optimizer is None:
@@ -61,6 +59,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
             self.optimizer = optimizer
             self.tr_optimizer = tr_optimizer
 
+            self._prob_network_name = "prob_network"
             if prob_network is None:
                 prob_network = MLP(
                     input_shape=input_shape,
@@ -68,7 +67,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
                     hidden_sizes=hidden_sizes,
                     hidden_nonlinearity=hidden_nonlinearity,
                     output_nonlinearity=tf.nn.softmax,
-                    name="prob_network")
+                    name=self._prob_network_name)
 
             l_prob = prob_network.output_layer
 
@@ -91,8 +90,10 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
 
             normalized_xs_var = (xs_var - x_mean_var) / x_std_var
 
-            prob_var = L.get_output(
-                l_prob, {prob_network.input_layer: normalized_xs_var})
+            with tf.name_scope(
+                    self._prob_network_name, values=[normalized_xs_var]):
+                prob_var = L.get_output(
+                    l_prob, {prob_network.input_layer: normalized_xs_var})
 
             old_info_vars = dict(prob=old_prob_var)
             info_vars = dict(prob=prob_var)
@@ -167,16 +168,24 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
         prob = self.f_prob(np.asarray(xs))
         return self._dist.log_likelihood(np.asarray(ys), dict(prob=prob))
 
-    def dist_info_sym(self, x_var):
-        normalized_xs_var = (x_var - self.x_mean_var) / self.x_std_var
-        prob = L.get_output(self.l_prob,
-                            {self.prob_network.input_layer: normalized_xs_var})
+    def dist_info_sym(self, x_var, name=None):
+        with tf.name_scope(name, "dist_info_sym", [x_var]):
+            normalized_xs_var = (x_var - self.x_mean_var) / self.x_std_var
+            with tf.name_scope(
+                    self._prob_network_name, values=[normalized_xs_var]):
+                prob = L.get_output(
+                    self.l_prob,
+                    {self.prob_network.input_layer: normalized_xs_var})
         return dict(prob=prob)
 
-    def log_likelihood_sym(self, x_var, y_var):
-        normalized_xs_var = (x_var - self.x_mean_var) / self.x_std_var
-        prob = L.get_output(self.l_prob,
-                            {self.prob_network.input_layer: normalized_xs_var})
+    def log_likelihood_sym(self, x_var, y_var, name=None):
+        with tf.name_scope(name, "log_likelihood_sym", [x_var, y_var]):
+            normalized_xs_var = (x_var - self.x_mean_var) / self.x_std_var
+            with tf.name_scope(
+                    self._prob_network_name, values=[normalized_xs_var]):
+                prob = L.get_output(
+                    self.l_prob,
+                    {self.prob_network.input_layer: normalized_xs_var})
         return self._dist.log_likelihood_sym(y_var, dict(prob=prob))
 
     def get_param_values(self, **tags):


### PR DESCRIPTION
Enclosing scope is completely removed to avoid the unwanted duplication
of TensorFlow variables, and instead variable_scope is used to create
variables that will be further shared, while name_scope is used to group
operations that interact with the shared variables.