### PR TITLE
Use Lasagne directly instead of a private fork

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
         - jsonmerge
         - joblib==0.10.3
         - jupyter
-        - git+https://github.com/jonashen/Lasagne.git@b4fd25809c446f8c7b1c0d80283eb25c66e06960#egg=lasagne
+        - git+https://github.com/Lasagne/Lasagne.git@a61b76fd991f84c50acdb7bea02118899b5fefe1#egg=lasagne
         - mako
         - matplotlib
         - memory_profiler


### PR DESCRIPTION
This PR fixes a tuple() to int() comparison bug that resulted in `tests.test_networks` and `tests.test_algos` failing. Furthermore, this bug fix enables us to install Lasagne directly rather than a private fork. 

Note: if we want to use the latest version of Lasagne we will need to clone Lasagne into `rlworkgroup/Lasagne` and address [this](https://github.com/Lasagne/Lasagne/issues/867) issue using a new commit. However, this is beyond the scope of this PR.

Ref: #182, #184, #214 