### PR TITLE
Add shebang lines and executable bits to examples

### DIFF
--- a/examples/resume_training.py
+++ b/examples/resume_training.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import json
 import os

--- a/examples/sim_policy.py
+++ b/examples/sim_policy.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 
 import joblib

--- a/examples/tf/__init__.py
+++ b/examples/tf/__init__.py
@@ -1,1 +1,0 @@
-"""Examples using TensorFlow environments."""

--- a/examples/tf/cluster_demo.py
+++ b/examples/tf/cluster_demo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 
 from garage.baselines import LinearFeatureBaseline

--- a/examples/tf/cluster_gym_mujoco_demo.py
+++ b/examples/tf/cluster_gym_mujoco_demo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 
 import gym

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with DDPG algorithm.
 

--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with ERWR algorithm.
 

--- a/examples/tf/example_tensorboard_logger.py
+++ b/examples/tf/example_tensorboard_logger.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import tensorflow as tf
 
 from garage.misc import logger

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with DDPG + HER algorithm.
 

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with PPO algorithm.
 

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with VPG algorithm.
 

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.box2d import CartpoleEnv

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import gym
 
 from garage.baselines import LinearFeatureBaseline

--- a/examples/tf/trpo_swimmer.py
+++ b/examples/tf/trpo_swimmer.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from garage.baselines import LinearFeatureBaseline
 from garage.envs import normalize
 from garage.envs.mujoco import SwimmerEnv

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This is an example to train a task with VPG algorithm.
 


### PR DESCRIPTION
This PR adds a valid Unix shebang line to each example and marks it as
executable, so that they can be run as standard Unix scripts without
invoking Python.

Before:
```sh
python examples/tf/ddpg_pendulum.py
```

After:
```sh
. examples/tf/ddpg_pendulum.py
```

It also removes the `__init__.py` from the examples folder, since it's
a folder full of examples, not an importable Python package.