### PR TITLE
Fixup TensorBoardOutput flaws

### DIFF
--- a/garage/experiment/local_tf_runner.py
+++ b/garage/experiment/local_tf_runner.py
@@ -126,6 +126,7 @@ class LocalRunner:
         self.sampler = sampler_cls(algo, env, **sampler_args)
 
         self.initialize_tf_vars()
+        logger.log(self.sess.graph)
         self.has_setup = True
 
     def initialize_tf_vars(self):

--- a/garage/logger/simple_outputs.py
+++ b/garage/logger/simple_outputs.py
@@ -58,8 +58,8 @@ class FileOutput(LogOutput, metaclass=abc.ABCMeta):
 
     def __init__(self, file_name, mode='w'):
         mkdir_p(os.path.dirname(file_name))
-        self._log_file = open(file_name,
-                              mode)  # Open the log file in child class
+        # Open the log file in child class
+        self._log_file = open(file_name, mode)
 
     def close(self):
         """Close any files used by the output."""
@@ -81,7 +81,7 @@ class TextOutput(FileOutput):
     def __init__(self, file_name, with_timestamp=True):
         super().__init__(file_name, 'a')
         self._with_timestamp = with_timestamp
-        self._delimiter = " | "
+        self._delimiter = ' | '
 
     @property
     def types_accepted(self):


### PR DESCRIPTION
* Handle prefixes properly
  The original implementation used the `prefix` argument to record as
  tag prefix. This is not how prefix is used in the codebase

* Fix graph saving
  Somehow tensorboardX doesn't support saving TensorFlow graphs (only
  PyTorch and ONNX), so we add a helper to do this

* Make graphs a first class loggable
  Switches implementation to save TF graphs just like any other object
  passed to `Logger.log()`. Updates `LocalTfRunner` to log graphs by
  default

Fixes #597 #600 