### PR TITLE
Refactor GaussianMLPRegressor to use models

### DIFF
--- a/garage/tf/baselines/__init__.py
+++ b/garage/tf/baselines/__init__.py
@@ -7,8 +7,8 @@ from garage.tf.baselines.gaussian_mlp_baseline_with_model import (
     GaussianMLPBaselineWithModel)
 
 __all__ = [
-    "DeterministicMLPBaseline",
-    "GaussianConvBaseline",
-    "GaussianMLPBaseline",
-    "GaussianMLPBaselineWithModel",
+    'DeterministicMLPBaseline',
+    'GaussianConvBaseline',
+    'GaussianMLPBaseline',
+    'GaussianMLPBaselineWithModel',
 ]

--- a/garage/tf/baselines/__init__.py
+++ b/garage/tf/baselines/__init__.py
@@ -3,9 +3,12 @@ from garage.tf.baselines.deterministic_mlp_baseline import (
     DeterministicMLPBaseline)
 from garage.tf.baselines.gaussian_conv_baseline import GaussianConvBaseline
 from garage.tf.baselines.gaussian_mlp_baseline import GaussianMLPBaseline
+from garage.tf.baselines.gaussian_mlp_baseline_with_model import (
+    GaussianMLPBaselineWithModel)
 
 __all__ = [
     "DeterministicMLPBaseline",
     "GaussianConvBaseline",
     "GaussianMLPBaseline",
+    "GaussianMLPBaselineWithModel",
 ]

--- a/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
@@ -1,0 +1,65 @@
+"""This module implements gaussian mlp baseline."""
+import numpy as np
+
+from garage.misc.overrides import overrides
+from garage.np.baselines import Baseline
+from garage.tf.regressors import GaussianMLPRegressorWithModel
+
+
+class GaussianMLPBaselineWithModel(Baseline):
+    """A value function using gaussian mlp network."""
+
+    def __init__(
+            self,
+            env_spec,
+            subsample_factor=1.,
+            num_seq_inputs=1,
+            regressor_args=None,
+            name="GaussianMLPBaselineWithModel",
+    ):
+        """
+        Constructor.
+
+        :param env_spec:
+        :param subsample_factor:
+        :param num_seq_inputs:
+        :param regressor_args:
+        """
+        super().__init__(env_spec)
+        if regressor_args is None:
+            regressor_args = dict()
+
+        self._regressor = GaussianMLPRegressorWithModel(
+            input_shape=(
+                env_spec.observation_space.flat_dim * num_seq_inputs, ),
+            output_dim=1,
+            name=name,
+            **regressor_args)
+        self.name = name
+
+    @overrides
+    def fit(self, paths):
+        """Fit regressor based on paths."""
+        observations = np.concatenate([p["observations"] for p in paths])
+        returns = np.concatenate([p["returns"] for p in paths])
+        self._regressor.fit(observations, returns.reshape((-1, 1)))
+
+    @overrides
+    def predict(self, path):
+        """Predict value based on paths."""
+        return self._regressor.predict(path["observations"]).flatten()
+
+    @overrides
+    def get_param_values(self, **tags):
+        """Get parameter values."""
+        return self._regressor.get_param_values(**tags)
+
+    @overrides
+    def set_param_values(self, flattened_params, **tags):
+        """Set parameter values to val."""
+        self._regressor.set_param_values(flattened_params, **tags)
+
+    @overrides
+    def get_params_internal(self, **tags):
+        """Get internal parameters."""
+        return self._regressor.get_params_internal(**tags)

--- a/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
@@ -1,4 +1,4 @@
-"""This module implements gaussian mlp baseline."""
+"""A value function (baseline) based on a GaussianMLP model."""
 import numpy as np
 
 from garage.misc.overrides import overrides
@@ -15,7 +15,7 @@ class GaussianMLPBaselineWithModel(Baseline):
             subsample_factor=1.,
             num_seq_inputs=1,
             regressor_args=None,
-            name="GaussianMLPBaselineWithModel",
+            name='GaussianMLPBaselineWithModel',
     ):
         """
         Constructor.
@@ -40,14 +40,14 @@ class GaussianMLPBaselineWithModel(Baseline):
     @overrides
     def fit(self, paths):
         """Fit regressor based on paths."""
-        observations = np.concatenate([p["observations"] for p in paths])
-        returns = np.concatenate([p["returns"] for p in paths])
+        observations = np.concatenate([p['observations'] for p in paths])
+        returns = np.concatenate([p['returns'] for p in paths])
         self._regressor.fit(observations, returns.reshape((-1, 1)))
 
     @overrides
     def predict(self, path):
         """Predict value based on paths."""
-        return self._regressor.predict(path["observations"]).flatten()
+        return self._regressor.predict(path['observations']).flatten()
 
     @overrides
     def get_param_values(self, **tags):

--- a/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
@@ -7,7 +7,7 @@ from garage.tf.regressors import GaussianMLPRegressorWithModel
 
 
 class GaussianMLPBaselineWithModel(Baseline):
-    """A value function using gaussian mlp network."""
+    """A value function using Gaussian MLP network."""
 
     def __init__(
             self,

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,5 +1,9 @@
 from garage.tf.models.base import Model
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
+from garage.tf.models.gaussian_mlp_regressor_model import (
+    GaussianMLPRegressorModel)
 from garage.tf.models.mlp_model import MLPModel
 
-__all__ = ["Model", "GaussianMLPModel", "MLPModel"]
+__all__ = [
+    "Model", "GaussianMLPModel", "GaussianMLPRegressorModel", "MLPModel"
+]

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,9 +1,5 @@
 from garage.tf.models.base import Model
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
-from garage.tf.models.gaussian_mlp_regressor_model import (
-    GaussianMLPRegressorModel)
 from garage.tf.models.mlp_model import MLPModel
 
-__all__ = [
-    "Model", "GaussianMLPModel", "GaussianMLPRegressorModel", "MLPModel"
-]
+__all__ = ['Model', 'GaussianMLPModel', 'MLPModel']

--- a/garage/tf/models/gaussian_mlp_regressor_model.py
+++ b/garage/tf/models/gaussian_mlp_regressor_model.py
@@ -1,0 +1,95 @@
+"""GaussianMLPRegressorModel."""
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.models import GaussianMLPModel
+
+
+class GaussianMLPRegressorModel(GaussianMLPModel):
+    """
+    GaussianMLPRegressorModel.
+
+    Args:
+    :param output_dim: Output dimension of the model.
+    :param name: Name of the model.
+    :param hidden_sizes: List of sizes for the fully-connected hidden
+        layers.
+    :param learn_std: Is std trainable.
+    :param init_std: Initial value for std.
+    :param adaptive_std: Is std a neural network. If False, it will be a
+        parameter.
+    :param std_share_network: Boolean for whether mean and std share the same
+        network.
+    :param std_hidden_sizes: List of sizes for the fully-connected layers
+        for std.
+    :param min_std: Whether to make sure that the std is at least some
+        threshold value, to avoid numerical issues.
+    :param max_std: Whether to make sure that the std is at most some
+        threshold value, to avoid numerical issues.
+    :param std_hidden_nonlinearity: Nonlinearity for each hidden layer in
+        the std network.
+    :param std_output_nonlinearity: Nonlinearity for output layer in
+        the std network.
+    :param std_parametrization: How the std should be parametrized. There
+        are a few options:
+        - exp: the logarithm of the std will be stored, and applied a
+            exponential transformation
+        - softplus: the std will be computed as log(1+exp(x))
+    :param hidden_nonlinearity: Nonlinearity used for each hidden layer.
+    :param output_nonlinearity: Nonlinearity for the output layer.
+    """
+
+    def __init__(self, output_dim, name='GaussianMLPRegressorModel', **kwargs):
+        # Network parameters
+        super().__init__(output_dim=output_dim, name=name, **kwargs)
+
+    def network_output_spec(self):
+        """Network output spec."""
+        return [
+            'sample', 'means', 'log_stds', 'std_param', 'normalized_means',
+            'normalized_log_stds', 'x_mean', 'x_std', 'y_mean', 'y_std', 'dist'
+        ]
+
+    def _build(self, state_input):
+
+        input_shape = tuple(state_input.get_shape().as_list()[1:])
+        with tf.variable_scope('normalized_vars'):
+            x_mean_var = tf.get_variable(
+                name="x_mean",
+                shape=(1, ) + input_shape,
+                dtype=np.float32,
+                initializer=tf.zeros_initializer(),
+                trainable=False)
+            x_std_var = tf.get_variable(
+                name="x_std_var",
+                shape=(1, ) + input_shape,
+                dtype=np.float32,
+                initializer=tf.ones_initializer(),
+                trainable=False)
+            y_mean_var = tf.get_variable(
+                name="y_mean_var",
+                shape=(1, self._output_dim),
+                dtype=np.float32,
+                initializer=tf.zeros_initializer(),
+                trainable=False)
+            y_std_var = tf.get_variable(
+                name="y_std_var",
+                shape=(1, self._output_dim),
+                dtype=np.float32,
+                initializer=tf.ones_initializer(),
+                trainable=False)
+
+        normalized_xs_var = (state_input - x_mean_var) / x_std_var
+
+        sample, normalized_mean, normalized_log_std, std_param, dist = super(
+        )._build(normalized_xs_var)
+
+        with tf.name_scope("mean_network"):
+            means_var = normalized_mean * y_std_var + y_mean_var
+
+        with tf.name_scope("std_network"):
+            log_stds_var = normalized_log_std + tf.log(y_std_var)
+
+        return (sample, means_var, log_stds_var, std_param, normalized_mean,
+                normalized_log_std, x_mean_var, x_std_var, y_mean_var,
+                y_std_var, dist)

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -14,7 +14,7 @@ class Policy2:
     def __init__(self, name, env_spec):
         self._name = name
         self._env_spec = env_spec
-        self._variable_scope = tf.VariableScope(name)
+        self._variable_scope = tf.VariableScope(reuse=False, name=name)
 
     # Should be implemented by all policies
 

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -116,7 +116,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                 elif std_parametrization == 'softplus':
                     init_std_param = np.log(np.exp(init_std) - 1)
                 else:
-                    raise NotImplementedError
+                    raise NotImplementedError('std_parametrization')
                 if adaptive_std:
                     b = tf.constant_initializer(init_std_param)
                     std_network = MLP(

--- a/garage/tf/policies/gaussian_mlp_policy.py
+++ b/garage/tf/policies/gaussian_mlp_policy.py
@@ -116,7 +116,8 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                 elif std_parametrization == 'softplus':
                     init_std_param = np.log(np.exp(init_std) - 1)
                 else:
-                    raise NotImplementedError('std_parametrization')
+                    raise ValueError('Invalid argument for std_parametrization'
+                                     ': {}'.format(std_parametrization))
                 if adaptive_std:
                     b = tf.constant_initializer(init_std_param)
                     std_network = MLP(

--- a/garage/tf/regressors/__init__.py
+++ b/garage/tf/regressors/__init__.py
@@ -1,3 +1,4 @@
+from garage.tf.regressors.base import StochasticRegressor
 from garage.tf.regressors.bernoulli_mlp_regressor import (
     BernoulliMLPRegressor)
 from garage.tf.regressors.categorical_mlp_regressor import (
@@ -6,11 +7,12 @@ from garage.tf.regressors.deterministic_mlp_regressor import (
     DeterministicMLPRegressor)
 from garage.tf.regressors.gaussian_conv_regressor import GaussianConvRegressor
 from garage.tf.regressors.gaussian_mlp_regressor import GaussianMLPRegressor
+from garage.tf.regressors.gaussian_mlp_regressor_with_model import (
+    GaussianMLPRegressorWithModel)
 
 __all__ = [
-    "BernoulliMLPRegressor",
-    "CategoricalMLPRegressor",
-    "DeterministicMLPRegressor",
-    "GaussianMLPRegressor",
-    "GaussianConvRegressor",
+    "BernoulliMLPRegressor", "CategoricalMLPRegressor",
+    "DeterministicMLPRegressor", "GaussianMLPRegressor",
+    "GaussianMLPRegressorWithModel", "GaussianConvRegressor",
+    "StochasticRegressor"
 ]

--- a/garage/tf/regressors/__init__.py
+++ b/garage/tf/regressors/__init__.py
@@ -7,12 +7,14 @@ from garage.tf.regressors.deterministic_mlp_regressor import (
     DeterministicMLPRegressor)
 from garage.tf.regressors.gaussian_conv_regressor import GaussianConvRegressor
 from garage.tf.regressors.gaussian_mlp_regressor import GaussianMLPRegressor
+from garage.tf.regressors.gaussian_mlp_regressor_model import (
+    GaussianMLPRegressorModel)
 from garage.tf.regressors.gaussian_mlp_regressor_with_model import (
     GaussianMLPRegressorWithModel)
 
 __all__ = [
-    "BernoulliMLPRegressor", "CategoricalMLPRegressor",
-    "DeterministicMLPRegressor", "GaussianMLPRegressor",
-    "GaussianMLPRegressorWithModel", "GaussianConvRegressor",
-    "StochasticRegressor"
+    'BernoulliMLPRegressor', 'CategoricalMLPRegressor',
+    'DeterministicMLPRegressor', 'GaussianMLPRegressor',
+    'GaussianMLPRegressorModel', 'GaussianMLPRegressorWithModel',
+    'GaussianConvRegressor', 'StochasticRegressor'
 ]

--- a/garage/tf/regressors/base.py
+++ b/garage/tf/regressors/base.py
@@ -1,0 +1,99 @@
+"""Regressor base classes with Parameterized."""
+import tensorflow as tf
+
+from garage.tf.core import Parameterized
+
+
+class Regressor(Parameterized):
+    """
+    Regressor base class.
+
+    Args:
+        input_shape: Input shape.
+        output_dim: Output dimension.
+        name: Name of the regressor.
+    """
+
+    def __init__(self, input_shape, output_dim, name):
+        Parameterized.__init__(self)
+        self._input_shape = input_shape
+        self._output_dim = output_dim
+        self._name = name
+        self._variable_scope = tf.VariableScope(reuse=False, name=name)
+
+    def fit(self, xs, ys):
+        """
+        Fit with input data xs and label ys.
+
+        Args:
+            xs: Input data.
+            ys: Label of input data.
+        """
+        raise NotImplementedError
+
+    def predict(self, xs):
+        """
+        Predict ys based on input xs.
+
+        Args:
+            xs: Input data.
+        """
+        raise NotImplementedError
+
+    def get_params_internal(self, **tags):
+        """Get trainable vars."""
+        return self._variable_scope.trainable_variables()
+
+
+class StochasticRegressor(Regressor):
+    """
+    StochasticRegressor base class.
+
+    Args:
+        input_shape: Input shape.
+        output_dim: Output dimension.
+        name: Name of the regressor.
+    """
+
+    def __init__(self, input_shape, output_dim, name):
+        super().__init__(input_shape, output_dim, name)
+
+    def sample_predict(self, xs):
+        """
+        Sample one possible output from the prediction distribution.
+
+        Args:
+            xs: Input data.
+        """
+        raise NotImplementedError
+
+    def predict_log_likelihood(self, xs, ys):
+        """
+        Return the maximum likelihood estimate of the predicted y and input ys.
+
+        Args:
+            xs: Input data.
+            ys: Label of input data.
+        """
+        raise NotImplementedError
+
+    def log_likelihood_sym(self, x_var, y_var, name=None):
+        """
+        Symbolic graph of the log likelihood.
+
+        Args:
+            x_var: Input tf.Tensor for the input data.
+            y_var: Input tf.Tensor for the label of data.
+            name: Name of the new graph.
+        """
+        raise NotImplementedError
+
+    def dist_info_sym(self, x_var, name=None):
+        """
+        Symbolic graph of the distribution.
+
+        Args:
+            x_var: Input tf.Tensor for the input data.
+            name: Name of the new graph.
+        """
+        raise NotImplementedError

--- a/garage/tf/regressors/base.py
+++ b/garage/tf/regressors/base.py
@@ -1,10 +1,10 @@
 """Regressor base classes with Parameterized."""
-import tensorflow as tf
+import abc
 
 from garage.tf.core import Parameterized
 
 
-class Regressor(Parameterized):
+class Regressor(Parameterized, abc.ABC):
     """
     Regressor base class.
 
@@ -19,7 +19,7 @@ class Regressor(Parameterized):
         self._input_shape = input_shape
         self._output_dim = output_dim
         self._name = name
-        self._variable_scope = tf.VariableScope(reuse=False, name=name)
+        self._variable_scope = None
 
     def fit(self, xs, ys):
         """

--- a/garage/tf/regressors/base.py
+++ b/garage/tf/regressors/base.py
@@ -58,25 +58,6 @@ class StochasticRegressor(Regressor):
     def __init__(self, input_shape, output_dim, name):
         super().__init__(input_shape, output_dim, name)
 
-    def sample_predict(self, xs):
-        """
-        Sample one possible output from the prediction distribution.
-
-        Args:
-            xs: Input data.
-        """
-        raise NotImplementedError
-
-    def predict_log_likelihood(self, xs, ys):
-        """
-        Return the maximum likelihood estimate of the predicted y and input ys.
-
-        Args:
-            xs: Input data.
-            ys: Label of input data.
-        """
-        raise NotImplementedError
-
     def log_likelihood_sym(self, x_var, y_var, name=None):
         """
         Symbolic graph of the log likelihood.

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -238,7 +238,6 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
                 0, num_samples_tot,
                 int(num_samples_tot * self._subsample_factor))
             xs, ys = xs[idx], ys[idx]
-
         sess = tf.get_default_session()
         if self._normalize_inputs:
             # recompute normalizing constants for inputs

--- a/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -39,9 +39,14 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
     :param output_nonlinearity: Nonlinearity for the output layer.
     """
 
-    def __init__(self, output_dim, name='GaussianMLPRegressorModel', **kwargs):
+    def __init__(self,
+                 input_shape,
+                 output_dim,
+                 name='GaussianMLPRegressorModel',
+                 **kwargs):
         # Network parameters
         super().__init__(output_dim=output_dim, name=name, **kwargs)
+        self._input_shape = input_shape
 
     def network_output_spec(self):
         """Network output spec."""
@@ -51,29 +56,27 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
         ]
 
     def _build(self, state_input):
-
-        input_shape = tuple(state_input.get_shape().as_list()[1:])
         with tf.variable_scope('normalized_vars'):
             x_mean_var = tf.get_variable(
-                name="x_mean",
-                shape=(1, ) + input_shape,
+                name='x_mean',
+                shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
             x_std_var = tf.get_variable(
-                name="x_std_var",
-                shape=(1, ) + input_shape,
+                name='x_std_var',
+                shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.ones_initializer(),
                 trainable=False)
             y_mean_var = tf.get_variable(
-                name="y_mean_var",
+                name='y_mean_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
             y_std_var = tf.get_variable(
-                name="y_std_var",
+                name='y_std_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
                 initializer=tf.ones_initializer(),
@@ -84,10 +87,10 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
         sample, normalized_mean, normalized_log_std, std_param, dist = super(
         )._build(normalized_xs_var)
 
-        with tf.name_scope("mean_network"):
+        with tf.name_scope('mean_network'):
             means_var = normalized_mean * y_std_var + y_mean_var
 
-        with tf.name_scope("std_network"):
+        with tf.name_scope('std_network'):
             log_stds_var = normalized_log_std + tf.log(y_std_var)
 
         return (sample, means_var, log_stds_var, std_param, normalized_mean,

--- a/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -7,7 +7,10 @@ from garage.tf.models import GaussianMLPModel
 
 class GaussianMLPRegressorModel(GaussianMLPModel):
     """
-    GaussianMLPRegressorModel.
+    GaussianMLPRegressor based on garage.tf.models.Model class.
+
+    This class can be used to perform regression by fitting a Gaussian
+    distribution to the outputs.
 
     Args:
     :param output_dim: Output dimension of the model.

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -11,7 +11,7 @@ from garage.tf.regressors import StochasticRegressor
 
 class GaussianMLPRegressorWithModel(StochasticRegressor):
     """
-    GaussianMLPRegressorWithModel.
+    GaussianMLPRegressor with garage.tf.models.GaussianMLPRegressorModel.
 
     A class for performing regression by fitting a Gaussian distribution
     to the outputs.

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -108,7 +108,9 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
             ys_var = tf.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
             old_means_var = tf.placeholder(
-                dtype=tf.float32, name='ys', shape=(None, self._output_dim))
+                dtype=tf.float32,
+                name='old_means',
+                shape=(None, self._output_dim))
             old_log_stds_var = tf.placeholder(
                 dtype=tf.float32,
                 name='old_log_stds',
@@ -218,30 +220,6 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
         """
         return self._f_predict(xs)
 
-    def sample_predict(self, xs):
-        """
-        Sample one possible output from the prediction distribution.
-
-        :param xs:
-        :return:
-
-        """
-        means, log_stds = self._f_pdists(xs)
-        return self.model.networks['default'].dist.sample(
-            dict(mean=means, log_std=log_stds))
-
-    def predict_log_likelihood(self, xs, ys):
-        """
-        Return the maximum likelihood estimate of the predicted y and input ys.
-
-        Args:
-            xs: Input data.
-            ys: Label of input data.
-        """
-        means, log_stds = self._f_pdists(xs)
-        return self.model.networks['default'].dist.log_likelihood(
-            ys, dict(mean=means, log_std=log_stds))
-
     def log_likelihood_sym(self, x_var, y_var, name=None):
         """
         Symbolic graph of the log likelihood.
@@ -254,8 +232,8 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
         with tf.variable_scope(self._variable_scope):
             self.model.build(x_var, name=name)
 
-        means_var = self.model.networks[name].mean
-        log_stds_var = self.model.networks[name].log_std
+        means_var = self.model.networks[name].means
+        log_stds_var = self.model.networks[name].log_stds
 
         return self.model.networks[name].dist.log_likelihood_sym(
             y_var, dict(mean=means_var, log_std=log_stds_var))

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -1,0 +1,263 @@
+"""GaussianMLPRegressorWithModel."""
+import numpy as np
+import tensorflow as tf
+
+from garage.logger import tabular
+from garage.tf.misc import tensor_utils
+from garage.tf.models import GaussianMLPRegressorModel
+from garage.tf.optimizers import LbfgsOptimizer, PenaltyLbfgsOptimizer
+from garage.tf.regressors import StochasticRegressor
+
+
+class GaussianMLPRegressorWithModel(StochasticRegressor):
+    """
+    GaussianMLPRegressorWithModel.
+
+    A class for performing regression by fitting a Gaussian distribution
+    to the outputs.
+
+    :param input_shape: Shape of the input data.
+    :param output_dim: Dimension of output.
+    :param hidden_sizes: Number of hidden units of each layer of the mean
+     network.
+    :param hidden_nonlinearity: Non-linearity used for each layer of the
+     mean network.
+    :param optimizer: Optimizer for minimizing the negative log-likelihood.
+    :param use_trust_region: Whether to use trust region constraint.
+    :param max_kl_step: KL divergence constraint for each iteration
+    :param learn_std: Whether to learn the standard deviations. Only
+     effective if adaptive_std is False. If adaptive_std is True, this
+     parameter is ignored, and the weights for the std network are always
+     earned.
+    :param adaptive_std: Whether to make the std a function of the states.
+    :param std_share_network: Whether to use the same network as the mean.
+    :param std_hidden_sizes: Number of hidden units of each layer of the
+     std network. Only used if `std_share_network` is False. It defaults to
+     the same architecture as the mean.
+    :param std_nonlinearity: Non-linearity used for each layer of the std
+     network. Only used if `std_share_network` is False. It defaults to the
+     same non-linearity as the mean.
+    """
+
+    def __init__(self,
+                 input_shape,
+                 output_dim,
+                 name="GaussianMLPRegressorWithModel",
+                 hidden_sizes=(32, 32),
+                 hidden_nonlinearity=tf.nn.tanh,
+                 optimizer=None,
+                 optimizer_args=None,
+                 use_trust_region=True,
+                 max_kl_step=0.01,
+                 learn_std=True,
+                 init_std=1.0,
+                 adaptive_std=False,
+                 std_share_network=False,
+                 std_hidden_sizes=(32, 32),
+                 std_nonlinearity=None,
+                 layer_normalization=False,
+                 normalize_inputs=True,
+                 normalize_outputs=True,
+                 subsample_factor=1.0):
+        super().__init__(input_shape, output_dim, name)
+        self._use_trust_region = use_trust_region
+        self._subsample_factor = subsample_factor
+        self._max_kl_step = max_kl_step
+        self._normalize_inputs = normalize_inputs
+        self._normalize_outputs = normalize_outputs
+
+        with tf.variable_scope(self._variable_scope):
+            if optimizer_args is None:
+                optimizer_args = dict()
+            if optimizer is None:
+                if use_trust_region:
+                    optimizer = PenaltyLbfgsOptimizer(**optimizer_args)
+                else:
+                    optimizer = LbfgsOptimizer(**optimizer_args)
+            else:
+                optimizer = optimizer(**optimizer_args)
+            self._optimizer = optimizer
+
+        self.model = GaussianMLPRegressorModel(
+            output_dim=self._output_dim,
+            hidden_sizes=hidden_sizes,
+            hidden_nonlinearity=hidden_nonlinearity,
+            output_nonlinearity=None,
+            learn_std=learn_std,
+            adaptive_std=adaptive_std,
+            std_share_network=std_share_network,
+            init_std=init_std,
+            min_std=None,
+            max_std=None,
+            std_hidden_sizes=std_hidden_sizes,
+            std_hidden_nonlinearity=std_nonlinearity,
+            std_output_nonlinearity=None,
+            std_parameterization='exp',
+            layer_normalization=layer_normalization)
+
+        self._initialize()
+
+    def _initialize(self):
+        input_var = tf.placeholder(
+            tf.float32, shape=(None, ) + self._input_shape)
+
+        with tf.variable_scope(self._variable_scope):
+            self.model.build(input_var)
+            ys_var = tf.placeholder(
+                dtype=tf.float32, name="ys", shape=(None, self._output_dim))
+            old_means_var = tf.placeholder(
+                dtype=tf.float32, name="ys", shape=(None, self._output_dim))
+            old_log_stds_var = tf.placeholder(
+                dtype=tf.float32,
+                name="old_log_stds",
+                shape=(None, self._output_dim))
+
+            y_mean_var = self.model.networks['default'].y_mean
+            y_std_var = self.model.networks['default'].y_std
+            means_var = self.model.networks['default'].means
+            log_stds_var = self.model.networks['default'].log_stds
+            normalized_means_var = self.model.networks[
+                'default'].normalized_means
+            normalized_log_stds_var = self.model.networks[
+                'default'].normalized_log_stds
+
+            normalized_ys_var = (ys_var - y_mean_var) / y_std_var
+
+            normalized_old_means_var = (old_means_var - y_mean_var) / y_std_var
+            normalized_old_log_stds_var = old_log_stds_var - tf.log(y_std_var)
+
+            normalized_dist_info_vars = dict(
+                mean=normalized_means_var, log_std=normalized_log_stds_var)
+
+            mean_kl = tf.reduce_mean(
+                self.model.networks['default'].dist.kl_sym(
+                    dict(
+                        mean=normalized_old_means_var,
+                        log_std=normalized_old_log_stds_var),
+                    normalized_dist_info_vars,
+                ))
+
+            loss = -tf.reduce_mean(
+                self.model.networks['default'].dist.log_likelihood_sym(
+                    normalized_ys_var, normalized_dist_info_vars))
+
+            self._f_predict = tensor_utils.compile_function([input_var],
+                                                            means_var)
+            self._f_pdists = tensor_utils.compile_function(
+                [input_var], [means_var, log_stds_var])
+
+            optimizer_args = dict(
+                loss=loss,
+                target=self,
+                network_outputs=[
+                    normalized_means_var, normalized_log_stds_var
+                ],
+            )
+
+            if self._use_trust_region:
+                optimizer_args["leq_constraint"] = (mean_kl, self._max_kl_step)
+                optimizer_args["inputs"] = [
+                    input_var, ys_var, old_means_var, old_log_stds_var
+                ]
+            else:
+                optimizer_args["inputs"] = [input_var, ys_var]
+
+            with tf.name_scope("update_opt"):
+                self._optimizer.update_opt(**optimizer_args)
+
+    def fit(self, xs, ys):
+        """Fit with input data xs and label ys."""
+        if self._subsample_factor < 1:
+            num_samples_tot = xs.shape[0]
+            idx = np.random.randint(
+                0, num_samples_tot,
+                int(num_samples_tot * self._subsample_factor))
+            xs, ys = xs[idx], ys[idx]
+
+        sess = tf.get_default_session()
+        if self._normalize_inputs:
+            # recompute normalizing constants for inputs
+            sess.run([
+                tf.assign(self.model.networks['default'].x_mean,
+                          np.mean(xs, axis=0, keepdims=True)),
+                tf.assign(self.model.networks['default'].x_std,
+                          np.std(xs, axis=0, keepdims=True) + 1e-8),
+            ])
+        if self._normalize_outputs:
+            # recompute normalizing constants for outputs
+            sess.run([
+                tf.assign(self.model.networks['default'].y_mean,
+                          np.mean(ys, axis=0, keepdims=True)),
+                tf.assign(self.model.networks['default'].y_std,
+                          np.std(ys, axis=0, keepdims=True) + 1e-8),
+            ])
+        if self._use_trust_region:
+            old_means, old_log_stds = self._f_pdists(xs)
+            inputs = [xs, ys, old_means, old_log_stds]
+        else:
+            inputs = [xs, ys]
+        loss_before = self._optimizer.loss(inputs)
+        if self._name:
+            prefix = self._name + "/"
+        else:
+            prefix = ""
+        tabular.record(prefix + 'LossBefore', loss_before)
+        self._optimizer.optimize(inputs)
+        loss_after = self._optimizer.loss(inputs)
+        tabular.record(prefix + 'LossAfter', loss_after)
+        if self._use_trust_region:
+            tabular.record(prefix + 'MeanKL',
+                           self._optimizer.constraint_val(inputs))
+        tabular.record(prefix + 'dLoss', loss_before - loss_after)
+
+    def predict(self, xs):
+        """
+        Return the maximum likelihood estimate of the predicted y.
+
+        :param xs:
+        :return:
+
+        """
+        return self._f_predict(xs)
+
+    def sample_predict(self, xs):
+        """
+        Sample one possible output from the prediction distribution.
+
+        :param xs:
+        :return:
+
+        """
+        means, log_stds = self._f_pdists(xs)
+        return self.model.networks['default'].dist.sample(
+            dict(mean=means, log_std=log_stds))
+
+    def predict_log_likelihood(self, xs, ys):
+        """
+        Return the maximum likelihood estimate of the predicted y and input ys.
+
+        Args:
+            xs: Input data.
+            ys: Label of input data.
+        """
+        means, log_stds = self._f_pdists(xs)
+        return self.model.networks['default'].dist.log_likelihood(
+            ys, dict(mean=means, log_std=log_stds))
+
+    def log_likelihood_sym(self, x_var, y_var, name=None):
+        """
+        Symbolic graph of the log likelihood.
+
+        Args:
+            x_var: Input tf.Tensor for the input data.
+            y_var: Input tf.Tensor for the label of data.
+            name: Name of the new graph.
+        """
+        with tf.variable_scope(self._variable_scope):
+            self.model.build(x_var, name=name)
+
+        means_var = self.model.networks[name].mean
+        log_stds_var = self.model.networks[name].log_std
+
+        return self.model.networks[name].dist.log_likelihood_sym(
+            y_var, dict(mean=means_var, log_std=log_stds_var))

--- a/tests/fixtures/regressors/__init__.py
+++ b/tests/fixtures/regressors/__init__.py
@@ -1,0 +1,4 @@
+from tests.fixtures.regressors.simple_gaussian_mlp_regressor import (
+    SimpleGaussianMLPRegressor)
+
+__all__ = ["SimpleGaussianMLPRegressor"]

--- a/tests/fixtures/regressors/__init__.py
+++ b/tests/fixtures/regressors/__init__.py
@@ -1,4 +1,4 @@
 from tests.fixtures.regressors.simple_gaussian_mlp_regressor import (
     SimpleGaussianMLPRegressor)
 
-__all__ = ["SimpleGaussianMLPRegressor"]
+__all__ = ['SimpleGaussianMLPRegressor']

--- a/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
@@ -8,7 +8,7 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
 
     def __init__(self, input_shape, output_dim, name, *args, **kwargs):
         super().__init__(input_shape, output_dim, name)
-        self.param_values = tf.get_variable("{}/params".format(name), [100])
+        self.param_values = tf.get_variable('{}/params'.format(name), [100])
         tf.get_default_session().run(
             tf.variables_initializer([self.param_values]))
         self.ys = None

--- a/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
@@ -1,0 +1,30 @@
+import tensorflow as tf
+
+from garage.tf.regressors import StochasticRegressor
+
+
+class SimpleGaussianMLPRegressor(StochasticRegressor):
+    """Simple GaussianMLPModel for testing."""
+
+    def __init__(self, input_shape, output_dim, name, *args, **kwargs):
+        super().__init__(input_shape, output_dim, name)
+        self.param_values = tf.get_variable("{}/params".format(name), [100])
+        tf.get_default_session().run(
+            tf.variables_initializer([self.param_values]))
+        self.ys = None
+
+    def fit(self, xs, ys):
+        self.ys = ys
+
+    def predict(self, xs):
+        return self.ys
+
+    def get_param_values(self, *args, **kwargs):
+        return tf.get_default_session().run(self.param_values)
+
+    def set_param_values(self, flattened_params, *args, **kwargs):
+        tf.get_default_session().run(
+            tf.assign(self.param_values, flattened_params))
+
+    def get_params_internal(self, *args, **kwargs):
+        return [self.param_values]

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
@@ -44,8 +44,8 @@ class TestGaussianMLPBaseline(TfGraphTestCase):
             new_gmb = GaussianMLPBaselineWithModel(
                 env_spec=box_env.spec, name='GaussianMLPBaselineWithModel2')
         old_param_values = gmb.get_param_values()
-        old_new_param_values = new_gmb.get_param_values()
-        assert not np.array_equal(old_param_values, old_new_param_values)
+        new_param_values = new_gmb.get_param_values()
+        assert not np.array_equal(old_param_values, new_param_values)
         new_gmb.set_param_values(old_param_values)
         new_param_values = new_gmb.get_param_values()
         assert np.array_equal(old_param_values, new_param_values)

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from garage.tf.baselines import GaussianMLPBaselineWithModel
+from garage.tf.envs import TfEnv
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestGaussianMLPBaseline(TfGraphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.box_env = TfEnv(DummyBoxEnv(obs_dim=(2, )))
+        self.gmb = GaussianMLPBaselineWithModel(env_spec=self.box_env.spec)
+
+    def tearDown(self):
+        super().tearDown()
+        self.box_env.close()
+
+    def test_fit(self):
+        obs = [{
+            'observations': [[0, 0]],
+            'returns': [0]
+        }, {
+            'observations': [[1, 1]],
+            'returns': [1]
+        }, {
+            'observations': [[2, 2]],
+            'returns': [2]
+        }]
+
+        for _ in range(100):
+            self.gmb.fit(obs)
+
+        paths = {'observations': [[0, 0], [1, 1], [2, 2]]}
+
+        prediction = self.gmb.predict(paths)
+        assert np.allclose(prediction, [0, 1, 2], rtol=0, atol=1e-3)

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
@@ -9,7 +9,7 @@ from tests.fixtures.envs.dummy import DummyBoxEnv
 class TestGaussianMLPBaseline(TfGraphTestCase):
     def setUp(self):
         super().setUp()
-        self.box_env = TfEnv(DummyBoxEnv(obs_dim=(2, )))
+        self.box_env = TfEnv(DummyBoxEnv(obs_dim=(1, )))
         self.gmb = GaussianMLPBaselineWithModel(env_spec=self.box_env.spec)
 
     def tearDown(self):
@@ -17,21 +17,17 @@ class TestGaussianMLPBaseline(TfGraphTestCase):
         self.box_env.close()
 
     def test_fit(self):
-        obs = [{
-            'observations': [[0, 0]],
-            'returns': [0]
-        }, {
-            'observations': [[1, 1]],
-            'returns': [1]
-        }, {
-            'observations': [[2, 2]],
-            'returns': [2]
-        }]
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
 
         for _ in range(100):
             self.gmb.fit(obs)
 
-        paths = {'observations': [[0, 0], [1, 1], [2, 2]]}
-
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
         prediction = self.gmb.predict(paths)
-        assert np.allclose(prediction, [0, 1, 2], rtol=0, atol=1e-3)
+
+        expected = [0, -1, -0.707, 0, 0.707, 1, 0]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline.py
@@ -1,33 +1,65 @@
+from unittest import mock
+
+from nose2.tools.params import params
 import numpy as np
+import tensorflow as tf
 
 from garage.tf.baselines import GaussianMLPBaselineWithModel
 from garage.tf.envs import TfEnv
 from tests.fixtures import TfGraphTestCase
 from tests.fixtures.envs.dummy import DummyBoxEnv
+from tests.fixtures.regressors import SimpleGaussianMLPRegressor
 
 
 class TestGaussianMLPBaseline(TfGraphTestCase):
-    def setUp(self):
-        super().setUp()
-        self.box_env = TfEnv(DummyBoxEnv(obs_dim=(1, )))
-        self.gmb = GaussianMLPBaselineWithModel(env_spec=self.box_env.spec)
+    @params([1], [2], [1, 1], [2, 2])
+    def test_fit(self, obs_dim):
+        box_env = TfEnv(DummyBoxEnv(obs_dim=obs_dim))
+        with mock.patch(('garage.tf.baselines.'
+                         'gaussian_mlp_baseline_with_model.'
+                         'GaussianMLPRegressorWithModel'),
+                        new=SimpleGaussianMLPRegressor):
+            gmb = GaussianMLPBaselineWithModel(env_spec=box_env.spec)
+        paths = [{
+            'observations': [np.full(obs_dim, 1)],
+            'returns': [1]
+        }, {
+            'observations': [np.full(obs_dim, 2)],
+            'returns': [2]
+        }]
+        gmb.fit(paths)
 
-    def tearDown(self):
-        super().tearDown()
-        self.box_env.close()
+        obs = {'observations': [np.full(obs_dim, 1), np.full(obs_dim, 2)]}
+        prediction = gmb.predict(obs)
+        assert np.array_equal(prediction, [1, 2])
 
-    def test_fit(self):
-        data = np.linspace(-np.pi, np.pi, 1000)
-        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+    @params([1], [2], [1, 1], [2, 2])
+    def test_param_values(self, obs_dim):
+        box_env = TfEnv(DummyBoxEnv(obs_dim=obs_dim))
+        with mock.patch(('garage.tf.baselines.'
+                         'gaussian_mlp_baseline_with_model.'
+                         'GaussianMLPRegressorWithModel'),
+                        new=SimpleGaussianMLPRegressor):
+            gmb = GaussianMLPBaselineWithModel(env_spec=box_env.spec)
+            new_gmb = GaussianMLPBaselineWithModel(
+                env_spec=box_env.spec, name='GaussianMLPBaselineWithModel2')
+        old_param_values = gmb.get_param_values()
+        old_new_param_values = new_gmb.get_param_values()
+        assert not np.array_equal(old_param_values, old_new_param_values)
+        new_gmb.set_param_values(old_param_values)
+        new_param_values = new_gmb.get_param_values()
+        assert np.array_equal(old_param_values, new_param_values)
 
-        for _ in range(100):
-            self.gmb.fit(obs)
-
-        paths = {
-            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
-                             [np.pi / 4], [np.pi / 2], [np.pi]]
-        }
-        prediction = self.gmb.predict(paths)
-
-        expected = [0, -1, -0.707, 0, 0.707, 1, 0]
-        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+    @params([1], [2], [1, 1], [2, 2])
+    def test_get_params_internal(self, obs_dim):
+        box_env = TfEnv(DummyBoxEnv(obs_dim=obs_dim))
+        with mock.patch(('garage.tf.baselines.'
+                         'gaussian_mlp_baseline_with_model.'
+                         'GaussianMLPRegressorWithModel'),
+                        new=SimpleGaussianMLPRegressor):
+            gmb = GaussianMLPBaselineWithModel(
+                env_spec=box_env.spec, regressor_args=dict())
+        params_interal = gmb.get_params_internal()
+        trainable_params = tf.trainable_variables(
+            scope='GaussianMLPBaselineWithModel')
+        assert np.array_equal(params_interal, trainable_params)

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
@@ -1,0 +1,103 @@
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.optimizers import PenaltyLbfgsOptimizer
+from garage.tf.regressors import GaussianMLPRegressorWithModel
+from tests.fixtures import TfGraphTestCase
+
+
+class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
+    def test_fit(self):
+        gmr = GaussianMLPRegressorWithModel(input_shape=(1, ), output_dim=1)
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        for _ in range(100):
+            gmr.fit(observations, returns.reshape((-1, 1)))
+
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
+
+        prediction = gmr.predict(paths['observations'])
+
+        expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+    def test_fit_custom(self):
+        gmr = GaussianMLPRegressorWithModel(
+            input_shape=(1, ),
+            output_dim=1,
+            subsample_factor=0.9,
+            normalize_inputs=False,
+            normalize_outputs=False)
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        for _ in range(100):
+            gmr.fit(observations, returns.reshape((-1, 1)))
+
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
+
+        prediction = gmr.predict(paths['observations'])
+
+        expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+    def test_fit_without_trusted_region(self):
+        gmr = GaussianMLPRegressorWithModel(
+            input_shape=(1, ), output_dim=1, use_trust_region=False)
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        for _ in range(100):
+            gmr.fit(observations, returns.reshape((-1, 1)))
+
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
+
+        prediction = gmr.predict(paths['observations'])
+
+        expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+    @params((1, (1, )), (1, (2, )), (2, (3, )), (2, (1, 1)), (3, (2, 2)))
+    def test_log_likelihood_sym(self, output_dim, input_shape):
+        gmr = GaussianMLPRegressorWithModel(
+            input_shape=input_shape,
+            output_dim=output_dim,
+            optimizer=PenaltyLbfgsOptimizer,
+            optimizer_args=dict())
+
+        new_input_var = tf.placeholder(
+            tf.float32, shape=(None, ) + input_shape)
+        new_ys_var = tf.placeholder(
+            dtype=tf.float32, name='ys', shape=(None, output_dim))
+
+        data = np.random.random(size=input_shape)
+        label = np.ones(output_dim)
+
+        outputs = gmr.log_likelihood_sym(
+            new_input_var, new_ys_var, name='ll_sym')
+        ll_from_sym = self.sess.run(
+            outputs, feed_dict={
+                new_input_var: [data],
+                new_ys_var: [label]
+            })
+        mean, log_std = gmr._f_pdists([data])
+        ll = gmr.model.networks['default'].dist.log_likelihood(
+            [label], dict(mean=mean, log_std=log_std))
+        assert np.allclose(ll, ll_from_sym, rtol=0, atol=1e-5)

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
@@ -8,14 +8,56 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
-    def test_fit(self):
+    def test_fit_normalized(self):
         gmr = GaussianMLPRegressorWithModel(input_shape=(1, ), output_dim=1)
         data = np.linspace(-np.pi, np.pi, 1000)
         obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
 
         observations = np.concatenate([p['observations'] for p in obs])
         returns = np.concatenate([p['returns'] for p in obs])
-        for _ in range(100):
+        returns = returns.reshape((-1, 1))
+        for _ in range(150):
+            gmr.fit(observations, returns)
+
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
+
+        prediction = gmr.predict(paths['observations'])
+
+        expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+        x_mean = self.sess.run(gmr.model.networks['default'].x_mean)
+        x_mean_expected = np.mean(observations, axis=0, keepdims=True)
+        x_std = self.sess.run(gmr.model.networks['default'].x_std)
+        x_std_expected = np.std(observations, axis=0, keepdims=True)
+
+        assert np.allclose(x_mean, x_mean_expected)
+        assert np.allclose(x_std, x_std_expected)
+
+        y_mean = self.sess.run(gmr.model.networks['default'].y_mean)
+        y_mean_expected = np.mean(returns, axis=0, keepdims=True)
+        y_std = self.sess.run(gmr.model.networks['default'].y_std)
+        y_std_expected = np.std(returns, axis=0, keepdims=True)
+
+        assert np.allclose(y_mean, y_mean_expected)
+        assert np.allclose(y_std, y_std_expected)
+
+    def test_fit_unnormalized(self):
+        gmr = GaussianMLPRegressorWithModel(
+            input_shape=(1, ),
+            output_dim=1,
+            subsample_factor=0.9,
+            normalize_inputs=False,
+            normalize_outputs=False)
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        for _ in range(150):
             gmr.fit(observations, returns.reshape((-1, 1)))
 
         paths = {
@@ -28,19 +70,30 @@ class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
         expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-    def test_fit_custom(self):
+        x_mean = self.sess.run(gmr.model.networks['default'].x_mean)
+        x_mean_expected = np.zeros_like(x_mean)
+        x_std = self.sess.run(gmr.model.networks['default'].x_std)
+        x_std_expected = np.ones_like(x_std)
+        assert np.array_equal(x_mean, x_mean_expected)
+        assert np.array_equal(x_std, x_std_expected)
+
+        y_mean = self.sess.run(gmr.model.networks['default'].y_mean)
+        y_mean_expected = np.zeros_like(y_mean)
+        y_std = self.sess.run(gmr.model.networks['default'].y_std)
+        y_std_expected = np.ones_like(y_std)
+
+        assert np.allclose(y_mean, y_mean_expected)
+        assert np.allclose(y_std, y_std_expected)
+
+    def test_fit_smaller_subsample_factor(self):
         gmr = GaussianMLPRegressorWithModel(
-            input_shape=(1, ),
-            output_dim=1,
-            subsample_factor=0.9,
-            normalize_inputs=False,
-            normalize_outputs=False)
+            input_shape=(1, ), output_dim=1, subsample_factor=0.9)
         data = np.linspace(-np.pi, np.pi, 1000)
         obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
 
         observations = np.concatenate([p['observations'] for p in obs])
         returns = np.concatenate([p['returns'] for p in obs])
-        for _ in range(100):
+        for _ in range(150):
             gmr.fit(observations, returns.reshape((-1, 1)))
 
         paths = {
@@ -61,7 +114,7 @@ class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
 
         observations = np.concatenate([p['observations'] for p in obs])
         returns = np.concatenate([p['returns'] for p in obs])
-        for _ in range(100):
+        for _ in range(150):
             gmr.fit(observations, returns.reshape((-1, 1)))
 
         paths = {


### PR DESCRIPTION
New class GaussianMLPRegressorWithModel which does the following:
* Remove Serializable
* It contains a GaussianMLPRegressorModel which inherits from
  GaussianMLPModel