### PR TITLE
Fixup TensorBoardOutput

### DIFF
--- a/garage/logger/tensor_board_output.py
+++ b/garage/logger/tensor_board_output.py
@@ -50,13 +50,13 @@ class TensorBoardOutput(LogOutput):
         """
         if isinstance(data, TabularInput):
             self._waiting_for_dump.append(
-                functools.partial(self._record_tabular, data, prefix))
+                functools.partial(self._record_tabular, data))
         else:
             raise ValueError('Unacceptable type.')
 
-    def _record_tabular(self, data, prefix, step):
+    def _record_tabular(self, data, step):
         for key, value in data.as_dict.items():
-            self._record_kv(prefix + key, value, step)
+            self._record_kv(key, value, step)
             data.mark(key)
 
     def _record_kv(self, key, value, step):

--- a/tests/garage/logger/test_tensor_board_output.py
+++ b/tests/garage/logger/test_tensor_board_output.py
@@ -86,11 +86,11 @@ class TestTensorBoardOutputMocked(TBOutputTest):
         bar = 10.0
         self.tabular.record('foo', foo)
         self.tabular.record('bar', bar)
-        self.tensor_board_output.record(self.tabular, prefix='a/')
+        self.tensor_board_output.record(self.tabular)
         self.tensor_board_output.dump()
 
-        self.mock_writer.add_scalar.assert_any_call('a/foo', foo, 0)
-        self.mock_writer.add_scalar.assert_any_call('a/bar', bar, 0)
+        self.mock_writer.add_scalar.assert_any_call('foo', foo, 0)
+        self.mock_writer.add_scalar.assert_any_call('bar', bar, 0)
 
     def test_record_tfp_distribution(self):
         histo_shape = np.ones((1000, 10))


### PR DESCRIPTION
TensorBoardOutput currently uses the `prefix` parameter as a key path
prefix for TensorBoard, which is not how prefix is currently used
around the codebase (e.g. in LocalTfRunner).

This produces bad output to TensorBoard (e.g. every epoch in its own
key space)

This PR makes TensorBoardOutput ignore the `prefix` parameter to
record(). In the future, we should figure out if we can unify the
notion of prefixes and key spaces in the logger.