### PR TITLE
Correct setup scripts for MuJoCo 2.0

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -179,10 +179,10 @@ else
   print_warning "MuJoCo is already installed"
 fi
 # Set up MuJoCo 2.0 (for dm_control)
-if [[ ! -d "${HOME}/.mujoco/mjpro200" ]]; then
+if [[ ! -d "${HOME}/.mujoco/mujoco200_linux" ]]; then
   mkdir -p "${HOME}"/.mujoco
   MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
-  wget https://www.roboti.us/download/mjpro200_linux.zip -O "${MUJOCO_ZIP}"
+  wget https://www.roboti.us/download/mujoco200_linux.zip -O "${MUJOCO_ZIP}"
   unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 fi
 # Configure MuJoCo as a shared library

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -202,10 +202,10 @@ else
   print_warning "MuJoCo is already installed"
 fi
 # Set up MuJoCo 2.0 (for dm_control)
-if [[ ! -d "${HOME}/.mujoco/mjpro200" ]]; then
+if [[ ! -d "${HOME}/.mujoco/mujoco200_macos" ]]; then
   mkdir -p "${HOME}"/.mujoco
   MUJOCO_ZIP="$(mktemp -d)/mujoco.zip"
-  wget https://www.roboti.us/download/mjpro200_macos.zip -O "${MUJOCO_ZIP}"
+  wget https://www.roboti.us/download/mujoco200_macos.zip -O "${MUJOCO_ZIP}"
   unzip -u "${MUJOCO_ZIP}" -d "${HOME}"/.mujoco
 fi
 # Configure MuJoCo as a shared library


### PR DESCRIPTION
MuJoCo changed their naming convention for versions inside .mujoco, but
I didn't catch this in #494