### PR TITLE
Bump gym version to 0.10.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
         # installed. This is stupid, but harmless.
         - git+https://github.com/deepmind/dm_control.git@c24ec9f5f3cb3c25c6571c89c9f60bf3350f5711#egg=dm_control
         - flask
-        - gym[all]==0.10.8
+        - gym[all]==0.10.11
         - box2d-py>=2.3.4
         - hyperopt
         - ipdb


### PR DESCRIPTION
Based on the [commit history](https://github.com/openai/gym/compare/0.10.8...master) this should be an uneventful upgrade.