### PR TITLE
Remove all `log_diagnostics` calls on envs

### DIFF
--- a/garage/tf/algos/batch_polopt.py
+++ b/garage/tf/algos/batch_polopt.py
@@ -149,7 +149,6 @@ class BatchPolopt(RLAlgorithm):
         return last_average_return
 
     def log_diagnostics(self, paths):
-        self.env.log_diagnostics(paths)
         self.policy.log_diagnostics(paths)
         self.baseline.log_diagnostics(paths)
 


### PR DESCRIPTION
The package gym.Env neither has a log_diagnostics function nor we can
ensure other envs in the future will have this function either.