### PR TITLE
Lock dm_control version (#344)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
         # find a build dependency (absl-py). Later pip executes the `install`
         # command again and the install succeeds because absl-py has been
         # installed. This is stupid, but harmless.
-        - git+https://github.com/deepmind/dm_control.git#egg=dm_control
+        - git+https://github.com/deepmind/dm_control.git@c24ec9f5f3cb3c25c6571c89c9f60bf3350f5711#egg=dm_control
         - flask
         - gym[all]==0.10.5
         - hyperopt


### PR DESCRIPTION
dm_control is now updated to support Mujoco v2.00, and it breaks our
current code. By default we install Mujoco v1.50 and this commit locks
dm_control to the last version that supports Mujoco v1.50. 

This PR fixes #344 .