### PR TITLE
Copy local files at the end of docker-compose

### DIFF
--- a/docker/Dockerfile.headless
+++ b/docker/Dockerfile.headless
@@ -13,8 +13,5 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# Add code stub last
-COPY . /root/code/garage
-
 # Ready, set, go.
 ENTRYPOINT ["docker/entrypoint-headless.sh"]

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -1,5 +1,5 @@
 ARG PARENT_IMAGE=rlworkgroup/garage-base
 FROM $PARENT_IMAGE
 
-# Ready, set, go.
-ENTRYPOINT ["docker/entrypoint-nvidia.sh"]
+# Add code stub last
+COPY . /root/code/garage

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -7,7 +7,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.base
     image: rlworkgroup/garage-base
-  garage-ci:
+  garage-ci-no-files:
     build:
       cache_from:
         - rlworkgroup/garage-ci:latest
@@ -15,4 +15,13 @@ services:
       dockerfile: docker/Dockerfile.headless
       args:
         - PARENT_IMAGE=rlworkgroup/garage-base
+    image: rlworkgroup/garage-ci-no-files
+  garage-ci:
+    build:
+      cache_from:
+        - rlworkgroup/garage-ci:latest
+      context: ../
+      dockerfile: docker/Dockerfile.runtime
+      args:
+        - PARENT_IMAGE=rlworkgroup/garage-ci-no-files
     image: ${TAG}

--- a/docker/docker-compose-headless.yml
+++ b/docker/docker-compose-headless.yml
@@ -7,7 +7,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.base
     image: rlworkgroup/garage-base
-  garage-headless:
+  garage-headless-no-files:
     build:
       cache_from:
         - rlworkgroup/garage-headless:latest
@@ -15,4 +15,13 @@ services:
       dockerfile: docker/Dockerfile.headless
       args:
         - PARENT_IMAGE=rlworkgroup/garage-base
+    image: rlworkgroup/garage-headless-no-files
+  garage-headless:
+    build:
+      cache_from:
+        - rlworkgroup/garage-headless:latest
+      context: ../
+      dockerfile: docker/Dockerfile.runtime
+      args:
+        - PARENT_IMAGE=rlworkgroup/garage-headless-no-files
     image: ${TAG}

--- a/docker/docker-compose-nvidia.yml
+++ b/docker/docker-compose-nvidia.yml
@@ -9,10 +9,21 @@ services:
       args:
         - PARENT_IMAGE=nvidia/opengl:1.0-glvnd-runtime-ubuntu16.04
     image: rlworkgroup/garage-base-nvidia
-  garage-nvidia:
+  garage-nvidia-no-files:
     build:
+      cache_from:
+        - rlworkgroup/garage-nvidia:latest
       context: ../
       dockerfile: docker/Dockerfile.nvidia
       args:
         - PARENT_IMAGE=rlworkgroup/garage-base-nvidia
+    image: rlworkgroup/garage-nvidia-no-files
+  garage-nvidia:
+    build:
+      cache_from:
+        - rlworkgroup/garage-nvidia:latest
+      context: ../
+      dockerfile: docker/Dockerfile.runtime
+      args:
+        - PARENT_IMAGE=rlworkgroup/garage-nvidia-no-files
     image: ${TAG}


### PR DESCRIPTION
To avoid rebuilding most of the docker images due to a change in the
local repository, the files are now copied in the last "layer" of the
docker-compose pipeline for all the current image types: ci, headless
and nvidia, and the "last" layer is in the new file Dockerfile.runtime.