### PR TITLE
Copy MuJoCo key before installing the conda env

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -103,7 +103,8 @@ print_warning() {
 }
 
 # Verify there's a file in the mjkey path
-test -f "${_arg_mjkey}" || _PRINT_HELP=yes die \
+test "$(file -b --mime-type ${_arg_mjkey})" == "text/plain" \
+  || _PRINT_HELP=yes die \
   "The path ${_arg_mjkey} of the MuJoCo key is not valid." 1
 
 # Make sure that we're under the garage directory
@@ -194,6 +195,9 @@ fi
 . "${CONDA_SH}"
 conda update -q -y conda
 
+# We need a MuJoCo key to import mujoco_py
+cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+
 # Create conda environment
 conda env create -f environment.yml
 if [[ "${?}" -ne 0 ]]; then
@@ -217,12 +221,6 @@ conda activate garage
     # pygpu is required by Theano to run on GPU
     conda install pygpu
   fi
-
-  # We need a MuJoCo key to import mujoco_py
-  cp ${_arg_mjkey} "${HOME}"/.mujoco/mjkey.txt
-
-  # Build mujoco-py and check it's correctly installed
-  python -c 'import mujoco_py'
 
   # Install git hooks
   pre-commit install -t pre-commit

--- a/scripts/setup_osx.sh
+++ b/scripts/setup_osx.sh
@@ -133,7 +133,8 @@ if [[ ! " ${VERIFIED_OSX_VERSIONS[@]} " =~ " ${VER} " ]]; then
 fi
 
 # Verify there's a file in the mjkey path
-test -f "${_arg_mjkey}" || _PRINT_HELP=yes die \
+test "$(file -b --mime-type ${_arg_mjkey})" == "text/plain" \
+  || _PRINT_HELP=yes die \
   "The path ${_arg_mjkey} of the MuJoCo key is not valid." 1
 
 # Make sure that we're under the garage directory
@@ -215,6 +216,9 @@ fi
 . "${CONDA_SH}"
 conda update -q -y conda
 
+# We need a MuJoCo key to import mujoco_py
+cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+
 # Create conda environment
 conda env create -f environment.yml
 if [[ "${?}" -ne 0 ]]; then
@@ -229,12 +233,6 @@ conda activate garage
 
   # 'Install' garage as an editable package
   pip install -e .
-
-  # We need a MuJoCo key to import mujoco_py
-  cp ${_arg_mjkey} "${HOME}"/.mujoco/mjkey.txt
-
-  # Build mujoco-py and check it's correctly installed
-  python -c 'import mujoco_py'
 
   # Install git hooks
   pre-commit install -t pre-commit


### PR DESCRIPTION
Currently the dm-control installation calls the MuJoCo package during
its installation, and since no MuJoCo key is present, there's an error
during the installation.