### PR TITLE
Use GitHub standard .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,43 +1,141 @@
-data
-*.pyc
-*-checkpoint.ipynb
-.DS_Store
-*.h5
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
 *.log
-*.npz
-secrets.py
-*.avi
-*.mp4
-build
-build_linux
-.idea
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+
+# garage-specific stuff below this line
+
+# Other IDEs and editors
 *.sublime-project
 *.sublime-workspace
-run_experiment.sh
-scratch-notebooks
-launch_scripts
-*.sh.e*
-*.sh.o*
-MUJOCO_LOG.TXT
-vendor/mujoco
 .project
 .pydevproject
-*.pdf
-.env
-snippets
-private
-lua
-iterate.dat
-.env
-src/
-.settings
-.pods
-docs/_build
-blackbox.zip
-blackbox
-garage/config_personal.py
 *.swp
-sandbox/
-.gitmodules
 *.orig
-.coverage
+.idea
+.settings
+
+# MacOS
+.DS_Store
+
+# no submodules, please
+.gitmodules
+
+# garage-specific exclusions
+data/
+garage/config_personal.py
+sandbox/
+MUJOCO_LOG.TXT


### PR DESCRIPTION
This PR adds the GitHub Python .gitignore file, plus a list of garage-
specific exclusions.

Source:
https://github.com/github/gitignore/blob/master/Python.gitignore

Hopefully this will make for a more-reliable git experience.