### PR TITLE
Update coverage configuration in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,4 +34,5 @@ based_on_style = pep8
 allow_multiline_lambdas = true
 
 [coverage:run]
-source = garage
+branch = true
+source = ./garage


### PR DESCRIPTION
This PR tweaks the coverage configuration in setup.cfg

* Turn on branch coverage (supported by CodeCov)
* Specify source as files rather than a package name
  Hopefully this will make coverage count lines in files which are
  never imported during testing