### PR TITLE
Add reccurrent policy to NPO

### DIFF
--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -4,7 +4,8 @@ from garage.envs.box2d import CartpoleEnv
 from garage.tf.algos import TRPO
 import garage.tf.core.layers as L
 from garage.tf.envs import TfEnv
-from garage.tf.optimizers import ConjugateGradientOptimizer, FiniteDifferenceHvp
+from garage.tf.optimizers import ConjugateGradientOptimizer
+from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import GaussianLSTMPolicy
 
 env = TfEnv(normalize(CartpoleEnv()))
@@ -27,6 +28,6 @@ algo = TRPO(
     n_itr=10,
     discount=0.99,
     step_size=0.01,
-    optimizer=ConjugateGradientOptimizer(
-        hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+    optimizer=ConjugateGradientOptimizer,
+    optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
 algo.train()

--- a/garage/tf/algos/trpo.py
+++ b/garage/tf/algos/trpo.py
@@ -23,12 +23,13 @@ class TRPO(NPO):
                  optimizer=None,
                  optimizer_args=None,
                  **kwargs):
-        if kl_constraint == KLConstraint.HARD:
-            optimizer = ConjugateGradientOptimizer
-        elif kl_constraint == KLConstraint.SOFT:
-            optimizer = PenaltyLbfgsOptimizer
-        else:
-            raise NotImplementedError("Unknown KLConstraint")
+        if not optimizer:
+            if kl_constraint == KLConstraint.HARD:
+                optimizer = ConjugateGradientOptimizer
+            elif kl_constraint == KLConstraint.SOFT:
+                optimizer = PenaltyLbfgsOptimizer
+            else:
+                raise NotImplementedError("Unknown KLConstraint")
 
         if optimizer_args is None:
             optimizer_args = dict()

--- a/garage/tf/policies/__init__.py
+++ b/garage/tf/policies/__init__.py
@@ -1,5 +1,7 @@
 from garage.tf.policies.base import Policy
 from garage.tf.policies.base import StochasticPolicy
+from garage.tf.policies.categorical_gru_policy import CategoricalGRUPolicy
+from garage.tf.policies.categorical_lstm_policy import CategoricalLSTMPolicy
 from garage.tf.policies.categorical_mlp_policy import CategoricalMLPPolicy
 from garage.tf.policies.continuous_mlp_policy import ContinuousMLPPolicy
 from garage.tf.policies.deterministic_mlp_policy import DeterministicMLPPolicy

--- a/garage/tf/policies/categorical_conv_policy.py
+++ b/garage/tf/policies/categorical_conv_policy.py
@@ -23,7 +23,7 @@ class CategoricalConvPolicy(StochasticPolicy, LayersPowered, Serializable):
             hidden_nonlinearity=tf.nn.relu,
             output_nonlinearity=tf.nn.softmax,
             prob_network=None,
-            name=None,
+            name="CategoricalConvPolicy",
     ):
         """
         :param env_spec: A spec for the mdp.

--- a/garage/tf/policies/categorical_gru_policy.py
+++ b/garage/tf/policies/categorical_gru_policy.py
@@ -17,7 +17,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name=None,
+            name="CategoricalGRUPolicy",
             hidden_dim=32,
             feature_network=None,
             state_include_action=True,
@@ -102,9 +102,9 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                 out_prob_hidden = tf.identity(out_prob_hidden,
                                               "prob_step_hidden")
 
-            self.f_step_prob = tensor_utils.compile_function([
-                flat_input_var, prob_network.step_prev_hidden_layer.input_var
-            ], [out_prob_step, out_prob_hidden])
+            self.f_step_prob = tensor_utils.compile_function(
+                [flat_input_var, prob_network.step_prev_state_layer.input_var],
+                [out_prob_step, out_prob_hidden])
 
             self.input_dim = input_dim
             self.action_dim = action_dim
@@ -140,7 +140,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                         self._prob_network_name, values=[all_input_var]):
                     prob = L.get_output(self.prob_network.output_layer,
                                         {self.l_input: all_input_var})
-                return dict(prob)
+                return dict(prob=prob)
             else:
                 flat_input_var = tf.reshape(all_input_var,
                                             (-1, self.input_dim))
@@ -152,7 +152,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                             self.l_input: all_input_var,
                             self.feature_network.input_layer: flat_input_var
                         })
-                return dict(prob)
+                return dict(prob=prob)
 
     @property
     def vectorized(self):

--- a/garage/tf/policies/categorical_mlp_policy.py
+++ b/garage/tf/policies/categorical_mlp_policy.py
@@ -15,7 +15,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name=None,
+            name="CategoricalMLPPolicy",
             hidden_sizes=(32, 32),
             hidden_nonlinearity=tf.nn.tanh,
             prob_network=None,
@@ -34,6 +34,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
 
         Serializable.quick_init(self, locals())
 
+        self.name = name
         self._prob_network_name = "prob_network"
         with tf.variable_scope(name, "CategoricalMLPPolicy"):
             if prob_network is None:

--- a/garage/tf/policies/deterministic_mlp_policy.py
+++ b/garage/tf/policies/deterministic_mlp_policy.py
@@ -13,7 +13,7 @@ from garage.tf.spaces import Box
 class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
     def __init__(self,
                  env_spec,
-                 name=None,
+                 name="DeterministicMLPPolicy",
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.relu,
                  output_nonlinearity=tf.nn.tanh,
@@ -45,6 +45,7 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
                 [prob_network.input_layer.input_var], prob_network_output)
 
         self.prob_network = prob_network
+        self.name = name
 
         # Note the deterministic=True argument. It makes sure that when getting
         # actions from single observations, we do not update params in the

--- a/garage/tf/policies/gaussian_gru_policy.py
+++ b/garage/tf/policies/gaussian_gru_policy.py
@@ -17,7 +17,7 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name=None,
+            name="GaussianGRUPolicy",
             hidden_dim=32,
             feature_network=None,
             state_include_action=True,

--- a/garage/tf/policies/gaussian_lstm_policy.py
+++ b/garage/tf/policies/gaussian_lstm_policy.py
@@ -16,7 +16,7 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name=None,
+            name="GaussianLSTMPolicy",
             hidden_dim=32,
             feature_network=None,
             state_include_action=True,

--- a/tests/tf/policies/test_categorical_policies.py
+++ b/tests/tf/policies/test_categorical_policies.py
@@ -1,0 +1,41 @@
+"""
+This script creates a unittest that tests Categorical policies in
+garage.tf.policies.
+"""
+import unittest
+
+import gym
+from nose2 import tools
+
+from garage.baselines import LinearFeatureBaseline
+from garage.envs import normalize
+from garage.tf.algos import TRPO
+from garage.tf.envs import TfEnv
+from garage.tf.policies import CategoricalGRUPolicy
+from garage.tf.policies import CategoricalLSTMPolicy
+from garage.tf.policies import CategoricalMLPPolicy
+
+policies = [CategoricalGRUPolicy, CategoricalLSTMPolicy, CategoricalMLPPolicy]
+
+
+class TestCategoricalPolicies(unittest.TestCase):
+    @tools.params(*policies)
+    def test_categorical_policies(self, policy_cls):
+        env = TfEnv(normalize(gym.make("CartPole-v0")))
+
+        policy = policy_cls(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            batch_size=4000,
+            max_path_length=100,
+            n_itr=1,
+            discount=0.99,
+            step_size=0.01,
+            plot=True)
+        algo.train()

--- a/tests/tf/policies/test_gaussian_policies.py
+++ b/tests/tf/policies/test_gaussian_policies.py
@@ -1,23 +1,29 @@
 """
-This script creates a unittest that tests CategoricalMLPPolicy in
+This script creates a unittest that tests Gaussian policies in
 garage.tf.policies.
 """
 import unittest
 
-import gym
+from nose2 import tools
 
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
+from garage.envs.box2d import CartpoleEnv
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
-from garage.tf.policies import CategoricalMLPPolicy
+from garage.tf.policies import GaussianGRUPolicy
+from garage.tf.policies import GaussianLSTMPolicy
+from garage.tf.policies import GaussianMLPPolicy
+
+policies = [GaussianGRUPolicy, GaussianLSTMPolicy, GaussianMLPPolicy]
 
 
-class TestCategoricalMLPPolicy(unittest.TestCase):
-    def test_categorical_mlp_policy(self):
-        env = TfEnv(normalize(gym.make("CartPole-v0")))
+class TestGaussianPolicies(unittest.TestCase):
+    @tools.params(*policies)
+    def test_gaussian_policies(self, policy_cls):
+        env = TfEnv(normalize(CartpoleEnv()))
 
-        policy = CategoricalMLPPolicy(
+        policy = policy_cls(
             name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)

--- a/tests/tf/policies/test_policies.py
+++ b/tests/tf/policies/test_policies.py
@@ -8,6 +8,8 @@ import unittest
 from tests.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
 
 from garage.tf.envs import TfEnv
+from garage.tf.policies import CategoricalGRUPolicy
+from garage.tf.policies import CategoricalLSTMPolicy
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.policies import DeterministicMLPPolicy
@@ -21,6 +23,10 @@ class TestTfPolicies(unittest.TestCase):
         """Test the policies initialization."""
         box_env = TfEnv(DummyBoxEnv())
         discrete_env = TfEnv(DummyDiscreteEnv())
+        categorical_gru_policy = CategoricalGRUPolicy(
+            env_spec=discrete_env, hidden_dim=1)
+        categorical_lstm_policy = CategoricalLSTMPolicy(
+            env_spec=discrete_env, hidden_dim=1)
         categorical_mlp_policy = CategoricalMLPPolicy(
             env_spec=discrete_env, hidden_sizes=(1, ))
         continuous_mlp_policy = ContinuousMLPPolicy(


### PR DESCRIPTION
Add recurrent policy support to NPO so that recurrent policies can be
used in NPO/TRPO/PPO. This includes:

 - Fix a bug in tf/NPO. Not all the policies have `_dist` attribute,
   change it to use distribution property.
 - Add recurrent policy implementation to NPO. Recurrent policies use
   unflatten inputs.

Fixes: #199 , #162 