### PR TITLE
Use only CodeCov for coverage tracking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
   # Pull cached docker image
   - docker pull rlworkgroup/garage-ci:latest
-  # Pull CodeClimate reporter
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
-  - chmod +x cc-test-reporter
 
 install:
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"

--- a/scripts/travisci/check_tests.sh
+++ b/scripts/travisci/check_tests.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-./cc-test-reporter before-build
 coverage run -m nose2 -c setup.cfg -E 'not cron_job and not huge and not flaky'
-TEST_EXIT_CODE="$?"
 coverage xml
 bash <(curl -s https://codecov.io/bash)
-coveralls
-python-codacy-coverage -r coverage.xml
-./cc-test-reporter after-build --exit-code $TEST_EXIT_CODE

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,7 @@ extras['all'] = list(set(sum(extras.values(), [])))
 extras['dev'] = [
     # Please keep alphabetized
     'baselines @ https://api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3',  # noqa: E501
-    'codacy-coverage',
     'coverage',
-    'coveralls',
     'flake8',
     'flake8-docstrings==1.3.0',
     'flake8-import-order',


### PR DESCRIPTION
In #316 we introduced several code coverage tracking providers to the
CI pipeline, and resolved to remove all but one of them after a trial
period.

CodeCov has proven to be the clear winner for our project and workflow,
so I'm removing all of the other reporters. This will hopefully
simplify the CI pipeline a little bit.