### PR TITLE
Add miscellaneous changes for benchmarking

### DIFF
--- a/garage/baselines/linear_feature_baseline.py
+++ b/garage/baselines/linear_feature_baseline.py
@@ -5,9 +5,10 @@ from garage.misc.overrides import overrides
 
 
 class LinearFeatureBaseline(Baseline):
-    def __init__(self, env_spec, reg_coeff=1e-5):
+    def __init__(self, env_spec, reg_coeff=1e-5, name="LinearFeatureBaseline"):
         self._coeffs = None
         self._reg_coeff = reg_coeff
+        self.name = name
 
     @overrides
     def get_param_values(self, **tags):

--- a/garage/tf/algos/npo.py
+++ b/garage/tf/algos/npo.py
@@ -51,9 +51,9 @@ class NPO(BatchPolopt):
                  name="NPO",
                  policy=None,
                  policy_ent_coeff=0.0,
-                 use_softplus_entropy=True,
-                 use_neg_logli_entropy=True,
-                 stop_entropy_gradient=True,
+                 use_softplus_entropy=False,
+                 use_neg_logli_entropy=False,
+                 stop_entropy_gradient=False,
                  **kwargs):
         self.name = name
         self._name_scope = tf.name_scope(self.name)
@@ -114,6 +114,9 @@ class NPO(BatchPolopt):
         logger.record_tabular("{}/KLBefore".format(self.policy.name),
                               policy_kl_before)
         logger.record_tabular("{}/KL".format(self.policy.name), policy_kl)
+        clip_frac = self.f_clip_frac(*policy_opt_input_values)
+        logger.record_tabular("{}/ClipFrac".format(self.policy.name),
+                              clip_frac)
 
         pol_ent = self.f_policy_entropy(*policy_opt_input_values)
         logger.record_tabular("{}/Entropy".format(self.policy.name),
@@ -238,11 +241,8 @@ class NPO(BatchPolopt):
 
     def _build_policy_loss(self, i):
         pol_dist = self.policy.distribution
-
         policy_entropy = self._build_entropy_term(i)
-
-        with tf.name_scope("augmented_rewards"):
-            rewards = i.reward_var + (self.policy_ent_coeff * policy_entropy)
+        rewards = i.reward_var
 
         with tf.name_scope("policy_loss"):
             advantages = compute_advantages(
@@ -352,6 +352,9 @@ class NPO(BatchPolopt):
                         1 - self.lr_clip_range,
                         1 + self.lr_clip_range,
                         name="lr_clip")
+                    clip_frac = tf.reduce_mean(
+                        tf.to_float(
+                            tf.greater(tf.abs(lr - 1.0), self.lr_clip_range)))
                     if self.policy.recurrent:
                         surr_clip = lr_clip * advantages * i.valid_var
                     else:
@@ -359,6 +362,8 @@ class NPO(BatchPolopt):
                     obj = tf.minimum(surrogate, surr_clip, name="surr_obj")
                 else:
                     raise NotImplementedError("Unknown PGLoss")
+
+                obj += self.policy_ent_coeff * policy_entropy
 
                 # Maximize E[surrogate objective] by minimizing
                 # -E_t[surrogate objective]
@@ -372,6 +377,11 @@ class NPO(BatchPolopt):
                 flatten_inputs(self._policy_opt_inputs),
                 pol_mean_kl,
                 log_name="f_policy_kl")
+
+            self.f_clip_frac = tensor_utils.compile_function(
+                flatten_inputs(self._policy_opt_inputs),
+                clip_frac,
+                log_name="f_clip_frac")
 
             self.f_rewards = tensor_utils.compile_function(
                 flatten_inputs(self._policy_opt_inputs),
@@ -390,38 +400,47 @@ class NPO(BatchPolopt):
     def _build_entropy_term(self, i):
         with tf.name_scope("policy_entropy"):
             if self.policy.recurrent:
-                policy_dist_info_flat = self.policy.dist_info_sym(
+                policy_dist_info = self.policy.dist_info_sym(
                     i.obs_var,
                     i.policy_state_info_vars,
                     name="policy_dist_info")
-                policy_neg_log_likeli_flat = self.policy.distribution.log_likelihood_sym(  # noqa: E501
+
+                policy_neg_log_likeli = self.policy.distribution.log_likelihood_sym(  # noqa: E501
                     i.action_var,
-                    policy_dist_info_flat,
+                    policy_dist_info,
                     name="policy_log_likeli")
+
+                if self._use_neg_logli_entropy:
+                    policy_entropy = policy_neg_log_likeli
+                else:
+                    policy_entropy = self.policy.distribution.entropy_sym(
+                        policy_dist_info)
+
             else:
                 policy_dist_info_flat = self.policy.dist_info_sym(
                     i.flat.obs_var,
                     i.flat.policy_state_info_vars,
                     name="policy_dist_info_flat_entropy")
-                policy_neg_log_likeli_flat = self.policy.distribution.log_likelihood_sym(  # noqa: E501
-                    i.flat.action_var,
+
+                policy_dist_info_valid = filter_valids_dict(
                     policy_dist_info_flat,
+                    i.flat.valid_var,
+                    name="policy_dist_info_valid")
+
+                policy_neg_log_likeli_valid = self.policy.distribution.log_likelihood_sym(  # noqa: E501
+                    i.valid.action_var,
+                    policy_dist_info_valid,
                     name="policy_log_likeli")
 
-            if self._use_neg_logli_entropy:
-                policy_entropy_flat = policy_neg_log_likeli_flat
-            else:
-                policy_entropy_flat = self.policy.distribution.entropy_sym(
-                    policy_dist_info_flat)
-
-            policy_entropy = tf.reshape(policy_entropy_flat,
-                                        [-1, self.max_path_length])
+                if self._use_neg_logli_entropy:
+                    policy_entropy = policy_neg_log_likeli_valid
+                else:
+                    policy_entropy = self.policy.distribution.entropy_sym(
+                        policy_dist_info_valid)
 
             # This prevents entropy from becoming negative for small policy std
             if self._use_softplus_entropy:
                 policy_entropy = tf.nn.softplus(policy_entropy)
-
-            policy_entropy = policy_entropy * i.valid_var
 
             if self._stop_entropy_gradient:
                 policy_entropy = tf.stop_gradient(policy_entropy)
@@ -464,7 +483,8 @@ class NPO(BatchPolopt):
         # Calculate explained variance
         ev = special.explained_variance_1d(
             np.concatenate(baselines), aug_returns)
-        logger.record_tabular("Baseline/ExplainedVariance", ev)
+        logger.record_tabular(
+            "{}/ExplainedVariance".format(self.baseline.name), ev)
 
         # Fit baseline
         logger.log("Fitting baseline...")

--- a/garage/tf/algos/npo.py
+++ b/garage/tf/algos/npo.py
@@ -114,10 +114,6 @@ class NPO(BatchPolopt):
         logger.record_tabular("{}/KLBefore".format(self.policy.name),
                               policy_kl_before)
         logger.record_tabular("{}/KL".format(self.policy.name), policy_kl)
-        clip_frac = self.f_clip_frac(*policy_opt_input_values)
-        logger.record_tabular("{}/ClipFrac".format(self.policy.name),
-                              clip_frac)
-
         pol_ent = self.f_policy_entropy(*policy_opt_input_values)
         logger.record_tabular("{}/Entropy".format(self.policy.name),
                               np.mean(pol_ent))
@@ -352,9 +348,6 @@ class NPO(BatchPolopt):
                         1 - self.lr_clip_range,
                         1 + self.lr_clip_range,
                         name="lr_clip")
-                    clip_frac = tf.reduce_mean(
-                        tf.to_float(
-                            tf.greater(tf.abs(lr - 1.0), self.lr_clip_range)))
                     if self.policy.recurrent:
                         surr_clip = lr_clip * advantages * i.valid_var
                     else:
@@ -377,11 +370,6 @@ class NPO(BatchPolopt):
                 flatten_inputs(self._policy_opt_inputs),
                 pol_mean_kl,
                 log_name="f_policy_kl")
-
-            self.f_clip_frac = tensor_utils.compile_function(
-                flatten_inputs(self._policy_opt_inputs),
-                clip_frac,
-                log_name="f_clip_frac")
 
             self.f_rewards = tensor_utils.compile_function(
                 flatten_inputs(self._policy_opt_inputs),

--- a/garage/tf/baselines/deterministic_mlp_baseline.py
+++ b/garage/tf/baselines/deterministic_mlp_baseline.py
@@ -17,6 +17,7 @@ class DeterministicMLPBaseline(Baseline, Parameterized, Serializable):
             subsample_factor=1.,
             num_seq_inputs=1,
             regressor_args=None,
+            name="DeterministicMLPBaseline",
     ):
         """
         Constructor.
@@ -36,8 +37,9 @@ class DeterministicMLPBaseline(Baseline, Parameterized, Serializable):
             input_shape=(
                 env_spec.observation_space.flat_dim * num_seq_inputs, ),
             output_dim=1,
-            name="DeterministicMLPBaseline",
+            name=name,
             **regressor_args)
+        self.name = name
 
     @overrides
     def get_param_values(self, **tags):

--- a/garage/tf/baselines/gaussian_conv_baseline.py
+++ b/garage/tf/baselines/gaussian_conv_baseline.py
@@ -22,6 +22,7 @@ class GaussianConvBaseline(Baseline, Parameterized, Serializable):
             env_spec,
             subsample_factor=1.,
             regressor_args=None,
+            name="GaussianConvBaseline",
     ):
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
@@ -33,8 +34,9 @@ class GaussianConvBaseline(Baseline, Parameterized, Serializable):
         self._regressor = GaussianConvRegressor(
             input_shape=env_spec.observation_space.shape,
             output_dim=1,
-            name="GaussianConvBaseline",
+            name=name,
             **regressor_args)
+        self.name = name
 
     @overrides
     def fit(self, paths):

--- a/garage/tf/baselines/gaussian_mlp_baseline.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline.py
@@ -17,6 +17,7 @@ class GaussianMLPBaseline(Baseline, Parameterized, Serializable):
             subsample_factor=1.,
             num_seq_inputs=1,
             regressor_args=None,
+            name="GaussianMLPBaseline",
     ):
         """
         Constructor.
@@ -36,8 +37,9 @@ class GaussianMLPBaseline(Baseline, Parameterized, Serializable):
             input_shape=(
                 env_spec.observation_space.flat_dim * num_seq_inputs, ),
             output_dim=1,
-            name="GaussianMLPBaseline",
+            name=name,
             **regressor_args)
+        self.name = name
 
     @overrides
     def fit(self, paths):

--- a/garage/tf/regressors/bernoulli_mlp_regressor.py
+++ b/garage/tf/regressors/bernoulli_mlp_regressor.py
@@ -29,7 +29,7 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
             optimizer=None,
             tr_optimizer=None,
             use_trust_region=True,
-            step_size=0.01,
+            max_kl_step=0.01,
             normalize_inputs=True,
             no_initial_trust_region=True,
     ):
@@ -42,7 +42,7 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
         mean network.
         :param optimizer: Optimizer for minimizing the negative log-likelihood.
         :param use_trust_region: Whether to use trust region constraint.
-        :param step_size: KL divergence constraint for each iteration
+        :param max_kl_step: KL divergence constraint for each iteration
         """
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
@@ -115,7 +115,7 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
                 target=self,
                 network_outputs=[p_var],
                 inputs=[xs_var, ys_var, old_p_var],
-                leq_constraint=(mean_kl, step_size))
+                leq_constraint=(mean_kl, max_kl_step))
 
             self.use_trust_region = use_trust_region
             self.name = name

--- a/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/garage/tf/regressors/categorical_mlp_regressor.py
@@ -33,7 +33,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
             optimizer=None,
             tr_optimizer=None,
             use_trust_region=True,
-            step_size=0.01,
+            max_kl_step=0.01,
             normalize_inputs=True,
             no_initial_trust_region=True,
     ):
@@ -46,7 +46,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
         mean network.
         :param optimizer: Optimizer for minimizing the negative log-likelihood.
         :param use_trust_region: Whether to use trust region constraint.
-        :param step_size: KL divergence constraint for each iteration
+        :param max_kl_step: KL divergence constraint for each iteration
         """
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
@@ -124,7 +124,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
                 target=self,
                 network_outputs=[prob_var],
                 inputs=[xs_var, ys_var, old_prob_var],
-                leq_constraint=(mean_kl, step_size))
+                leq_constraint=(mean_kl, max_kl_step))
 
             self.use_trust_region = use_trust_region
             self.name = name

--- a/garage/tf/regressors/gaussian_conv_regressor.py
+++ b/garage/tf/regressors/gaussian_conv_regressor.py
@@ -61,7 +61,7 @@ class GaussianConvRegressor(LayersPowered, Serializable, Parameterized):
                  optimizer=None,
                  optimizer_args=dict(),
                  use_trust_region=True,
-                 step_size=0.01):
+                 max_kl_step=0.01):
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
         self._mean_network_name = "mean_network"
@@ -228,7 +228,7 @@ class GaussianConvRegressor(LayersPowered, Serializable, Parameterized):
             )
 
             if use_trust_region:
-                optimizer_args["leq_constraint"] = (mean_kl, step_size)
+                optimizer_args["leq_constraint"] = (mean_kl, max_kl_step)
                 optimizer_args["inputs"] = [
                     xs_var, ys_var, old_means_var, old_log_stds_var
                 ]

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -29,7 +29,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
                  optimizer=None,
                  optimizer_args=None,
                  use_trust_region=True,
-                 step_size=0.01,
+                 max_kl_step=0.01,
                  learn_std=True,
                  init_std=1.0,
                  adaptive_std=False,
@@ -48,7 +48,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
          mean network.
         :param optimizer: Optimizer for minimizing the negative log-likelihood.
         :param use_trust_region: Whether to use trust region constraint.
-        :param step_size: KL divergence constraint for each iteration
+        :param max_kl_step: KL divergence constraint for each iteration
         :param learn_std: Whether to learn the standard deviations. Only
          effective if adaptive_std is False. If adaptive_std is True, this
          parameter is ignored, and the weights for the std network are always
@@ -213,7 +213,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             )
 
             if use_trust_region:
-                optimizer_args["leq_constraint"] = (mean_kl, step_size)
+                optimizer_args["leq_constraint"] = (mean_kl, max_kl_step)
                 optimizer_args["inputs"] = [
                     xs_var, ys_var, old_means_var, old_log_stds_var
                 ]

--- a/tests/benchmarks/test_benchmark_ddpg.py
+++ b/tests/benchmarks/test_benchmark_ddpg.py
@@ -2,8 +2,8 @@
 This script creates a regression test over garage-DDPG and baselines-DDPG.
 
 It get Mujoco1M benchmarks from baselines benchmark, and test each task in
-its trail times on garage model and baselines model. For each task, there will
-be `trail` times with different random seeds. For each trail, there will be two
+its trial times on garage model and baselines model. For each task, there will
+be `trial` times with different random seeds. For each trial, there will be two
 log directories corresponding to baselines and garage. And there will be a plot
 plotting the average return curve from baselines and garage.
 """
@@ -36,6 +36,7 @@ from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
+from tests.wrappers import AutoStopEnv
 
 # Hyperparams for baselines and garage
 params = {
@@ -66,11 +67,13 @@ class TestBenchmarkDDPG(unittest.TestCase):
         mujoco1m = benchmarks.get_benchmark("Mujoco1M")
 
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
-        benchmark_dir = "./benchmark_ddpg/%s/" % timestamp
+        benchmark_dir = "./data/local/benchmarks/ddpg/%s/" % timestamp
 
         for task in mujoco1m["tasks"]:
             env_id = task["env_id"]
             env = gym.make(env_id)
+            baseline_env = AutoStopEnv(
+                env_name=env_id, max_path_length=params["n_rollout_steps"])
             seeds = random.sample(range(100), task["trials"])
 
             task_dir = osp.join(benchmark_dir, env_id)
@@ -79,19 +82,22 @@ class TestBenchmarkDDPG(unittest.TestCase):
             baselines_csvs = []
             garage_csvs = []
 
-            for trail in range(task["trials"]):
+            for trial in range(task["trials"]):
                 env.reset()
-                seed = seeds[trail]
+                baseline_env.reset()
+                seed = seeds[trial]
 
-                trail_dir = task_dir + "/trail_%d_seed_%d" % (trail + 1, seed)
-                garage_dir = trail_dir + "/garage"
-                baselines_dir = trail_dir + "/baselines"
+                trial_dir = task_dir + "/trial_%d_seed_%d" % (trial + 1, seed)
+                garage_dir = trial_dir + "/garage"
+                baselines_dir = trial_dir + "/baselines"
 
-                # Run garage algorithms
-                garage_csv = run_garage(env, seed, garage_dir)
+                with tf.Graph().as_default():
+                    # Run garage algorithms
+                    garage_csv = run_garage(env, seed, garage_dir)
 
-                # Run baselines algorithms
-                baselines_csv = run_baselines(env, seed, baselines_dir)
+                    # Run baselines algorithms
+                    baselines_csv = run_baselines(baseline_env, seed,
+                                                  baselines_dir)
 
                 garage_csvs.append(garage_csv)
                 baselines_csvs.append(baselines_csv)
@@ -105,7 +111,7 @@ class TestBenchmarkDDPG(unittest.TestCase):
                 g_y="AverageReturn",
                 b_x="total/epochs",
                 b_y="rollout/return",
-                trails=task["trials"],
+                trials=task["trials"],
                 seeds=seeds,
                 plt_file=plt_file,
                 env_id=env_id)
@@ -120,66 +126,63 @@ def run_garage(env, seed, log_dir):
     Replace the ddpg with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return:
     """
     deterministic.set_seed(seed)
 
-    with tf.Graph().as_default():
-        with LocalRunner() as runner:
-            env = TfEnv(env)
-            # Set up params for ddpg
-            action_noise = OUStrategy(env.spec, sigma=params["sigma"])
+    with LocalRunner() as runner:
+        env = TfEnv(env)
+        # Set up params for ddpg
+        action_noise = OUStrategy(env.spec, sigma=params["sigma"])
 
-            policy = ContinuousMLPPolicy(
-                env_spec=env.spec,
-                name="Policy",
-                hidden_sizes=params["policy_hidden_sizes"],
-                hidden_nonlinearity=tf.nn.relu,
-                output_nonlinearity=tf.nn.tanh)
+        policy = ContinuousMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=params["policy_hidden_sizes"],
+            hidden_nonlinearity=tf.nn.relu,
+            output_nonlinearity=tf.nn.tanh)
 
-            qf = ContinuousMLPQFunction(
-                env_spec=env.spec,
-                name="QFunction",
-                hidden_sizes=params["qf_hidden_sizes"],
-                hidden_nonlinearity=tf.nn.relu)
+        qf = ContinuousMLPQFunction(
+            env_spec=env.spec,
+            hidden_sizes=params["qf_hidden_sizes"],
+            hidden_nonlinearity=tf.nn.relu)
 
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=params["replay_buffer_size"],
-                time_horizon=params["n_rollout_steps"])
+        replay_buffer = SimpleReplayBuffer(
+            env_spec=env.spec,
+            size_in_transitions=params["replay_buffer_size"],
+            time_horizon=params["n_rollout_steps"])
 
-            ddpg = DDPG(
-                env,
-                policy=policy,
-                qf=qf,
-                replay_buffer=replay_buffer,
-                policy_lr=params["policy_lr"],
-                qf_lr=params["qf_lr"],
-                target_update_tau=params["tau"],
-                max_path_length=params["n_rollout_steps"],
-                n_train_steps=params["n_train_steps"],
-                discount=params["discount"],
-                min_buffer_size=int(1e4),
-                exploration_strategy=action_noise,
-                policy_optimizer=tf.train.AdamOptimizer,
-                qf_optimizer=tf.train.AdamOptimizer)
+        ddpg = DDPG(
+            env,
+            policy=policy,
+            qf=qf,
+            replay_buffer=replay_buffer,
+            policy_lr=params["policy_lr"],
+            qf_lr=params["qf_lr"],
+            target_update_tau=params["tau"],
+            max_path_length=params["n_rollout_steps"],
+            n_train_steps=params["n_train_steps"],
+            discount=params["discount"],
+            min_buffer_size=int(1e4),
+            exploration_strategy=action_noise,
+            policy_optimizer=tf.train.AdamOptimizer,
+            qf_optimizer=tf.train.AdamOptimizer)
 
-            # Set up logger since we are not using run_experiment
-            tabular_log_file = osp.join(log_dir, "progress.csv")
-            tensorboard_log_dir = osp.join(log_dir)
-            garage_logger.add_tabular_output(tabular_log_file)
-            garage_logger.set_tensorboard_dir(tensorboard_log_dir)
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, "progress.csv")
+        tensorboard_log_dir = osp.join(log_dir)
+        garage_logger.add_tabular_output(tabular_log_file)
+        garage_logger.set_tensorboard_dir(tensorboard_log_dir)
 
-            runner.setup(ddpg, env)
-            runner.train(
-                n_epochs=params['n_epochs'],
-                n_epoch_cycles=params['n_epoch_cycles'])
+        runner.setup(ddpg, env)
+        runner.train(
+            n_epochs=params['n_epochs'],
+            n_epoch_cycles=params['n_epoch_cycles'])
 
-            garage_logger.remove_tabular_output(tabular_log_file)
+        garage_logger.remove_tabular_output(tabular_log_file)
 
-            return tabular_log_file
+        return tabular_log_file
 
 
 def run_baselines(env, seed, log_dir):
@@ -189,7 +192,7 @@ def run_baselines(env, seed, log_dir):
     Replace the ddpg and its training with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return
     """
@@ -199,7 +202,7 @@ def run_baselines(env, seed, log_dir):
     env.seed(seed)
 
     # Set up logger for baselines
-    configure(dir=log_dir)
+    configure(dir=log_dir, format_strs=['stdout', 'log', 'csv', 'tensorboard'])
     baselines_logger.info('rank {}: seed={}, logdir={}'.format(
         rank, seed, baselines_logger.get_dir()))
 
@@ -246,7 +249,7 @@ def run_baselines(env, seed, log_dir):
     return osp.join(log_dir, "progress.csv")
 
 
-def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
+def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id):
     """
     Plot benchmark from csv files of garage and baselines.
 
@@ -256,27 +259,27 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
     :param g_y: Y column names of garage csv.
     :param b_x: X column names of baselines csv.
     :param b_y: Y column names of baselines csv.
-    :param trails: Number of trails in the task.
+    :param trials: Number of trials in the task.
     :param seeds: A list contains all the seeds in the task.
     :param plt_file: Path of the plot png file.
     :param env_id: String contains the id of the environment.
     :return:
     """
     assert len(b_csvs) == len(g_csvs)
-    for trail in range(trails):
-        seed = seeds[trail]
+    for trial in range(trials):
+        seed = seeds[trial]
 
-        df_g = pd.read_csv(g_csvs[trail])
-        df_b = pd.read_csv(b_csvs[trail])
+        df_g = pd.read_csv(g_csvs[trial])
+        df_b = pd.read_csv(b_csvs[trial])
 
         plt.plot(
             df_g[g_x],
             df_g[g_y],
-            label="garage_trail%d_seed%d" % (trail + 1, seed))
+            label="garage_trial%d_seed%d" % (trial + 1, seed))
         plt.plot(
             df_b[b_x],
             df_b[b_y],
-            label="baselines_trail%d_seed%d" % (trail + 1, seed))
+            label="baselines_trial%d_seed%d" % (trial + 1, seed))
 
     plt.legend()
     plt.xlabel("Epoch")

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -2,8 +2,8 @@
 This script creates a regression test over garage-PPO and baselines-PPO.
 
 Unlike garage, baselines doesn't set max_path_length. It keeps steps the action
-until it's done. So you need to change the baselines source code to make it
-stops at length 100.
+until it's done. So we introduced tests.wrappers.AutoStopEnv wrapper to set
+done=True when it reaches max_path_length.
 """
 import datetime
 import multiprocessing
@@ -32,7 +32,9 @@ from garage.misc import logger as garage_logger
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
+from garage.tf.optimizers import FirstOrderOptimizer
 from garage.tf.policies import GaussianMLPPolicy
+from tests.wrappers import AutoStopEnv
 
 
 class TestBenchmarkPPO(unittest.TestCase):
@@ -45,10 +47,13 @@ class TestBenchmarkPPO(unittest.TestCase):
         mujoco1m = benchmarks.get_benchmark("Mujoco1M")
 
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
-        benchmark_dir = "./benchmark_ppo/%s/" % timestamp
+        benchmark_dir = "./data/local/benchmarks/ppo/%s/" % timestamp
         for task in mujoco1m["tasks"]:
             env_id = task["env_id"]
+
             env = gym.make(env_id)
+            baseline_env = AutoStopEnv(env_name=env_id, max_path_length=100)
+
             seeds = random.sample(range(100), task["trials"])
 
             task_dir = osp.join(benchmark_dir, env_id)
@@ -57,20 +62,22 @@ class TestBenchmarkPPO(unittest.TestCase):
             baselines_csvs = []
             garage_csvs = []
 
-            for trail in range(task["trials"]):
-                env.reset()
-                seed = seeds[trail]
+            for trial in range(task['trials']):
+                seed = seeds[trial]
 
-                trail_dir = task_dir + "/trail_%d_seed_%d" % (trail + 1, seed)
-                garage_dir = trail_dir + "/garage"
-                baselines_dir = trail_dir + "/baselines"
+                trial_dir = task_dir + "/trial_%d_seed_%d" % (trial + 1, seed)
+                garage_dir = trial_dir + "/garage"
+                baselines_dir = trial_dir + "/baselines"
 
-                # Run garage algorithms
-                garage_csv = run_garage(env, seed, garage_dir)
+                with tf.Graph().as_default():
+                    # Run baselines algorithms
+                    baseline_env.reset()
+                    baselines_csv = run_baselines(baseline_env, seed,
+                                                  baselines_dir)
 
-                # Run baselines algorithms
-                env.reset()
-                baselines_csv = run_baselines(env, seed, baselines_dir)
+                    # Run garage algorithms
+                    env.reset()
+                    garage_csv = run_garage(env, seed, garage_dir)
 
                 garage_csvs.append(garage_csv)
                 baselines_csvs.append(baselines_csv)
@@ -81,10 +88,10 @@ class TestBenchmarkPPO(unittest.TestCase):
                 b_csvs=baselines_csvs,
                 g_csvs=garage_csvs,
                 g_x="Iteration",
-                g_y="AverageReturn",
+                g_y="EpisodeRewardMean",
                 b_x="nupdates",
                 b_y="eprewmean",
-                trails=task["trials"],
+                trials=task['trials'],
                 seeds=seeds,
                 plt_file=plt_file,
                 env_id=env_id)
@@ -99,63 +106,64 @@ def run_garage(env, seed, log_dir):
     Replace the ppo with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return:
     """
     deterministic.set_seed(seed)
 
-    with tf.Graph().as_default():
-        with LocalRunner() as runner:
-            env = TfEnv(normalize(env))
+    with LocalRunner() as runner:
+        env = TfEnv(normalize(env))
 
-            policy = GaussianMLPPolicy(
-                name="policy",
-                env_spec=env.spec,
+        policy = GaussianMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=(64, 64),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(
                 hidden_sizes=(64, 64),
-                hidden_nonlinearity=tf.nn.tanh,
-                output_nonlinearity=None,
-            )
-
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(
-                    hidden_sizes=(64, 64),
-                    use_trust_region=True,
-                ),
-            )
-
-            algo = PPO(
-                env=env,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.95,
-                clip_range=0.1,
-                policy_ent_coeff=0.0,
+                use_trust_region=False,
+                optimizer=FirstOrderOptimizer,
                 optimizer_args=dict(
                     batch_size=32,
                     max_epochs=10,
-                    tf_optimizer_args=dict(
-                        learning_rate=3e-4,
-                        epsilon=1e-5,
-                    ),
+                    tf_optimizer_args=dict(learning_rate=1e-3),
                 ),
-                plot=False,
-            )
+            ),
+        )
 
-            # Set up logger since we are not using run_experiment
-            tabular_log_file = osp.join(log_dir, "progress.csv")
-            garage_logger.add_tabular_output(tabular_log_file)
-            garage_logger.set_tensorboard_dir(log_dir)
+        algo = PPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            gae_lambda=0.95,
+            lr_clip_range=0.2,
+            policy_ent_coeff=0.0,
+            optimizer_args=dict(
+                batch_size=32,
+                max_epochs=10,
+                tf_optimizer_args=dict(learning_rate=1e-3),
+            ),
+            plot=False,
+        )
 
-            runner.setup(algo, env)
-            runner.train(n_epochs=488, batch_size=2048)
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, "progress.csv")
+        garage_logger.add_tabular_output(tabular_log_file)
+        garage_logger.set_tensorboard_dir(log_dir)
 
-            garage_logger.remove_tabular_output(tabular_log_file)
+        runner.setup(algo, env)
+        runner.train(n_epochs=488, batch_size=2048)
 
-            return tabular_log_file
+        garage_logger.remove_tabular_output(tabular_log_file)
+
+        return tabular_log_file
 
 
 def run_baselines(env, seed, log_dir):
@@ -165,7 +173,7 @@ def run_baselines(env, seed, log_dir):
     Replace the ppo and its training with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return
     """
@@ -177,7 +185,7 @@ def run_baselines(env, seed, log_dir):
     tf.Session(config=config).__enter__()
 
     # Set up logger for baselines
-    configure(dir=log_dir)
+    configure(dir=log_dir, format_strs=['stdout', 'log', 'csv', 'tensorboard'])
     baselines_logger.info('rank {}: seed={}, logdir={}'.format(
         0, seed, baselines_logger.get_dir()))
 
@@ -201,16 +209,16 @@ def run_baselines(env, seed, log_dir):
         noptepochs=10,
         log_interval=1,
         ent_coef=0.0,
-        lr=3e-4,
+        lr=1e-3,
         vf_coef=0.5,
-        max_grad_norm=0.5,
-        cliprange=0.1,
+        max_grad_norm=None,
+        cliprange=0.2,
         total_timesteps=int(1e6))
 
     return osp.join(log_dir, "progress.csv")
 
 
-def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
+def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id):
     """
     Plot benchmark from csv files of garage and baselines.
 
@@ -220,27 +228,27 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
     :param g_y: Y column names of garage csv.
     :param b_x: X column names of baselines csv.
     :param b_y: Y column names of baselines csv.
-    :param trails: Number of trails in the task.
+    :param trials: Number of trials in the task.
     :param seeds: A list contains all the seeds in the task.
     :param plt_file: Path of the plot png file.
     :param env_id: String contains the id of the environment.
     :return:
     """
     assert len(b_csvs) == len(g_csvs)
-    for trail in range(trails):
-        seed = seeds[trail]
+    for trial in range(trials):
+        seed = seeds[trial]
 
-        df_g = pd.read_csv(g_csvs[trail])
-        df_b = pd.read_csv(b_csvs[trail])
+        df_g = pd.read_csv(g_csvs[trial])
+        df_b = pd.read_csv(b_csvs[trial])
 
         plt.plot(
             df_g[g_x],
             df_g[g_y],
-            label="garage_trail%d_seed%d" % (trail + 1, seed))
+            label="garage_trial%d_seed%d" % (trial + 1, seed))
         plt.plot(
             df_b[b_x],
             df_b[b_y],
-            label="baselines_trail%d_seed%d" % (trail + 1, seed))
+            label="baselines_trial%d_seed%d" % (trial + 1, seed))
 
     plt.legend()
     plt.xlabel("Iteration")

--- a/tests/benchmarks/test_benchmark_trpo.py
+++ b/tests/benchmarks/test_benchmark_trpo.py
@@ -2,8 +2,8 @@
 This script creates a regression test over garage-TRPO and baselines-TRPO.
 
 Unlike garage, baselines doesn't set max_path_length. It keeps steps the action
-until it's done. So you need to change the baselines source code to make it
-stops at length 100. You also need to change the
+until it's done. So we introduced tests.wrappers.AutoStopEnv wrapper to set
+done=True when it reaches max_path_length. We also need to change the
 garage.tf.samplers.BatchSampler to smooth the reward curve.
 """
 import datetime
@@ -13,7 +13,6 @@ import unittest
 
 from baselines import logger as baselines_logger
 from baselines.bench import benchmarks
-from baselines.common.cmd_util import make_mujoco_env
 from baselines.common.tf_util import _PLACEHOLDER_CACHE
 from baselines.ppo1.mlp_policy import MlpPolicy
 from baselines.trpo_mpi import trpo_mpi
@@ -30,6 +29,7 @@ from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicy
+from tests.wrappers import AutoStopEnv
 
 
 class TestBenchmarkPPO(unittest.TestCase):
@@ -43,10 +43,12 @@ class TestBenchmarkPPO(unittest.TestCase):
         mujoco1m = benchmarks.get_benchmark("Mujoco1M")
 
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
-        benchmark_dir = "./benchmark_trpo/%s/" % timestamp
+        benchmark_dir = "./data/local/benchmarks/trpo/%s/" % timestamp
         for task in mujoco1m["tasks"]:
             env_id = task["env_id"]
             env = gym.make(env_id)
+            baseline_env = AutoStopEnv(env_name=env_id, max_path_length=100)
+
             seeds = random.sample(range(100), task["trials"])
 
             task_dir = osp.join(benchmark_dir, env_id)
@@ -55,20 +57,23 @@ class TestBenchmarkPPO(unittest.TestCase):
             baselines_csvs = []
             garage_csvs = []
 
-            for trail in range(task["trials"]):
+            for trial in range(task["trials"]):
                 _PLACEHOLDER_CACHE.clear()
-                env.reset()
-                seed = seeds[trail]
+                seed = seeds[trial]
 
-                trail_dir = task_dir + "/trail_%d_seed_%d" % (trail + 1, seed)
-                garage_dir = trail_dir + "/garage"
-                baselines_dir = trail_dir + "/baselines"
+                trial_dir = task_dir + "/trial_%d_seed_%d" % (trial + 1, seed)
+                garage_dir = trial_dir + "/garage"
+                baselines_dir = trial_dir + "/baselines"
 
-                baselines_csv = run_baselines(env_id, seed, baselines_dir)
+                with tf.Graph().as_default():
+                    # Run garage algorithms
+                    env.reset()
+                    garage_csv = run_garage(env, seed, garage_dir)
 
-                # Run garage algorithms
-                env.reset()
-                garage_csv = run_garage(env, seed, garage_dir)
+                    # Run baseline algorithms
+                    baseline_env.reset()
+                    baselines_csv = run_baselines(baseline_env, seed,
+                                                  baselines_dir)
 
                 garage_csvs.append(garage_csv)
                 baselines_csvs.append(baselines_csv)
@@ -77,10 +82,10 @@ class TestBenchmarkPPO(unittest.TestCase):
                 b_csvs=baselines_csvs,
                 g_csvs=garage_csvs,
                 g_x="Iteration",
-                g_y="AverageReturn",
-                b_x="Iter",
+                g_y="EpisodeRewardMean",
+                b_x="EpThisIter",
                 b_y="EpRewMean",
-                trails=task["trials"],
+                trials=task["trials"],
                 seeds=seeds,
                 plt_file=plt_file,
                 env_id=env_id)
@@ -97,65 +102,63 @@ def run_garage(env, seed, log_dir):
     Replace the trpo with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return:import baselines.common.tf_util as U
     """
     deterministic.set_seed(seed)
 
-    with tf.Graph().as_default():
-        with LocalRunner() as runner:
-            env = TfEnv(normalize(env))
+    with LocalRunner() as runner:
+        env = TfEnv(normalize(env))
 
-            policy = GaussianMLPPolicy(
-                name="policy",
-                env_spec=env.spec,
+        policy = GaussianMLPPolicy(
+            env_spec=env.spec,
+            hidden_sizes=(32, 32),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+
+        baseline = GaussianMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=dict(
                 hidden_sizes=(32, 32),
-                hidden_nonlinearity=tf.nn.tanh,
-                output_nonlinearity=None,
-            )
+                use_trust_region=True,
+            ),
+        )
 
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(
-                    hidden_sizes=(32, 32),
-                    use_trust_region=True,
-                ),
-            )
+        algo = TRPO(
+            env=env,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=100,
+            discount=0.99,
+            gae_lambda=0.98,
+            max_kl_step=0.01,
+            policy_ent_coeff=0.0,
+            plot=False,
+        )
 
-            algo = TRPO(
-                env=env,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                clip_range=0.1,
-                policy_ent_coeff=0.0,
-                plot=False,
-            )
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, "progress.csv")
+        garage_logger.add_tabular_output(tabular_log_file)
+        garage_logger.set_tensorboard_dir(log_dir)
 
-            # Set up logger since we are not using run_experiment
-            tabular_log_file = osp.join(log_dir, "progress.csv")
-            garage_logger.add_tabular_output(tabular_log_file)
-            garage_logger.set_tensorboard_dir(log_dir)
+        runner.setup(algo, env)
+        runner.train(n_epochs=976, batch_size=1024)
 
-            runner.setup(algo, env)
-            runner.train(n_epochs=976, batch_size=1024)
+        garage_logger.remove_tabular_output(tabular_log_file)
 
-            garage_logger.remove_tabular_output(tabular_log_file)
-
-            return tabular_log_file
+        return tabular_log_file
 
 
-def run_baselines(env_id, seed, log_dir):
+def run_baselines(env, seed, log_dir):
     """
     Create baselines model and training.
 
     Replace the trpo and its training with the algorithm you want to run.
 
     :param env: Environment of the task.
-    :param seed: Random seed for the trail.
+    :param seed: Random seed for the trial.
     :param log_dir: Log dir path.
     :return
     """
@@ -171,7 +174,6 @@ def run_baselines(env_id, seed, log_dir):
                 hid_size=32,
                 num_hid_layers=2)
 
-        env = make_mujoco_env(env_id, seed)
         trpo_mpi.learn(
             env,
             policy_fn,
@@ -189,7 +191,7 @@ def run_baselines(env_id, seed, log_dir):
     return osp.join(log_dir, "progress.csv")
 
 
-def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
+def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id):
     """
     Plot benchmark from csv files of garage and baselines.
 
@@ -199,27 +201,27 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trails, seeds, plt_file, env_id):
     :param g_y: Y column names of garage csv.
     :param b_x: X column names of baselines csv.
     :param b_y: Y column names of baselines csv.
-    :param trails: Number of trails in the task.
+    :param trials: Number of trials in the task.
     :param seeds: A list contains all the seeds in the task.
     :param plt_file: Path of the plot png file.
     :param env_id: String contains the id of the environment.
     :return:
     """
     assert len(b_csvs) == len(g_csvs)
-    for trail in range(trails):
-        seed = seeds[trail]
+    for trial in range(trials):
+        seed = seeds[trial]
 
-        df_g = pd.read_csv(g_csvs[trail])
-        df_b = pd.read_csv(b_csvs[trail])
+        df_g = pd.read_csv(g_csvs[trial])
+        df_b = pd.read_csv(b_csvs[trial])
 
         plt.plot(
             df_g[g_x],
             df_g[g_y],
-            label="garage_trail%d_seed%d" % (trail + 1, seed))
+            label="garage_trial%d_seed%d" % (trial + 1, seed))
         plt.plot(
             df_b[b_x],
             df_b[b_y],
-            label="baselines_trail%d_seed%d" % (trail + 1, seed))
+            label="baselines_trial%d_seed%d" % (trial + 1, seed))
 
     plt.legend()
     plt.xlabel("Iteration")

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -1,0 +1,24 @@
+import gym
+
+
+class AutoStopEnv(gym.Wrapper):
+    """A env wrapper that stops rollout at step max_path_length."""
+
+    def __init__(self, env=None, env_name="", max_path_length=100):
+        if env_name:
+            super().__init__(gym.make(env_name))
+        else:
+            super().__init__(env)
+        self._rollout_step = 0
+        self._max_path_length = max_path_length
+
+    def step(self, actions):
+        self._rollout_step += 1
+        next_obs, reward, done, info = self.env.step(actions)
+        if self._rollout_step == self._max_path_length:
+            done = True
+            self._rollout_step = 0
+        return next_obs, reward, done, info
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)


### PR DESCRIPTION
* Algorithm
   * Fix entropy in tf/algos/npo.py. According to the PPO paper, the term
     `policy_ent_coeff * pol_ent` should be added to the policy gradient
     loss instead of the reward. By fixing this, the policy stddev will
     decrease if policy_ent_coeff is very small.
   * Also addressed issue #442.

 * Sampler
   * baselines logs average return of the recent 100 trajectories. Add
     info to garage.tf.BatchSampler. Note this is a temp fix to use
     benchmark.

 * Benchmark
    * Update the current benchmark to work properly. This includes:
      * Add AutoStopEnv wrapper. baselines doesn't set done=True in its
        VecNormEnv. To make the sampler behavior consistent with garage,
        the AutoStopEnv wrapper will set done to True after
        `max_path_length` steps.
      * Replace `trial` typo in test_benchmark_*.py.
      * Move tf.Graph() to parent function as baselines can't run
        multiple times in the same tf graph.
    * Add tensorboard log support to baselines. 
    * Currently, the test_benchmark_ppo and test_benchmark_trpo works.
      test_benchmark_ddpg and test_benchmark_her may not work. For further
      info please refer to issue #568. 

  * Regressor
    * Rename `step_size` to `max_kl_step` in tf/regressors to consistent
      with the naming convention garage uses.
    * Add name to baselines so that NPO can use its name in
     `_fit_baseline`.

Note this PR made some band-aid fix in order to make the benchmark work.
They should be addressed when the sampler and new logger is merged. 