### PR TITLE
Use scipy.stats distribution types in the logger

### DIFF
--- a/garage/logger/__init__.py
+++ b/garage/logger/__init__.py
@@ -2,6 +2,7 @@
 
 This module instantiates a global logger singleton.
 """
+from garage.logger.histogram import Histogram
 from garage.logger.logger import Logger, LogOutput
 from garage.logger.simple_outputs import StdOutput, TextOutput
 from garage.logger.tabular_input import TabularInput
@@ -14,7 +15,7 @@ tabular = TabularInput()
 snapshotter = Snapshotter()
 
 __all__ = [
-    'Logger', 'CsvOutput', 'StdOutput', 'TextOutput', 'LogOutput',
+    'Histogram', 'Logger', 'CsvOutput', 'StdOutput', 'TextOutput', 'LogOutput',
     'Snapshotter', 'TabularInput', 'TensorBoardOutput', 'logger', 'tabular',
     'snapshotter'
 ]

--- a/garage/logger/histogram.py
+++ b/garage/logger/histogram.py
@@ -1,0 +1,21 @@
+"""Histogram logger input."""
+import numpy as np
+
+
+class Histogram(np.ndarray):
+    """A `garage.logger` input representing a histogram of raw data.
+
+    This is implemented as a typed view of a numpy array. It will accept
+    input that `numpy.asarray` will.
+
+    See https://docs.scipy.org/doc/numpy/user/basics.subclassing.html for
+    details on implementation.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        """Reimplement `numpy.ndarray.__new__`.
+
+        Creates objects of this class using `numpy.asarray`, then view-casts
+        them back into the class `Histogram`.
+        """
+        return np.asarray(*args, **kwargs).view(cls)


### PR DESCRIPTION
Replaces tensorflow_probability types used in TensorBoardOutput with
equivalent types from scipy.stats. Also adds a simple mechanism for
logging histograms of raw samples called `garage.logger.Histogram`.

The origin of this PR is a critical performance implication of using
tensorflow_probability types to represent distributions. In practice,
algorithms will need to create a new tfp.Distribution object every time
they log a distribution value. The logger cannot evaluate most ops in
the algorithm's TF graph, because they require a feed_dict to evalaute.

To get around this, most people would just construct a new Distribution
op with their concrete data:
```python
with tf.name_scope('logging'):
    dist = tfp.distributions.MultivariateNormalDiag(
        loc=means, scale_diag=stds)

tabular.record('Normal', dist)
```

Unfortunately, this modified the TF graph which is slow. Repeated
modifications to the graph appear make the runtime of `tf.Session.run`
scale quadratically in the number of modifications. This slows
algorithms to a crawl in a few hundred iterations.

I expect this situation might be fixed in TF 2.0, but for now it is
safest to remove this feature from the logger and use scipy.stats,
which provides just as much expressiveness.