### PR TITLE
Move DmControl{Env, Viewer} to a separate package

### DIFF
--- a/garage/envs/__init__.py
+++ b/garage/envs/__init__.py
@@ -1,7 +1,5 @@
 from garage.envs.base import GarageEnv
 from garage.envs.base import Step
-from garage.envs.dm_control_env import DmControlEnv
-from garage.envs.dm_control_viewer import DmControlViewer
 from garage.envs.env_spec import EnvSpec
 from garage.envs.grid_world_env import GridWorldEnv
 from garage.envs.identification_env import IdentificationEnv  # noqa: I100

--- a/garage/envs/dm_control/__init__.py
+++ b/garage/envs/dm_control/__init__.py
@@ -1,0 +1,7 @@
+"""
+Wrappers for the DeepMind Control Suite.
+
+See https://github.com/deepmind/dm_control
+"""
+from garage.envs.dm_control.dm_control_viewer import DmControlViewer
+from garage.envs.dm_control.dm_control_env import DmControlEnv  # noqa: I100

--- a/garage/envs/dm_control/dm_control_env.py
+++ b/garage/envs/dm_control/dm_control_env.py
@@ -3,11 +3,10 @@ from dm_control.rl.control import flatten_observation
 from dm_control.rl.environment import StepType
 import gym
 import numpy as np
-import pygame
 
 from garage.core import Serializable
 from garage.envs import Step
-from garage.envs.dm_control_viewer import DmControlViewer
+from garage.envs.dm_control import DmControlViewer
 
 
 class DmControlEnv(gym.Env, Serializable):
@@ -39,10 +38,9 @@ class DmControlEnv(gym.Env, Serializable):
         time_step = self._env.step(action)
         if time_step.reward:
             self._total_reward += time_step.reward
-        return Step(flatten_observation(time_step.observation), \
-                time_step.reward, \
-                time_step.step_type == StepType.LAST, \
-                **time_step.observation)
+        return Step(
+            flatten_observation(time_step.observation), time_step.reward,
+            time_step.step_type == StepType.LAST, **time_step.observation)
 
     def reset(self):
         self._total_reward = 0

--- a/garage/envs/dm_control/dm_control_viewer.py
+++ b/garage/envs/dm_control/dm_control_viewer.py
@@ -4,7 +4,7 @@ import pygame
 CAPTION = "dm_control viewer"
 
 
-class DmControlViewer():
+class DmControlViewer:
     def __init__(self):
         pygame.init()
         pygame.display.set_caption(CAPTION)

--- a/tests/test_dm_control.py
+++ b/tests/test_dm_control.py
@@ -2,8 +2,8 @@ import unittest
 
 from dm_control import suite
 
-from garage.envs import DmControlEnv
 from garage.envs import normalize
+from garage.envs.dm_control import DmControlEnv
 
 
 def run_task(domain_name, task_name):


### PR DESCRIPTION
This PR moves DmControlEnv and DmControlViewer to their own package,
so that they are not automatically imported any time garage.env is
imported (which, for practical purposes, is always). Previously, this
meant that effectively all launchers import dm_control and pygame,
slowing the launch process, increasing memory footprint, and making
launchers more prone to crashing.