### PR TITLE
Update scripts/setup_linux.sh for TensorFlow 1.12

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -231,7 +231,7 @@ conda activate garage
   if [[ "${_arg_gpu}" = on ]]; then
     # Remove any TensorFlow installations before installing the GPU flavor
     pip uninstall -y tensorflow
-    pip install "tensorflow-gpu<1.10,>=1.9.0"
+    pip install "tensorflow-gpu<1.13,>=1.12.0"
 
   fi
 


### PR DESCRIPTION
scripts/setup_linux.sh optionally installs tensorflow-gpu. Its version
needs so track the garage TensorFlow version, but I forgot to update it
in #500.

This PR updates the scripts/setup_linux.sh to use tensorflow-gpu
version 1.12