### PR TITLE
Add a GitHandler to switch to a target commit 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -49,6 +49,7 @@ dependencies:
         - scipy
         - tensorboard
         - Theano==1.0.2
+        - GitPython
         # dev dependencies below this line
         - git+https://github.com/openai/baselines.git@f2729693253c0ef4d4086231d36e0a4307ec1cb3#egg=baselines
         - flake8

--- a/garage/config.py
+++ b/garage/config.py
@@ -56,8 +56,6 @@ FAST_CODE_SYNC = True
 
 FAST_CODE_SYNC_IGNORES = [".git", "data", ".pods"]
 
-GIT_REPO_URL = "https://github.com/rlworkgroup/garage.git"
-
 KUBE_DEFAULT_RESOURCES = {
     "requests": {
         "cpu": 0.8,

--- a/garage/config.py
+++ b/garage/config.py
@@ -56,6 +56,8 @@ FAST_CODE_SYNC = True
 
 FAST_CODE_SYNC_IGNORES = [".git", "data", ".pods"]
 
+GIT_REPO_URL = "https://github.com/rlworkgroup/garage.git"
+
 KUBE_DEFAULT_RESOURCES = {
     "requests": {
         "cpu": 0.8,

--- a/garage/config_personal_template.py
+++ b/garage/config_personal_template.py
@@ -45,3 +45,5 @@ DOCKER_CODE_DIR = "/root/code/garage"
 AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY", "<insert aws key>")
 
 AWS_ACCESS_SECRET = os.environ.get("AWS_ACCESS_SECRET", "<insert aws secret>")
+
+GIT_REPO_URL = "https://github.com/rlworkgroup/garage.git"

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -46,11 +46,6 @@ class GitHandler:
         assert remote_found, colored("The garage remote couldn't be found " \
                                      "in the git working directory %s" %
                                      self.work_dir, "red")
-        assert not self.repo.git.diff(diff_filter="U"), \
-                colored("Unmerged paths were found, so the working " \
-                        "directory could be in the middle of a merge " \
-                        "conflict. Fix the conflicts first before running " \
-                        "the experiment.", "red")
 
     def _check_url(self, repo_url):
         """Return true if one of the remotes points to the repository URL."""
@@ -61,6 +56,13 @@ class GitHandler:
                     valid_url = True
                     break
         return valid_url
+
+    def _check_unmerged_paths(self):
+        assert not self.repo.git.diff(diff_filter="U"), \
+                colored("Unmerged paths were found, so the working " \
+                        "directory could be in the middle of a merge " \
+                        "conflict. Fix the conflicts first before running " \
+                        "the experiment.", "red")
 
     def create_branch(self, branch_name, ref="HEAD"):
         """Create a branch on the reference."""
@@ -298,6 +300,7 @@ class GitHandler:
             the experiment once the reference is checked out.
 
         """
+        self._check_unmerged_paths()
         # Imports are here to avoid circular dependencies within garage.misc
         import garage.misc.instrument
         from garage.misc import instrument

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -61,11 +61,11 @@ class GitHandler:
         return valid_url
 
     def create_branch(self, branch_name, target_ref="HEAD"):
-        """Create a branch on the targer reference."""
+        """Create a branch on the target reference."""
         self.repo.git.branch(branch_name, target_ref)
 
     def checkout_new_branch(self, branch_name, target_ref="HEAD"):
-        """Create a branch on the targer reference."""
+        """Create a branch on the target reference."""
         self.repo.git.checkout(branch_name, target_ref, b=True)
 
     def checkout(self, branch_name):
@@ -73,7 +73,7 @@ class GitHandler:
         self.repo.git.checkout(branch_name)
 
     def delete_branch(self, branch_name):
-        """Create a branch on the targer reference."""
+        """Create a branch on the target reference."""
         self.repo.git.branch(branch_name, D=True)
 
     def get_branch_sha(self, branch_name):
@@ -98,11 +98,11 @@ class GitHandler:
         return self.get_sha(full_branch_name)
 
     def create_tag(self, tag_name, target_ref="HEAD"):
-        """Create a tag on the targer reference."""
+        """Create a tag on the target reference."""
         self.repo.git.tag(tag_name, target_ref)
 
     def delete_tag(self, tag_name):
-        """Create a tag on the targer reference."""
+        """Create a tag on the target reference."""
         self.repo.git.tag(tag_name, d=True)
 
     def get_tag_sha(self, tag_name):
@@ -238,7 +238,13 @@ class GitHandler:
 
         Parameters
         ----------
-        - target: same description as in method run_experiment_on_target.
+        - target: a key-value string, where the key indicates the type of
+            target (tag, branch, sha), and the value the reference for the
+            corresponding type. For example:
+                sha: 8d54s23a
+                branch: my_branch
+                branch: remote/master
+                tag: my_tag
 
         Returns
         -------

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -3,12 +3,12 @@ import importlib
 import signal
 import time
 
+from git import Repo
 from git.exc import BadName, GitCommandError
 from termcolor import colored
 
 from garage.config import GIT_REPO_URL
 from garage.config import PROJECT_PATH
-from git import Repo
 
 
 class GitHandler:

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -1,0 +1,383 @@
+"""Perform different git tasks while running experiments."""
+import importlib
+import signal
+import time
+
+import sh
+from termcolor import colored
+
+from garage.config import GIT_REPO_URL
+from garage.config import PROJECT_PATH
+
+
+def cmd_to_string(command):
+    """Return the output of the executed command as a string.
+
+    Parameter
+    ---------
+    - command: it's an executed command from the sh package.
+
+    """
+    str_cmd = "%s" % command
+    # Remove next line character
+    return str_cmd[:-1]
+
+
+def cmd_to_string_array(command):
+    """Return the output of the executed command as a string array.
+
+    The output is split by the new line character and each element is added to
+    the array.
+
+    Parameter
+    ---------
+    - command: it's an executed command from the sh package.
+
+    """
+    cmd_str = "%s" % command
+    srt_arr = cmd_str.split("\n")
+    # Remove next line character
+    srt_arr = srt_arr[:-1]
+    return srt_arr
+
+
+class GitHandler:
+    """Execute diverse git commands.
+
+    This class makes use of the sh package to execute git commands just like
+    in the terminal shell, with the convenience of grouping commands to perform
+    more complex tasks.
+
+    Preconditions of this class:
+        - The working directory is not in the middle of a conflict
+        resolution.
+        - No branch is named HEAD.
+    """
+
+    def __init__(self, work_directory=PROJECT_PATH, repo_url=GIT_REPO_URL):
+        """Verify the git working directory.
+
+        It's verified that the working directory exists and contains a
+        git working directory by obtaining the name of the remotes.
+        Then, it's checked that one of the remotes points to the garage
+        repository by checking the repository URL.
+
+        Parameters
+        ----------
+        - work_directory: working directory of the git repository
+        - repo_url: URL of the git repository found in the working directory
+
+        """
+        self.work_dir = work_directory
+        self.valid_targets = {
+            "branch": self.get_branch_sha,
+            "sha": self.get_sha,
+            "tag": self.get_tag_sha
+        }
+        self.git = sh.git.bake(_cwd=self.work_dir)
+        self.remotes = self.get_remotes()
+        assert self.remotes, colored(
+            "There are no remotes in the git "
+            "working directory %s" % self.work_dir, "red")
+        remote_found = self._check_url(repo_url)
+        assert remote_found, colored("The garage remote couldn't be found " \
+                                     "in the git working directory %s" %
+                                     self.work_dir, "red")
+
+    def get_remotes(self):
+        """Return a list with the names of the remotes in the repository."""
+        repos = []
+        try:
+            remote_cmd = self.git.remote()
+            remotes = cmd_to_string_array(remote_cmd)
+        except sh.ErrorReturnCode_128:
+            print(
+                colored(
+                    "There's no git working directory at %s" % (self.work_dir),
+                    "red"))
+            raise
+        return remotes
+
+    def _check_url(self, repo_url):
+        """Return true if one of the remotes points to the repository URL."""
+        valid_url = False
+        remote_keys = ["remote.%s.url" % rem_name for rem_name in self.remotes]
+        for rem_key in remote_keys:
+            config_cmd = self.git.config("--get", rem_key)
+            remote_url = cmd_to_string(config_cmd)
+            if remote_url == repo_url:
+                valid_url = True
+                break
+        return valid_url
+
+    def create_branch(self, branch_name, target_ref="HEAD"):
+        """Create a branch on the targer reference."""
+        self.git.branch(branch_name, target_ref)
+
+    def checkout_new_branch(self, branch_name, target_ref="HEAD"):
+        """Create a branch on the targer reference."""
+        self.git.checkout("-b", branch_name, target_ref)
+
+    def checkout(self, branch_name):
+        """Checkout a branch."""
+        self.git.checkout(branch_name)
+
+    def delete_branch(self, branch_name):
+        """Create a branch on the targer reference."""
+        self.git.branch("-D", branch_name)
+
+    def get_branch_sha(self, branch_name):
+        """Return the 40 character SHA of the branch name.
+
+        The name can be that of a local or remote branch.
+        """
+        # Local branches may contain slashes just like remote branches
+        remote_branch = False
+        sha = ""
+        for remote in self.remotes:
+            remote = remote + "/"
+            if branch_name.startswith(remote):
+                remote_branch = True
+                break
+
+        if remote_branch:
+            full_branch_name = "refs/remotes/" + branch_name
+        else:
+            full_branch_name = "refs/heads/" + branch_name
+
+        return self.get_sha(full_branch_name)
+
+    def create_tag(self, tag_name, target_ref="HEAD"):
+        """Create a tag on the targer reference."""
+        self.git.tag(tag_name, target_ref)
+
+    def delete_tag(self, tag_name):
+        """Create a tag on the targer reference."""
+        self.git.tag("-d", tag_name)
+
+    def get_tag_sha(self, tag_name):
+        """Return the 40 character SHA of the tag name."""
+        full_tag_name = "refs/tags/" + tag_name
+        return self.get_sha(full_tag_name)
+
+    def reset(self, reference="HEAD"):
+        """Reset the working directory to the indicated reference."""
+        self.git.reset("--hard", reference)
+
+    def get_sha(self, reference="HEAD"):
+        """Return the 40 character SHA of the reference.
+
+        The reference can be a local branch ("refs/heads/<branch_name>"), a
+        remote branch ("refs/remotes/<branch_name>"), a tag
+        ("refs/tags/<tag_name>"), HEAD or a SHA.
+        Passing a SHA as reference comes useful to verify the SHA is valid.
+        HEAD is just a reference to the commit where the working directory is
+        currently checked out.
+
+        If the reference is not valid, the exception sh.ErrorReturnCode_128 is
+        thrown.
+        """
+        reference = reference + "^{object}"
+        try:
+            rev_cmd = self.git("rev-parse", reference)
+            sha = cmd_to_string(rev_cmd)
+        except sh.ErrorReturnCode_128:
+            print(
+                colored("The reference %s does not exist", "red") % reference)
+            raise
+        return sha
+
+    def create_stash(self):
+        """Stashes the local changes that have not been staged.
+
+        The stash is not stored anywhere in the ref namespace so the user does
+        not have remove it manually later.
+
+        Returns
+        -------
+        The 40 character SHA if local changes were found, or an empty string
+        otherwise.
+
+        """
+        stash_sha = ""
+        try:
+            diff_cmd = self.git.diff("--exit-code")
+        except sh.ErrorReturnCode_1:
+            # Exit code 1 means there are differences
+            create_stash_cmd = self.git.stash.create()
+            stash_sha = cmd_to_string(create_stash_cmd)
+            pass
+        return stash_sha
+
+    def get_current_branch_name(self):
+        """Return the name of the checked out branch.
+
+        If the HEAD is in detached state, an empty string is returned.
+
+        Precondition
+        ------------
+        - No branch (local or remote) in the repository is named "HEAD".
+
+        """
+        rev_cmd = self.git("rev-parse", "--abbrev-ref", "HEAD")
+        curr_branch_name = cmd_to_string(rev_cmd)
+        if curr_branch_name == "HEAD":
+            curr_branch_name = ""
+        return curr_branch_name
+
+    def run_experiment_on_target(self, target, exp_args):
+        """Run a experiment on the indicated commit defined by target.
+
+        After the target is verified, if there are any non-staged changes in
+        the working directory, they're stashed, the target commit is checked
+        out, the experiment is executed and the working directory is restored
+        at the end, including the stashed changes.
+
+        Parameters
+        ----------
+        - target: a key-value string, where the key indicates the type of
+            target (tag, branch, sha), and the value the reference for the
+            corresponding type. For example:
+                sha: 8d54s23a
+                branch: my_branch
+                branch: remote/master
+                tag: my_tag
+        - exp_args: it's a dictionary of arguments obtained from the function
+            run_experiment at garage.misc.instrument, that will be passed to
+            the experiment once the target is checked out.
+
+        Precondition
+        ------------
+        - The working directory is not in the middle of a conflict resolution.
+
+        """
+        assert isinstance(target, str), ("The git target has to be a string")
+        self.target = target
+        self.target_sha = self._verify_target(self.target)
+        self.restore_sha = self.get_sha()
+        self.stash_sha = self.create_stash()
+        self.branch_name = self.get_current_branch_name()
+        self.target_branch_name = ("run_exp_on_" + str(int(time.time())))
+        try:
+            self._switch_to_target(self.target_branch_name, self.target_sha)
+            current_sha = self.get_sha()
+            self._run_experiment(exp_args)
+        except BaseException:
+            print(colored(
+                "If the working area is damaged after " \
+                "an unexpected error while trying to\nswitch to the " \
+                "target in the repository, run the following command(s) " \
+                "to\nrestore it:", "yellow"))
+            if self.branch_name:
+                print(
+                    colored("$ git checkout %s" % (self.branch_name),
+                            "yellow"))
+            else:
+                print(
+                    colored("$ git reset --hard %s" % (self.restore_sha),
+                            "yellow"))
+
+            if self.stash_sha:
+                print(
+                    colored("$ git stash apply %s" % (self.stash_sha),
+                            "yellow"))
+            raise
+        finally:
+            self._restore_working_dir(self.target_branch_name, self.stash_sha,
+                                      self.branch_name, self.restore_sha)
+
+    def _verify_target(self, target):
+        """Verify the key-value target is valid.
+
+        Parameters
+        ----------
+        - target: same description as in method run_experiment_on_target.
+
+        Returns
+        -------
+        If the target is valid, the corresponding SHA.
+
+        """
+        target = [target.strip() for target in target.split(":")]
+        sha = ""
+        assert (len(target) == 2 and target[0]
+                and target[1]), self._get_target_use_message()
+        try:
+            verify = self.valid_targets[target[0]]
+            sha = verify(target[1])
+        except KeyError:
+            print(self._get_target_use_message())
+            raise
+        return sha
+
+    def _get_target_use_message(self):
+        """Print a use message if the user passed an invalid target."""
+        return colored(
+            "\nInvalid target: targets can be defined with a SHA, branch " \
+            "name (local or remote) or tag\nas shown " \
+            "in the following examples:\nsha: 8d54s23a" \
+            "\nbranch: my_branch\nbranch: remote/master\ntag: my_tag\n",
+            "yellow")
+
+    def _switch_to_target(self, target_branch_name, target_sha):
+        """Clean working directory and check out the target branch.
+
+        The target branch is created during the checkout operation.
+        SIGINT is temporarily blocked while performing the git operations to
+        avoid corrupting the working directory.
+        """
+        # Block SIGINT to avoid ending in an unknown state
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
+        # Clean working directory
+        self.reset()
+        # Change to target directory using a new branch
+        self.checkout_new_branch(target_branch_name, target_sha)
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})
+
+    def _run_experiment(self, exp_args):
+        """Call method run_experiment at garage.misc.instrument.
+
+        The git target is removed from the dictionary of arguments passed to
+        run_experiment, and the key arguments are updated directly into the
+        run_experiment arguments.
+
+        Parameters
+        ----------
+        - exp_args: it's a dictionary of arguments obtained from the function
+            run_experiment at garage.misc.instrument, that will be passed to
+            the experiment once the target is checked out.
+
+        """
+        # Imports are here to avoid circular dependencies within garage.misc
+        import garage.misc.instrument
+        from garage.misc import instrument
+        if "git_target" in exp_args:
+            exp_args.pop("git_target")
+        if "kwargs" in exp_args:
+            kwargs = exp_args["kwargs"]
+            exp_args.pop("kwargs")
+            exp_args.update(kwargs)
+        importlib.reload(garage.misc.instrument)
+        instrument.run_experiment(**exp_args)
+
+    def _restore_working_dir(self,
+                             target_branch_name,
+                             stash_sha="",
+                             branch_name="",
+                             restore_sha=""):
+        """Restore the working directory once the experiment is done.
+
+        Any stashed changes are applied as well.
+        SIGINT is temporarily blocked while performing the git operations to
+        avoid corrupting the working directory.
+        """
+        # Block SIGINT to avoid ending in an unknown state
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
+        if branch_name:
+            self.checkout(branch_name)
+        else:
+            self.reset(restore_sha)
+        if stash_sha:
+            self.git.stash.apply(stash_sha)
+        self.delete_branch(target_branch_name)
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT})

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -7,8 +7,8 @@ from git import Repo
 from git.exc import BadName
 from termcolor import colored
 
+from garage.config import GIT_REPO_URL
 from garage.config import PROJECT_PATH
-from garage.config_personal import GIT_REPO_URL
 
 
 class GitHandler:

--- a/garage/misc/git_handler.py
+++ b/garage/misc/git_handler.py
@@ -35,10 +35,9 @@ def cmd_to_string_array(command):
 
     """
     cmd_str = "%s" % command
-    srt_arr = cmd_str.split("\n")
+    str_arr = cmd_str.split("\n")
     # Remove next line character
-    srt_arr = srt_arr[:-1]
-    return srt_arr
+    return str_arr[:-1]
 
 
 class GitHandler:

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -19,9 +19,9 @@ import numpy as np
 
 from garage import config
 from garage.core import Serializable
-from garage.misc.git_handler import GitHandler
 from garage.misc.console import mkdir_p
 from garage.misc.ext import AttrDict
+from garage.misc.git_handler import GitHandler
 from garage.viskit.core import flatten
 
 

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -349,7 +349,7 @@ def run_experiment(stub_method_call=None,
                    script="scripts/run_experiment.py",
                    python_command="python",
                    mode="local",
-                   git_target=None,
+                   git_ref=None,
                    dry=False,
                    docker_image=None,
                    aws_config=None,
@@ -409,7 +409,7 @@ def run_experiment(stub_method_call=None,
      periodically during execution.
     :param periodic_sync_interval: Time interval between each periodic sync,
      in seconds.
-    :param git_target: if set, the target commit it points to is checked out
+    :param git_ref: if set, the git reference it points to is checked out
      before running the experiment. This parameter is defined as a key value
      that works for branches, tags or SHAs, for example: "branch: master",
      "branch: origin/master", "tag: my_tag" or "sha: 4d93a274bcd2de0a".
@@ -418,9 +418,9 @@ def run_experiment(stub_method_call=None,
         "Must provide at least either stub_method_call or batch_tasks"
     saved_args = locals()
 
-    if git_target:
+    if git_ref:
         git_handler = GitHandler()
-        git_handler.run_experiment_on_target(git_target, saved_args)
+        git_handler.run_experiment_on_ref(git_ref, saved_args)
         return
 
     if use_cloudpickle is None:

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from garage import config
 from garage.core import Serializable
+from garage.misc.git_handler import GitHandler
 from garage.misc.console import mkdir_p
 from garage.misc.ext import AttrDict
 from garage.viskit.core import flatten
@@ -348,6 +349,7 @@ def run_experiment(stub_method_call=None,
                    script="scripts/run_experiment.py",
                    python_command="python",
                    mode="local",
+                   git_target=None,
                    dry=False,
                    docker_image=None,
                    aws_config=None,
@@ -407,9 +409,19 @@ def run_experiment(stub_method_call=None,
      periodically during execution.
     :param periodic_sync_interval: Time interval between each periodic sync,
      in seconds.
+    :param git_target: if set, the target commit it points to is checked out
+     before running the experiment. This parameter is defined as a key value
+     that works for branches, tags or SHAs, for example: "branch: master",
+     "branch: origin/master", "tag: my_tag" or "sha: 4d93a274bcd2de0a".
     """
     assert stub_method_call is not None or batch_tasks is not None, \
         "Must provide at least either stub_method_call or batch_tasks"
+    saved_args = locals()
+
+    if git_target:
+        git_handler = GitHandler()
+        git_handler.run_experiment_on_target(git_target, saved_args)
+        return
 
     if use_cloudpickle is None:
         for maybe_stub in (batch_tasks or [stub_method_call]):

--- a/garage/misc/logger.py
+++ b/garage/misc/logger.py
@@ -8,6 +8,7 @@ import os
 import os.path as osp
 import pickle
 import sys
+import types
 
 import dateutil.tz
 import joblib
@@ -15,6 +16,7 @@ import numpy as np
 
 from garage.misc.autoargs import get_all_parameters
 from garage.misc.console import colorize, mkdir_p
+from garage.misc.git_handler import GitHandler
 from garage.misc.tabulate import tabulate
 from garage.misc.tensorboard_output import TensorBoardOutput
 
@@ -86,6 +88,11 @@ def remove_tabular_output(file_name):
 def set_tensorboard_dir(dir_name):
     _tensorboard.set_dir(dir_name)
     log("tensorboard data will be logged into:" + dir_name)
+
+
+def log_repo_sha():
+    git_handler = GitHandler()
+    log("running experiment on SHA %s" % git_handler.get_sha())
 
 
 def set_snapshot_dir(dir_name):
@@ -220,7 +227,7 @@ table_printer = TerminalTablePrinter()
 
 
 def dump_tensorboard(*args, **kwargs):
-    if len(_tabular) > 0:
+    if _tabular:
         tabular_dict = dict(_tabular)
     step = None
     if _tensorboard_step_key and _tensorboard_step_key in tabular_dict:
@@ -230,7 +237,7 @@ def dump_tensorboard(*args, **kwargs):
 
 def dump_tabular(*args, **kwargs):
     wh = kwargs.pop("write_header", None)
-    if len(_tabular) > 0:
+    if _tabular:
         if _log_tabular_only:
             table_printer.print_tabular(_tabular)
         else:
@@ -304,7 +311,7 @@ def log_parameters(log_file, args, classes):
 def stub_to_json(stub_sth):
     from garage.misc import instrument
     if isinstance(stub_sth, instrument.StubObject):
-        assert len(stub_sth.args) == 0
+        assert not stub_sth.args
         data = dict()
         for k, v in stub_sth.kwargs.items():
             data[k] = stub_to_json(v)
@@ -331,7 +338,7 @@ def stub_to_json(stub_sth):
         return {stub_to_json(k): stub_to_json(v) for k, v in stub_sth.items()}
     elif isinstance(stub_sth, (list, tuple)):
         return list(map(stub_to_json, stub_sth))
-    elif type(stub_sth) == type(lambda: None):
+    elif isinstance(stub_sth, (types.FunctionType, types.BuiltinFunctionType)):
         if stub_sth.__module__ is not None:
             return stub_sth.__module__ + "." + stub_sth.__name__
         return stub_sth.__name__
@@ -388,7 +395,7 @@ def record_tabular_misc_stat(key, values, placement='back'):
     else:
         prefix = key
         suffix = ""
-    if len(values) > 0:
+    if values:
         record_tabular(prefix + "Average" + suffix, np.average(values))
         record_tabular(prefix + "Std" + suffix, np.std(values))
         record_tabular(prefix + "Median" + suffix, np.median(values))

--- a/scripts/run_experiment.py
+++ b/scripts/run_experiment.py
@@ -148,6 +148,7 @@ def run_experiment(argv):
     logger.add_text_output(text_log_file)
     logger.add_tabular_output(tabular_log_file)
     logger.set_tensorboard_dir(log_dir)
+    logger.log_repo_sha()
     prev_snapshot_dir = logger.get_snapshot_dir()
     prev_mode = logger.get_snapshot_mode()
     logger.set_snapshot_dir(log_dir)

--- a/tests/misc/test_git_handler.py
+++ b/tests/misc/test_git_handler.py
@@ -1,0 +1,263 @@
+import time
+
+import sh
+from termcolor import colored
+
+from garage.misc.git_handler import GitHandler
+
+
+def time_str():
+    return str(int(time.time()))
+
+
+def error_init_git_handler(exception, git_hdlr_arg):
+    error_found = False
+
+    try:
+        git_handler = GitHandler(**git_hdlr_arg)
+    except exception:
+        error_found = True
+
+    assert error_found, (
+        "Argument %s in GitHandler must throw %s" % (git_hdlr_arg, exception))
+
+
+def test_init_git_handler():
+    invalid_dir = "/invalid/dir"
+    invalid_url = "https://github.com/invalid/repo.git"
+    not_git_dir = "../"
+
+    invalid_dir_arg = {"work_directory": "/invalid/dir"}
+    error_init_git_handler(FileNotFoundError, invalid_dir_arg)
+
+    invalid_url_arg = {"repo_url": "https://github.com/invalid/repo.git"}
+    error_init_git_handler(AssertionError, invalid_url_arg)
+
+    not_git_dir_arg = {"work_directory": "../"}
+    error_init_git_handler(sh.ErrorReturnCode_128, not_git_dir_arg)
+
+
+def verify_branch(branch_name, branch_exists, git_handler, sha_to_verify=""):
+    """Verify whether the branch exits or not.
+
+    If branch_exists is false, then it's verified that the branch identified by
+    branch_name does not exist, and it's verified it exists otherwise.
+    """
+    confirm_branch = branch_exists
+
+    try:
+        branch_sha = git_handler.get_branch_sha(branch_name)
+    except sh.ErrorReturnCode_128:
+        confirm_branch = not confirm_branch
+
+    if branch_exists:
+        assert confirm_branch, ("Branch %s must exist." % branch_name)
+        if sha_to_verify:
+            assert sha_to_verify == branch_sha, \
+                    ("Branch %s is not matching the right sha %s"
+                     % (branch_name, sha_to_verify))
+    else:
+        assert confirm_branch, ("Branch %s must not exist." % branch_name)
+
+
+def test_branch_sha():
+    git_handler = GitHandler()
+
+    invalid_remote_branch = "origin_" + time_str() + "/master"
+    verify_branch(invalid_remote_branch, False, git_handler)
+
+    valid_remote_branch = "origin/master"
+    verify_branch(valid_remote_branch, True, git_handler)
+
+    # Verify a branch does not exist
+    local_branch = "branch_" + time_str()
+    verify_branch(local_branch, False, git_handler)
+
+    # Create a branch and verify it exist
+    git_handler.create_branch(local_branch)
+    verify_branch(local_branch, True, git_handler)
+    git_handler.delete_branch(local_branch)
+
+    # Create a local branch in a specific target and verify its SHA
+    sha_on_master = "5c5f63674fe6a39125f0bca1e35a01e2a53f6637"
+    local_branch = "branch_" + sha_on_master[:8] + "_" + time_str()
+    git_handler.create_branch(local_branch, sha_on_master)
+    verify_branch(local_branch, True, git_handler, sha_on_master)
+    git_handler.delete_branch(local_branch)
+
+    # Retrieve the name of the current branch if there's a branch currently
+    # checked out or the SHA where the detached HEAD is before switching
+    current_branch = git_handler.get_current_branch_name()
+    if not current_branch:
+        current_sha = git_handler.get_sha()
+    # Create and switch to a branch, and verify its name
+    local_branch = "branch_" + time_str()
+    git_handler.checkout_new_branch(local_branch)
+    retrieved_branch_name = git_handler.get_current_branch_name()
+    assert local_branch == retrieved_branch_name, \
+            "The branch %s must be checked out" % local_branch
+    if current_branch:
+        git_handler.checkout(current_branch)
+    else:
+        git_handler.reset(current_sha)
+    git_handler.delete_branch(local_branch)
+
+
+def verify_tag(tag_name, tag_exists, git_handler, sha_to_verify=""):
+    """Verify whether the tag exits or not.
+
+    If tag_exists is false, then it's verified that the tag identified by
+    tag_name does not exist, and it's verified it exists otherwise.
+    """
+    confirm_tag = tag_exists
+
+    try:
+        tag_sha = git_handler.get_tag_sha(tag_name)
+    except sh.ErrorReturnCode_128:
+        confirm_tag = not confirm_tag
+
+    if tag_exists:
+        assert confirm_tag, ("Tag %s must exist." % tag_name)
+        if sha_to_verify:
+            assert sha_to_verify == tag_sha, \
+                    ("Tag %s is not matching the right sha %s"
+                     % (tag_name, sha_to_verify))
+    else:
+        assert confirm_tag, ("Tag %s must not exist." % tag_name)
+
+
+def test_tag_sha():
+    git_handler = GitHandler()
+
+    # Verify that a tag is not in repository
+    invalid_tag = "tag_" + time_str()
+    verify_tag(invalid_tag, False, git_handler)
+
+    # Create a tag in a specific target and verify its SHA
+    tag_name = "tag_" + time_str()
+    sha_on_master = "5378034533a47dad101c6f60e628a64442b439ed"
+    git_handler.create_tag(tag_name, sha_on_master)
+    verify_tag(tag_name, True, git_handler, sha_on_master)
+    git_handler.delete_tag(tag_name)
+
+
+def test_sha():
+    git_handler = GitHandler()
+
+    head_sha = git_handler.get_sha()
+    assert head_sha, "The SHA of the HEAD must be returned with get_sha()"
+
+    # Verify a real SHA
+    sha_to_verify = "cc5d4627a7306c3586257f29c2def6121d7f04ec"
+    returned_sha = git_handler.get_sha(sha_to_verify)
+    assert sha_to_verify == returned_sha, ("The SHA returned by get_sha() " \
+                                           "is unexpected")
+
+    # Verify a short real SHA
+    short_sha_to_verify = "dfbe8ae2"
+    returned_sha = git_handler.get_sha(short_sha_to_verify)
+    assert returned_sha.startswith(short_sha_to_verify), \
+            "The SHA returned by get_sha() is unexpected"
+
+    # Verify a fake SHA
+    sha_to_verify = "779fea67d6ab6c8085507c71697bd27d15835b91"
+    fake_sha = False
+    try:
+        returned_sha = git_handler.get_sha(sha_to_verify)
+        print(returned_sha)
+    except sh.ErrorReturnCode_128:
+        fake_sha = True
+    assert fake_sha, ("The SHA returned by get_sha() is unexpected")
+
+
+def test_verify_target():
+    git_handler = GitHandler()
+
+    # Verify that a tag, branch and sha do not exist using a key-value as input
+    tag_name = "tag_" + time_str()
+    invalid_target = False
+    try:
+        git_handler._verify_target("tag: " + tag_name)
+    except sh.ErrorReturnCode_128:
+        invalid_target = True
+    assert invalid_target, "The tag %s must be invalid" % tag_name
+
+    branch_name = "branch_" + time_str()
+    invalid_target = False
+    try:
+        git_handler._verify_target("branch: " + branch_name)
+    except sh.ErrorReturnCode_128:
+        invalid_target = True
+    assert invalid_target, "The branch %s must be invalid" % branch_name
+
+    invalid_sha = "5730843353" + time_str()
+    invalid_target = False
+    try:
+        git_handler._verify_target("sha: " + invalid_sha)
+    except sh.ErrorReturnCode_128:
+        invalid_target = True
+    assert invalid_target, "The sha %s must be invalid" % invalid_sha
+
+    # Create tag and branch on a specific SHA in repository, and then verify
+    # the key-value for the tag, branch and sha
+    tag_name = "tag_" + time_str()
+    sha_on_master = "5378034533a47dad101c6f60e628a64442b439ed"
+    git_handler.create_tag(tag_name, sha_on_master)
+    sha_retrieved = git_handler._verify_target("tag: " + tag_name)
+    assert sha_on_master == sha_retrieved, \
+            "The tag %s must be valid" % tag_name
+    git_handler.delete_tag(tag_name)
+
+    branch_name = "branch_" + time_str()
+    sha_on_master = "5378034533a47dad101c6f60e628a64442b439ed"
+    git_handler.create_branch(branch_name, sha_on_master)
+    sha_retrieved = git_handler._verify_target("branch: " + branch_name)
+    assert sha_on_master == sha_retrieved, \
+            "The branch %s must be invalid" % branch_name
+    git_handler.delete_branch(branch_name)
+
+    sha_on_master = "5378034533a47dad101c6f60e628a64442b439ed"
+    sha_retrieved = git_handler._verify_target("sha: " + sha_on_master)
+    assert sha_on_master == sha_retrieved, \
+            "The SHA %s must be invalid" % sha_on_master
+
+
+def test_switch_and_restore():
+    # This test is basically the same as the method run_experiment_on_target
+    # except for calling run_experiment to avoid running any training.
+    git_handler = GitHandler()
+    sha_on_master = "5378034533a47dad101c6f60e628a64442b439ed"
+    target_sha = git_handler._verify_target("sha: " + sha_on_master)
+    restore_sha = git_handler.get_sha()
+    stash_sha = git_handler.create_stash()
+    branch_name = git_handler.get_current_branch_name()
+    target_branch_name = "run_exp_on_" + time_str()
+    try:
+        git_handler._switch_to_target(target_branch_name, target_sha)
+        current_sha = git_handler.get_sha()
+        # Once the working directory is switched, it's asserted that the HEAD
+        # is at the target based on the SHA
+        assert current_sha == target_sha, \
+                "The working area must be at SHA %s" % target_sha
+    except BaseException:
+        print(colored(
+            "If the working area is damaged after " \
+            "an unexpected error while trying to\nswitch to the " \
+            "target in the repository, run the following command(s) " \
+            "to\nrestore it:", "yellow"))
+        if branch_name:
+            print(colored("$ git checkout %s" % (branch_name), "yellow"))
+        else:
+            print(colored("$ git reset --hard %s" % (restore_sha), "yellow"))
+
+        if stash_sha:
+            print(colored("$ git stash apply %s" % (stash_sha), "yellow"))
+        raise
+    finally:
+        git_handler._restore_working_dir(target_branch_name, stash_sha,
+                                         branch_name, restore_sha)
+        current_sha = git_handler.get_sha()
+        # Once the working directory is restored, it's asserted that the HEAD
+        # is at the right commit based on the SHA
+        assert current_sha == restore_sha, \
+                "The working area must be at SHA %s" % restore_sha


### PR DESCRIPTION
The new class GitHandler is incorporated along with the function
run_experiment to allow the users to run experiments at a desired commit
based on a branch name (remote or local), tag name or SHA. The parameter
passed to run_experiment is a key value, for example:
- branch: feature_branch
- branch: origin/master
- tag: baseline_052318
- sha: 4d93a274bcd2de0

Besides this specific feature, GitHandler provides methods to interact
with simple git operations for future features.
Also, a test file is provided to make sure the implementation of
GitHandler is working correctly.