### PR TITLE
Move KNOWN_GYM_NOT_CLOSE_VIEWER to envs base

### DIFF
--- a/garage/envs/base.py
+++ b/garage/envs/base.py
@@ -8,7 +8,14 @@ import gym
 
 from garage.core import Parameterized
 from garage.core import Serializable
-from tests.quirks import KNOWN_GYM_NOT_CLOSE_VIEWER
+
+# The gym environments using one of the packages in the following list as entry
+# points don't close their viewer windows.
+KNOWN_GYM_NOT_CLOSE_VIEWER = [
+    # Please keep alphabetized
+    "gym.envs.mujoco",
+    "gym.envs.robotics"
+]
 
 
 class GarageEnv(gym.Wrapper, Parameterized, Serializable, metaclass=ABCMeta):

--- a/tests/quirks.py
+++ b/tests/quirks.py
@@ -20,9 +20,3 @@ KNOWN_GYM_RENDER_NOT_IMPLEMENTED = [
     "NChain-v0",
     "Roulette-v0",
 ]
-
-KNOWN_GYM_NOT_CLOSE_VIEWER = [
-    # Please keep alphabetized
-    "gym.envs.mujoco",
-    "gym.envs.robotics"
-]


### PR DESCRIPTION
Since tests is one step above garage.envs in the directory hierarchy,
the class GarageEnv cannot be correctly imported when running code from
inside the garage folder.
This dependency is removed by moving the list KNOWN_GYM_NOT_CLOSE_VIEWER
which is the only dependency from garage/envs/base in tests/quirks.