### PR TITLE
Fix bug in tests/tf/policies

### DIFF
--- a/tests/tf/algos/test_ppo.py
+++ b/tests/tf/algos/test_ppo.py
@@ -8,18 +8,25 @@ import gym
 import tensorflow as tf
 
 from garage.envs import normalize
+import garage.misc.logger as logger
+from garage.misc.tensorboard_output import TensorBoardOutput
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
 
 
-class TestTRPO(unittest.TestCase):
-    def test_trpo_pendulum(self):
+class TestPPO(unittest.TestCase):
+    def setUp(self):
+        self.sess = tf.Session(graph=tf.Graph())
+        self.sess.__enter__()
+        logger._tensorboard = TensorBoardOutput()
+
+    def test_ppo_pendulum(self):
         """Test PPO with Pendulum environment."""
+        logger._tensorboard = TensorBoardOutput()
         env = TfEnv(normalize(gym.make("Pendulum-v0")))
         policy = GaussianMLPPolicy(
-            name="policy",
             env_spec=env.spec,
             hidden_sizes=(32, 32),
             hidden_nonlinearity=tf.nn.tanh,
@@ -41,5 +48,5 @@ class TestTRPO(unittest.TestCase):
             policy_ent_coeff=0.0,
             plot=False,
         )
-        last_avg_ret = algo.train()
-        assert last_avg_ret > -400
+        last_avg_ret = algo.train(sess=self.sess)
+        assert last_avg_ret > -1000

--- a/tests/tf/algos/test_trpo.py
+++ b/tests/tf/algos/test_trpo.py
@@ -8,6 +8,8 @@ import gym
 import tensorflow as tf
 
 from garage.envs import normalize
+import garage.misc.logger as logger
+from garage.misc.tensorboard_output import TensorBoardOutput
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
@@ -15,11 +17,16 @@ from garage.tf.policies import GaussianMLPPolicy
 
 
 class TestTRPO(unittest.TestCase):
+    def setUp(self):
+        self.sess = tf.Session(graph=tf.Graph())
+        self.sess.__enter__()
+        logger._tensorboard = TensorBoardOutput()
+
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
+        logger._tensorboard = TensorBoardOutput()
         env = TfEnv(normalize(gym.make("Pendulum-v0")))
         policy = GaussianMLPPolicy(
-            name="policy",
             env_spec=env.spec,
             hidden_sizes=(32, 32),
             hidden_nonlinearity=tf.nn.tanh,
@@ -41,5 +48,5 @@ class TestTRPO(unittest.TestCase):
             policy_ent_coeff=0.0,
             plot=False,
         )
-        last_avg_ret = algo.train()
-        assert last_avg_ret > -400
+        last_avg_ret = algo.train(sess=self.sess)
+        assert last_avg_ret > -1000

--- a/tests/tf/policies/test_categorical_policies.py
+++ b/tests/tf/policies/test_categorical_policies.py
@@ -6,11 +6,16 @@ import unittest
 
 import gym
 from nose2 import tools
+import tensorflow as tf
 
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
+import garage.misc.logger as logger
+from garage.misc.tensorboard_output import TensorBoardOutput
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
+from garage.tf.optimizers import ConjugateGradientOptimizer
+from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import CategoricalGRUPolicy
 from garage.tf.policies import CategoricalLSTMPolicy
 from garage.tf.policies import CategoricalMLPPolicy
@@ -19,12 +24,16 @@ policies = [CategoricalGRUPolicy, CategoricalLSTMPolicy, CategoricalMLPPolicy]
 
 
 class TestCategoricalPolicies(unittest.TestCase):
+    def setUp(self):
+        self.sess = tf.Session(graph=tf.Graph())
+        self.sess.__enter__()
+        logger._tensorboard = TensorBoardOutput()
+
     @tools.params(*policies)
     def test_categorical_policies(self, policy_cls):
         env = TfEnv(normalize(gym.make("CartPole-v0")))
 
-        policy = policy_cls(
-            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = policy_cls(name="policy", env_spec=env.spec)
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
@@ -37,5 +46,9 @@ class TestCategoricalPolicies(unittest.TestCase):
             n_itr=1,
             discount=0.99,
             step_size=0.01,
-            plot=True)
-        algo.train()
+            plot=True,
+            optimizer=ConjugateGradientOptimizer,
+            optimizer_args=dict(
+                hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)),
+        )
+        algo.train(sess=self.sess)

--- a/tests/tf/policies/test_gaussian_policies.py
+++ b/tests/tf/policies/test_gaussian_policies.py
@@ -5,12 +5,17 @@ garage.tf.policies.
 import unittest
 
 from nose2 import tools
+import tensorflow as tf
 
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.box2d import CartpoleEnv
+import garage.misc.logger as logger
+from garage.misc.tensorboard_output import TensorBoardOutput
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
+from garage.tf.optimizers import ConjugateGradientOptimizer
+from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import GaussianGRUPolicy
 from garage.tf.policies import GaussianLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
@@ -19,12 +24,17 @@ policies = [GaussianGRUPolicy, GaussianLSTMPolicy, GaussianMLPPolicy]
 
 
 class TestGaussianPolicies(unittest.TestCase):
+    def setUp(self):
+        self.sess = tf.Session(graph=tf.Graph())
+        self.sess.__enter__()
+        logger._tensorboard = TensorBoardOutput()
+
     @tools.params(*policies)
     def test_gaussian_policies(self, policy_cls):
+        logger._tensorboard = TensorBoardOutput()
         env = TfEnv(normalize(CartpoleEnv()))
 
-        policy = policy_cls(
-            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = policy_cls(name="policy", env_spec=env.spec)
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
@@ -37,5 +47,9 @@ class TestGaussianPolicies(unittest.TestCase):
             n_itr=1,
             discount=0.99,
             step_size=0.01,
-            plot=True)
-        algo.train()
+            plot=True,
+            optimizer=ConjugateGradientOptimizer,
+            optimizer_args=dict(
+                hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)),
+        )
+        algo.train(sess=self.sess)


### PR DESCRIPTION
Two problems cause the unittests fail.

1) When running several tests at the same time, we should reset the tf
computation graph, or use tf.Graph().as_default().
2) The other problem locates in
garage.misc.TensorBoardOutput.record_histogram. In a single test, we
call algo.train() multiple times, but the
TensorBoardOutput._histogram_summary_op didn't clear when we run a new
policy. For now, I choose to initialize TensorBoardOutput on every test.