### PR TITLE
Move some easy deps from conda to pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,55 +4,53 @@ channels:
     - https://conda.anaconda.org/conda-forge
 dependencies:
     - python==3.5.2
+    # Please keep alphabetized
+    - mkl-service=1.1.2
+    - mkl==2017.0.4
     - numpy==1.14.5
     - scipy
-    - mkl==2017.0.4
-    - path.py
-    - python-dateutil
-    - joblib==0.10.3
-    - mako
-    - ipywidgets
-    - flask
-    - matplotlib
-    - pandas
-    - mkl-service=1.1.2
-    # absl-py must be installed via conda rather than pip, because for some
-    # reason depedencies from the pip stanza are not available during the build
-    # phase of other packages in the pip stanza
-    - absl-py
     # dev dependencies below this line
     - pre_commit
     - pip:
-        - pyprind
-        - ipdb
+        # Please keep alphabetized
+        - awscli
         - boto3
-        - PyOpenGL
-        - pyzmq
-        - mujoco-py<1.50.2,>=1.50.1
-        - pygame
         - Box2D>=2.3.2
         - cached_property
         - cloudpickle
-        - git+https://github.com/Theano/Theano.git@3b51141a46affe9505f0e3f283020820b2c0251e#egg=theano
-        - git+https://github.com/jonashen/Lasagne.git@b4fd25809c446f8c7b1c0d80283eb25c66e06960#egg=lasagne
-        - git+https://github.com/plotly/plotly.py.git@2594076e29584ede2d09f2aa40a8a195b3f3fc66#egg=plotly
         - git+https://github.com/deepmind/dm_control.git#egg=dm_control
-        - awscli
+        - flask
         - gym[all]==0.10.5
-        - pyglet
-        - jupyter
         - hyperopt
-        - polling
-        - tensorboard
+        - ipdb
+        - ipywidgets
         - jsonmerge
-        - protobuf
+        - joblib==0.10.3
+        - jupyter
+        - git+https://github.com/jonashen/Lasagne.git@b4fd25809c446f8c7b1c0d80283eb25c66e06960#egg=lasagne
+        - mako
+        - matplotlib
         - memory_profiler
+        - mujoco-py<1.50.2,>=1.50.1
+        - pandas
+        - path.py
+        - git+https://github.com/plotly/plotly.py.git@2594076e29584ede2d09f2aa40a8a195b3f3fc66#egg=plotly
+        - polling
+        - protobuf
+        - pygame
+        - pyglet
+        - PyOpenGL
+        - pyprind
+        - python-dateutil
+        - pyzmq
+        - tensorboard
+        - git+https://github.com/Theano/Theano.git@3b51141a46affe9505f0e3f283020820b2c0251e#egg=theano
         # dev dependencies below this line
-        - nose2
+        - git+https://github.com/openai/baselines.git@f2729693253c0ef4d4086231d36e0a4307ec1cb3#egg=baselines
         - flake8
-        - flake8-import-order
         - flake8-docstrings==1.3.0
+        - flake8-import-order
+        - nose2
         - pep8-naming==0.7.0
         - pylint==1.9.2
         - yapf
-        - git+https://github.com/openai/baselines.git@f2729693253c0ef4d4086231d36e0a4307ec1cb3#egg=baselines


### PR DESCRIPTION
This PR moves the least-dangerous deps from conda to pip installation.

numpy/scipy have been omitted because they are fundamental deps with
binary platform-specific distributions, and thus most likely to break.