### PR TITLE
Clean up warnings in the test suite

### DIFF
--- a/garage/envs/base.py
+++ b/garage/envs/base.py
@@ -1,6 +1,5 @@
 """Wrapper class that converts gym.Env into GarageEnv."""
 import collections
-import warnings
 
 from akro import Box
 from akro import Dict
@@ -26,7 +25,7 @@ KNOWN_GYM_NOT_CLOSE_VIEWER = [
 ]
 
 
-class GarageEnv(gym.Wrapper, Parameterized, Serializable):
+class GarageEnv(gym.Wrapper, Serializable):
     """
     Returns an abstract Garage wrapper class for gym.Env.
 
@@ -94,34 +93,6 @@ class GarageEnv(gym.Wrapper, Parameterized, Serializable):
                                 and isinstance(env_itr.viewer, MjViewer)):
                             glfw.destroy_window(env_itr.viewer.window)
                             break
-
-    def get_params_internal(self, **tags):
-        """
-        Returns an empty list if env.get_params() is called.
-
-        Returns:
-            An empty list
-        """
-        warnings.warn("get_params_internal is deprecated", DeprecationWarning)
-        return []
-
-    @property
-    def horizon(self):
-        """
-        Get the maximum episode steps for the wrapped env.
-
-        Returns:
-            max_episode_steps (int)
-        """
-        if self.env.spec is not None:
-            return self.env.spec.max_episode_steps
-        else:
-            return NotImplementedError
-
-    def log_diagnostics(self, paths, *args, **kwargs):
-        """No env supports this function call."""
-        warnings.warn("log_diagnostics is deprecated", DeprecationWarning)
-        pass
 
     @property
     def spec(self):

--- a/garage/experiment/experiment.py
+++ b/garage/experiment/experiment.py
@@ -812,9 +812,9 @@ def launch_ec2(params_list,
                 #         fi
                 #     done & echo log sync initiated
                 # """.format(log_dir=log_dir, remote_log_dir=remote_log_dir, aws_region=config.AWS_REGION_NAME))  # noqa: E501
-                sio.write("""
+                sio.write('''
                     while /bin/true; do
-                        if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \  -f 2) ]
+                        if [ -z $(curl -Is http://169.254.169.254/latest/meta-data/spot/termination-time | head -1 | grep 404 | cut -d \\  -f 2) ]
                           then
                             logger "Running shutdown hook."
                             aws s3 cp /home/ubuntu/user_data.log {remote_log_dir}/stdout.log
@@ -825,7 +825,7 @@ def launch_ec2(params_list,
                             sleep 5
                         fi
                     done & echo log sync initiated
-                """.format(  # noqa: E501, W605
+                '''.format(  # noqa: E501, W605
                     log_dir=log_dir,
                     remote_log_dir=remote_log_dir))
         if use_gpu:

--- a/garage/sampler/parallel_sampler.py
+++ b/garage/sampler/parallel_sampler.py
@@ -88,11 +88,6 @@ def _worker_set_policy_params(g, params, scope=None):
     g.policy.set_param_values(params)
 
 
-def _worker_set_env_params(g, params, scope=None):
-    g = _get_scoped_g(g, scope)
-    g.env.set_param_values(params)
-
-
 def _worker_collect_one_path(g, max_path_length, scope=None):
     g = _get_scoped_g(g, scope)
     path = rollout(g.env, g.policy, max_path_length)
@@ -102,7 +97,6 @@ def _worker_collect_one_path(g, max_path_length, scope=None):
 def sample_paths(policy_params,
                  max_samples,
                  max_path_length=np.inf,
-                 env_params=None,
                  scope=None):
     """
     :param policy_params: parameters for the policy. This will be updated on
@@ -117,10 +111,6 @@ def sample_paths(policy_params,
     singleton_pool.run_each(
         _worker_set_policy_params,
         [(policy_params, scope)] * singleton_pool.n_parallel)
-    if env_params is not None:
-        singleton_pool.run_each(
-            _worker_set_env_params,
-            [(env_params, scope)] * singleton_pool.n_parallel)
     return singleton_pool.run_collect(
         _worker_collect_one_path,
         threshold=max_samples,

--- a/garage/tf/core/layers.py
+++ b/garage/tf/core/layers.py
@@ -2,7 +2,7 @@ from collections import deque
 from collections import OrderedDict
 from difflib import get_close_matches
 import functools
-from inspect import getargspec
+import inspect
 from itertools import chain
 import math
 from warnings import warn
@@ -884,10 +884,12 @@ class ReshapeLayer(Layer):
                 # output_shape[dim] = None
                 # masked_output_shape[dim] = None
         # From the shapes, compute the sizes of the input and output tensor
-        input_size = (None if any(x is None for x in masked_input_shape) else
-                      np.prod(masked_input_shape))
-        output_size = (None if any(x is None for x in masked_output_shape) else
-                       np.prod(masked_output_shape))
+        input_size = (None if any(
+            x is None
+            for x in masked_input_shape) else np.prod(masked_input_shape))
+        output_size = (None if any(
+            x is None
+            for x in masked_output_shape) else np.prod(masked_output_shape))
         del masked_input_shape, masked_output_shape
         # Finally, infer value for -1 if needed
         if -1 in output_shape:
@@ -1534,7 +1536,6 @@ class PseudoLSTMLayer(Layer):
                 initializer=tf.concat(axis=1, values=[h0s, c0s]))
             shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
             shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-            shuffled_cs = shuffled_hcs[:, :, self.num_units:]
             return shuffled_hs
 
 
@@ -1734,7 +1735,6 @@ class LSTMLayer(Layer):
                 initializer=tf.concat(axis=1, values=[h0s, c0s]))
             shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
             shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-            shuffled_cs = shuffled_hcs[:, :, self.num_units:]
             if 'recurrent_state_output' in kwargs:
                 kwargs['recurrent_state_output'][self] = shuffled_hcs
             return shuffled_hs
@@ -1867,7 +1867,6 @@ class TfBasicLSTMLayer(Layer):
                 )
                 shuffled_hcs = tf.transpose(hcs, (1, 0, 2))
                 shuffled_hs = shuffled_hcs[:, :, :self.num_units]
-                shuffled_cs = shuffled_hcs[:, :, self.num_units:]
                 return shuffled_hs
 
     def get_output_shape_for(self, input_shape):
@@ -2101,7 +2100,8 @@ def get_output(layer_or_layers, inputs=None, **kwargs):
                     "mapping this layer to an input expression." % layer)
             all_outputs[layer] = layer.get_output_for(layer_inputs, **kwargs)
             try:
-                names, _, _, defaults = getargspec(layer.get_output_for)
+                names, _, _, defaults, _, _, _ = inspect.getfullargspec(
+                    layer.get_output_for)
             except TypeError:
                 # If introspection is not possible, skip it
                 pass

--- a/garage/tf/samplers/batch_sampler.py
+++ b/garage/tf/samplers/batch_sampler.py
@@ -31,10 +31,8 @@ class BatchSampler(BaseSampler):
 
     def obtain_samples(self, itr):
         cur_policy_params = self.algo.policy.get_param_values()
-        cur_env_params = self.algo.env.get_param_values()
         paths = parallel_sampler.sample_paths(
             policy_params=cur_policy_params,
-            env_params=cur_env_params,
             max_samples=self.algo.batch_size,
             max_path_length=self.algo.max_path_length,
             scope=self.algo.scope,
@@ -60,9 +58,9 @@ class BatchSampler(BaseSampler):
 
         for idx, path in enumerate(paths):
             path_baselines = np.append(all_path_baselines[idx], 0)
-            deltas = path["rewards"] + \
-                     self.algo.discount * path_baselines[1:] - \
-                     path_baselines[:-1]
+            deltas = path["rewards"] \
+                + self.algo.discount * path_baselines[1:] \
+                - path_baselines[:-1]
             path["advantages"] = special.discount_cumsum(
                 deltas, self.algo.discount * self.algo.gae_lambda)
             path["deltas"] = deltas

--- a/tests/garage/envs/dm_control/test_dm_control_env.py
+++ b/tests/garage/envs/dm_control/test_dm_control_env.py
@@ -41,7 +41,7 @@ class TestDmControlEnv(unittest.TestCase):
         a_copy = copy(a)
         env.step(a)
         if isinstance(a, collections.Iterable):
-            self.assertEquals(a.all(), a_copy.all())
+            self.assertEqual(a.all(), a_copy.all())
         else:
-            self.assertEquals(a, a_copy)
+            self.assertEqual(a, a_copy)
         env.close()

--- a/tests/garage/envs/test_grid_world_env.py
+++ b/tests/garage/envs/test_grid_world_env.py
@@ -21,5 +21,5 @@ class TestGridWorldEnv(unittest.TestCase):
         a_copy = a
         env.reset()
         env.step(a)
-        self.assertEquals(a, a_copy)
+        self.assertEqual(a, a_copy)
         env.close()

--- a/tests/garage/envs/test_normalized_gym.py
+++ b/tests/garage/envs/test_normalized_gym.py
@@ -23,7 +23,7 @@ class TestNormalizedGym(unittest.TestCase):
         a_copy = a
         self.env.reset()
         self.env.step(a)
-        self.assertEquals(a, a_copy)
+        self.assertEqual(a, a_copy)
 
     def test_flatten(self):
         for _ in range(10):

--- a/tests/garage/envs/test_point_env.py
+++ b/tests/garage/envs/test_point_env.py
@@ -20,5 +20,5 @@ class TestPointEnv(unittest.TestCase):
         a_copy = a.copy()
         env.reset()
         env.step(a)
-        self.assertEquals(a.all(), a_copy.all())
+        self.assertEqual(a.all(), a_copy.all())
         env.close()


### PR DESCRIPTION
* Warn only once from GarageEnv about deprecated methods
* Replace deprecated uses of assertEquals with assertEqual in tests
* Replace deprecated use of inspect.getargspec() with
  inspect.getfullargspec() in garage/tf/core/layers.py
* Properly-escape a backslash in experiment.py