### PR TITLE
Pin tensorflow-probability to 0.5.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ required = [
     'scipy',
     'tensorboard',
     'tensorflow<1.13,>=1.12.0',
-    'tensorflow-probability'
+    'tensorflow-probability<0.6.0,>=0.5.0',  # for tensorflow 1.12
 ]
 
 # Dependencies for optional features


### PR DESCRIPTION
TFP upgraded their package this morning to 0.6.0, which requires
TensorFlow 1.13. Their versioning scheme with respect to main
TensorFlow is opaque, so we will just have to track this manually.

This caused a silent breakage in the CI (e.g. https://travis-ci.com/rlworkgroup/garage/builds/102405158).

I am tracking the false-positive from a failing CI in 