### PR TITLE
Remove Python 2-style class declarations

### DIFF
--- a/garage/algos/base.py
+++ b/garage/algos/base.py
@@ -1,4 +1,4 @@
-class Algorithm(object):
+class Algorithm:
     pass
 
 

--- a/garage/algos/cma_es_lib.py
+++ b/garage/algos/cma_es_lib.py
@@ -436,7 +436,7 @@ need for an inverse gp-transformation, relies on collections module,
 not sure what happens if set to ``False``. """
 
 
-class MetaParameters(object):
+class MetaParameters:
     """meta parameters are either "modifiable constants" or refer to
     options from ``CMAOptions`` or are arguments to ``fmin`` or to the
     ``NoiseHandler`` class constructor.
@@ -684,7 +684,7 @@ def unitdoctest():
     pass
 
 
-class _BlancClass(object):
+class _BlancClass:
     """blanc container class for having a collection of attributes,
     that might/should at some point become a more tailored class"""
 
@@ -865,7 +865,7 @@ if not use_archives:
             pass
 
 
-class BestSolution(object):
+class BestSolution:
     """container to keep track of the best solution seen"""
 
     def __init__(self, x=None, f=np.inf, evals=None):
@@ -930,7 +930,7 @@ class BestSolution(object):
 # ____________________________________________________________
 # ____________________________________________________________
 #
-class BoundaryHandlerBase(object):
+class BoundaryHandlerBase:
     """hacked base class """
 
     def __init__(self, bounds):
@@ -1398,7 +1398,7 @@ class BoundPenalty(BoundaryHandlerBase):
 # ____________________________________________________________
 # ____________________________________________________________
 #
-class BoxConstraintsTransformationBase(object):
+class BoxConstraintsTransformationBase:
     """Implements a transformation into boundaries and is used for
     boundary handling::
 
@@ -1783,7 +1783,7 @@ class BoxConstraintsLinQuadTransformation(BoxConstraintsTransformationBase):
             return (ub + au) - 2 * (au * (ub - y))**0.5
 
 
-class GenoPheno(object):
+class GenoPheno:
     """Genotype-phenotype transformation.
 
     Method `pheno` provides the transformation from geno- to phenotype,
@@ -2086,7 +2086,7 @@ class GenoPheno(object):
 # check out built-in package abc: class ABCMeta, abstractmethod, abstractproperty...
 # see http://docs.python.org/whatsnew/2.6.html PEP 3119 abstract base classes
 #
-class OOOptimizer(object):
+class OOOptimizer:
     """"abstract" base class for an Object Oriented Optimizer interface.
 
      Relevant methods are `__init__`, `ask`, `tell`, `stop`, `result`,
@@ -2318,7 +2318,7 @@ class OOOptimizer(object):
 _experimental = False
 
 
-class CMAAdaptSigmaBase(object):
+class CMAAdaptSigmaBase:
     """step-size adaptation base class, implementing hsig functionality
     via an isotropic evolution path.
 
@@ -5452,7 +5452,7 @@ class _CMAStopDict(dict):
 
 # ____________________________________________________________
 # ____________________________________________________________
-class _CMAParameters(object):
+class _CMAParameters:
     """strategy parameters like population size and learning rates.
 
     Note:
@@ -6174,7 +6174,7 @@ def fmin(
 # _____________________________________________________________________
 # _____________________________________________________________________
 #
-class BaseDataLogger(object):
+class BaseDataLogger:
     """"abstract" base class for a data logger that can be used with an `OOOptimizer`
 
     Details: attribute `modulo` is used in ``OOOptimizer.optimize``
@@ -7504,7 +7504,7 @@ def _fileToMatrix(file_name):
 
 # ____________________________________________________________
 # ____________________________________________________________
-class NoiseHandler(object):
+class NoiseHandler:
     """Noise handling according to [Hansen et al 2009, A Method for
     Handling Uncertainty in Evolutionary Optimization...]
 
@@ -7808,7 +7808,7 @@ class NoiseHandler(object):
 
 # ____________________________________________________________
 # ____________________________________________________________
-class Sections(object):
+class Sections:
     """plot sections through an objective function.
 
     A first rational thing to do, when facing an (expensive)
@@ -8016,7 +8016,7 @@ class _Error(Exception):
 # ____________________________________________________________
 # ____________________________________________________________
 #
-class ElapsedTime(object):
+class ElapsedTime:
     """using ``time.clock`` with overflow handling to measure CPU time.
 
     Example:
@@ -8058,11 +8058,11 @@ class ElapsedTime(object):
         return self.elapsedtime
 
 
-class Misc(object):
+class Misc:
     # ____________________________________________________________
     # ____________________________________________________________
     #
-    class MathHelperFunctions(object):
+    class MathHelperFunctions:
         """static convenience math helper functions, if the function name
         is preceded with an "a", a numpy array is returned
 
@@ -8287,7 +8287,7 @@ class Misc(object):
 
         """
 
-        # class eig(object):
+        # class eig:
         #     def __call__(self, C):
 
         # Householder transformation of a symmetric matrix V into tridiagonal form.
@@ -8613,7 +8613,7 @@ def pprint(to_be_printed):
 pp = pprint
 
 
-class ConstRandnShift(object):
+class ConstRandnShift:
     """``ConstRandnShift()(x)`` adds a fixed realization of
     ``stddev * randn(len(x))`` to the vector x.
 
@@ -8660,7 +8660,7 @@ class ConstRandnShift(object):
         return self.__call__(np.zeros(dimension))
 
 
-class Rotation(object):
+class Rotation:
     """Rotation class that implements an orthogonal linear transformation,
     one for each dimension.
 
@@ -8721,14 +8721,14 @@ rotate = Rotation()
 #
 
 
-class FFWrapper(object):
+class FFWrapper:
     """
     A collection of (yet experimental) classes to implement fitness
     transformations and wrappers. Aliased to `FF2` below.
 
     """
 
-    class FitnessTransformation(object):
+    class FitnessTransformation:
         """This class does nothing but serve as an interface template.
         Typical use-case::
 
@@ -8948,7 +8948,7 @@ class FFWrapper(object):
             return self.inner_fitness(
                 array(x, copy=False), *(args + self.args), **self.kwargs)
 
-    class UnknownFF(object):
+    class UnknownFF:
         """search in [-10, 10] for the unknown (optimum)"""
 
         def __init__(self, seed=2):
@@ -8989,7 +8989,7 @@ class FFWrapper(object):
 FF2 = FFWrapper
 
 
-class FitnessFunctions(object):
+class FitnessFunctions:
     """ versatile container for test objective functions """
 
     def __init__(self):

--- a/garage/baselines/base.py
+++ b/garage/baselines/base.py
@@ -1,7 +1,7 @@
 from garage.misc import autoargs
 
 
-class Baseline(object):
+class Baseline:
     def __init__(self, env_spec):
         self._mdp_spec = env_spec
 

--- a/garage/contrib/ros/robots/kinematics_interfaces.py
+++ b/garage/contrib/ros/robots/kinematics_interfaces.py
@@ -6,7 +6,7 @@ import rospy
 from sensor_msgs.msg import JointState
 
 
-class ForwardKinematics(object):
+class ForwardKinematics:
     """Interface to MoveIt! forward kinematics service."""
 
     def __init__(self):
@@ -66,7 +66,7 @@ class ForwardKinematics(object):
         return fk_result
 
 
-class InverseKinematics(object):
+class InverseKinematics:
     """Interface to MoveIt! inverse kinematics service."""
 
     def __init__(self):
@@ -126,7 +126,7 @@ class InverseKinematics(object):
         return ik_result
 
 
-class StateValidity(object):
+class StateValidity:
     """Interface to MoveIt! StateValidity service."""
 
     def __init__(self):

--- a/garage/contrib/ros/robots/robot.py
+++ b/garage/contrib/ros/robots/robot.py
@@ -3,7 +3,7 @@ robot Interface
 """
 
 
-class Robot(object):
+class Robot:
     def reset(self):
         """
         User uses this to reset the robot at the beginning of every training

--- a/garage/contrib/ros/worlds/block_world.py
+++ b/garage/contrib/ros/worlds/block_world.py
@@ -23,7 +23,7 @@ except ImportError:
         "   VICON_TOPICS = []")
 
 
-class Block(object):
+class Block:
     def __init__(self, name, initial_pos, random_delta_range, resource=None):
         """
         Task Object interface

--- a/garage/contrib/ros/worlds/gazebo.py
+++ b/garage/contrib/ros/worlds/gazebo.py
@@ -5,7 +5,7 @@ from gazebo_msgs.srv import DeleteModel, SpawnModel
 import rospy
 
 
-class Gazebo(object):
+class Gazebo:
     set_model_pose_pub = rospy.Publisher(
         '/gazebo/set_model_state', ModelState, queue_size=20)
     spawn_sdf = rospy.ServiceProxy('/gazebo/spawn_sdf_model', SpawnModel)

--- a/garage/contrib/ros/worlds/world.py
+++ b/garage/contrib/ros/worlds/world.py
@@ -1,7 +1,7 @@
 import os.path as osp
 
 
-class World(object):
+class World:
     MODEL_DIR = osp.join(osp.dirname(__file__), 'models')
 
     def initialize(self):

--- a/garage/core/serializable.py
+++ b/garage/core/serializable.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 
 
-class Serializable(object):
+class Serializable:
     def __init__(self, *args, **kwargs):
         self.__args = args
         self.__kwargs = kwargs

--- a/garage/envs/box2d/parser/xml_attr_types.py
+++ b/garage/envs/box2d/parser/xml_attr_types.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class Type(object):
+class Type:
     def __eq__(self, other):
         return self.__class__ == other.__class__
 

--- a/garage/envs/box2d/parser/xml_box2d.py
+++ b/garage/envs/box2d/parser/xml_box2d.py
@@ -358,7 +358,7 @@ class XmlControl(XmlElem):
         extra_data.controls.append(self)
 
 
-class ExtraData(object):
+class ExtraData:
     def __init__(self):
         self.states = []
         self.controls = []

--- a/garage/envs/box2d/parser/xml_types.py
+++ b/garage/envs/box2d/parser/xml_types.py
@@ -8,7 +8,7 @@ def _extract_type(typ):
         return typ
 
 
-class AttrDecl(object):
+class AttrDecl:
     pass
 
 
@@ -61,7 +61,7 @@ class XmlAttr(AttrDecl):
             return None
 
 
-class XmlElem(object):
+class XmlElem:
 
     tag = None
     Meta = None

--- a/garage/envs/mujoco/gather/embedded_viewer.py
+++ b/garage/envs/mujoco/gather/embedded_viewer.py
@@ -14,7 +14,7 @@ PyMjvCamera = cymj.PyMjvCamera
 MjMOUSE_ZOOM = 5
 
 
-class EmbeddedViewer(object):
+class EmbeddedViewer:
     def __init__(self):
         self.last_render_time = 0
 

--- a/garage/exploration_strategies/base.py
+++ b/garage/exploration_strategies/base.py
@@ -1,4 +1,4 @@
-class ExplorationStrategy(object):
+class ExplorationStrategy:
     def get_action(self, t, observation, policy, **kwargs):
         raise NotImplementedError
 

--- a/garage/misc/console.py
+++ b/garage/misc/console.py
@@ -45,7 +45,7 @@ def log(s):  # , send_telegram=False):
     sys.stdout.flush()
 
 
-class SimpleMessage(object):
+class SimpleMessage:
     def __init__(self, msg, logger=log):
         self.msg = msg
         self.logger = logger
@@ -63,7 +63,7 @@ class SimpleMessage(object):
 MESSAGE_DEPTH = 0
 
 
-class Message(object):
+class Message:
     def __init__(self, msg):
         self.msg = msg
 

--- a/garage/misc/ext.py
+++ b/garage/misc/ext.py
@@ -38,7 +38,7 @@ def compact(x):
 
 
 # Immutable, lazily evaluated dict
-class LazyDict(object):
+class LazyDict:
     def __init__(self, **kwargs):
         self._lazy_dict = kwargs
         self._dict = {}

--- a/garage/misc/instrument.py
+++ b/garage/misc/instrument.py
@@ -24,7 +24,7 @@ from garage.misc.ext import AttrDict
 from garage.viskit.core import flatten
 
 
-class StubBase(object):
+class StubBase:
     def __getitem__(self, item):
         return StubMethodCall(self, "__getitem__", args=[item], kwargs=dict())
 
@@ -171,7 +171,7 @@ class VariantDict(AttrDict):
         return {k: v for k, v in self.items() if k not in self._hidden_keys}
 
 
-class VariantGenerator(object):
+class VariantGenerator:
     """
     Usage:
 

--- a/garage/misc/logger.py
+++ b/garage/misc/logger.py
@@ -194,7 +194,7 @@ def tabular_prefix(key):
     pop_tabular_prefix()
 
 
-class TerminalTablePrinter(object):
+class TerminalTablePrinter:
     def __init__(self):
         self.headers = None
         self.tabulars = []

--- a/garage/misc/nb_utils.py
+++ b/garage/misc/nb_utils.py
@@ -43,7 +43,7 @@ def plot_experiments(name_or_patterns,
         plt.legend(plots, legends)
 
 
-class Experiment(object):
+class Experiment:
     def __init__(self, progress, params, pkl_data=None):
         self.progress = progress
         self.params = params
@@ -72,7 +72,7 @@ def uniq(seq):
     return [x for x in seq if not (x in seen or seen_add(x))]
 
 
-class ExperimentDatabase(object):
+class ExperimentDatabase:
     def __init__(self, data_folder, names_or_patterns='*'):
         self._load_experiments(data_folder, names_or_patterns)
 

--- a/garage/misc/overrides.py
+++ b/garage/misc/overrides.py
@@ -37,7 +37,7 @@ def overrides(method):
     How to use:
     from overrides import overrides
 
-    class SuperClass(object):
+    class SuperClass:
 
         def method(self):
             return 2

--- a/garage/misc/viewer2d.py
+++ b/garage/misc/viewer2d.py
@@ -3,7 +3,7 @@ import pygame
 import pygame.gfxdraw
 
 
-class Colors(object):
+class Colors:
     black = (0, 0, 0)
     white = (255, 255, 255)
     blue = (0, 0, 255)
@@ -11,7 +11,7 @@ class Colors(object):
     green = (0, 255, 0)
 
 
-class Viewer2D(object):
+class Viewer2D:
     def __init__(self, size=(640, 480), xlim=None, ylim=None):
         pygame.init()
         screen = pygame.display.set_mode(size)

--- a/garage/optimizers/minibatch_dataset.py
+++ b/garage/optimizers/minibatch_dataset.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class BatchDataset(object):
+class BatchDataset:
     def __init__(self, inputs, batch_size, extra_inputs=None):
         self._inputs = [i for i in inputs]
         if extra_inputs is None:

--- a/garage/replay_buffer/replay_buffer.py
+++ b/garage/replay_buffer/replay_buffer.py
@@ -11,7 +11,7 @@ algorithms.
 import numpy as np
 
 
-class ReplayBuffer(object):
+class ReplayBuffer:
     """
     This class caches transitions in the training of RL algorithms.
 

--- a/garage/sampler/base.py
+++ b/garage/sampler/base.py
@@ -6,7 +6,7 @@ import garage.misc.logger as logger
 from garage.sampler import utils
 
 
-class Sampler(object):
+class Sampler:
     def start_worker(self):
         """
         Initialize the sampler, e.g. launching parallel workers if necessary.

--- a/garage/sampler/stateful_pool.py
+++ b/garage/sampler/stateful_pool.py
@@ -10,7 +10,7 @@ import pyprind
 from garage.misc import logger
 
 
-class ProgBarCounter(object):
+class ProgBarCounter:
     def __init__(self, total_count):
         self.total_count = total_count
         self.max_progress = 1000000
@@ -35,11 +35,11 @@ class ProgBarCounter(object):
             self.pbar.stop()
 
 
-class SharedGlobal(object):
+class SharedGlobal:
     pass
 
 
-class StatefulPool(object):
+class StatefulPool:
     def __init__(self):
         self.n_parallel = 1
         self.pool = None

--- a/garage/spaces/base.py
+++ b/garage/spaces/base.py
@@ -1,4 +1,4 @@
-class Space(object):
+class Space:
     """
     Provides a classification state spaces and action spaces,
     so you can write generic code that applies to any Environment.

--- a/garage/tf/core/layers.py
+++ b/garage/tf/core/layers.py
@@ -12,7 +12,7 @@ import tensorflow as tf
 from tensorflow.python.training import moving_averages
 
 
-class G(object):
+class G:
     pass
 
 
@@ -116,7 +116,7 @@ def conv_output_length(input_length, filter_size, stride, pad=0):
     return output_length
 
 
-class Layer(object):
+class Layer:
     def __init__(self,
                  incoming,
                  name=None,
@@ -320,7 +320,7 @@ class ConcatLayer(MergeLayer):
 concat = ConcatLayer  # shortcut
 
 
-class XavierUniformInitializer(object):
+class XavierUniformInitializer:
     def __call__(self, shape, dtype=tf.float32, name=None, *args, **kwargs):
         if len(shape) == 2:
             n_inputs, n_outputs = shape
@@ -334,7 +334,7 @@ class XavierUniformInitializer(object):
                 -init_range, init_range, dtype=dtype)(shape)
 
 
-class HeUniformInitializer(object):
+class HeUniformInitializer:
     def __call__(self, shape, dtype=tf.float32, name=None, *args, **kwargs):
         if len(shape) == 2:
             n_inputs, _ = shape
@@ -355,7 +355,7 @@ def py_ortho_init(scale):
     return _init
 
 
-class OrthogonalInitializer(object):
+class OrthogonalInitializer:
     def __init__(self, scale=1.1):
         self.scale = scale
 

--- a/garage/tf/core/network.py
+++ b/garage/tf/core/network.py
@@ -217,7 +217,7 @@ class ConvNetwork(LayersPowered, Serializable):
         return self._l_in.input_var
 
 
-class GRUNetwork(object):
+class GRUNetwork:
     def __init__(self,
                  input_shape,
                  output_dim,
@@ -342,7 +342,7 @@ class GRUNetwork(object):
         return self._hid_init_param
 
 
-class LSTMNetwork(object):
+class LSTMNetwork:
     def __init__(self,
                  input_shape,
                  output_dim,

--- a/garage/tf/core/parameterized.py
+++ b/garage/tf/core/parameterized.py
@@ -16,7 +16,7 @@ def suppress_params_loading():
     load_params = True
 
 
-class Parameterized(object):
+class Parameterized:
     def __init__(self):
         self._cached_params = {}
         self._cached_param_dtypes = {}

--- a/garage/tf/distributions/base.py
+++ b/garage/tf/distributions/base.py
@@ -1,4 +1,4 @@
-class Distribution(object):
+class Distribution:
     @property
     def dim(self):
         raise NotImplementedError

--- a/garage/tf/envs/parallel_vec_env_executor.py
+++ b/garage/tf/envs/parallel_vec_env_executor.py
@@ -77,7 +77,7 @@ def worker_collect_env_time(G):
     return G.env_time
 
 
-class ParallelVecEnvExecutor(object):
+class ParallelVecEnvExecutor:
     def __init__(self, env, n, max_path_length, scope=None):
         if scope is None:
             # initialize random scope

--- a/garage/tf/envs/vec_env_executor.py
+++ b/garage/tf/envs/vec_env_executor.py
@@ -5,7 +5,7 @@ import numpy as np
 from garage.tf.misc import tensor_utils
 
 
-class VecEnvExecutor(object):
+class VecEnvExecutor:
     def __init__(self, envs, max_path_length):
         self.envs = envs
         self._action_space = envs[0].action_space

--- a/garage/tf/optimizers/conjugate_gradient_optimizer.py
+++ b/garage/tf/optimizers/conjugate_gradient_optimizer.py
@@ -9,7 +9,7 @@ from garage.misc.ext import sliced_fun
 from garage.tf.misc import tensor_utils
 
 
-class PerlmutterHvp(object):
+class PerlmutterHvp:
     def __init__(self, num_slices=1):
         self.target = None
         self.reg_coeff = None
@@ -68,7 +68,7 @@ class PerlmutterHvp(object):
         return eval
 
 
-class FiniteDifferenceHvp(object):
+class FiniteDifferenceHvp:
     def __init__(self,
                  base_eps=1e-8,
                  symmetric=True,

--- a/garage/theano/core/network.py
+++ b/garage/theano/core/network.py
@@ -216,7 +216,7 @@ class GRUStepLayer(L.MergeLayer):
         return self._gru_layer.step(x, hprev)
 
 
-class GRUNetwork(object):
+class GRUNetwork:
     def __init__(self,
                  input_shape,
                  output_dim,
@@ -306,7 +306,7 @@ class GRUNetwork(object):
         return self._hid_init_param
 
 
-class ConvNetwork(object):
+class ConvNetwork:
     def __init__(
             self,
             input_shape,

--- a/garage/theano/distributions/base.py
+++ b/garage/theano/distributions/base.py
@@ -1,7 +1,7 @@
 import theano.tensor as TT
 
 
-class Distribution(object):
+class Distribution:
     @property
     def dim(self):
         raise NotImplementedError

--- a/garage/viskit/core.py
+++ b/garage/viskit/core.py
@@ -171,7 +171,7 @@ def extract_distinct_params(exps_data,
     return filtered
 
 
-class Selector(object):
+class Selector:
     def __init__(self, exps_data, filters=None, custom_filters=None):
         self._exps_data = exps_data
         if filters is None:
@@ -228,7 +228,7 @@ def hex_to_rgb(hex, opacity=1.0):
         int(hex[:2], 16), int(hex[2:4], 16), int(hex[4:6], 16), opacity)
 
 
-# class VisApp(object):
+# class VisApp:
 #
 #
 #     def __init__(self, exp_folder_path):

--- a/tests/garage/theano/core/test_instrument.py
+++ b/tests/garage/theano/core/test_instrument.py
@@ -5,7 +5,7 @@ from garage.misc import instrument
 # https://gist.github.com/jrast/109f70f9b4c52bab4252
 
 
-class TestClass(object):
+class TestClass:
     @property
     def arr(self):
         return [1, 2, 3]


### PR DESCRIPTION
This PR removes all Python 2 new-style class declarations.

i.e. if a class from Python 2 was declared as
```python
class Foo(object):
    pass
```
in Python 3 it is sufficient to write
```python
class Foo:
    pass
```