### PR TITLE
Remove config_personal_template.py from setups

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -246,9 +246,6 @@ conda activate garage
 }
 conda deactivate
 
-# Copy template of personal configurations so users can set them later
-cp garage/config_personal_template.py garage/config_personal.py
-
 # Add garage to python modules
 
 if [[ "${_arg_modify_bashrc}" != on ]]; then

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -261,9 +261,6 @@ conda activate garage
 }
 conda deactivate
 
-# Copy template of personal configurations so users can set them later
-cp garage/config_personal_template.py garage/config_personal.py
-
 # Add garage to python modules
 if [[ "${_arg_modify_bashrc}" != on ]]; then
   echo -e "\nRemember to execute the following commands before running garage:"


### PR DESCRIPTION
The file config_personal_template.py does not longer exist in the garage
repository because the personal configuration is now set using
environment variables.
Since the file cannot be copied anymore, it has to be removed from the
setup scripts to avoid installation errors.