### PR TITLE
Fix AttributeError in updating 'mujoco_py.cymj.PyMjData'

### DIFF
--- a/garage/envs/mujoco/mujoco_env.py
+++ b/garage/envs/mujoco/mujoco_env.py
@@ -115,35 +115,17 @@ class MujocoEnv(gym.Env):
             self.sim.data.qacc[:] = self.init_qacc
             self.sim.data.ctrl[:] = self.init_ctrl
         else:
-            start = 0
+            datums = [
+                self.sim.data.qpos,
+                self.sim.data.qvel,
+                self.sim.data.qacc,
+                self.sim.data.ctrl,
+            ]
+            dims = [d.shape[0] for d in datums]
+            offsets = [0] + list(np.cumsum(dims)[:-1])
 
-            # update qpos
-            datum = self.sim.data.qpos
-            datum_dim = datum.shape[0]
-            datum = init_state[start:start + datum_dim]
-            self.sim.data.qpos[:] = datum
-            start += datum_dim
-
-            # update qvel
-            datum = self.sim.data.qvel
-            datum_dim = datum.shape[0]
-            datum = init_state[start:start + datum_dim]
-            self.sim.data.qvel[:] = datum
-            start += datum_dim
-
-            # update qacc
-            datum = self.sim.data.qacc
-            datum_dim = datum.shape[0]
-            datum = init_state[start:start + datum_dim]
-            self.sim.data.qacc[:] = datum
-            start += datum_dim
-
-            # update ctrl
-            datum = self.sim.data.ctrl
-            datum_dim = datum.shape[0]
-            datum = init_state[start:start + datum_dim]
-            self.sim.data.ctrl[:] = datum
-            start += datum_dim
+            for datum, dim, offset in zip(datums, dims, offsets):
+                datum[:] = init_state[offset:offset + dim]
 
     @overrides
     def reset(self, init_state=None):

--- a/garage/envs/mujoco/mujoco_env.py
+++ b/garage/envs/mujoco/mujoco_env.py
@@ -116,12 +116,34 @@ class MujocoEnv(gym.Env):
             self.sim.data.ctrl[:] = self.init_ctrl
         else:
             start = 0
-            for datum_name in ["qpos", "qvel", "qacc", "ctrl"]:
-                datum = getattr(self.sim.data, datum_name)
-                datum_dim = datum.shape[0]
-                datum = init_state[start:start + datum_dim]
-                exec('self.sim.data.%s[:] = datum' % datum_name)
-                start += datum_dim
+
+            # update qpos
+            datum = self.sim.data.qpos
+            datum_dim = datum.shape[0]
+            datum = init_state[start:start + datum_dim]
+            self.sim.data.qpos[:] = datum
+            start += datum_dim
+
+            # update qvel
+            datum = self.sim.data.qvel
+            datum_dim = datum.shape[0]
+            datum = init_state[start:start + datum_dim]
+            self.sim.data.qvel[:] = datum
+            start += datum_dim
+
+            # update qacc
+            datum = self.sim.data.qacc
+            datum_dim = datum.shape[0]
+            datum = init_state[start:start + datum_dim]
+            self.sim.data.qacc[:] = datum
+            start += datum_dim
+
+            # update ctrl
+            datum = self.sim.data.ctrl
+            datum_dim = datum.shape[0]
+            datum = init_state[start:start + datum_dim]
+            self.sim.data.ctrl[:] = datum
+            start += datum_dim
 
     @overrides
     def reset(self, init_state=None):

--- a/garage/envs/mujoco/mujoco_env.py
+++ b/garage/envs/mujoco/mujoco_env.py
@@ -120,7 +120,7 @@ class MujocoEnv(gym.Env):
                 datum = getattr(self.sim.data, datum_name)
                 datum_dim = datum.shape[0]
                 datum = init_state[start:start + datum_dim]
-                setattr(self.sim.data, datum_name, datum)
+                exec('self.sim.data.%s[:] = datum' % datum_name)
                 start += datum_dim
 
     @overrides


### PR DESCRIPTION
Fix error: `AttributeError: attribute 'qpos' of 'mujoco_py.cymj.PyMjData' objects is not writable` when running `reset_mujoco()` on `MujocoEnv`. See https://github.com/rlworkgroup/garage/issues/452.

More specifically:
```
Traceback (most recent call last):
  File "garage/scripts/run_experiment.py", line 242, in <module>
    run_experiment(sys.argv)
  File "garage/scripts/run_experiment.py", line 185, in run_experiment
    method_call(variant_data)
  File "./examples/pusher_pretrain.py", line 81, in run_experiment
    env = normalize(PusherEnv(goal=variant.get('goal')))
  File "softqlearning/softqlearning/environments/pusher.py", line 37, in __init__
    super(PusherEnv, self).__init__(file_path=self.FILE_PATH)
  File "garage/garage/envs/mujoco/mujoco_env.py", line 85, in __init__
    self.reset()
  File "softqlearning/softqlearning/environments/pusher.py", line 130, in reset
    super(PusherEnv, self).reset(full_state)
  File "garage/garage/envs/mujoco/mujoco_env.py", line 134, in reset
    self.reset_mujoco(init_state)
  File "garage/garage/envs/mujoco/mujoco_env.py", line 122, in reset_mujoco
    self.sim.data.qpos = datum
AttributeError: attribute 'qpos' of 'mujoco_py.cymj.PyMjData' objects is not writable
```