### PR TITLE
Fix CategoricalMLPPolicy

### DIFF
--- a/garage/tf/distributions/categorical.py
+++ b/garage/tf/distributions/categorical.py
@@ -91,7 +91,7 @@ class Categorical(Distribution):
 
     def entropy(self, info):
         probs = info["prob"]
-        return -np.sum(probs * np.log(probs + TINY), axis=1)
+        return -np.sum(probs * np.log(probs + TINY), axis=-1)
 
     def log_likelihood_sym(self, x_var, dist_info_vars, name=None):
         with tf.name_scope(name, "log_likelihood_sym",

--- a/garage/tf/policies/categorical_mlp_policy.py
+++ b/garage/tf/policies/categorical_mlp_policy.py
@@ -51,7 +51,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
             with tf.name_scope(self._prob_network_name):
                 prob_network_outputs = L.get_output(prob_network.output_layer)
             self._f_prob = tensor_utils.compile_function(
-                [prob_network.input_layer.input_var], [prob_network_outputs])
+                [prob_network.input_layer.input_var], prob_network_outputs)
 
             self._dist = Categorical(env_spec.action_space.n)
 
@@ -68,7 +68,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
             with tf.name_scope(self._prob_network_name, values=[obs_var]):
                 prob = L.get_output(
                     self._l_prob, {self._l_obs: tf.cast(obs_var, tf.float32)})
-            return dict(prob)
+            return dict(prob=prob)
 
     @overrides
     def dist_info(self, obs, state_infos=None):

--- a/garage/tf/policies/deterministic_mlp_policy.py
+++ b/garage/tf/policies/deterministic_mlp_policy.py
@@ -42,7 +42,7 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
             self._l_prob = prob_network.output_layer
             self._l_obs = prob_network.input_layer
             self._f_prob = tensor_utils.compile_function(
-                [prob_network.input_layer.input_var], [prob_network_output])
+                [prob_network.input_layer.input_var], prob_network_output)
 
         self.prob_network = prob_network
 

--- a/tests/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/tf/policies/test_categorical_mlp_policy.py
@@ -1,0 +1,35 @@
+"""
+This script creates a unittest that tests CategoricalMLPPolicy in
+garage.tf.policies.
+"""
+import unittest
+
+import gym
+
+from garage.baselines import LinearFeatureBaseline
+from garage.envs import normalize
+from garage.tf.algos import TRPO
+from garage.tf.envs import TfEnv
+from garage.tf.policies import CategoricalMLPPolicy
+
+
+class TestCategoricalMLPPolicy(unittest.TestCase):
+    def test_categorical_mlp_policy(self):
+        env = TfEnv(normalize(gym.make("CartPole-v0")))
+
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=4000,
+            max_path_length=100,
+            n_itr=1,
+            discount=0.99,
+            step_size=0.01,
+            plot=True)
+        algo.train()


### PR DESCRIPTION
The problem is that CategoricalMLPPolicy._f_prob and
tf.Distribution.Categorical. It returns wrong shape array.

Fixes: #263 