### PR TITLE
Fix pre_commit version to avoid exception errors

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
     # cma requires numpy to install
     - numpy==1.14.5
     # dev dependencies below this line
-    - pre_commit
     - pip:
         # Please keep alphabetized
         - awscli
@@ -41,6 +40,7 @@ dependencies:
         - path.py
         - git+https://github.com/plotly/plotly.py.git@2594076e29584ede2d09f2aa40a8a195b3f3fc66#egg=plotly
         - polling
+        - pre_commit
         - protobuf
         - psutil
         - pygame


### PR DESCRIPTION
When updating the conda garage environment, pre_commit gets updated to
v1.14.2, which throws the following exception when trying to push a
commit to the remote repository:

Traceback (most recent call last):
File "/home/aigonzal/miniconda2/envs/garage/bin/pre-commit", line 7,
in <module>
    from pre_commit.main import main
File "/home/aigonzal/miniconda2/envs/garage/lib/python3.6/site-
packages/pre_commit/main.py", line 12, in <module>
    from pre_commit.commands.autoupdate import autoupdate
File "/home/aigonzal/miniconda2/envs/garage/lib/python3.6/site-
packages/pre_commit/commands/autoupdate.py", line 14, in <module>
    from pre_commit.clientlib import CONFIG_SCHEMA
File "/home/aigonzal/miniconda2/envs/garage/lib/python3.6/site-
packages/pre_commit/clientlib.py", line 169, in <module>
    for hook_id, values in _meta
File "/home/aigonzal/miniconda2/envs/garage/lib/python3.6/site-
packages/pre_commit/clientlib.py", line 170, in <listcomp>
    for key, value in values
AttributeError: module 'cfgv' has no attribute 'ConditionalOptional'
error: failed to push some refs to
'https://github.com/rlworkgroup/garage.git'

Fixing it to v.1.14.0 solves the issue.