### PR TITLE
Fix pickling in tf/regressors

### DIFF
--- a/garage/tf/baselines/deterministic_mlp_baseline.py
+++ b/garage/tf/baselines/deterministic_mlp_baseline.py
@@ -26,6 +26,7 @@ class DeterministicMLPBaseline(Baseline, Parameterized, Serializable):
         :param num_seq_inputs: number of sequence inputs.
         :param regressor_args: regressor arguments.
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
         super(DeterministicMLPBaseline, self).__init__(env_spec)
         if regressor_args is None:
@@ -59,3 +60,7 @@ class DeterministicMLPBaseline(Baseline, Parameterized, Serializable):
     def predict(self, path):
         """Predict value based on paths."""
         return self._regressor.predict(path["observations"]).flatten()
+
+    @overrides
+    def get_params_internal(self, **tags):
+        return self._regressor.get_params_internal(**tags)

--- a/garage/tf/baselines/gaussian_mlp_baseline.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline.py
@@ -2,13 +2,13 @@
 import numpy as np
 
 from garage.baselines import Baseline
-from garage.core import Parameterized
 from garage.core import Serializable
 from garage.misc.overrides import overrides
+from garage.tf.core import Parameterized
 from garage.tf.regressors import GaussianMLPRegressor
 
 
-class GaussianMLPBaseline(Baseline, Parameterized):
+class GaussianMLPBaseline(Baseline, Parameterized, Serializable):
     """A value function using gaussian mlp network."""
 
     def __init__(
@@ -26,6 +26,7 @@ class GaussianMLPBaseline(Baseline, Parameterized):
         :param num_seq_inputs:
         :param regressor_args:
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
         super(GaussianMLPBaseline, self).__init__(env_spec)
         if regressor_args is None:
@@ -59,3 +60,7 @@ class GaussianMLPBaseline(Baseline, Parameterized):
     def set_param_values(self, flattened_params, **tags):
         """Set parameter values to val."""
         self._regressor.set_param_values(flattened_params, **tags)
+
+    @overrides
+    def get_params_internal(self, **tags):
+        return self._regressor.get_params_internal(**tags)

--- a/garage/tf/regressors/bernoulli_mlp_regressor.py
+++ b/garage/tf/regressors/bernoulli_mlp_regressor.py
@@ -5,6 +5,7 @@ from garage.core import Serializable
 from garage.misc import logger
 from garage.tf.core import LayersPowered
 from garage.tf.core import MLP
+from garage.tf.core import Parameterized
 import garage.tf.core.layers as L
 from garage.tf.distributions import Bernoulli
 from garage.tf.misc import tensor_utils
@@ -12,7 +13,7 @@ from garage.tf.optimizers import ConjugateGradientOptimizer
 from garage.tf.optimizers import LbfgsOptimizer
 
 
-class BernoulliMLPRegressor(LayersPowered, Serializable):
+class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
     """
     A class for performing regression (or classification, really) by fitting a
     bernoulli distribution to each of the output units.
@@ -43,6 +44,7 @@ class BernoulliMLPRegressor(LayersPowered, Serializable):
         :param use_trust_region: Whether to use trust region constraint.
         :param step_size: KL divergence constraint for each iteration
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
         with tf.variable_scope(name):
@@ -165,9 +167,3 @@ class BernoulliMLPRegressor(LayersPowered, Serializable):
     def predict_log_likelihood(self, xs, ys):
         p = self.f_p(np.asarray(xs))
         return self._dist.log_likelihood(np.asarray(ys), dict(p=p))
-
-    def get_param_values(self, **tags):
-        return LayersPowered.get_param_values(self, **tags)
-
-    def set_param_values(self, flattened_params, **tags):
-        return LayersPowered.set_param_values(self, flattened_params, **tags)

--- a/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/garage/tf/regressors/categorical_mlp_regressor.py
@@ -5,6 +5,7 @@ from garage.core import Serializable
 from garage.misc import logger
 from garage.tf.core import LayersPowered
 from garage.tf.core import MLP
+from garage.tf.core import Parameterized
 import garage.tf.core.layers as L
 from garage.tf.distributions import Categorical
 from garage.tf.misc import tensor_utils
@@ -14,7 +15,7 @@ from garage.tf.optimizers import LbfgsOptimizer
 NONE = list()
 
 
-class CategoricalMLPRegressor(LayersPowered, Serializable):
+class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
     """
     A class for performing regression (or classification, really) by fitting a
     categorical distribution to the outputs. Assumes that the outputs will be
@@ -47,6 +48,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
         :param use_trust_region: Whether to use trust region constraint.
         :param step_size: KL divergence constraint for each iteration
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
         with tf.variable_scope(name, "CategoricalMLPRegressor"):
@@ -187,9 +189,3 @@ class CategoricalMLPRegressor(LayersPowered, Serializable):
                     self.l_prob,
                     {self.prob_network.input_layer: normalized_xs_var})
         return self._dist.log_likelihood_sym(y_var, dict(prob=prob))
-
-    def get_param_values(self, **tags):
-        return LayersPowered.get_param_values(self, **tags)
-
-    def set_param_values(self, flattened_params, **tags):
-        return LayersPowered.set_param_values(self, flattened_params, **tags)

--- a/garage/tf/regressors/deterministic_mlp_regressor.py
+++ b/garage/tf/regressors/deterministic_mlp_regressor.py
@@ -5,6 +5,7 @@ from garage.core import Serializable
 from garage.misc import logger
 from garage.tf.core import LayersPowered
 from garage.tf.core import MLP
+from garage.tf.core import Parameterized
 import garage.tf.core.layers as L
 from garage.tf.misc import tensor_utils
 from garage.tf.optimizers import LbfgsOptimizer
@@ -12,7 +13,7 @@ from garage.tf.optimizers import LbfgsOptimizer
 NONE = list()
 
 
-class DeterministicMLPRegressor(LayersPowered, Serializable):
+class DeterministicMLPRegressor(LayersPowered, Serializable, Parameterized):
     """
     A class for performing nonlinear regression.
     """
@@ -39,6 +40,7 @@ class DeterministicMLPRegressor(LayersPowered, Serializable):
         mean network.
         :param optimizer: Optimizer for minimizing the negative log-likelihood.
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
         with tf.variable_scope(name, "DeterministicMLPRegressor"):
@@ -136,9 +138,3 @@ class DeterministicMLPRegressor(LayersPowered, Serializable):
 
     def predict(self, xs):
         return self.f_predict(np.asarray(xs))
-
-    def get_param_values(self, **tags):
-        return LayersPowered.get_param_values(self, **tags)
-
-    def set_param_values(self, flattened_params, **tags):
-        return LayersPowered.set_param_values(self, flattened_params, **tags)

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -5,6 +5,7 @@ from garage.core import Serializable
 from garage.misc import logger
 from garage.tf.core import LayersPowered
 from garage.tf.core import MLP
+from garage.tf.core import Parameterized
 import garage.tf.core.layers as L
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.misc import tensor_utils
@@ -12,7 +13,7 @@ from garage.tf.optimizers import LbfgsOptimizer
 from garage.tf.optimizers import PenaltyLbfgsOptimizer
 
 
-class GaussianMLPRegressor(LayersPowered, Serializable):
+class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
     """
     A class for performing regression by fitting a Gaussian distribution to the
     outputs.
@@ -61,6 +62,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable):
          network. Only used if `std_share_network` is False. It defaults to the
          same non-linearity as the mean.
         """
+        Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
         self._mean_network_name = "mean_network"
         self._std_network_name = "std_network"
@@ -318,9 +320,3 @@ class GaussianMLPRegressor(LayersPowered, Serializable):
 
             return self._dist.log_likelihood_sym(
                 y_var, dict(mean=means_var, log_std=log_stds_var))
-
-    def get_param_values(self, **tags):
-        return LayersPowered.get_param_values(self, **tags)
-
-    def set_param_values(self, flattened_params, **tags):
-        LayersPowered.set_param_values(self, flattened_params, **tags)


### PR DESCRIPTION
Pickling is broken in tf/regressor because tf/baselines didn't implement
get_params_internal method.

Also, inherit tf/regressors from Parameterized and delete unnecessary
get/set params methods.

Fixes: #247 