### PR TITLE
Add git-ignored files in flake8 excluded files

### DIFF
--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -36,7 +36,10 @@ W605  # invalid escape sequence
 
 # Files or directories to exclude from checks applied to all files.
 exclude_all=(
-./tests/'*',.git,__pycache__
+./tests/'*'
+.git
+__pycache__
+$(cat .gitignore)
 )
 
 
@@ -56,6 +59,7 @@ W504  # line break after binary operator
 # Files or directories to exclude from checks applied to changed files.
 exclude_changed=(
 ./tests/'*'
+$(cat .gitignore)
 )
 
 
@@ -70,6 +74,7 @@ W503  # line break before binary operator
 # Files or directories to exclude from checks applied to added files.
 exclude_added=(
 ./tests/'*'
+$(cat .gitignore)
 )
 
 
@@ -87,7 +92,9 @@ W503  # line break before binary operator
 
 # Files or directories to exclude from checks applied to all files.
 test_exclude_all=(
-  .git,__pycache__
+.git
+__pycache__
+$(cat .gitignore)
 )
 
 
@@ -100,6 +107,7 @@ D  # docstring rules disabled
 
 # Files or directories to exclude from checks applied to changed test files.
 test_exclude_changed=(
+$(cat .gitignore)
 )
 
 
@@ -112,6 +120,7 @@ D  # docstring rules disabled
 
 # Files or directories to exclude from checks applied to added test files.
 test_exclude_added=(
+$(cat .gitignore)
 )
 
 


### PR DESCRIPTION
Since now flake8 runs locally before pushing a commit remotely, it may
throw errors for ignored files. This commit fixes that by adding all the
files in .gitignore in all the lists of excluded files inside the script
check_flake8.