### PR TITLE
Bug fixes for importing Box

### DIFF
--- a/garage/envs/box2d/box2d_env.py
+++ b/garage/envs/box2d/box2d_env.py
@@ -2,6 +2,7 @@ from copy import copy
 import os.path as osp
 
 import gym
+import gym.spaces
 import mako.lookup
 import mako.template
 import numpy as np

--- a/garage/envs/mujoco/mujoco_env.py
+++ b/garage/envs/mujoco/mujoco_env.py
@@ -5,6 +5,7 @@ import warnings
 
 from cached_property import cached_property
 import gym
+import gym.spaces
 import mako.lookup
 import mako.template
 from mujoco_py import functions

--- a/garage/envs/mujoco/mujoco_env.py
+++ b/garage/envs/mujoco/mujoco_env.py
@@ -168,8 +168,7 @@ class MujocoEnv(gym.Env):
 
     def inject_action_noise(self, action):
         # generate action noise
-        noise = self.action_noise * \
-                np.random.normal(size=action.shape)
+        noise = self.action_noise * np.random.normal(size=action.shape)
         # rescale the noise to make it proportional to the action bounds
         lb, ub = self.action_bounds
         noise = 0.5 * (ub - lb) * noise

--- a/garage/envs/normalized_env.py
+++ b/garage/envs/normalized_env.py
@@ -1,4 +1,5 @@
 import gym
+import gym.spaces
 import numpy as np
 
 from garage.core import Serializable

--- a/garage/envs/util.py
+++ b/garage/envs/util.py
@@ -1,4 +1,4 @@
-import gym
+import gym.spaces
 import numpy as np
 
 from garage.misc import special

--- a/tests/garage/envs/test_normalized_env.py
+++ b/tests/garage/envs/test_normalized_env.py
@@ -2,11 +2,17 @@ import pickle
 import unittest
 
 from garage.envs.box2d import CartpoleEnv
-from garage.envs.normalized_env import NormalizedEnv
+from garage.envs.mujoco import SwimmerEnv
+from garage.envs.normalized_env import normalize, NormalizedEnv
 from tests.helpers import step_env
 
 
 class TestNormalizedEnv(unittest.TestCase):
+    def test_can_create_env(self):
+        # Fixes https://github.com/rlworkgroup/garage/pull/420
+        env = normalize(SwimmerEnv())
+        assert env
+
     def test_pickleable(self):
         inner_env = CartpoleEnv(obs_noise=5.)
         env = NormalizedEnv(inner_env, scale_reward=10.)


### PR DESCRIPTION
There are two major changes:
1. Change importing `gym.spaces.Box` to `from gym.spaces import Box`
2. Add `spec` property method for `MujocoEnv` to fix the no method error when calling `env.spec`