### PR TITLE
Add vanilla loss to NPO

### DIFF
--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -1,11 +1,11 @@
 """
 This is an example to train a task with ERWR algorithm.
 
-Here it run CartpoleEnv on ERWR with 40 iterations.
+Here it runs CartpoleEnv on ERWR with 100 iterations.
 
 Results:
-    AverageDiscountedReturn: 120
-    RiseTime: itr 2
+    AverageReturn: 600
+    RiseTime: itr 57
 """
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
@@ -31,7 +31,7 @@ def run_task(*_):
         baseline=baseline,
         batch_size=10000,
         max_path_length=100,
-        n_itr=40,
+        n_itr=100,
         discount=0.99)
     algo.train()
 

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -39,7 +39,7 @@ def run_task(*_):
         max_path_length=100,
         n_itr=488,
         discount=0.99,
-        step_size=0.01,
+        lr_clip_range=0.01,
         optimizer_args=dict(batch_size=32, max_epochs=10),
         plot=False)
     algo.train()

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -1,25 +1,48 @@
+"""
+This is an example to train a task with VPG algorithm.
+
+Here it runs CartpoleEnv with 100 iterations.
+
+Results:
+    AverageReturn: 1000
+    RiseTime: itr 50
+"""
+
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.box2d import CartpoleEnv
+from garage.experiment import run_experiment
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
 
-env = TfEnv(normalize(CartpoleEnv()))
 
-policy = GaussianMLPPolicy(
-    name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    """Wrap TRPO training task in the run_task function."""
+    env = TfEnv(normalize(CartpoleEnv()))
 
-baseline = LinearFeatureBaseline(env_spec=env.spec)
+    policy = GaussianMLPPolicy(
+        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-algo = TRPO(
-    env=env,
-    policy=policy,
-    baseline=baseline,
-    batch_size=4000,
-    max_path_length=100,
-    n_itr=40,
-    discount=0.99,
-    step_size=0.01,
-    plot=True)
-algo.train()
+    baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+    algo = TRPO(
+        env=env,
+        policy=policy,
+        baseline=baseline,
+        batch_size=4000,
+        max_path_length=100,
+        n_itr=100,
+        discount=0.99,
+        max_kl_step=0.01,
+        plot=False)
+    algo.train()
+
+
+run_experiment(
+    run_task,
+    n_parallel=1,
+    snapshot_mode="last",
+    seed=1,
+    plot=False,
+)

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -25,9 +25,9 @@ algo = TRPO(
     baseline=baseline,
     batch_size=4000,
     max_path_length=100,
-    n_itr=10,
+    n_itr=100,
     discount=0.99,
-    step_size=0.01,
+    max_kl_step=0.01,
     optimizer=ConjugateGradientOptimizer,
     optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
 algo.train()

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -23,7 +23,7 @@ algo = TRPO(
     max_path_length=200,
     n_itr=120,
     discount=0.99,
-    step_size=0.01,
+    max_kl_step=0.01,
 )
 
 run_experiment(algo.train(), n_parallel=1, snapshot_mode="last", seed=1)

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -1,24 +1,47 @@
+"""
+This is an example to train a task with VPG algorithm.
+
+Here it runs CartpoleEnv with 100 iterations.
+
+Results:
+    AverageReturn: 1000
+    RiseTime: itr 60
+"""
+
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.box2d import CartpoleEnv
+from garage.experiment import run_experiment
 from garage.tf.algos import VPG
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
 
-env = TfEnv(normalize(CartpoleEnv()))
 
-policy = GaussianMLPPolicy(
-    name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    """Wrap VPG training task in the run_task function."""
+    env = TfEnv(normalize(CartpoleEnv()))
 
-baseline = LinearFeatureBaseline(env_spec=env.spec)
+    policy = GaussianMLPPolicy(
+        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-algo = VPG(
-    env=env,
-    policy=policy,
-    baseline=baseline,
-    batch_size=10000,
-    max_path_length=100,
-    n_itr=40,
-    discount=0.99,
-    optimizer_args=dict(tf_optimizer_args=dict(learning_rate=0.01, )))
-algo.train()
+    baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+    algo = VPG(
+        env=env,
+        policy=policy,
+        baseline=baseline,
+        batch_size=10000,
+        max_path_length=100,
+        n_itr=100,
+        discount=0.99,
+        optimizer_args=dict(tf_optimizer_args=dict(learning_rate=0.01, )))
+    algo.train()
+
+
+run_experiment(
+    run_task,
+    n_parallel=1,
+    snapshot_mode="last",
+    seed=1,
+    plot=False,
+)

--- a/garage/tf/algos/ppo.py
+++ b/garage/tf/algos/ppo.py
@@ -24,7 +24,7 @@ class PPO(NPO):
             if optimizer_args is None:
                 optimizer_args = dict()
         super(PPO, self).__init__(
-            pg_loss=PGLoss.CLIP,
+            pg_loss=PGLoss.SURROGATE_CLIP,
             optimizer=optimizer,
             optimizer_args=optimizer_args,
             name="PPO",

--- a/garage/tf/algos/trpo.py
+++ b/garage/tf/algos/trpo.py
@@ -15,7 +15,9 @@ class KLConstraint(Enum):
 
 class TRPO(NPO):
     """
-    Trust Region Policy Optimization
+    Trust Region Policy Optimization.
+
+    See https://arxiv.org/abs/1502.05477.
     """
 
     def __init__(self,
@@ -35,7 +37,7 @@ class TRPO(NPO):
             optimizer_args = dict()
 
         super(TRPO, self).__init__(
-            pg_loss=PGLoss.VANILLA,
+            pg_loss=PGLoss.SURROGATE,
             optimizer=optimizer,
             optimizer_args=optimizer_args,
             name="TRPO",

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -1,5 +1,5 @@
 """
-This script creates a test that fails when garage.tf.algos.PPO performance is
+This script creates a test that fails when garage.tf.algos.NPO performance is
 too low.
 """
 import gym
@@ -7,17 +7,16 @@ import tensorflow as tf
 
 from garage.envs import normalize
 import garage.misc.logger as logger
-from garage.tf.algos import PPO
+from garage.tf.algos import NPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
-from garage.tf.policies import GaussianLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
 from tests.fixtures import TfGraphTestCase
 
 
-class TestPPO(TfGraphTestCase):
-    def test_ppo_pendulum(self):
-        """Test PPO with Pendulum environment."""
+class TestNPO(TfGraphTestCase):
+    def test_npo_pendulum(self):
+        """Test NPO with Pendulum environment."""
         logger.reset()
         env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
         policy = GaussianMLPPolicy(
@@ -30,7 +29,7 @@ class TestPPO(TfGraphTestCase):
             env_spec=env.spec,
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
-        algo = PPO(
+        algo = NPO(
             env=env,
             policy=policy,
             baseline=baseline,
@@ -38,33 +37,32 @@ class TestPPO(TfGraphTestCase):
             max_path_length=100,
             n_itr=10,
             discount=0.99,
-            lr_clip_range=0.01,
-            optimizer_args=dict(batch_size=32, max_epochs=10),
+            gae_lambda=0.98,
+            policy_ent_coeff=0.0,
             plot=False,
         )
         last_avg_ret = algo.train(sess=self.sess)
-        assert last_avg_ret > 40
+        assert last_avg_ret > 35
 
-    def test_ppo_pendulum_recurrent(self):
-        """Test PPO with Pendulum environment and recurrent policy."""
+    def test_npo_unknown_pg_loss(self):
+        """Test NPO with unkown policy gradient loss."""
         logger.reset()
         env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
-        policy = GaussianLSTMPolicy(env_spec=env.spec, )
+        policy = GaussianMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=(64, 64),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
         baseline = GaussianMLPBaseline(
             env_spec=env.spec,
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
-        algo = PPO(
-            env=env,
-            policy=policy,
-            baseline=baseline,
-            batch_size=2048,
-            max_path_length=100,
-            n_itr=10,
-            discount=0.99,
-            lr_clip_range=0.01,
-            optimizer_args=dict(batch_size=32, max_epochs=10),
-            plot=False,
-        )
-        last_avg_ret = algo.train(sess=self.sess)
-        assert last_avg_ret > 40
+        with self.assertRaises(NotImplementedError) as context:
+            NPO(
+                env=env,
+                policy=policy,
+                baseline=baseline,
+                pg_loss="random pg_loss",
+            )
+        assert "Unknown PGLoss" in str(context.exception)

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -18,10 +18,10 @@ class TestTRPO(TfGraphTestCase):
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
         logger.reset()
-        env = TfEnv(normalize(gym.make("Pendulum-v0")))
+        env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
         policy = GaussianMLPPolicy(
             env_spec=env.spec,
-            hidden_sizes=(32, 32),
+            hidden_sizes=(64, 64),
             hidden_nonlinearity=tf.nn.tanh,
             output_nonlinearity=None,
         )
@@ -33,7 +33,7 @@ class TestTRPO(TfGraphTestCase):
             env=env,
             policy=policy,
             baseline=baseline,
-            batch_size=1024,
+            batch_size=2048,
             max_path_length=100,
             n_itr=10,
             discount=0.99,
@@ -42,4 +42,34 @@ class TestTRPO(TfGraphTestCase):
             plot=False,
         )
         last_avg_ret = algo.train(sess=self.sess)
-        assert last_avg_ret > -1000
+        assert last_avg_ret > 50
+
+    def test_trpo_unknown_kl_constraint(self):
+        """Test TRPO with unkown KL constraints."""
+        logger.reset()
+        env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
+        policy = GaussianMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=(64, 64),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(hidden_sizes=(32, 32)),
+        )
+        with self.assertRaises(NotImplementedError) as context:
+            TRPO(
+                env=env,
+                policy=policy,
+                baseline=baseline,
+                batch_size=2048,
+                max_path_length=100,
+                n_itr=10,
+                discount=0.99,
+                gae_lambda=0.98,
+                policy_ent_coeff=0.0,
+                plot=False,
+                kl_constraint="random kl_constraint",
+            )
+        assert "Unknown KLConstraint" in str(context.exception)


### PR DESCRIPTION
1. VPG uses a different loss function than NPO and its variants. VPG
uses the vanilla loss, as VPG uses direct gradient estimator from policy
score function, NPO calculates the derivation using importance sampling.
Thus, we need to add the 'real' vanilla loss to NPO to inherit from NPO.
The Enum is kept in this commit instead of string.
2. Update examples.