### PR TITLE
Fix name scope in TensorBoardOutput

### DIFF
--- a/examples/tf/example_tensorboard_logger.py
+++ b/examples/tf/example_tensorboard_logger.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 
 from garage.misc import logger
 
-logger.set_tensorboard_dir("./histogram_example")
+logger.set_tensorboard_dir("data/local/histogram_example")
 N = 400
 for i in range(N):
     sess = tf.Session()

--- a/garage/misc/tensorboard_output.py
+++ b/garage/misc/tensorboard_output.py
@@ -66,16 +66,15 @@ class TensorBoardOutput:
         self._dump_tensors()
 
     def record_histogram(self, key, val, name=None):
-        with tf.name_scope(name, "record_histogram"):
-            if str(key) not in self._histogram_ds:
+        if str(key) not in self._histogram_ds:
+            with tf.name_scope(name, "record_histogram"):
                 self._histogram_ds[str(key)] = tf.Variable(val)
-                self._histogram_summary_op.append(
-                    tf.summary.histogram(
-                        str(key), self._histogram_ds[str(key)]))
-                self._histogram_summary_op_merge = tf.summary.merge(
-                    self._histogram_summary_op)
+            self._histogram_summary_op.append(
+                tf.summary.histogram(str(key), self._histogram_ds[str(key)]))
+            self._histogram_summary_op_merge = tf.summary.merge(
+                self._histogram_summary_op)
 
-            self._feed[self._histogram_ds[str(key)]] = val
+        self._feed[self._histogram_ds[str(key)]] = val
 
     def record_histogram_by_type(self,
                                  histogram_type,


### PR DESCRIPTION
There is a bug in tensorboard_output.record_histogram, which creates `record_histogram/gass` space in TensorBaord instead of `gass`. This PR fixes it.