### PR TITLE
Fix caching and CodeCov in garage-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,13 @@ install:
   - TAG="${tag}" make build-ci
 
 script:
-  - TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_precommit.sh"
+  - ci_env="$(bash <(curl -s https://codecov.io/env))"
+  - ADD_ARGS="${ci_env}" TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_precommit.sh"
   - |
     if [[ "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
-      TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_cronjob_tests.sh"
+      ADD_ARGS="${ci_env}" TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_cronjob_tests.sh"
     else
-      TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_tests.sh"
+      ADD_ARGS="${ci_env}" TAG="${tag}" make run-ci RUN_CMD="scripts/travisci/check_tests.sh"
     fi
 
 after_success:

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -24,15 +24,12 @@ RUN \
     # For building glfw
     cmake \
     xorg-dev \
-    # Dummy X server
-    xvfb \
-    libosmesa6-dev \
-    pulseaudio \
     # mujoco_py
     # See https://github.com/openai/mujoco-py/blob/master/Dockerfile
     # 16.04 repo is too old, install glfw from source instead
     # libglfw3 \
     libglew-dev \
+    libosmesa6-dev \
     patchelf \
     # OpenAI gym
     # See https://github.com/openai/gym/blob/master/Dockerfile
@@ -82,10 +79,10 @@ RUN conda update -q -y conda
 COPY environment.yml /root/code/garage/environment.yml
 
 # We need a MuJoCo key to install mujoco_py
-# MAKE SURE TO DELETE MJKEY.TXT SO THAT WE DON'T PUBLISH THE KEY
-# NOTE: You MUST create and delete the mjkey.txt within the same RUN command
+# In this step only the presence of the file mjkey.txt is required, so we only
+# create an empty file
 ARG MJKEY
-RUN echo "${MJKEY}" > /root/.mujoco/mjkey.txt && \
+RUN touch /root/.mujoco/mjkey.txt && \
   conda env create -f /root/code/garage/environment.yml && \
   rm -rf /opt/conda/pkgs/* && \
   rm /root/.mujoco/mjkey.txt

--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -1,5 +1,17 @@
 ARG PARENT_IMAGE=rlworkgroup/garage-base
 FROM $PARENT_IMAGE
 
+# apt dependencies
+RUN \
+  apt-get -y -q update && \
+  # Prevents debconf from prompting for user input
+  # See https://github.com/phusion/baseimage-docker/issues/58
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    # Dummy X server
+    xvfb \
+    pulseaudio && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
 # Ready, set, go.
 ENTRYPOINT ["docker/entrypoint-headless.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,24 +42,17 @@ This binds a volume between your host path and the path in garage at
 
 ### Build and run the image
 
-To build the headless image, first clone this repository and move to the root
-folder of your local repository. If you have your MuJoCo key at
-`~/.mujoco/mjkey.txt`, simply execute:
+To build the headless image, first clone this repository, move to the root
+folder of your local repository and then execute:
 ```
 make build-headless
-```
-
-Alternatively, you can specify the path to your MuJoCo key with the variable
-`MJKEY_PATH`:
-```
-make build-headless MJKEY_PATH="..."
 ```
 
 To build and run the container, execute;
 ```
 make run-headless RUN_CMD="python examples/tf/trpo_cartpole.py"
 ```
-Where RUN_CMD specifies the executable to run in the container
+Where RUN_CMD specifies the executable to run in the container.
 
 The previous command adds a volume from the data folder inside your cloned
 garage repository to the data folder in the garage container, so any experiment
@@ -74,14 +67,30 @@ If you want to specify another name for the container, do so with the variable
 make run-headless RUN_CMD="..." CONTAINER_NAME="my_container"
 ```
 
+If you need to use MuJoCo, you need to place your key at `~/.mujoco/mjkey.txt`
+or specify the corresponding path through the MJKEY_PATH variable:
+```
+make run-headless RUN_CMD="..." MJKEY_PATH="/home/user/mjkey.txt"
+```
+
+If you require to pass addtional arguments to the the make commands, you can
+use the variable ADD_ARGS, for example:
+```
+make build-headless ADD_ARGS="--build-arg MY_VAR=123"
+make run-headless ADD_ARGS="-e MY_VAR=123"
+```
+
 #### Prerequisites
 
 Be aware of the following prerequisites to build the image.
 
-- Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce)
-- Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
+- Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce). Tested
+  on version 18.09.0.
+- Install [Docker Compose](https://docs.docker.com/compose/install/#install-compose). Tested
+  on version 1.23.2.
 
-Tested on Ubuntu 16.04.
+Tested on Ubuntu 16.04. It's recommended to use the versions indicated above
+for docker-ce and docker-compose.
 
 ## nvidia image
 

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -3,14 +3,14 @@ services:
   garage-base:
     build:
       cache_from:
-        - rlworkgroup/garage-headless:latest
+        - rlworkgroup/garage-ci:latest
       context: ../
       dockerfile: docker/Dockerfile.base
     image: rlworkgroup/garage-base
-  garage-headless:
+  garage-ci:
     build:
       cache_from:
-        - rlworkgroup/garage-headless:latest
+        - rlworkgroup/garage-ci:latest
       context: ../
       dockerfile: docker/Dockerfile.headless
       args:

--- a/docker/docker-compose-nvidia.yml
+++ b/docker/docker-compose-nvidia.yml
@@ -5,14 +5,14 @@ services:
       cache_from:
         - rlworkgroup/garage-nvidia:latest
       context: ../
-      dockerfile: docker/Dockerfile
+      dockerfile: docker/Dockerfile.base
       args:
         - PARENT_IMAGE=nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04
-    image: rlworkgroup/garage-nvidia-base
+    image: rlworkgroup/garage-base-nvidia
   garage-nvidia:
     build:
       context: ../
       dockerfile: docker/Dockerfile.nvidia
       args:
-        - PARENT_IMAGE=rlworkgroup/garage-nvidia-base
-    image: rlworkgroup/garage-nvidia
+        - PARENT_IMAGE=rlworkgroup/garage-base-nvidia
+    image: ${TAG}

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -2,9 +2,9 @@
 # This script installs garage on Linux distributions.
 #
 # NOTICE: To keep consistency across this script, scripts/setup_macos.sh and
-# docker/Dockerfile, if there's any changes applied to this file, specially
-# regarding the installation of dependencies, apply those same changes to the
-# mentioned files.
+# docker/Dockerfile.base, if there's any changes applied to this file,
+# specially regarding the installation of dependencies, apply those same
+# changes to the mentioned files.
 
 # Exit if any error occurs
 set -e

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -2,9 +2,9 @@
 # This script installs garage on macOS distributions.
 #
 # NOTICE: To keep consistency across this script, scripts/setup_linux.sh and
-# docker/Dockerfile, if there's any changes applied to this file, specially
-# regarding the installation of dependencies, apply those same changes to the
-# mentioned files.
+# docker/Dockerfile.base, if there's any changes applied to this file,
+# specially regarding the installation of dependencies, apply those same
+# changes to the mentioned files.
 
 # Exit if any error occurs
 set -e


### PR DESCRIPTION
The docker image for garage-ci was having the following issues:
- The codecov environment variables were not expanding correctly when
calling docker-run though a makefile in Travis.
- Caching was not working

First, the ci image got its own compose file docker-compose-ci to simply
things. To solve the codecov issue, the (bash<curl) operation was moved
from the makefile to the travis file, since the operation was not 
expanding properly when called from the makefile.
To pass the environment variables of codecov generated in travis, the 
variable ADD_ARGS was added in the makefile to pass these or any other
environment variables required in the future. This was documented in the 
README.md.
For caching, the wrong tag was used, since ":latest" was getting
appended to the name tag, giving an invalid value for cache image name.
Since each image type has its own compose file now, the tags for caching
are now hard-coded to their corresponding image types.
Also, only the presence of the mjkey.txt is needed to install mujoco-py, so an
empty file named mjkey.txt is created in the Dockerfile instead of passing the
real key.
Finally, the file Dockerfile was renamed to Dockerfile.base.