### PR TITLE
Exit with a non-zero status in check_tests script

### DIFF
--- a/scripts/travisci/check_cronjob_tests.sh
+++ b/scripts/travisci/check_cronjob_tests.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+set -e
 
 nose2 -c setup.cfg -A cron_job

--- a/scripts/travisci/check_tests.sh
+++ b/scripts/travisci/check_tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 ./cc-test-reporter before-build
 coverage run -m nose2 -c setup.cfg -E 'not cron_job and not huge and not flaky'


### PR DESCRIPTION
Both scripts check_test and check_cronjob_test are used when running
Travis CI, and it was observed that the CI was still passing if any of
the commands in the scripts failed.
The argument -e is now set in both scripts to exit the scripts with non-
zero status if case any of their commands fail.