### PR TITLE
Conditionally import lasagne or tf to set the seed

### DIFF
--- a/garage/misc/ext.py
+++ b/garage/misc/ext.py
@@ -132,13 +132,15 @@ def set_seed(seed):
     seed %= 4294967294
     global seed_
     seed_ = seed
-    import lasagne
     random.seed(seed)
     np.random.seed(seed)
-    lasagne.random.set_rng(np.random.RandomState(seed))
+    if "theano" in sys.modules:
+        import lasagne
+        lasagne.random.set_rng(np.random.RandomState(seed))
     try:
-        import tensorflow as tf
-        tf.set_random_seed(seed)
+        if "tensorflow" in sys.modules:
+            import tensorflow as tf
+            tf.set_random_seed(seed)
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
When launching experiments with run_experiment the function set_seed is
in charge of setting the random seed across the different packages used
in garage. However, we should keep from import theano when only using
tensorflow and vice versa.
To detect if theano and/or tensorflow are being used, we check if they
appear in the list of packages already imported.