### PR TITLE
Fix replay buffer dtype

### DIFF
--- a/garage/replay_buffer/base.py
+++ b/garage/replay_buffer/base.py
@@ -18,11 +18,7 @@ import numpy as np
 class ReplayBuffer(metaclass=abc.ABCMeta):
     """Abstract class for Replay Buffer."""
 
-    def __init__(self,
-                 env_spec,
-                 size_in_transitions,
-                 time_horizon,
-                 dtype=np.float32):
+    def __init__(self, env_spec, size_in_transitions, time_horizon):
         """
         Initialize the data used in ReplayBuffer.
 
@@ -37,7 +33,6 @@ class ReplayBuffer(metaclass=abc.ABCMeta):
         self._initialized_buffer = False
         self._buffer = {}
         self._episode_buffer = {}
-        self._dtype = dtype
 
     def store_episode(self):
         """Add an episode to the buffer."""
@@ -70,9 +65,10 @@ class ReplayBuffer(metaclass=abc.ABCMeta):
     def _initialize_buffer(self, **kwargs):
         for key, value in kwargs.items():
             self._episode_buffer[key] = list()
+            values = np.array(value)
             self._buffer[key] = np.zeros(
-                [self._size, self._time_horizon, *np.array(value).shape[1:]],
-                dtype=self._dtype)
+                [self._size, self._time_horizon, *values.shape[1:]],
+                dtype=values.dtype)
         self._initialized_buffer = True
 
     def _get_storage_idx(self, size_increment=1):

--- a/garage/replay_buffer/base.py
+++ b/garage/replay_buffer/base.py
@@ -49,7 +49,7 @@ class ReplayBuffer(metaclass=abc.ABCMeta):
         """Sample a transition of batch_size."""
         raise NotImplementedError
 
-    def add_transition(self, **kwargs):
+    def add_transitions(self, **kwargs):
         """Add one transition into the replay buffer."""
         if not self._initialized_buffer:
             self._initialize_buffer(**kwargs)

--- a/garage/replay_buffer/simple_replay_buffer.py
+++ b/garage/replay_buffer/simple_replay_buffer.py
@@ -19,7 +19,7 @@ class SimpleReplayBuffer(ReplayBuffer):
     @overrides
     def sample(self, batch_size):
         """Sample a transition of batch_size."""
-        assert self._n_transitions_stored > batch_size
+        assert self._n_transitions_stored >= batch_size
         buffer = {}
         for key in self._buffer.keys():
             buffer[key] = self._buffer[key][:self._current_size]

--- a/garage/tf/samplers/off_policy_vectorized_sampler.py
+++ b/garage/tf/samplers/off_policy_vectorized_sampler.py
@@ -101,7 +101,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
                 env_infos = [dict() for _ in range(self.vec_env.num_envs)]
 
             if self.algo.input_include_goal:
-                self.algo.replay_buffer.add_transition(
+                self.algo.replay_buffer.add_transitions(
                     observation=obs,
                     action=actions,
                     goal=d_g,
@@ -115,7 +115,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
                     ],
                 )
             else:
-                self.algo.replay_buffer.add_transition(
+                self.algo.replay_buffer.add_transitions(
                     observation=obses,
                     action=actions,
                     reward=rewards * self.algo.reward_scale,

--- a/tests/fixtures/envs/dummy/dummy_discrete_env.py
+++ b/tests/fixtures/envs/dummy/dummy_discrete_env.py
@@ -22,7 +22,7 @@ class DummyDiscreteEnv(DummyEnv):
 
     def reset(self):
         """Reset the environment."""
-        self.state = np.zeros(1)
+        self.state = np.zeros(1, dtype=np.float32)
         return self.state
 
     def step(self, action):

--- a/tests/garage/replay_buffer/test_replay_buffer.py
+++ b/tests/garage/replay_buffer/test_replay_buffer.py
@@ -10,7 +10,7 @@ class TestReplayBuffer(unittest.TestCase):
         obs = env.reset()
         replay_buffer = SimpleReplayBuffer(
             env_spec=env, size_in_transitions=100, time_horizon=1)
-        replay_buffer.add_transition(
+        replay_buffer.add_transitions(
             observation=[obs], action=[env.action_space.sample()])
         sample = replay_buffer.sample(1)
         sample_obs = sample['observation']

--- a/tests/garage/replay_buffer/test_replay_buffer.py
+++ b/tests/garage/replay_buffer/test_replay_buffer.py
@@ -1,0 +1,20 @@
+import unittest
+
+from garage.replay_buffer import SimpleReplayBuffer
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+
+class TestReplayBuffer(unittest.TestCase):
+    def test_replay_buffer_dtype(self):
+        env = DummyDiscreteEnv()
+        obs = env.reset()
+        replay_buffer = SimpleReplayBuffer(
+            env_spec=env, size_in_transitions=100, time_horizon=1)
+        replay_buffer.add_transition(
+            observation=[obs], action=[env.action_space.sample()])
+        sample = replay_buffer.sample(1)
+        sample_obs = sample['observation']
+        sample_action = sample['action']
+
+        assert sample_obs.dtype == env.observation_space.dtype
+        assert sample_action.dtype == env.action_space.dtype


### PR DESCRIPTION
Replay buffer should not have a default dtype, since each of the element in the replay buffer should have dtype same as the source, e.g. observation should have dtype same as env.observation_space. One example is DQN with pixel environment, we want the observation in replay buffer to be type `np.uint8`, same as the observation space. 