### PR TITLE
Fix some logging issues in the new local runner

### DIFF
--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -12,7 +12,7 @@ Results:
 import gym
 import tensorflow as tf
 
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.exploration_strategies import OUStrategy
 from garage.replay_buffer import SimpleReplayBuffer
 from garage.tf.algos import DDPG
@@ -20,41 +20,50 @@ from garage.tf.envs import TfEnv
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
 
-with LocalRunner() as runner:
-    env = TfEnv(gym.make('InvertedDoublePendulum-v2'))
 
-    action_noise = OUStrategy(env.spec, sigma=0.2)
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make('InvertedDoublePendulum-v2'))
 
-    policy = ContinuousMLPPolicy(
-        env_spec=env.spec,
-        hidden_sizes=[64, 64],
-        hidden_nonlinearity=tf.nn.relu,
-        output_nonlinearity=tf.nn.tanh)
+        action_noise = OUStrategy(env.spec, sigma=0.2)
 
-    qf = ContinuousMLPQFunction(
-        env_spec=env.spec,
-        hidden_sizes=[64, 64],
-        hidden_nonlinearity=tf.nn.relu)
+        policy = ContinuousMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=[64, 64],
+            hidden_nonlinearity=tf.nn.relu,
+            output_nonlinearity=tf.nn.tanh)
 
-    replay_buffer = SimpleReplayBuffer(
-        env_spec=env.spec, size_in_transitions=int(1e6), time_horizon=100)
+        qf = ContinuousMLPQFunction(
+            env_spec=env.spec,
+            hidden_sizes=[64, 64],
+            hidden_nonlinearity=tf.nn.relu)
 
-    ddpg = DDPG(
-        env,
-        policy=policy,
-        policy_lr=1e-4,
-        qf_lr=1e-3,
-        qf=qf,
-        replay_buffer=replay_buffer,
-        target_update_tau=1e-2,
-        max_path_length=100,
-        n_train_steps=50,
-        discount=0.9,
-        min_buffer_size=int(1e4),
-        exploration_strategy=action_noise,
-        policy_optimizer=tf.train.AdamOptimizer,
-        qf_optimizer=tf.train.AdamOptimizer)
+        replay_buffer = SimpleReplayBuffer(
+            env_spec=env.spec, size_in_transitions=int(1e6), time_horizon=100)
 
-    runner.setup(algo=ddpg, env=env)
+        ddpg = DDPG(
+            env,
+            policy=policy,
+            policy_lr=1e-4,
+            qf_lr=1e-3,
+            qf=qf,
+            replay_buffer=replay_buffer,
+            target_update_tau=1e-2,
+            max_path_length=100,
+            n_train_steps=50,
+            discount=0.9,
+            min_buffer_size=int(1e4),
+            exploration_strategy=action_noise,
+            policy_optimizer=tf.train.AdamOptimizer,
+            qf_optimizer=tf.train.AdamOptimizer)
 
-    runner.train(n_epochs=500, n_epoch_cycles=20)
+        runner.setup(algo=ddpg, env=env)
+
+        runner.train(n_epochs=500, n_epoch_cycles=20)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -9,26 +9,35 @@ Results:
     RiseTime: itr 34
 """
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import ERWR
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(env_name="CartPole-v1")
 
-    policy = CategoricalMLPPolicy(
-        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(env_name="CartPole-v1")
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = ERWR(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo=algo, env=env)
+        algo = ERWR(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99)
 
-    runner.train(n_epochs=100, batch_size=10000, plot=True)
+        runner.setup(algo=algo, env=env)
+
+        runner.train(n_epochs=100, batch_size=10000, plot=True)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -11,7 +11,7 @@ Results (may vary by seed):
 import gym
 import tensorflow as tf
 
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.exploration_strategies import OUStrategy
 from garage.replay_buffer import HerReplayBuffer
 from garage.tf.algos import DDPG
@@ -19,54 +19,59 @@ from garage.tf.envs import TfEnv
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
 
-with LocalRunner() as runner:
-    env = TfEnv(gym.make('FetchReach-v1'))
 
-    action_noise = OUStrategy(env.spec, sigma=0.2)
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make('FetchReach-v1'))
 
-    policy = ContinuousMLPPolicy(
-        env_spec=env.spec,
-        name="Policy",
-        hidden_sizes=[256, 256, 256],
-        hidden_nonlinearity=tf.nn.relu,
-        output_nonlinearity=tf.nn.tanh,
-        input_include_goal=True,
-    )
+        action_noise = OUStrategy(env.spec, sigma=0.2)
 
-    qf = ContinuousMLPQFunction(
-        env_spec=env.spec,
-        name="QFunction",
-        hidden_sizes=[256, 256, 256],
-        hidden_nonlinearity=tf.nn.relu,
-        input_include_goal=True,
-    )
+        policy = ContinuousMLPPolicy(
+            env_spec=env.spec,
+            name="Policy",
+            hidden_sizes=[256, 256, 256],
+            hidden_nonlinearity=tf.nn.relu,
+            output_nonlinearity=tf.nn.tanh,
+            input_include_goal=True,
+        )
 
-    replay_buffer = HerReplayBuffer(
-        env_spec=env.spec,
-        size_in_transitions=int(1e6),
-        time_horizon=100,
-        replay_k=0.4,
-        reward_fun=env.compute_reward)
+        qf = ContinuousMLPQFunction(
+            env_spec=env.spec,
+            name="QFunction",
+            hidden_sizes=[256, 256, 256],
+            hidden_nonlinearity=tf.nn.relu,
+            input_include_goal=True,
+        )
 
-    ddpg = DDPG(
-        env,
-        policy=policy,
-        policy_lr=1e-3,
-        qf_lr=1e-3,
-        qf=qf,
-        replay_buffer=replay_buffer,
-        plot=False,
-        target_update_tau=0.05,
-        max_path_length=100,
-        n_train_steps=40,
-        discount=0.9,
-        exploration_strategy=action_noise,
-        policy_optimizer=tf.train.AdamOptimizer,
-        qf_optimizer=tf.train.AdamOptimizer,
-        buffer_batch_size=256,
-        input_include_goal=True,
-    )
+        replay_buffer = HerReplayBuffer(
+            env_spec=env.spec,
+            size_in_transitions=int(1e6),
+            time_horizon=100,
+            replay_k=0.4,
+            reward_fun=env.compute_reward)
 
-    runner.setup(algo=ddpg, env=env)
+        ddpg = DDPG(
+            env,
+            policy=policy,
+            policy_lr=1e-3,
+            qf_lr=1e-3,
+            qf=qf,
+            replay_buffer=replay_buffer,
+            plot=False,
+            target_update_tau=0.05,
+            max_path_length=100,
+            n_train_steps=40,
+            discount=0.9,
+            exploration_strategy=action_noise,
+            policy_optimizer=tf.train.AdamOptimizer,
+            qf_optimizer=tf.train.AdamOptimizer,
+            buffer_batch_size=256,
+            input_include_goal=True,
+        )
 
-    runner.train(n_epochs=50, n_epoch_cycles=20)
+        runner.setup(algo=ddpg, env=env)
+
+        runner.train(n_epochs=50, n_epoch_cycles=20)
+
+
+run_experiment(run_task, snapshot_mode="last", seed=1)

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -12,28 +12,33 @@ Results:
 import gym
 
 from garage.envs import normalize
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
 
-    policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(64, 64))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
 
-    baseline = GaussianMLPBaseline(env_spec=env.spec)
+        policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(64, 64))
 
-    algo = PPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99,
-        lr_clip_range=0.01,
-        optimizer_args=dict(batch_size=32, max_epochs=10))
+        baseline = GaussianMLPBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
+        algo = PPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            lr_clip_range=0.01,
+            optimizer_args=dict(batch_size=32, max_epochs=10))
 
-    runner.train(n_epochs=488, batch_size=2048, plot=False)
+        runner.setup(algo, env)
+
+        runner.train(n_epochs=488, batch_size=2048, plot=False)
+
+
+run_experiment(run_task, snapshot_mode="last", seed=1)

--- a/examples/tf/reps_gym_cartpole.py
+++ b/examples/tf/reps_gym_cartpole.py
@@ -11,24 +11,33 @@ Results:
 import gym
 
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import REPS
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(gym.make("CartPole-v0"))
 
-    policy = CategoricalMLPPolicy(env_spec=env.spec, hidden_sizes=[32, 32])
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make("CartPole-v0"))
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(env_spec=env.spec, hidden_sizes=[32, 32])
 
-    algo = REPS(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=100, batch_size=4000, plot=False)
+        algo = REPS(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=4000, plot=False)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -9,26 +9,35 @@ Results:
     RiseTime: itr 13
 """
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(env_name="CartPole-v1")
 
-    policy = CategoricalMLPPolicy(
-        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(env_name="CartPole-v1")
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = TRPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99,
-        max_kl_step=0.01)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=100, batch_size=4000)
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            max_kl_step=0.01)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=4000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/trpo_cartpole_batch_sampler.py
+++ b/examples/tf/trpo_cartpole_batch_sampler.py
@@ -9,7 +9,7 @@ Results:
     RiseTime: itr 13
 """
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
@@ -19,26 +19,35 @@ batch_size = 4000
 max_path_length = 500
 n_envs = batch_size // max_path_length
 
-with LocalRunner(max_cpus=n_envs) as runner:
-    env = TfEnv(env_name="CartPole-v1")
 
-    policy = CategoricalMLPPolicy(
-        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner(max_cpus=n_envs) as runner:
+        env = TfEnv(env_name="CartPole-v1")
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = TRPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=max_path_length,
-        discount=0.99,
-        max_kl_step=0.01)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(
-        algo=algo,
-        env=env,
-        sampler_cls=BatchSampler,
-        sampler_args={'n_envs': n_envs})
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=max_path_length,
+            discount=0.99,
+            max_kl_step=0.01)
 
-    runner.train(n_epochs=100, batch_size=4000, plot=False)
+        runner.setup(
+            algo=algo,
+            env=env,
+            sampler_cls=BatchSampler,
+            sampler_args={'n_envs': n_envs})
+
+        runner.train(n_epochs=100, batch_size=4000, plot=False)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -11,7 +11,7 @@ Results:
     RiseTime: itr 13
 """
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import TRPO
 import garage.tf.core.layers as L
 from garage.tf.envs import TfEnv
@@ -19,27 +19,37 @@ from garage.tf.optimizers import ConjugateGradientOptimizer
 from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import CategoricalLSTMPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(env_name="CartPole-v1")
 
-    policy = CategoricalLSTMPolicy(
-        name="policy",
-        env_spec=env.spec,
-        lstm_layer_cls=L.TfBasicLSTMLayer,
-        # gru_layer_cls=L.GRULayer,
-    )
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(env_name="CartPole-v1")
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalLSTMPolicy(
+            name="policy",
+            env_spec=env.spec,
+            lstm_layer_cls=L.TfBasicLSTMLayer,
+            # gru_layer_cls=L.GRULayer,
+        )
 
-    algo = TRPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99,
-        max_kl_step=0.01,
-        optimizer=ConjugateGradientOptimizer,
-        optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=100, batch_size=4000)
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            max_kl_step=0.01,
+            optimizer=ConjugateGradientOptimizer,
+            optimizer_args=dict(
+                hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=4000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -3,27 +3,36 @@
 import gym
 
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(gym.make("CartPole-v0"))
 
-    policy = CategoricalMLPPolicy(
-        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make("CartPole-v0"))
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = TRPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=200,
-        discount=0.99,
-        max_kl_step=0.01,
-    )
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=120, batch_size=4000)
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=200,
+            discount=0.99,
+            max_kl_step=0.01,
+        )
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=120, batch_size=4000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/trpo_swimmer.py
+++ b/examples/tf/trpo_swimmer.py
@@ -2,25 +2,34 @@
 import gym
 
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(gym.make('Swimmer-v2'))
 
-    policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make('Swimmer-v2'))
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = TRPO(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=500,
-        discount=0.99,
-        step_size=0.01)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=40, batch_size=4000)
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=500,
+            discount=0.99,
+            step_size=0.01)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=40, batch_size=4000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -9,26 +9,35 @@ Results:
     RiseTime: itr 16
 """
 from garage.baselines import LinearFeatureBaseline
-from garage.experiment import LocalRunner
+from garage.experiment import LocalRunner, run_experiment
 from garage.tf.algos import VPG
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
-with LocalRunner() as runner:
-    env = TfEnv(env_name='CartPole-v1')
 
-    policy = CategoricalMLPPolicy(
-        name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
+def run_task(*_):
+    with LocalRunner() as runner:
+        env = TfEnv(env_name='CartPole-v1')
 
-    baseline = LinearFeatureBaseline(env_spec=env.spec)
+        policy = CategoricalMLPPolicy(
+            name="policy", env_spec=env.spec, hidden_sizes=(32, 32))
 
-    algo = VPG(
-        env=env,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=100,
-        discount=0.99,
-        optimizer_args=dict(tf_optimizer_args=dict(learning_rate=0.01, )))
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    runner.setup(algo, env)
-    runner.train(n_epochs=100, batch_size=10000)
+        algo = VPG(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            optimizer_args=dict(tf_optimizer_args=dict(learning_rate=0.01, )))
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=10000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode="last",
+    seed=1,
+)

--- a/garage/tf/algos/ddpg.py
+++ b/garage/tf/algos/ddpg.py
@@ -196,7 +196,7 @@ class DDPG(OffPolicyRLAlgorithm):
 
         if itr % self.n_epoch_cycles == 0:
             logger.log("Training finished")
-            logger.log("Saving snapshot #{}".format(epoch))
+            logger.log("Saving snapshot #{}".format(int(epoch)))
             params = self.get_itr_snapshot(epoch, paths)
             logger.save_itr_params(epoch, params)
             logger.log("Saved")

--- a/garage/tf/algos/npo.py
+++ b/garage/tf/algos/npo.py
@@ -119,10 +119,6 @@ class NPO(BatchPolopt):
         logger.record_tabular("{}/Entropy".format(self.policy.name),
                               np.mean(pol_ent))
 
-        num_traj = samples_data["actions"].shape[0]
-        actions = samples_data["actions"][:num_traj, ...]
-        logger.record_histogram("{}/Actions".format(self.policy.name), actions)
-
         self._fit_baseline(samples_data)
 
     @overrides

--- a/garage/tf/samplers/on_policy_vectorized_sampler.py
+++ b/garage/tf/samplers/on_policy_vectorized_sampler.py
@@ -112,16 +112,14 @@ class OnPolicyVectorizedSampler(BatchSampler):
             pbar.inc(len(obses))
             obses = next_obses
 
-        if whole_paths:
-            return paths
-        else:
-            paths_truncated = truncate_paths(paths, batch_size)
-            return paths_truncated
-
         pbar.stop()
 
         logger.record_tabular("PolicyExecTime", policy_time)
         logger.record_tabular("EnvExecTime", env_time)
         logger.record_tabular("ProcessExecTime", process_time)
 
-        return paths
+        if whole_paths:
+            return paths
+        else:
+            paths_truncated = truncate_paths(paths, batch_size)
+            return paths_truncated

--- a/tests/garage/tf/misc/test_tensorboard.py
+++ b/tests/garage/tf/misc/test_tensorboard.py
@@ -1,0 +1,11 @@
+import unittest
+
+import numpy as np
+
+from garage.misc.logger import logger
+
+
+class TestTensorboard(unittest.TestCase):
+    def test_histogram(self):
+        vals = np.ones((2, 3, 4))
+        logger.record_histogram('key', vals)


### PR DESCRIPTION
I removed `run_experiment()` from examples in #541 . This will by default not dump loggings to file and tensorboard and this is not desired. In this PR I make run_experiment() back and fix some other logging issues.

**Changlog**
- Use run_experiment() in examples to set up the logger to use tensorboard.
- Remove logging of histogram of actions. 
- Fix ProcessExecTime not logged issue in on-policy sampler.

**Note**
Logging of action histogram is removed because tensorflow only supports logging histogram of a tensor of fixed shape, but the number of actions is dynamic in each epoch.

Previously we logged the histogram of actions by truncating sampels to the minimum number of trajectories (`=batch_size / max_path_length`). This is not possible because the algorithm doesn't know batch_size anymore. The old way of logging actions was also not accurate, because it logged after the `max_path_length` zero padding.

**TODO**
Log action histogram in plotter or somewhere else, but not in algorithm or policy. 