### PR TITLE
Add dockerfiles for garage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
     packages:
       - docker-ce
 
+env:
+  - DOCKER_COMPOSE_VERSION=1.23.2
+
 python:
   - "3.6.6"
 
@@ -24,49 +27,29 @@ before_install:
       "max-concurrent-uploads": 50
     }' | sudo tee /etc/docker/daemon.json
   - sudo service docker restart
-  # prevent garage from exiting on config
-  - cp garage/config_personal_template.py garage/config_personal.py
+  # Reinstall docker compose with the specified version. For more information, see:
+  # https://docs.travis-ci.com/user/docker/#using-docker-compose
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
   # Pull cached docker image
   - docker pull rlworkgroup/garage-ci:latest
+  # Pull CodeClimate reporter
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
+  - chmod +x cc-test-reporter
 
 install:
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
-  - |
-    docker build \
-      -f docker/Dockerfile.ci \
-      --cache-from rlworkgroup/garage-ci:latest \
-      --build-arg MJKEY="${MJKEY}" \
-      -t "${tag}" \
-      .
-
-before_script:
-  # Codecov utility to capture environment variables it needs
-  # This should be passed as an environment variable after `docker run`.
-  # e.g. `docker run ${ci_env} ...`
-  - ci_env="$(bash <(curl -s https://codecov.io/env))"
-  - |
-    docker-run() {
-      docker run \
-      ${ci_env} \
-      -e COVERALLS_REPO_TOKEN \
-      -e COVERALLS_SERVICE_NAME \
-      -e CODACY_PROJECT_TOKEN \
-      -e CC_TEST_REPORTER_ID \
-      -e TRAVIS_BRANCH \
-      -e TRAVIS_PULL_REQUEST \
-      -e TRAVIS_COMMIT_RANGE \
-      -e TRAVIS \
-      -e MJKEY \
-      "${tag}" "$@"
-    }
+  - TAG="${tag}" make build-ci
 
 script:
-  - docker-run scripts/travisci/check_precommit.sh
+  - TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_precommit.sh"
   - |
     if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
-      docker-run scripts/travisci/check_cronjob_tests.sh
+      TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_cronjob_tests.sh"
     else
-      docker-run scripts/travisci/check_tests.sh
+      TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_tests.sh"
     fi
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+.PHONY: build-ci build-headless build-nvidia \
+	run-ci run-headless run-nvidia
+
+# Path in host where the experiment data obtained in the container is stored
+DATA_PATH ?= $(shell pwd)/data
+# Set the environment variable MJKEY with the contents of the file specified by
+# MJKEY_PATH.
+MJKEY_PATH ?= ~/.mujoco/mjkey.txt
+# Prevent garage from exiting on config by making sure the personal config file
+# is already created
+CONFIG_PERSONAL := garage/config_personal.py
+
+build-ci: TAG ?= rlworkgroup/garage-ci
+build-ci: docker/docker-compose-headless.yml copy_config_personal
+	TAG=${TAG} \
+	docker-compose \
+		-f docker/docker-compose-headless.yml \
+		build \
+		--build-arg MJKEY="$${MJKEY}"
+
+build-headless: TAG ?= rlworkgroup/garage-headless
+build-headless: docker/docker-compose-headless.yml check-mjkey copy_config_personal
+	TAG=${TAG} \
+	docker-compose \
+		-f docker/docker-compose-headless.yml \
+		build \
+		--build-arg MJKEY="$$(cat ${MJKEY_PATH})"
+
+build-nvidia: docker/docker-compose-nvidia.yml check-mjkey copy_config_personal
+	docker-compose \
+		-f docker/docker-compose-nvidia.yml \
+		build \
+		--build-arg MJKEY="$$(cat ${MJKEY_PATH})"
+
+run-ci: SHELL := /usr/bin/env bash
+run-ci: TAG ?= rlworkgroup/garage-ci
+# The CI container requires environment variables to run CodeCov
+run-ci: CI_ENV := $$(bash <(curl -s https://codecov.io/env))
+run-ci:
+	docker run \
+		"${CI_ENV}" \
+		-e COVERALLS_REPO_TOKEN \
+		-e COVERALLS_SERVICE_NAME \
+		-e CODACY_PROJECT_TOKEN \
+		-e CC_TEST_REPORTER_ID \
+		-e TRAVIS_BRANCH \
+		-e TRAVIS_PULL_REQUEST \
+		-e TRAVIS_COMMIT_RANGE \
+		-e TRAVIS \
+		-e MJKEY \
+		${TAG} ${RUN_CMD}
+
+run-headless: CONTAINER_NAME ?= garage-headless
+run-headless: build-headless
+	docker run \
+		-it \
+		--rm \
+		-v $(DATA_PATH)/data/$(CONTAINER_NAME):/root/code/garage/data \
+		-e MJKEY="$$(cat $(MJKEY_PATH))" \
+		--name $(CONTAINER_NAME) \
+		rlworkgroup/garage-headless $(RUN_CMD)
+
+run-nvidia: CONTAINER_NAME ?= garage-nvidia
+run-nvidia: build-nvidia
+	xhost +local:docker
+	docker run \
+		-it \
+		--rm \
+		--runtime=nvidia \
+		-v /tmp/.X11-unix:/tmp/.X11-unix \
+		-v $(DATA_PATH)/data/$(CONTAINER_NAME):/root/code/garage/data \
+		-e DISPLAY=$(DISPLAY) \
+		-e QT_X11_NO_MITSHM=1 \
+		-e MJKEY="$$(cat $(MJKEY_PATH))" \
+		--name $(CONTAINER_NAME) \
+		rlworkgroup/garage-nvidia $(RUN_CMD)
+
+check-mjkey:
+ifeq (0, $(shell [ ! -f $(MJKEY_PATH) ]; echo $$? ))
+	$(error The MJKEY was not set: make sure to pass a valid MJKEY_PATH \
+		or put your key at ~/.mujoco/mjkey.txt)
+endif
+
+copy_config_personal:
+ifeq (0, $(shell [ ! -f $(CONFIG_PERSONAL) ]; echo $$? ))
+	$(warning No file for personal configuration was found. Copying from \
+		garage/config_personal_template.py)
+	cp garage/config_personal_template.py garage/config_personal.py
+endif

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@
 # and scripts/setup_macos.sh, if there's any changes applied to this file,
 # specially regarding the installation of dependencies, apply those same
 # changes to the mentioned files.
-FROM ubuntu:16.04
+ARG PARENT_IMAGE=ubuntu:16.04
+FROM $PARENT_IMAGE
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
@@ -99,13 +100,6 @@ WORKDIR /root/code/garage
 COPY .pre-commit-config.yaml /root/code/garage
 RUN ["/bin/bash", "-c", "source activate garage && git init && pre-commit"]
 
-# Pull CodeClimate reporter
-RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /root/code/garage/cc-test-reporter && \
-  chmod +x /root/code/garage/cc-test-reporter
-
 # Add code stub last
 COPY . /root/code/garage
 RUN ["/bin/bash", "-c", "source activate garage && pip install -e /root/code/garage && source deactivate garage"]
-
-# Ready, set, go.
-ENTRYPOINT ["docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -1,0 +1,5 @@
+ARG PARENT_IMAGE=rlworkgroup/garage-base
+FROM $PARENT_IMAGE
+
+# Ready, set, go.
+ENTRYPOINT ["docker/entrypoint-headless.sh"]

--- a/docker/Dockerfile.nvidia
+++ b/docker/Dockerfile.nvidia
@@ -1,0 +1,5 @@
+ARG PARENT_IMAGE=rlworkgroup/garage-base
+FROM $PARENT_IMAGE
+
+# Ready, set, go.
+ENTRYPOINT ["docker/entrypoint-nvidia.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,111 @@
+# Using Docker to run garage
+
+Currently there are two types of garage images:
+  - headless: garage without environment visualization.
+  - nvidia: garage with environment visualization using an NVIDIA graphics
+    card.
+
+## Headless image
+
+If you already have a copy of garage, proceed to subsection ["Build and run the
+image"], otherwise, keep reading.
+
+To run an example launcher in the container, execute:
+```
+docker run -it --rm rlworkgroup/garage-headless python examples/tf/trpo_cartpole.py
+```
+
+To run environments using MuJoCo, pass the contents of the MuJoCo key in a
+variable named MJKEY in the same docker-run command using `cat`. For example,
+if your key is at `~/.mujoco/mjkey.txt`, execute:
+```
+docker run \
+  -it \
+  --rm \
+  -e MJKEY="$(cat ~/.mujoco/mjkey.txt)" \
+  rlworkgroup/garage-headless python examples/theano/trpo_swimmer.py
+```
+
+To save the experiment data generated in the container, you need to specify a
+path where the files will be saved inside your host computer with the argument
+`-v` in the docker-run command. For example, if the path you want to use is
+at `/home/tmp/data`, execute:
+```
+docker run \
+  -it \
+  --rm \
+  -v /home/tmp/data:/root/code/garage/data \
+  rlworkgroup/garage-headless python examples/tf/trpo_cartpole.py
+```
+This binds a volume between your host path and the path in garage at
+`/root/code/garage/data`.
+
+### Build and run the image
+
+To build the headless image, first clone this repository and move to the root
+folder of your local repository. If you have your MuJoCo key at
+`~/.mujoco/mjkey.txt`, simply execute:
+```
+make build-headless
+```
+
+Alternatively, you can specify the path to your MuJoCo key with the variable
+`MJKEY_PATH`:
+```
+make build-headless MJKEY_PATH="..."
+```
+
+To build and run the container, execute;
+```
+make run-headless RUN_CMD="python examples/tf/trpo_cartpole.py"
+```
+Where RUN_CMD specifies the executable to run in the container
+
+The previous command adds a volume from the data folder inside your cloned
+garage repository to the data folder in the garage container, so any experiment
+results ran in the container will be saved in the data folder inside your
+cloned repository. The data is saved in a folder with the name of the container
+that generated the data, which by default is the name of the image type the
+container is based on with the date and time the container was launched.
+
+If you want to specify another name for the container, do so with the variable
+`CONTAINER_NAME`:
+```
+make run-headless RUN_CMD="..." CONTAINER_NAME="my_container"
+```
+
+#### Prerequisites
+
+Be aware of the following prerequisites to build the image.
+
+- Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce)
+- Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
+
+Tested on Ubuntu 16.04.
+
+## nvidia image
+
+The same commands for the headless image mentioned above apply for the nvidia
+image, except that the image name is defined by `rlworkgroup/garage-nvidia`.
+For example, to execute a launcher file:
+```
+docker run -it --rm rlworkgroup/garage-nvidia python examples/tf/trpo_cartpole.py
+```
+
+### Build and run the image
+
+The same rules for the headless image apply here, except that the target names
+are the following:
+```
+make build-nvidia
+make run-nvidia
+```
+
+#### Prerequisites
+
+Additional to the prerequisites for the headless image, make sure to have:
+- Install the latest NVIDIA driver, tested
+  on [nvidia-390](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/)
+- [Install nvidia-docker2](https://github.com/NVIDIA/nvidia-docker#ubuntu-140416041804-debian-jessiestretch)
+
+Tested on Ubuntu 16.04.

--- a/docker/docker-compose-headless.yml
+++ b/docker/docker-compose-headless.yml
@@ -1,0 +1,16 @@
+version: '2.2'
+services:
+  garage-base:
+    build:
+      cache_from:
+        - ${TAG}:latest
+      context: ../
+      dockerfile: docker/Dockerfile
+    image: rlworkgroup/garage-base
+  garage-headless:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.headless
+      args:
+        - PARENT_IMAGE=rlworkgroup/garage-base
+    image: ${TAG}

--- a/docker/docker-compose-nvidia.yml
+++ b/docker/docker-compose-nvidia.yml
@@ -1,0 +1,18 @@
+version: '2.2'
+services:
+  garage-base-nvidia:
+    build:
+      cache_from:
+        - rlworkgroup/garage-nvidia:latest
+      context: ../
+      dockerfile: docker/Dockerfile
+      args:
+        - PARENT_IMAGE=nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04
+    image: rlworkgroup/garage-nvidia-base
+  garage-nvidia:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.nvidia
+      args:
+        - PARENT_IMAGE=rlworkgroup/garage-nvidia-base
+    image: rlworkgroup/garage-nvidia

--- a/docker/entrypoint-nvidia.sh
+++ b/docker/entrypoint-nvidia.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Dockerfile entrypoint
+set -e
+
+# Get MuJoCo key from the environment
+echo "${MJKEY}" > /root/.mujoco/mjkey.txt
+
+# Activate conda environment
+source activate garage
+
+# Fixes Segmentation Fault
+# See: https://github.com/openai/mujoco-py/pull/145#issuecomment-356938564
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLEW.so
+
+export TF_CPP_MIN_LOG_LEVEL=3      # shut TensorFlow up
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${HOME}/.mujoco/mjpro150/bin"
+
+exec "$@"

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -2,7 +2,7 @@
 # This script installs garage on Linux distributions.
 #
 # NOTICE: To keep consistency across this script, scripts/setup_macos.sh and
-# docker/Dockerfile.ci, if there's any changes applied to this file, specially
+# docker/Dockerfile, if there's any changes applied to this file, specially
 # regarding the installation of dependencies, apply those same changes to the
 # mentioned files.
 

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -2,7 +2,7 @@
 # This script installs garage on macOS distributions.
 #
 # NOTICE: To keep consistency across this script, scripts/setup_linux.sh and
-# docker/Dockerfile.ci, if there's any changes applied to this file, specially
+# docker/Dockerfile, if there's any changes applied to this file, specially
 # regarding the installation of dependencies, apply those same changes to the
 # mentioned files.
 


### PR DESCRIPTION
Two versions were added:
- Release: image based on the latest stable release from garage
- Local: image built on top of the release image with local changes of
the garage repository

A makefile was added as well to build and run the corresponding
containers, as well as a README.md with the documentation for the docker
images.