### PR TITLE
Install MuJoCo 2.0

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -58,12 +58,18 @@ RUN git clone https://github.com/glfw/glfw.git && \
   cd ../../ && \
   rm -rf glfw
 
-# MuJoCo
-RUN mkdir /root/.mujoco && \
+# MuJoCo 1.5 (for gym)
+RUN mkdir -p /root/.mujoco && \
   wget https://www.roboti.us/download/mjpro150_linux.zip -O mujoco.zip && \
   unzip mujoco.zip -d $HOME/.mujoco && \
   rm mujoco.zip
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mjpro150/bin
+
+# MuJoCo 2.0 (for dm_control)
+RUN mkdir -p /root/.mujoco && \
+  wget https://www.roboti.us/download/mujoco200_linux.zip -O mujoco.zip && \
+  unzip mujoco.zip -d $HOME/.mujoco && \
+  rm mujoco.zip
 
 # conda
 RUN wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && \

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -169,14 +169,21 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
   echo -e "\n# Added by the garage installer" >> "${BASH_RC}"
 fi
 
-# Set up MuJoCo
+# Set up MuJoCo (for gym)
 if [[ ! -d "${HOME}/.mujoco/mjpro150" ]]; then
-  mkdir "${HOME}"/.mujoco
+  mkdir -p "${HOME}"/.mujoco
   MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
   wget https://www.roboti.us/download/mjpro150_linux.zip -O "${MUJOCO_ZIP}"
   unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 else
   print_warning "MuJoCo is already installed"
+fi
+# Set up MuJoCo 2.0 (for dm_control)
+if [[ ! -d "${HOME}/.mujoco/mjpro200" ]]; then
+  mkdir -p "${HOME}"/.mujoco
+  MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
+  wget https://www.roboti.us/download/mjpro200_linux.zip -O "${MUJOCO_ZIP}"
+  unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 fi
 # Configure MuJoCo as a shared library
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOME}/.mujoco/mjpro150/bin"

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -192,14 +192,21 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
   echo -e "\n# Added by the garage installer" >> "${BASH_PROF}"
 fi
 
-# Set up MuJoCo
+# Set up MuJoCo 1.5 (for gym)
 if [[ ! -d "${HOME}/.mujoco/mjpro150" ]]; then
-  mkdir "${HOME}"/.mujoco
+  mkdir -p "${HOME}"/.mujoco
   MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
   wget https://www.roboti.us/download/mjpro150_osx.zip -O "${MUJOCO_ZIP}"
   unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 else
   print_warning "MuJoCo is already installed"
+fi
+# Set up MuJoCo 2.0 (for dm_control)
+if [[ ! -d "${HOME}/.mujoco/mjpro200" ]]; then
+  mkdir -p "${HOME}"/.mujoco
+  MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
+  wget https://www.roboti.us/download/mjpro200_macos.zip -O "${MUJOCO_ZIP}"
+  unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 fi
 # Configure MuJoCo as a shared library
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOME}/.mujoco/mjpro150/bin"


### PR DESCRIPTION
This PR adds MuJoCo 2.0 installation to Dockerfiles and setup scripts,
in preparation for upgrading dm_control.

We install MuJoCo 2.0 alongside MuJoCo 1.5, because gym and mujoco_py
still requre MuJoCo 1.5. We also don't edit any of the LD_PRELOAD or
LD_LIBRARY_PATH additions (yet), since dm_control uses its own lookup
logic to find MuJoCo libraries. TBD whether our linker hacks will
interfere with dm_control's operation, though.