### PR TITLE
Ignore line break after binary op & in-place yapf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,10 +87,19 @@ repos:
     #     stages: [commit, push]
     -   id: trailing-whitespace         # Trims trailing whitespace.
         stages: [commit, push]
-
+# First pass: check format
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.25.0
     hooks:
     -   id: yapf
-        args: ['-dipr']
+        name: Check format by yapf
+        args: ['-dpr']
+        stages: [commit, push]
+# Second pass: format in-place
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.25.0
+    hooks:
+    -   id: yapf
+        name: Format in-place by yapf
+        args: ['-ipr']
         stages: [commit, push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,8 +89,8 @@ repos:
         stages: [commit, push]
 
 -   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.22.0
+    rev: v0.25.0
     hooks:
     -   id: yapf
-        args: ['-dpr']
+        args: ['-dipr']
         stages: [commit, push]

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -47,11 +47,10 @@ $(cat .gitignore)
 
 # Error codes ignored for changed files
 ignored_errors_changed=(
-# BREAK BEFORE BINARY OPERATOR
-# It enforces the break after the operator, which is acceptable, but it's
-# preferred to do it before the operator. Since YAPF enforces the preferred
-# style, this rule is ignored.
 D     # docstring rules disabled
+# We prefer break after binary operator, but YAPF breaks before and the behavior
+# is not configurable, so we disable related rules in flake8.
+# Ref: https://github.com/google/yapf/issues/647
 W503  # line break before binary operator
 W504  # line break after binary operator
 )

--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -69,6 +69,7 @@ $(cat .gitignore)
 ignored_errors_added=(
 D107  # missing docstring in __init__
 W503  # line break before binary operator
+W504  # line break after binary operator
 )
 
 # Files or directories to exclude from checks applied to added files.
@@ -88,6 +89,7 @@ E402  # module level import not at top of file
 E713  # test for membership should be 'not in'
 F841  # local variable is assigned to but never used
 W503  # line break before binary operator
+W504  # line break after binary operator
 )
 
 # Files or directories to exclude from checks applied to all files.


### PR DESCRIPTION
This PR contains several small fixes for code formatter.
- Enable in-place formatting in yapf.
Free your hand from running yapf manually.
- Ignore `W504  # line break after binary operator` flake8 check for added files. 
This is a blocking issue in commit check.
yapf and flake8 have conflict opinions on this rule. This check is currently ignored for modified files but not for added files. Adopt yapf's style. 
- Update yapf version to v0.25.0 in pre-commit.
This is a blocking issue in commit check.
There are two yapf in our system, one in pre-commit, the other in `environment.yml`. Currently the version of the first one is v0.22.0 but the later is v0.25.0 (the latest one in pypi). 
This is problematic because there are some small differences between these two versions. When someone formats their code using `yapf -i` (the newer version), the formatted code might be rejected by yapf in pre-commit (the older version).