### PR TITLE
Make the experiment wrapper a module

### DIFF
--- a/examples/resume_training.py
+++ b/examples/resume_training.py
@@ -42,7 +42,8 @@ if __name__ == "__main__":
         if args.log_dir is not None:
             params['log_dir'] = args.log_dir
         params['resume_from'] = args.file
-        command = to_local_command(params, script='scripts/run_experiment.py')
+        command = to_local_command(
+            params, script='garage.experiment.experiment_wrapper')
         print(command)
         try:
             subprocess.call(command, shell=True, env=os.environ)

--- a/garage/experiment/experiment.py
+++ b/garage/experiment/experiment.py
@@ -218,7 +218,7 @@ def run_experiment(method_call=None,
                    exp_prefix="experiment",
                    exp_name=None,
                    log_dir=None,
-                   script="scripts/run_experiment.py",
+                   script='garage.experiment.experiment_wrapper',
                    python_command="python",
                    mode="local",
                    dry=False,
@@ -379,7 +379,7 @@ def run_experiment(method_call=None,
             command = to_local_command(
                 task,
                 python_command=python_command,
-                script=osp.join(config.PROJECT_PATH, script),
+                script=script,
                 use_gpu=use_gpu)
             print(command)
             if dry:
@@ -545,10 +545,9 @@ def _to_param_val(v):
 
 def to_local_command(params,
                      python_command="python",
-                     script=osp.join(config.PROJECT_PATH,
-                                     'scripts/run_experiment.py'),
+                     script='garage.experiment.experiment_wrapper',
                      use_gpu=False):
-    command = python_command + " " + script
+    command = python_command + " -m " + script
     for k, v in config.ENV.items():
         command = ("%s=%s " % (k, v)) + command
     pre_commands = params.pop("pre_commands", None)
@@ -573,7 +572,7 @@ def to_local_command(params,
 def to_docker_command(params,
                       docker_image,
                       python_command="python",
-                      script='scripts/run_experiment.py',
+                      script='garage.experiment.experiment_wrapper',
                       pre_commands=None,
                       use_tty=False,
                       mujoco_path=None,
@@ -642,7 +641,7 @@ def to_docker_command(params,
         to_local_command(
             params,
             python_command=python_command,
-            script=osp.join(config.DOCKER_CODE_DIR, script),
+            script='garage.experiment.experiment_wrapper',
             use_gpu=use_gpu))
     # We for 2 min sleep after termination to allow for last syncs.
     if post_commands is None:
@@ -661,7 +660,7 @@ def launch_ec2(params_list,
                docker_image,
                code_full_path,
                python_command="python",
-               script='scripts/run_experiment.py',
+               script='garage.experiment.experiment_wrapper',
                aws_config=None,
                dry=False,
                terminate_machine=True,
@@ -1095,7 +1094,7 @@ def to_lab_kube_pod(params,
                     docker_image,
                     code_full_path,
                     python_command="python",
-                    script='scripts/run_experiment.py',
+                    script='garage.experiment.experiment_wrapper',
                     is_gpu=False,
                     sync_s3_pkl=False,
                     periodic_sync=True,

--- a/garage/experiment/experiment_wrapper.py
+++ b/garage/experiment/experiment_wrapper.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import ast
 import base64


### PR DESCRIPTION
This makes it easier to use garage as a library. It makes the
experiment wrapper script available inside the garage package path.

To avoid name collisions, this PR also renames the experiment wrapper
from `run_experiment.py` to `experiment_wrapper.py`.

Some hacky changes to garage.experiment are necessary to make this
work, but we will be deleting that module (and this wrapper) ASAP.