### PR TITLE
Set default GARAGE_AWS_S3_PATH to a string

### DIFF
--- a/garage/config.py
+++ b/garage/config.py
@@ -38,7 +38,7 @@ GARAGE_DOCKER_CODE_DIR = os.environ.get('GARAGE_DOCKER_CODE_DIR',
                                         '/root/code/garage')
 
 # AWS
-GARAGE_AWS_S3_PATH = os.environ.get('GARAGE_AWS_S3_PATH', None)
+GARAGE_AWS_S3_PATH = os.environ.get('GARAGE_AWS_S3_PATH', 'INVALID_S3_PATH')
 GARAGE_AWS_IMAGE_ID = os.environ.get('GARAGE_AWS_IMAGE_ID', None)
 GARAGE_AWS_INSTANCE_TYPE = os.environ.get('GARAGE_AWS_INSTANCE_TYPE',
                                           'm4.xlarge')


### PR DESCRIPTION
Replaces the default GARAGE_AWS_S3_PATH value with the string
'INVALID_S3_PATH', instead of `None`.

garage.experiment assumes this config always contains a valid string,
so non-AWS experiments can fail if it's not properly set.