### PR TITLE
Remove OcclussionEnv from convenience imports

### DIFF
--- a/garage/envs/__init__.py
+++ b/garage/envs/__init__.py
@@ -7,7 +7,6 @@ from garage.envs.noisy_env import DelayedActionEnv
 from garage.envs.noisy_env import NoisyObservationEnv
 from garage.envs.normalized_env import normalize
 from garage.envs.normalized_env import NormalizedEnv
-from garage.envs.occlusion_env import OcclusionEnv
 from garage.envs.sliding_mem_env import SlidingMemEnv
 
 __all__ = [
@@ -20,6 +19,5 @@ __all__ = [
     "NoisyObservationEnv",
     "normalize",
     "NormalizedEnv",
-    "OcclusionEnv",
     "SlidingMemEnv",
 ]


### PR DESCRIPTION
This avoids importing mujoco for non-mujoco tests.