### PR TITLE
Fix TensorFlow warning in NPO about IndexedSlices

### DIFF
--- a/garage/tf/algos/npo.py
+++ b/garage/tf/algos/npo.py
@@ -126,7 +126,7 @@ class NPO(BatchPolopt):
             reward_var = tensor_utils.new_tensor(
                 name="reward", ndim=2, dtype=tf.float32)
             valid_var = tf.placeholder(
-                tf.bool, shape=[None, None], name="valid")
+                tf.float32, shape=[None, None], name="valid")
             baseline_var = tensor_utils.new_tensor(
                 name="baseline", ndim=2, dtype=tf.float32)
 
@@ -373,8 +373,7 @@ class NPO(BatchPolopt):
             if self._use_softplus_entropy:
                 policy_entropy = tf.nn.softplus(policy_entropy)
 
-            policy_entropy = tf.reduce_mean(
-                policy_entropy * tf.to_float(i.valid_var))
+            policy_entropy = tf.reduce_mean(policy_entropy * i.valid_var)
 
         self.f_policy_entropy = tensor_utils.compile_function(
             flatten_inputs(self._policy_opt_inputs),

--- a/garage/tf/algos/npo.py
+++ b/garage/tf/algos/npo.py
@@ -126,7 +126,7 @@ class NPO(BatchPolopt):
             reward_var = tensor_utils.new_tensor(
                 name="reward", ndim=2, dtype=tf.float32)
             valid_var = tf.placeholder(
-                tf.float32, shape=[None, None], name="valid")
+                tf.bool, shape=[None, None], name="valid")
             baseline_var = tensor_utils.new_tensor(
                 name="baseline", ndim=2, dtype=tf.float32)
 
@@ -373,7 +373,8 @@ class NPO(BatchPolopt):
             if self._use_softplus_entropy:
                 policy_entropy = tf.nn.softplus(policy_entropy)
 
-            policy_entropy = tf.reduce_mean(policy_entropy * i.valid_var)
+            policy_entropy = tf.reduce_mean(
+                policy_entropy * tf.to_float(i.valid_var))
 
         self.f_policy_entropy = tensor_utils.compile_function(
             flatten_inputs(self._policy_opt_inputs),

--- a/garage/tf/distributions/categorical.py
+++ b/garage/tf/distributions/categorical.py
@@ -118,5 +118,6 @@ class Categorical(Distribution):
         with tf.name_scope(name, "sample_sym", [dist_info]):
             probs = dist_info["prob"]
             samples = tf.multinomial(tf.log(probs + 1e-8), num_samples=1)[:, 0]
+
             return tf.nn.embedding_lookup(
                 np.eye(self.dim, dtype=np.float32), samples)

--- a/garage/tf/misc/tensor_utils.py
+++ b/garage/tf/misc/tensor_utils.py
@@ -23,7 +23,10 @@ def flatten_batch_dict(d, name=None):
 
 
 def filter_valids(t, valid, name="filter_valids"):
-    return tf.dynamic_partition(t, tf.to_int32(valid), 2, name=name)[1]
+    # 'valid' is either 0 or 1 with dtype of tf.float32
+    # Must round before cast to prevent floating-error
+    return tf.dynamic_partition(
+        t, tf.to_int32(tf.round(valid)), 2, name=name)[1]
 
 
 def filter_valids_dict(d, valid, name=None):

--- a/garage/tf/misc/tensor_utils.py
+++ b/garage/tf/misc/tensor_utils.py
@@ -23,7 +23,7 @@ def flatten_batch_dict(d, name=None):
 
 
 def filter_valids(t, valid, name="filter_valids"):
-    return tf.boolean_mask(t, valid, name=name)
+    return tf.dynamic_partition(t, tf.to_int32(valid), 2, name=name)[1]
 
 
 def filter_valids_dict(d, valid, name=None):


### PR DESCRIPTION
NPO uses a boolean valid_var tensor to select a slice from a variety
of tensors related to action, policy and advantages. Previously we
used `tf.boolean_mask()` to do the selection, which internally calls
`tf.gather()` that emits `tf.IndexedSlices`. When calculating BP,
`tf.IndexedSlices` will be casted into a dense tf.Tensor with a
`"Converting sparse IndexedSlices to a dense Tensor of unknown shape"`
warning. This fix replaces `tf.boolean_mask()` with
`tf.dynamic_partition()`, which don't have such problem.

This difference of behavior is not documented in Tensorflow. It is
not clear if `tf.dynamic_partition()` will cause performance
regression.

This fixes #289.