### PR TITLE
Rename ProductSpace to TupleSpace

### DIFF
--- a/garage/spaces/__init__.py
+++ b/garage/spaces/__init__.py
@@ -2,6 +2,6 @@ from garage.spaces.base import Space
 from garage.spaces.box import Box
 from garage.spaces.dict import Dict
 from garage.spaces.discrete import Discrete
-from garage.spaces.product import Product
+from garage.spaces.tuple import Tuple
 
-__all__ = ["Space", "Box", "Dict", "Discrete", "Product"]
+__all__ = ["Space", "Box", "Dict", "Discrete", "Tuple"]

--- a/garage/spaces/tuple.py
+++ b/garage/spaces/tuple.py
@@ -3,7 +3,7 @@ import numpy as np
 from garage.spaces import Space
 
 
-class Product(Space):
+class Tuple(Space):
     def __init__(self, *components):
         if isinstance(components[0], (list, tuple)):
             assert len(components) == 1
@@ -59,7 +59,7 @@ class Product(Space):
         return unflat_xs_grouped
 
     def __eq__(self, other):
-        if not isinstance(other, Product):
+        if not isinstance(other, Tuple):
             return False
         return tuple(self.components) == tuple(other.components)
 

--- a/garage/tf/envs/base.py
+++ b/garage/tf/envs/base.py
@@ -10,7 +10,7 @@ from garage.misc.overrides import overrides
 from garage.tf.spaces import Box
 from garage.tf.spaces import Dict
 from garage.tf.spaces import Discrete
-from garage.tf.spaces import Product
+from garage.tf.spaces import Tuple
 
 
 class TfEnv(GarageEnv):
@@ -48,7 +48,7 @@ class TfEnv(GarageEnv):
         elif isinstance(space, GymDiscrete):
             return Discrete(space.n)
         elif isinstance(space, GymTuple):
-            return Product(list(map(self._to_garage_space, space.spaces)))
+            return Tuple(list(map(self._to_garage_space, space.spaces)))
         else:
             raise NotImplementedError
 

--- a/garage/tf/spaces/__init__.py
+++ b/garage/tf/spaces/__init__.py
@@ -3,6 +3,6 @@
 from garage.tf.spaces.box import Box
 from garage.tf.spaces.dict import Dict
 from garage.tf.spaces.discrete import Discrete
-from garage.tf.spaces.product import Product
+from garage.tf.spaces.tuple import Tuple
 
-__all__ = ["Box", "Dict", "Discrete", "Product"]
+__all__ = ["Box", "Dict", "Discrete", "Tuple"]

--- a/garage/tf/spaces/dict.py
+++ b/garage/tf/spaces/dict.py
@@ -14,7 +14,7 @@ from garage.misc.overrides import overrides
 from garage.spaces.dict import Dict as GarageDict
 from garage.tf.spaces.box import Box
 from garage.tf.spaces.discrete import Discrete
-from garage.tf.spaces.product import Product
+from garage.tf.spaces.tuple import Tuple
 
 
 class Dict(GarageDict):
@@ -183,6 +183,6 @@ class Dict(GarageDict):
         elif isinstance(space, GymDiscrete):
             return Discrete(space.n)
         elif isinstance(space, GymTuple):
-            return Product(list(map(self._to_garage_space, space.spaces)))
+            return Tuple(list(map(self._to_garage_space, space.spaces)))
         else:
             raise NotImplementedError

--- a/garage/tf/spaces/tuple.py
+++ b/garage/tf/spaces/tuple.py
@@ -1,11 +1,11 @@
-"""Spaces.Product for TensorFlow."""
+"""Spaces.Tuple for TensorFlow."""
 import tensorflow as tf
 
-from garage.spaces import Product as GarageProduct
+from garage.spaces import Tuple as GarageTuple
 
 
-class Product(GarageProduct):
-    """TensorFlow extension of garage.Product."""
+class Tuple(GarageTuple):
+    """TensorFlow extension of garage.Tuple."""
 
     def new_tensor_variable(self, name, extra_dims):
         """

--- a/garage/theano/envs/base.py
+++ b/garage/theano/envs/base.py
@@ -11,7 +11,7 @@ from garage.misc.overrides import overrides
 from garage.theano.spaces import Box
 from garage.theano.spaces import Dict
 from garage.theano.spaces import Discrete
-from garage.theano.spaces import Product
+from garage.theano.spaces import Tuple
 
 
 class TheanoEnv(GarageEnv):
@@ -42,7 +42,7 @@ class TheanoEnv(GarageEnv):
         elif isinstance(space, GymDiscrete):
             return Discrete(space.n)
         elif isinstance(space, GymTuple):
-            return Product(list(map(self._to_garage_space, space.spaces)))
+            return Tuple(list(map(self._to_garage_space, space.spaces)))
         else:
             raise NotImplementedError
 

--- a/garage/theano/spaces/__init__.py
+++ b/garage/theano/spaces/__init__.py
@@ -3,6 +3,6 @@
 from garage.theano.spaces.box import Box
 from garage.theano.spaces.dict import Dict
 from garage.theano.spaces.discrete import Discrete
-from garage.theano.spaces.product import Product
+from garage.theano.spaces.tuple import Tuple
 
-__all__ = ["Box", "Dict", "Discrete", "Product"]
+__all__ = ["Box", "Dict", "Discrete", "Tuple"]

--- a/garage/theano/spaces/dict.py
+++ b/garage/theano/spaces/dict.py
@@ -13,7 +13,7 @@ from garage.misc.overrides import overrides
 from garage.spaces.dict import Dict as GarageDict
 from garage.theano.spaces.box import Box
 from garage.theano.spaces.discrete import Discrete
-from garage.theano.spaces.product import Product
+from garage.theano.spaces.tuple import Tuple
 
 
 class Dict(GarageDict):
@@ -169,6 +169,6 @@ class Dict(GarageDict):
         elif isinstance(space, GymDiscrete):
             return Discrete(space.n)
         elif isinstance(space, GymTuple):
-            return Product(list(map(self._to_garage_space, space.spaces)))
+            return Tuple(list(map(self._to_garage_space, space.spaces)))
         else:
             raise NotImplementedError

--- a/garage/theano/spaces/tuple.py
+++ b/garage/theano/spaces/tuple.py
@@ -1,10 +1,10 @@
-"""Spaces.Product for Theano."""
-from garage.spaces import Product as GarageProduct
+"""Spaces.Tuple for Theano."""
+from garage.spaces import Tuple as GarageTuple
 from garage.theano.misc import tensor_utils
 
 
-class Product(GarageProduct):
-    """Theano extension of garage.Product."""
+class Tuple(GarageTuple):
+    """Theano extension of garage.Tuple."""
 
     def new_tensor_variable(self, name, extra_dims):
         """

--- a/tests/garage/spaces/test_tuple.py
+++ b/tests/garage/spaces/test_tuple.py
@@ -1,13 +1,13 @@
 import pickle
 import unittest
 
-from garage.tf.spaces import Discrete
-from garage.tf.spaces.product import Product
+from garage.spaces.tuple import Tuple
+from garage.theano.spaces import Discrete
 
 
-class TestProduct(unittest.TestCase):
+class TestTuple(unittest.TestCase):
     def test_pickleable(self):
-        obj = Product((Discrete(3), Discrete(2)))
+        obj = Tuple((Discrete(3), Discrete(2)))
         round_trip = pickle.loads(pickle.dumps(obj))
         assert round_trip
         assert round_trip.components == obj.components

--- a/tests/garage/tf/spaces/test_tuple.py
+++ b/tests/garage/tf/spaces/test_tuple.py
@@ -1,13 +1,13 @@
 import pickle
 import unittest
 
-from garage.spaces.product import Product
-from garage.theano.spaces import Discrete
+from garage.tf.spaces import Discrete
+from garage.tf.spaces.tuple import Tuple
 
 
-class TestProduct(unittest.TestCase):
+class TestTuple(unittest.TestCase):
     def test_pickleable(self):
-        obj = Product((Discrete(3), Discrete(2)))
+        obj = Tuple((Discrete(3), Discrete(2)))
         round_trip = pickle.loads(pickle.dumps(obj))
         assert round_trip
         assert round_trip.components == obj.components

--- a/tests/garage/theano/spaces/test_spaces.py
+++ b/tests/garage/theano/spaces/test_spaces.py
@@ -4,18 +4,18 @@ import numpy as np
 
 from garage.theano.spaces import Box
 from garage.theano.spaces import Discrete
-from garage.theano.spaces import Product
+from garage.theano.spaces import Tuple
 
 
 class TestSpaces(unittest.TestCase):
-    def test_product_space(self):
-        _ = Product([Discrete(3), Discrete(2)])
-        product_space = Product(Discrete(3), Discrete(2))
-        sample = product_space.sample()
-        assert product_space.contains(sample)
+    def test_tuple_space(self):
+        _ = Tuple([Discrete(3), Discrete(2)])
+        tuple_space = Tuple(Discrete(3), Discrete(2))
+        sample = tuple_space.sample()
+        assert tuple_space.contains(sample)
 
-    def test_product_space_unflatten_n(self):
-        space = Product([Discrete(3), Discrete(3)])
+    def test_tuple_space_unflatten_n(self):
+        space = Tuple([Discrete(3), Discrete(3)])
         np.testing.assert_array_equal(
             space.flatten((2, 2)),
             space.flatten_n([(2, 2)])[0])

--- a/tests/garage/theano/spaces/test_tuple.py
+++ b/tests/garage/theano/spaces/test_tuple.py
@@ -2,12 +2,12 @@ import pickle
 import unittest
 
 from garage.theano.spaces import Discrete
-from garage.theano.spaces.product import Product
+from garage.theano.spaces.tuple import Tuple
 
 
-class TestProduct(unittest.TestCase):
+class TestTuple(unittest.TestCase):
     def test_pickleable(self):
-        obj = Product((Discrete(3), Discrete(2)))
+        obj = Tuple((Discrete(3), Discrete(2)))
         round_trip = pickle.loads(pickle.dumps(obj))
         assert round_trip
         assert round_trip.components == obj.components


### PR DESCRIPTION
OpenAI gym's naming convention is to call a product space [TupleSpace](https://github.com/openai/gym/blob/master/gym/spaces/tuple_space.py). Thus, this PR renames all instances of ProductSpace to TupleSpace to keep garage consistent with gym. 

Ref: #287 