### PR TITLE
Add GaussianMLPModel and abstract class Model

### DIFF
--- a/garage/tf/core/mlp.py
+++ b/garage/tf/core/mlp.py
@@ -60,3 +60,4 @@ def mlp(input_var,
             bias_initializer=output_b_init,
             name="output")
     return l_out
+

--- a/garage/tf/core/mlp.py
+++ b/garage/tf/core/mlp.py
@@ -60,4 +60,3 @@ def mlp(input_var,
             bias_initializer=output_b_init,
             name="output")
     return l_out
-

--- a/garage/tf/core/parameter.py
+++ b/garage/tf/core/parameter.py
@@ -1,7 +1,6 @@
 """Parameter layer in TensorFlow."""
 
 import tensorflow as tf
-from tensorflow.python.ops.gen_array_ops import broadcast_to
 
 
 def parameter(input_var,
@@ -37,7 +36,9 @@ def parameter(input_var,
             initializer=initializer,
             trainable=trainable)
 
-        broadcast_shape = tf.concat(
-            axis=0, values=[tf.shape(input_var)[:-1], [length]])
-        p_broadcast = broadcast_to(p, shape=broadcast_shape)
-        return p_broadcast
+        ndim = input_var.get_shape().ndims
+        reshaped_p = tf.reshape(p, (1, ) * (ndim - 1) + (length, ))
+        tile_arg = tf.concat(
+            axis=0, values=[tf.shape(input_var)[:ndim - 1], [1]])
+        tiled = tf.tile(reshaped_p, tile_arg)
+        return tiled

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,0 +1,4 @@
+from garage.tf.models.base import Model
+from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
+
+__all__ = ["Model", "GaussianMLPModel"]

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,3 +1,5 @@
+"""Tensorflow models."""
+
 from garage.tf.models.base import Model
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
 

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,4 +1,4 @@
-"""Tensorflow models."""
+"""TensorFlow models."""
 
 from garage.tf.models.base import Model
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -1,50 +1,43 @@
-"""
-This file contains the abstraction class for models
-"""
+"""This file contains the abstraction class for models."""
 import tensorflow as tf
 
-from garage.tf.core import layers as L
-from garage.tf.core import Parameterized
 from garage.misc.overrides import overrides
+from garage.tf.core import Parameterized
 
 
 class Model(Parameterized):
-    """
-    Abstraction class for models.
-    """
+    """Abstraction class for models."""
 
     def __init__(self):
+        """Initialize a model."""
         Parameterized.__init__(self)
 
     def build_model(self):
         """
-        This function will build the whole graph for
-        the model. All tensors should be created here.
-        By calling this function, a copy of the same graph
-        should be created with the same parameters.
-        Currently three things are returned: inputs, outputs and
-        model_info. All of them are returned as dictionaries.
+        Build the whole graph for the model.
+
+        All tensors should be created here. By calling this function,
+        a copy of the same graph should be created with the same
+        parameters. Currently three things are returned: inputs,
+        outputs and model_info. All of them are returned as dictionaries.
         """
         raise NotImplementedError
 
     @property
     def inputs(self):
-        """
-        Tensors of the inputs
-        """
+        """Tensors of the inputs."""
         return self._inputs
 
     @property
     def outputs(self):
-        """
-        Tensors of the outputs
-        """
+        """Tensors of the outputs."""
         return self._outputs
 
     @overrides
     def get_params_internal(self, **tags):
         """
-        Function for pickling the model.
+        Retrieve the parameters to pickle the model.
+
         Args
             tags: a dictionary of tags, only support trainable for now.
         Return

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -12,7 +12,7 @@ class Model(Parameterized):
         """Initialize a model."""
         Parameterized.__init__(self)
 
-    def build_model(self):
+    def build_model(self, inputs=None, reuse=tf.AUTO_REUSE):
         """
         Build the whole graph for the model.
 
@@ -24,7 +24,7 @@ class Model(Parameterized):
         raise NotImplementedError
 
     @property
-    def inputs(self, inputs=None, reuse=tf.AUTO_REUSE):
+    def inputs(self):
         """Tensors of the inputs."""
         return self._inputs
 

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -8,6 +8,8 @@ from garage.tf.core import Parameterized
 
 class Model(KerasModel, Parameterized):
     """
+    This is a tautology for all the garage models.
+
     A model define a neural network model to build a graph for
     other primitivs (e.g. GaussianMLPPolicy and GaussianMLPBaseline).
     A model can be built by assembling different models. For example,

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -24,7 +24,7 @@ class Model(Parameterized):
         raise NotImplementedError
 
     @property
-    def inputs(self):
+    def inputs(self, inputs=None, reuse=tf.AUTO_REUSE):
         """Tensors of the inputs."""
         return self._inputs
 

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -1,0 +1,57 @@
+"""
+This file contains the abstraction class for models
+"""
+import tensorflow as tf
+
+from garage.tf.core import layers as L
+from garage.tf.core import Parameterized
+from garage.misc.overrides import overrides
+
+
+class Model(Parameterized):
+    """
+    Abstraction class for models.
+    """
+
+    def __init__(self):
+        Parameterized.__init__(self)
+
+    def build_model(self):
+        """
+        This function will build the whole graph for
+        the model. All tensors should be created here.
+        By calling this function, a copy of the same graph
+        should be created with the same parameters.
+        Currently three things are returned: inputs, outputs and
+        model_info. All of them are returned as dictionaries.
+        """
+        raise NotImplementedError
+
+    @property
+    def inputs(self):
+        """
+        Tensors of the inputs
+        """
+        return self._inputs
+
+    @property
+    def outputs(self):
+        """
+        Tensors of the outputs
+        """
+        return self._outputs
+
+    @overrides
+    def get_params_internal(self, **tags):
+        """
+        Function for pickling the model.
+        Args
+            tags: a dictionary of tags, only support trainable for now.
+        Return
+            parameters of the model.
+        """
+        if tags.get("trainable"):
+            params = [v for v in tf.trainable_variables(scope=self.name)]
+        else:
+            params = [v for v in tf.global_variables(scope=self.name)]
+        return params

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -1,15 +1,24 @@
-"""This file contains the abstraction class for models."""
+"""This file contains the tautology for garage models."""
 import tensorflow as tf
+from tensorflow.keras.models import Model as KerasModel
 
 from garage.misc.overrides import overrides
 from garage.tf.core import Parameterized
 
 
-class Model(Parameterized):
-    """Abstraction class for models."""
+class Model(KerasModel, Parameterized):
+    """
+    A model define a neural network model to build a graph for
+    other primitivs (e.g. GaussianMLPPolicy and GaussianMLPBaseline).
+    A model can be built by assembling different models. For example,
+    to define a VAEGaussianMLP Model, we need to build a VAE model
+    and a GaussianMLP Model. Then, we can assemble them in the
+    build_model function.
+    """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """Initialize a model."""
+        super(Model, self).__init__(*args, **kwargs)
         Parameterized.__init__(self)
 
     def build_model(self, inputs=None, reuse=tf.AUTO_REUSE):
@@ -23,16 +32,6 @@ class Model(Parameterized):
         """
         raise NotImplementedError
 
-    @property
-    def inputs(self):
-        """Tensors of the inputs."""
-        return self._inputs
-
-    @property
-    def outputs(self):
-        """Tensors of the outputs."""
-        return self._outputs
-
     @overrides
     def get_params_internal(self, **tags):
         """
@@ -41,7 +40,7 @@ class Model(Parameterized):
         Args
             tags: a dictionary of tags, only support trainable for now.
         Return
-            parameters of the model.
+            parameters of the model in tf.Tensor.
         """
         if tags.get("trainable"):
             params = [v for v in tf.trainable_variables(scope=self.name)]

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -1,0 +1,211 @@
+import numpy as np
+import tensorflow as tf
+
+from garage.core import Serializable
+from garage.misc import ext
+from garage.tf.core.networks import mlp, parameter
+from garage.tf.models import Model
+
+
+class GaussianMLPModel(Model, Serializable):
+    """Gaussian MLP Model"""
+    def __init__(self,
+                 input_dim,
+                 output_dim,
+                 name="GaussianMLPModel",
+                 hidden_sizes=(32, 32),
+                 learn_std=True,
+                 init_std=1.0,
+                 adaptive_std=False,
+                 std_share_network=False,
+                 std_hidden_sizes=(32, 32),
+                 min_std=1e-6,
+                 max_std=None,
+                 std_hidden_nonlinearity=tf.nn.tanh,
+                 hidden_nonlinearity=tf.nn.tanh,
+                 output_nonlinearity=None,
+                 std_parameterization='exp',
+                ):
+        """
+        :param input_dim: input dimension
+        :param output_dim: output dimension
+        :param name: name of the model
+        :param hidden_sizes: list of sizes for the fully-connected hidden
+          layers
+        :param learn_std: Is std trainable
+        :param init_std: Initial std
+        :param adaptive_std:
+        :param std_share_network:
+        :param std_hidden_sizes: list of sizes for the fully-connected layers
+          for std
+        :param min_std: whether to make sure that the std is at least some
+          threshold value, to avoid numerical issues
+        :param std_hidden_nonlinearity:
+        :param hidden_nonlinearity: nonlinearity used for each hidden layer
+        :param output_nonlinearity: nonlinearity for the output layer
+        :param mean_network: custom network for the output mean
+        :param std_network: custom network for the output log std
+        :param std_parametrization: how the std should be parametrized. There
+          are a few options:
+            - exp: the logarithm of the std will be stored, and applied a
+                exponential transformation
+            - softplus: the std will be computed as log(1+exp(x))
+        :return:
+        """
+
+        Serializable.quick_init(self, locals())
+        super(GaussianMLPModel, self).__init__()
+
+        self.name = name
+        self._variable_scope = tf.variable_scope(
+            self.name, reuse=tf.AUTO_REUSE)
+        self._name_scope = tf.name_scope(self.name)
+
+        # Network parameters
+        self._input_dim = input_dim
+        self._output_dim = output_dim
+        self._hidden_sizes = hidden_sizes
+        self._learn_std = learn_std
+        self._init_std = init_std
+        self._adaptive_std = adaptive_std
+        self._std_share_network = std_share_network
+        self._std_hidden_sizes = std_hidden_sizes
+        self._min_std = min_std
+        self._max_std = max_std
+        self._std_hidden_nonlinearity = std_hidden_nonlinearity
+        self._hidden_nonlinearity = hidden_nonlinearity
+        self._output_nonlinearity = output_nonlinearity
+        self._std_parameterization = std_parameterization
+
+        # Tranform std arguments to parameterized space
+        self._init_std_param = None
+        self._min_std_param = None
+        self._max_std_param = None
+        if self._std_parameterization == 'exp':
+            self._init_std_param = np.log(init_std)
+            if min_std:
+                self._min_std_param = np.log(min_std)
+            if max_std:
+                self._max_std_param = np.log(max_std)
+        elif self._std_parameterization == 'softplus':
+            self._init_std_param = np.log(np.exp(init_std) - 1)
+            if min_std:
+                self._min_std_param = np.log(np.exp(min_std) - 1)
+            if max_std:
+                self._max_std_param = np.log(np.exp(max_std) - 1)
+        else:
+            raise NotImplementedError
+
+        inputs, outputs, model_info = self.build_model()
+        self._inputs = inputs["input_var"]
+        
+        self._mean = outputs["mean"]
+        self._std = outputs["std"]
+        self._std_param = outputs["std_param"]
+        self._sample = outputs["sample"]
+        self._dist = model_info["dist"]
+
+        self._outputs = outputs
+
+    def build_model(self):
+        """
+        Build the graph
+        return:
+            inputs: a dict that contains input tensor
+            outputs: a dict that contains mean, 
+                std, parameterized std and sample tensors
+            model_info: a dict that contains the distribution tensor
+        """
+
+        input_var = tf.placeholder(
+            shape=[None, self._input_dim],
+            dtype=tf.float32,
+        )
+
+        with self._variable_scope:
+            if self._std_share_network:
+                 # mean and std networks share an MLP
+                b = np.concatenate(
+                    [
+                        np.zeros(self._output_dim),
+                        np.full(self._output_dim, self._init_std_param)
+                    ],
+                    axis=0)
+                b = tf.constant_initializer(b)
+                mean_std_network = mlp(
+                    input_var=input_var,
+                    output_dim=self._output_dim * 2,
+                    hidden_sizes=self._hidden_sizes,
+                    hidden_nonlinearity=self._hidden_nonlinearity,
+                    output_nonlinearity=self._output_nonlinearity,
+                    output_b_init=b,
+                    name="mean_std_network")
+
+                with tf.variable_scope("mean_network"):
+                    mean_network = mean_std_network[..., :self._output_dim]
+                with tf.variable_scope("std_network"):
+                    std_network = mean_std_network[..., self._output_dim:]
+            else:
+                mean_network = mlp(
+                        input_var=input_var,
+                        output_dim=self._output_dim,
+                        hidden_sizes=self._hidden_sizes,
+                        hidden_nonlinearity=self._hidden_nonlinearity,
+                        output_nonlinearity=self._output_nonlinearity,
+                        name="mean_network")
+
+                if self._adaptive_std:
+                    b = tf.constant_initializer(self._init_std_param)
+                    std_network = mlp(
+                        input_var=input_var,
+                        output_dim=self._output_dim,
+                        hidden_sizes=self._std_hidden_sizes,
+                        hidden_nonlinearity=self._std_hidden_nonlinearity,
+                        output_nonlinearity=self._output_nonlinearity,
+                        output_b_init=b,
+                        name="std_network")
+
+                else:
+                    p = tf.constant_initializer(self._init_std_param)
+                    std_network = parameter(
+                        input_var=input_var,
+                        length=self._output_dim,
+                        initializer=p,
+                        trainable=self._learn_std,
+                        name="std_network")
+
+            mean_var = mean_network
+            std_param_var = std_network
+
+            with tf.variable_scope("std_limits"):
+                if self._min_std_param:
+                    std_param_var = tf.maximum(std_param_var, self._min_std_param)
+                if self._max_std_param:
+                    std_param_var = tf.minimum(std_param_var, self._max_std_param)
+
+        with tf.variable_scope("std_parameterization"):
+            # build std_var with std parameterization
+            if self._std_parameterization == "exp":
+                std_var = tf.exp(std_param_var)
+            elif self._std_parameterization == "softplus":
+                std_var = tf.log(1. + tf.exp(std_param_var))
+            else:
+                raise NotImplementedError
+
+        dist = tf.contrib.distributions.MultivariateNormalDiag(mean_var, std_var)
+        sample_var = dist.sample(seed=ext.get_seed())
+
+        inputs = {
+            "input_var": input_var,
+        }
+        outputs = {
+            "mean": mean_var,
+            "std": std_var,
+            "std_param": std_param_var,
+            "sample": sample_var,
+        }
+        model_info = {
+            "dist": dist,
+        }
+
+        return inputs, outputs, model_info

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -5,7 +5,8 @@ import tensorflow as tf
 from garage.core import Serializable
 from garage.misc import ext
 from garage.misc.overrides import overrides
-from garage.tf.core.networks import mlp, parameter
+from garage.tf.core.mlp import mlp
+from garage.tf.core.parameter import parameter
 from garage.tf.models import Model
 
 

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -10,7 +10,12 @@ from garage.tf.models import Model
 
 
 class GaussianMLPModel(Model, Serializable):
-    """Gaussian MLP Model."""
+    """
+    Gaussian MLP Model.
+
+    This model models a gaussian distribution whose
+    mean and std are parameterized by an MLP.
+    """
 
     def __init__(
             self,
@@ -61,7 +66,7 @@ class GaussianMLPModel(Model, Serializable):
         Serializable.quick_init(self, locals())
         super(GaussianMLPModel, self).__init__()
 
-        self.name = name
+        self._name = name
         self._name_scope = tf.name_scope(self.name)
 
         # Network parameters
@@ -100,7 +105,7 @@ class GaussianMLPModel(Model, Serializable):
             raise NotImplementedError
 
         inputs, outputs, model_info = self.build_model()
-        self._inputs = inputs["input_var"]
+        self.inputs = inputs["input_var"]
 
         self.mean = outputs["mean"]
         self.std = outputs["std"]
@@ -108,7 +113,7 @@ class GaussianMLPModel(Model, Serializable):
         self.sample = outputs["sample"]
         self.dist = model_info["dist"]
 
-        self._outputs = outputs
+        self.outputs = outputs
 
     @overrides
     def build_model(self, inputs=None, reuse=tf.AUTO_REUSE):

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -12,7 +12,6 @@ from garage.tf.spaces import Box
 
 
 class GaussianMLPPolicy(StochasticPolicy, Parameterized, Serializable):
-
     def __init__(self,
                  env_spec,
                  name="GaussianMLPPolicy",
@@ -59,7 +58,7 @@ class GaussianMLPPolicy(StochasticPolicy, Parameterized, Serializable):
         super(GaussianMLPPolicy, self).__init__(env_spec)
         Parameterized.__init__(self)
         self.name = name
-        
+
         self.model = GaussianMLPModel(
             input_dim=env_spec.observation_space.flat_dim,
             output_dim=env_spec.action_space.flat_dim,
@@ -89,10 +88,9 @@ class GaussianMLPPolicy(StochasticPolicy, Parameterized, Serializable):
         flat_obs = self.observation_space.flatten(observation)
         feed_dict = {self.model.inputs: flat_obs}
         action, mean, std = sess.run(
-            [self.model.sample, self.model.mean, self.model.std], 
-            feed_dict=feed_dict
-        )
-        return action, dict(mean=mean, log_std=std) 
+            [self.model.sample, self.model.mean, self.model.std],
+            feed_dict=feed_dict)
+        return action, dict(mean=mean, log_std=std)
 
     def get_actions(self, observations, sess=None):
         if sess is None:
@@ -100,15 +98,14 @@ class GaussianMLPPolicy(StochasticPolicy, Parameterized, Serializable):
         flat_obs = self.observation_space.flatten_n(observations)
         feed_dict = {self.model.inputs: flat_obs}
         actions, means, stds = sess.run(
-            [self.model.sample, self.model.mean, self.model.std_param], 
-            feed_dict=feed_dict
-        )
+            [self.model.sample, self.model.mean, self.model.std_param],
+            feed_dict=feed_dict)
         return actions, dict(mean=means, log_std=stds)
 
     @property
     def distribution(self):
         return self._dist
-    
+
     def log_diagnostics(self, paths):
         log_stds = np.vstack(
             [path["agent_infos"]["log_std"] for path in paths])

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -83,25 +83,27 @@ class GaussianMLPPolicy(StochasticPolicy, Parameterized, Serializable):
     def vectorized(self):
         return True
 
-    def get_action(self, observation):
-        sess = tf.get_default_session()
+    def get_action(self, observation, sess=None):
+        if sess is None:
+            sess = tf.get_default_session()
         flat_obs = self.observation_space.flatten(observation)
         feed_dict = {self.model.inputs: flat_obs}
         action, mean, std = sess.run(
             [self.model.sample, self.model.mean, self.model.std], 
             feed_dict=feed_dict
         )
-        return action, dict(mean=mean, log_std=std) # TODO 
+        return action, dict(mean=mean, log_std=std) 
 
-    def get_actions(self, observations):
-        sess = tf.get_default_session()
+    def get_actions(self, observations, sess=None):
+        if sess is None:
+            sess = tf.get_default_session()
         flat_obs = self.observation_space.flatten_n(observations)
         feed_dict = {self.model.inputs: flat_obs}
         actions, means, stds = sess.run(
             [self.model.sample, self.model.mean, self.model.std_param], 
             feed_dict=feed_dict
         )
-        return actions, dict(mean=means, log_std=stds) # TODO
+        return actions, dict(mean=means, log_std=stds)
 
     @property
     def distribution(self):

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -8,19 +8,18 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestGaussianMLPModel(TfGraphTestCase):
-
     def test_gaussian_mlp_model(self):
         # Model that does not share networks and adapt std
         model1 = GaussianMLPModel(
-            input_dim=2, 
-            output_dim=2, 
+            input_dim=2,
+            output_dim=2,
             hidden_sizes=[3, 3],
         )
-        
+
         # Model that share networks
         model2 = GaussianMLPModel(
-            input_dim=2, 
-            output_dim=2, 
+            input_dim=2,
+            output_dim=2,
             hidden_sizes=[3, 3],
             std_share_network=True,
             output_nonlinearity=tf.nn.relu,
@@ -28,8 +27,8 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
         # Model that does not share network but adapt std
         model3 = GaussianMLPModel(
-            input_dim=2, 
-            output_dim=2, 
+            input_dim=2,
+            output_dim=2,
             hidden_sizes=[3, 3],
             adaptive_std=True,
             max_std=1.,
@@ -39,22 +38,22 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
         self.sess.run(tf.global_variables_initializer())
         for model in models:
-            results = self.sess.run(
-                model.outputs, 
-                feed_dict={model.inputs: np.zeros(shape=(2,2))}
-            )
+            self.sess.run(
+                model.outputs,
+                feed_dict={model.inputs: np.zeros(shape=(2, 2))})
 
     def test_model_pickle(self):
         model = GaussianMLPModel(
-            input_dim=2, 
-            output_dim=2, 
+            input_dim=2,
+            output_dim=2,
             hidden_sizes=[3, 3],
         )
         model_pickled = pickle.loads(pickle.dumps(model))
         self.sess.run(tf.global_variables_initializer())
         data = np.array([[1., 2.]])
         results = self.sess.run(model.outputs, feed_dict={model.inputs: data})
-        results_pickled = self.sess.run(model_pickled.outputs, feed_dict={model_pickled.inputs: data})
+        results_pickled = self.sess.run(
+            model_pickled.outputs, feed_dict={model_pickled.inputs: data})
 
         assert np.all(results["mean"] == results_pickled["mean"])
         assert np.all(results["std"] == results_pickled["std"])

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -48,9 +48,10 @@ class TestGaussianMLPModel(TfGraphTestCase):
             output_dim=2,
             hidden_sizes=[3, 3],
         )
-        model_pickled = pickle.loads(pickle.dumps(model))
         self.sess.run(tf.global_variables_initializer())
+        model_pickled = pickle.loads(pickle.dumps(model))
         data = np.array([[1., 2.]])
+
         results = self.sess.run(model.outputs, feed_dict={model.inputs: data})
         results_pickled = self.sess.run(
             model_pickled.outputs, feed_dict={model_pickled.inputs: data})

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -1,0 +1,60 @@
+import pickle
+
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.models import GaussianMLPModel
+from tests.fixtures import TfGraphTestCase
+
+
+class TestGaussianMLPModel(TfGraphTestCase):
+
+    def test_gaussian_mlp_model(self):
+        # Model that does not share networks and adapt std
+        model1 = GaussianMLPModel(
+            input_dim=2, 
+            output_dim=2, 
+            hidden_sizes=[3, 3],
+        )
+        
+        # Model that share networks
+        model2 = GaussianMLPModel(
+            input_dim=2, 
+            output_dim=2, 
+            hidden_sizes=[3, 3],
+            std_share_network=True,
+            output_nonlinearity=tf.nn.relu,
+        )
+
+        # Model that does not share network but adapt std
+        model3 = GaussianMLPModel(
+            input_dim=2, 
+            output_dim=2, 
+            hidden_sizes=[3, 3],
+            adaptive_std=True,
+            max_std=1.,
+        )
+
+        models = [model1, model2, model3]
+
+        self.sess.run(tf.global_variables_initializer())
+        for model in models:
+            results = self.sess.run(
+                model.outputs, 
+                feed_dict={model.inputs: np.zeros(shape=(2,2))}
+            )
+
+    def test_model_pickle(self):
+        model = GaussianMLPModel(
+            input_dim=2, 
+            output_dim=2, 
+            hidden_sizes=[3, 3],
+        )
+        model_pickled = pickle.loads(pickle.dumps(model))
+        self.sess.run(tf.global_variables_initializer())
+        data = np.array([[1., 2.]])
+        results = self.sess.run(model.outputs, feed_dict={model.inputs: data})
+        results_pickled = self.sess.run(model_pickled.outputs, feed_dict={model_pickled.inputs: data})
+
+        assert np.all(results["mean"] == results_pickled["mean"])
+        assert np.all(results["std"] == results_pickled["std"])


### PR DESCRIPTION
Implemented GaussianMLPModel. A import feature/contract of this abstraction is assuming that all tensors should be created in `build_model`. This allows users to make a copy of the graph with the same parameters. This is used in some cases e.g. MAML(#374).

Also, the model is not written with garage layers library. ref: #42 
Currently the model is using parameterized and serializable for pickling. 