### PR TITLE
Fix garage.spaces and enviroment wrapper bugs

### DIFF
--- a/garage/sampler/utils.py
+++ b/garage/sampler/utils.py
@@ -3,7 +3,6 @@ import time
 
 import numpy as np
 
-from garage.envs.util import flatten
 from garage.misc import tensor_utils
 
 
@@ -26,9 +25,9 @@ def rollout(env,
     while path_length < max_path_length:
         a, agent_info = agent.get_action(o)
         next_o, r, d, env_info = env.step(a)
-        observations.append(flatten(env.observation_space, o))
+        observations.append(env.observation_space.flatten(o))
         rewards.append(r)
-        actions.append(flatten(env.action_space, a))
+        actions.append(env.action_space.flatten(a))
         agent_infos.append(agent_info)
         env_infos.append(env_info)
         path_length += 1

--- a/tests/garage/algos/test_algos.py
+++ b/tests/garage/algos/test_algos.py
@@ -8,6 +8,7 @@ from garage.algos import CMAES
 from garage.algos.nop import NOP
 from garage.baselines import LinearFeatureBaseline
 from garage.baselines import ZeroBaseline
+from garage.envs import GarageEnv
 from garage.envs import GridWorldEnv
 from garage.envs.box2d import CartpoleEnv
 from tests.fixtures.policies import DummyPolicy
@@ -50,7 +51,7 @@ class TestAlgos(unittest.TestCase):
     def test_polopt_algo(self, algo_cls, env_cls, policy_cls, baseline_cls):
         print("Testing %s, %s, %s" % (algo_cls.__name__, env_cls.__name__,
                                       policy_cls.__name__))
-        env = env_cls()
+        env = GarageEnv(env_cls())
         policy = policy_cls(env_spec=env)
         baseline = baseline_cls(env_spec=env)
         algo = algo_cls(


### PR DESCRIPTION
* Fixes bug in garage/sampler/utils.py, where the sampler calls the
  flatten() helper (used for gym.spaces) rather than
  GarageEnv.flatten(). This is incorrect because the sampler assumes it
  is operating on a GarageEnv
* Changes GarageEnv to no longer be an ABC -- there are algorithms
  which depend only on numpy (not a NN library like TF or PyTorch), and
  those algorithms can use GarageEnv directly. No need for subclassing.
* Updates non-TF algorithm tests to use GarageEnv