### PR TITLE
Fix GaussianMLPolicyWithModel pickling bug

### DIFF
--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -3,6 +3,7 @@ from akro.tf import Box
 import numpy as np
 import tensorflow as tf
 
+from garage.tf.misc import tensor_utils
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
 from garage.tf.policies.base2 import StochasticPolicy2
 
@@ -77,21 +78,14 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
             std_output_nonlinearity=std_output_nonlinearity,
             std_parameterization=std_parameterization)
 
-        _, self._mean_var, self._log_std_var, _, self._dist = (
-            self.model.build(state_input))
-
-        self._f_dist = lambda x: tf.get_default_session().run(
-            [self._mean_var, self._log_std_var], feed_dict={state_input: x})
+        self.model.build(state_input)
 
     @property
     def vectorized(self):
         """Vectorized or not."""
         return True
 
-    def dist_info_sym(self,
-                      obs_var,
-                      state_info_vars=None,
-                      name='dist_info_sym'):
+    def dist_info_sym(self, obs_var, state_info_vars=None, name='default'):
         """Symbolic graph of the distribution."""
         _, mean_var, log_std_var, _, _ = self.model.build(obs_var, name=name)
         return dict(mean=mean_var, log_std=log_std_var)
@@ -99,7 +93,13 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     def get_action(self, observation):
         """Get action from the policy."""
         flat_obs = self.observation_space.flatten(observation)
-        mean, log_std = [x[0] for x in self._f_dist([flat_obs])]
+        _f_dist = tensor_utils.compile_function(
+            inputs=[self.model.networks['default'].input],
+            outputs=[
+                self.model.networks['default'].mean,
+                self.model.networks['default'].std
+            ])
+        mean, log_std = [x[0] for x in _f_dist([flat_obs])]
         rnd = np.random.normal(size=mean.shape)
         action = rnd * np.exp(log_std) + mean
         return action, dict(mean=mean, log_std=log_std)
@@ -107,7 +107,13 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     def get_actions(self, observations):
         """Get actions from the policy."""
         flat_obs = self.observation_space.flatten_n(observations)
-        means, log_stds = self._f_dist(flat_obs)
+        _f_dist = tensor_utils.compile_function(
+            inputs=[self.model.networks['default'].input],
+            outputs=[
+                self.model.networks['default'].mean,
+                self.model.networks['default'].std
+            ])
+        means, log_stds = _f_dist(flat_obs)
         rnd = np.random.normal(size=means.shape)
         actions = rnd * np.exp(log_stds) + means
         return actions, dict(mean=means, log_std=log_stds)
@@ -119,4 +125,4 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     @property
     def distribution(self):
         """Policy distribution."""
-        return self._dist
+        return self.model.networks['default'].dist

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -60,7 +60,6 @@ class TestGaussianMLPModel(TfGraphTestCase):
         assert mean_output_weights.shape[1] == 2
         assert std_output_weights.shape[1] == 2
 
-    ############
     def test_gaussian_mlp_model2_with_std_share_network(self):
         model = GaussianMLPModel2(output_dim=2, std_share_network=True)
         outputs = model.build(self.input_var)

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -153,7 +153,7 @@ class TestModel(TfGraphTestCase):
 
         assert np.array_equal(out, model_out)
 
-    def test_model_pickle(self):
+    def test_model_is_pickleable(self):
         data = np.ones((3, 5))
         model = SimpleModel(output_dim=2)
 
@@ -182,7 +182,7 @@ class TestModel(TfGraphTestCase):
 
         assert np.array_equal(model.name, model_pickled.name)
 
-    def test_complicated_model_pickle(self):
+    def test_complicated_model_is_pickleable(self):
         data = np.ones((3, 5))
 
         model = ComplicatedModel(output_dim=2)
@@ -206,7 +206,7 @@ class TestModel(TfGraphTestCase):
 
         assert np.array_equal(results, results2)
 
-    def test_complicated_model2_pickle(self):
+    def test_complicated_model2_is_pickleable(self):
         data = np.ones((3, 5))
 
         parent_model = SimpleModel(output_dim=4)
@@ -231,7 +231,7 @@ class TestModel(TfGraphTestCase):
 
         assert np.array_equal(results, results2)
 
-    def test_simple_model_pickle_same_parameters(self):
+    def test_simple_model_is_pickleable_with_same_parameters(self):
         model = SimpleModel(output_dim=2)
 
         with tf.Session(graph=tf.Graph()):
@@ -253,7 +253,7 @@ class TestModel(TfGraphTestCase):
 
             np.testing.assert_equal(all_one, model_pickled.parameters)
 
-    def test_simple_model_pickle_missing_parameters(self):
+    def test_simple_model_is_pickleable_with_missing_parameters(self):
         model = SimpleModel(output_dim=2)
 
         with tf.Session(graph=tf.Graph()):

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -179,6 +179,31 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
 
     def test_guassian_mlp_policy_pickle(self):
         with tf.Session(graph=tf.Graph()) as sess:
+            policy = GaussianMLPPolicyWithModel(env_spec=self.box_env)
+            # model is built in GaussianMLPPolicyWithModel.__init__
+            outputs = sess.run(
+                policy.model.networks['default'].sample,
+                feed_dict={policy.model.networks['default'].input: self.obs})
+            p = pickle.dumps(policy)
+
+        with tf.Session(graph=tf.Graph()) as sess:
+            policy_pickled = pickle.loads(p)
+            # After pickle, we need to build the model
+            # e.g. by policy.dist_info_sym
+            input_ph = self.box_env.observation_space.new_tensor_variable(
+                extra_dims=1, name='input_ph')
+            policy_pickled.dist_info_sym(input_ph)
+
+            outputs2 = sess.run(
+                policy_pickled.model.networks['default'].sample,
+                feed_dict={
+                    policy_pickled.model.networks['default'].input: self.obs
+                })
+
+        assert np.array_equal(outputs, outputs2)
+
+    def test_guassian_mlp_policy2_pickle(self):
+        with tf.Session(graph=tf.Graph()) as sess:
             policy = GaussianMLPPolicyWithModel2(env_spec=self.box_env)
             # model is built in GaussianMLPPolicyWithModel2.__init__
             outputs = sess.run(

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -177,7 +177,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
             self.policy4.likelihood_ratio_sym(
                 obs_ph2, self.policy3.model.networks['default'].dist)
 
-    def test_guassian_mlp_policy_pickle(self):
+    def test_guassian_mlp_policy_is_pickleable(self):
         with tf.Session(graph=tf.Graph()) as sess:
             policy = GaussianMLPPolicyWithModel(env_spec=self.box_env)
             # model is built in GaussianMLPPolicyWithModel.__init__
@@ -202,7 +202,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
 
         assert np.array_equal(outputs, outputs2)
 
-    def test_guassian_mlp_policy2_pickle(self):
+    def test_guassian_mlp_policy2_is_pickleable(self):
         with tf.Session(graph=tf.Graph()) as sess:
             policy = GaussianMLPPolicyWithModel2(env_spec=self.box_env)
             # model is built in GaussianMLPPolicyWithModel2.__init__


### PR DESCRIPTION
Previously GaussianMLPolicyWithModel cannot be pickled. To make it picklable, the operations that will create unpicklable objects (e.g. `tf.Tensor` object) need to be under `model.build()`, so that those unpicklable objects will be inside `Network`. `Model` will discard all `Network`s when pickling.

It also uses `tensor_util` so first stage refactoring would be easier.
