### PR TITLE
Remove repetitive prints of "using seed"

### DIFF
--- a/garage/misc/ext.py
+++ b/garage/misc/ext.py
@@ -5,8 +5,6 @@ import sys
 
 import numpy as np
 
-from garage.misc.console import colorize
-
 sys.setrecursionlimit(50000)
 
 

--- a/garage/misc/ext.py
+++ b/garage/misc/ext.py
@@ -143,7 +143,6 @@ def set_seed(seed):
         tf.set_random_seed(seed)
     except Exception as e:
         print(e)
-    print((colorize('using seed %s' % (str(seed)), 'green')))
 
 
 def get_seed():


### PR DESCRIPTION
The seed in use is printed by `garage.misc.ext.set_seed()`, but it's
also printed by the sampler for each worker when workers are spawned.
The proper place to print it is in the sampler, since single-process
users who set their seeds already know what they've set it to.