### PR TITLE
Update .gitignore with pipenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,12 @@ dmypy.json
 # no submodules, please
 .gitmodules
 
+# pipenv
+# Including these for now, since pipenv is not the authoritative environment
+# tool
+Pipfile
+Pipfile.lock
+
 # garage-specific exclusions
 data/
 garage/config_personal.py


### PR DESCRIPTION
This PR adds Pipfile and Pipfile.lock to .gitignore.

It will be appropriate to include these if/when we officially support pipenv.
For now, it's best if they don't accidentally end up in the repo.