### PR TITLE
Add imports check for lines end with parentheses

### DIFF
--- a/scripts/travisci/check_imports.py
+++ b/scripts/travisci/check_imports.py
@@ -18,6 +18,15 @@ def get_import_statement(node, lines):
     offset = -1
     stmt = lines[node.lineno + offset].strip()
 
+    # Join lines split by (
+    while stmt.endswith("("):
+        offset += 1
+        stmt = stmt[:-1]
+        stmt += lines[node.lineno + offset].strip()
+
+    while stmt.endswith(")"):
+        stmt = stmt[:-1]
+
     # Join lines split by \
     while stmt.endswith("\\"):
         offset += 1


### PR DESCRIPTION
PEP8 uses () to break lines. But check_imports.py recognizes () as an syntax error.
```
ERROR: garage/tf/baselines/__init__.py:2 - "from garage.tf.baselines.deterministic_mlp_baseline import (" failed with a SyntaxError.
ERROR: garage/tf/regressors/__init__.py:1 - "from garage.tf.regressors.bernoulli_mlp_regressor import (" failed with a SyntaxError.
ERROR: garage/tf/regressors/__init__.py:3 - "from garage.tf.regressors.categorical_mlp_regressor import (" failed with a SyntaxError.
ERROR: garage/tf/regressors/__init__.py:5 - "from garage.tf.regressors.deterministic_mlp_regressor import (" failed with a SyntaxError.
```
