### PR TITLE
Theano gpu support

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -89,3 +89,31 @@ Install Python modules
 .. code-block:: bash
 
   conda env create -f environment.yml
+  
+GPU Support
+===========
+
+To enable GPU support, you need to run express installation script with :code:`--gpu`. This options installs GPU-supported Tensorflow and necessary modules needed by Theano.
+
+Before you run garage, you need to specify directory CUDA library in environment varible :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming your CUDA version accrodingly. 
+
+.. code-block:: bash
+
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-9.0/lib64
+
+
+You should now be able to use GPU in Tensorflow. For Theano, two additional steps are needed. 
+
+* Specify CUDA root in :code:`~/.theanorc` (Create the file if it doesn't exist)
+
+.. code-block:: ini
+
+    [cuda]
+    root = /usr/local/cuda-9.0
+    
+* | `Enable GPU for theano <http://deeplearning.net/software/theano/tutorial/using_gpu.html>`_ by
+
+.. code-block:: bash
+
+    export THEANO_FLAGS=device=cuda,floatX=float32,force_device=True
+   

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -89,20 +89,20 @@ Install Python modules
 .. code-block:: bash
 
   conda env create -f environment.yml
-  
+
 GPU Support
 ===========
 
-To enable GPU support, you need to run express installation script with :code:`--gpu`. This options installs GPU-supported Tensorflow and necessary modules needed by Theano.
+To enable GPU support, you need to run the express installation script with the argument :code:`--gpu`. This options installs GPU-supported Tensorflow and modules needed by Theano.
 
-Before you run garage, you need to specify directory CUDA library in environment varible :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming your CUDA version accrodingly. 
+Before you run garage, you need to specify the directory for the CUDA library in environment varible :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming to your CUDA version accordingly.
 
 .. code-block:: bash
 
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-9.0/lib64
 
 
-You should now be able to use GPU in Tensorflow. For Theano, two additional steps are needed. 
+You should now be able to use GPU in Tensorflow. For Theano, two additional steps are needed.
 
 * Specify CUDA root in :code:`~/.theanorc` (Create the file if it doesn't exist)
 
@@ -110,10 +110,9 @@ You should now be able to use GPU in Tensorflow. For Theano, two additional step
 
     [cuda]
     root = /usr/local/cuda-9.0
-    
+
 * | `Enable GPU for theano <http://deeplearning.net/software/theano/tutorial/using_gpu.html>`_ by
 
 .. code-block:: bash
 
     export THEANO_FLAGS=device=cuda,floatX=float32,force_device=True
-   

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -95,7 +95,7 @@ GPU Support
 
 To enable GPU support, you need to run the express installation script with the argument :code:`--gpu`. This options installs GPU-supported Tensorflow and modules needed by Theano.
 
-Before you run garage, you need to specify the directory for the CUDA library in environment varible :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming to your CUDA version accordingly.
+Before you run garage, you need to specify the directory for the CUDA library in environment variable :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming to your CUDA version accordingly.
 
 .. code-block:: bash
 

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -35,16 +35,16 @@ _positionals=()
 # THE DEFAULTS INITIALIZATION - OPTIONALS
 _arg_mjkey=
 _arg_modify_bashrc="off"
-_arg_tf_gpu="off"
+_arg_gpu="off"
 
 print_help ()
 {
   printf '%s\n' "Installer of garage for Linux."
   printf 'Usage: %s [--mjkey <arg>] [--(no-)modify-bashrc] ' "$0"
-  printf '[--(no-)tf-gpu] [-h|--help]\n'
+  printf '[--(no-)gpu] [-h|--help]\n'
   printf '\t%s\n' "--mjkey: Path of the MuJoCo key (no default)"
-  printf '\t%s' "--tf-gpu,--no-tf-gpu: Install TensorFlow GPU instead of the "
-  printf '%s\n' "regular version (off by default)"
+  printf '\t%s' "--gpu,--no-gpu: Install GPU support of Tensorflow and Theano "
+  printf '%s\n' "(off by default)"
   printf '\t%s' "--modify-bashrc,--no-modify-bashrc: Set environment variables "
   printf '%s\n' "required by garage in .bashrc (off by default)"
   printf '\t%s\n' "-h,--help: Prints help"
@@ -70,8 +70,8 @@ parse_commandline ()
         test "${1:0:5}" = "--no-" && _arg_modify_bashrc="off"
         ;;
       --no-tf-gpu|--tf-gpu)
-        _arg_tf_gpu="on"
-        test "${1:0:5}" = "--no-" && _arg_tf_gpu="off"
+        _arg_gpu="on"
+        test "${1:0:5}" = "--no-" && _arg_gpu="off"
         ;;
       -h|--help)
         print_help
@@ -209,8 +209,8 @@ conda activate garage
   # 'Install' garage as an editable package
   pip install -e .
 
-  if [[ "${_arg_tf_gpu}" = on ]]; then
-    # Remove any TensorFlow installations before installing the GPU flavor
+  if [[ "${_arg_gpu}" = on ]]; then
+    # Remove any TensorFlow installations before installing the GPU flavor 
     pip uninstall -y tensorflow
     pip install "tensorflow-gpu<1.10,>=1.9.0"
 

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -209,10 +209,13 @@ conda activate garage
   # 'Install' garage as an editable package
   pip install -e .
 
-  # Remove any TensorFlow installations before installing the GPU flavor
   if [[ "${_arg_tf_gpu}" = on ]]; then
+    # Remove any TensorFlow installations before installing the GPU flavor
     pip uninstall -y tensorflow
     pip install "tensorflow-gpu<1.10,>=1.9.0"
+
+    # pygpu is required by Theano to run on GPU
+    conda install pygpu
   fi
 
   # Fix Box2D install

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -69,7 +69,7 @@ parse_commandline ()
         _arg_modify_bashrc="on"
         test "${1:0:5}" = "--no-" && _arg_modify_bashrc="off"
         ;;
-      --no-tf-gpu|--tf-gpu)
+      --no-gpu|--gpu)
         _arg_gpu="on"
         test "${1:0:5}" = "--no-" && _arg_gpu="off"
         ;;
@@ -210,7 +210,7 @@ conda activate garage
   pip install -e .
 
   if [[ "${_arg_gpu}" = on ]]; then
-    # Remove any TensorFlow installations before installing the GPU flavor 
+    # Remove any TensorFlow installations before installing the GPU flavor
     pip uninstall -y tensorflow
     pip install "tensorflow-gpu<1.10,>=1.9.0"
 


### PR DESCRIPTION
This PR fixes GPU support for Theano. 
- Replace `--tf-gpu` with `--gpu` to enable GPU support for both Tensorflow and Theano.
- Update documentation for extra steps needed to enable GPU support.

Closes #204 .