### PR TITLE
Use GaussianMLPPolicyWithModel for PPO

### DIFF
--- a/garage/experiment/local_tf_runner.py
+++ b/garage/experiment/local_tf_runner.py
@@ -261,6 +261,5 @@ class LocalRunner:
                 self.log_diagnostics(pause_for_plot)
                 logger.dump_all(itr)
                 tabular.clear()
-
         self.shutdown_worker()
         return last_return

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -37,7 +37,7 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
 
     def __init__(self,
                  env_spec,
-                 name='GaussianMLPPolicy',
+                 name='GaussianMLPPolicyWithModel',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.tanh,
                  output_nonlinearity=None,
@@ -58,7 +58,7 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
         self.action_dim = env_spec.action_space.flat_dim
 
         self.model = GaussianMLPModel(
-            name=name,
+            name='GaussianMLPModel',
             output_dim=self.action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
@@ -101,8 +101,6 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
         with tf.variable_scope(self._variable_scope):
             _, mean_var, log_std_var, _, _ = self.model.build(
                 obs_var, name=name)
-        mean_var = tf.reshape(mean_var, self.action_space.shape)
-        log_std_var = tf.reshape(log_std_var, self.action_space.shape)
         return dict(mean=mean_var, log_std=log_std_var)
 
     def get_action(self, observation):

--- a/tests/garage/tf/algos/test_ppo_with_model.py
+++ b/tests/garage/tf/algos/test_ppo_with_model.py
@@ -1,0 +1,45 @@
+"""
+This script creates a test that fails when garage.tf.algos.PPO performance is
+too low.
+"""
+import gym
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.experiment import LocalRunner
+from garage.tf.algos import PPO
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicyWithModel
+from tests.fixtures import TfGraphTestCase
+
+
+class TestPPOWithModel(TfGraphTestCase):
+    def test_ppo_pendulum_with_model(self):
+        """Test PPO with model, with Pendulum environment."""
+        with LocalRunner(self.sess) as runner:
+            env = TfEnv(normalize(gym.make("InvertedDoublePendulum-v2")))
+            policy = GaussianMLPPolicyWithModel(
+                env_spec=env.spec,
+                hidden_sizes=(64, 64),
+                hidden_nonlinearity=tf.nn.tanh,
+                output_nonlinearity=None,
+            )
+            baseline = GaussianMLPBaseline(
+                env_spec=env.spec,
+                regressor_args=dict(hidden_sizes=(32, 32)),
+            )
+            algo = PPO(
+                env_spec=env.spec,
+                policy=policy,
+                baseline=baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+            )
+            runner.setup(algo, env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 30
+
+            env.close()

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -190,10 +190,19 @@ class TestGaussianMLPModel(TfGraphTestCase):
             hidden_w_init=tf.ones_initializer(),
             output_w_init=tf.ones_initializer())
         outputs = model.build(input_var)
+
+        # get output bias
+        with tf.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.get_variable('dist_params/mean_std_network/output/bias')
+        # assign it to all ones
+        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
+
+        h = pickle.dumps(model)
         with tf.Session(graph=tf.Graph()) as sess:
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
-            model_pickled = pickle.loads(pickle.dumps(model))
+            model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
@@ -215,10 +224,19 @@ class TestGaussianMLPModel(TfGraphTestCase):
             hidden_w_init=tf.ones_initializer(),
             output_w_init=tf.ones_initializer())
         outputs = model.build(input_var)
+
+        # get output bias
+        with tf.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        # assign it to all ones
+        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
+
+        h = pickle.dumps(model)
         with tf.Session(graph=tf.Graph()) as sess:
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
-            model_pickled = pickle.loads(pickle.dumps(model))
+            model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
             assert np.array_equal(output1, output2)
@@ -243,10 +261,18 @@ class TestGaussianMLPModel(TfGraphTestCase):
             std_hidden_w_init=tf.ones_initializer(),
             std_output_w_init=tf.ones_initializer())
         outputs = model.build(input_var)
+
+        # get output bias
+        with tf.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        # assign it to all ones
+        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+
+        h = pickle.dumps(model)
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
         with tf.Session(graph=tf.Graph()) as sess:
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
-            model_pickled = pickle.loads(pickle.dumps(model))
+            model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
             assert np.array_equal(output1, output2)
@@ -274,7 +300,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
         expected_mean = np.full([1, output_dim], 5 * np.prod(hidden_sizes))
         expected_std_param = np.full([1, output_dim], np.log(np.exp(2) - 1))
-        expected_log_std = np.log(1. + np.exp(expected_std_param))
+        expected_log_std = np.log(np.log(1. + np.exp(expected_std_param)))
         assert np.array_equal(mean, expected_mean)
         assert np.allclose(std_param, expected_std_param)
         assert np.allclose(log_std, expected_log_std)
@@ -298,7 +324,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
             outputs[:-1], feed_dict={self.input_var: self.obs})
 
         expected_log_std = np.full([1, output_dim], np.log(10))
-        expected_std_param = np.full([1, output_dim], np.log(1))
+        expected_std_param = np.full([1, output_dim], np.log(10))
         assert np.allclose(log_std, expected_log_std)
         assert np.allclose(std_param, expected_std_param)
 
@@ -318,7 +344,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
             outputs[:-1], feed_dict={self.input_var: self.obs})
 
         expected_log_std = np.full([1, output_dim], np.log(1))
-        expected_std_param = np.full([1, output_dim], np.log(10))
+        expected_std_param = np.full([1, output_dim], np.log(1))
         assert np.allclose(log_std, expected_log_std)
         assert np.allclose(std_param, expected_std_param)
 
@@ -337,8 +363,8 @@ class TestGaussianMLPModel(TfGraphTestCase):
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self.input_var: self.obs})
 
-        expected_log_std = np.full([1, output_dim], np.log(np.exp(10) - 1))
-        expected_std_param = np.full([1, output_dim], np.log(np.exp(1) - 1))
+        expected_log_std = np.full([1, output_dim], np.log(10))
+        expected_std_param = np.full([1, output_dim], np.log(np.exp(10) - 1))
 
         assert np.allclose(log_std, expected_log_std)
         assert np.allclose(std_param, expected_std_param)
@@ -358,8 +384,8 @@ class TestGaussianMLPModel(TfGraphTestCase):
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self.input_var: self.obs})
 
-        expected_log_std = np.full([1, output_dim], np.log(np.exp(1) - 1))
-        expected_std_param = np.full([1, output_dim], np.log(np.exp(10) - 1))
+        expected_log_std = np.full([1, output_dim], np.log(1))
+        expected_std_param = np.full([1, output_dim], np.log(np.exp(1) - 1))
 
         assert np.allclose(log_std, expected_log_std)
         assert np.allclose(std_param, expected_std_param)

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -73,8 +73,9 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
 
         dist1_sym = policy.dist_info_sym(obs_ph, name='p1_sym')
 
-        expected_mean = np.full(action_dim, 0.5)
-        expected_log_std = np.full(action_dim, 0.5)
+        # flatten output
+        expected_mean = [np.full(np.prod(action_dim), 0.5)]
+        expected_log_std = [np.full(np.prod(action_dim), 0.5)]
 
         prob = self.sess.run(dist1_sym, feed_dict={obs_ph: [obs.flatten()]})
 

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model_transit.py
@@ -1,0 +1,181 @@
+"""
+Unit test for GaussianMLPPolicyWithModel.
+
+This test consists of four different GaussianMLPPolicy: P1, P2, P3
+and P4. P1 and P2 are from GaussianMLPPolicy, which does not use
+garage.tf.models.GaussianMLPModel while P3 and P4 do use.
+
+This test ensures the outputs from all the policies are the same,
+for the transition from using GaussianMLPPolicy to
+GaussianMLPPolicyWithModel.
+
+It covers get_action, get_actions, dist_info_sym, kl_sym,
+log_likelihood_sym, entropy_sym and likelihood_ratio_sym.
+"""
+from unittest import mock
+
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.envs import TfEnv
+from garage.tf.misc import tensor_utils
+from garage.tf.policies import GaussianMLPPolicy
+from garage.tf.policies import GaussianMLPPolicyWithModel
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestGaussianMLPPolicyWithModelTransit(TfGraphTestCase):
+    @mock.patch('tensorflow.random.normal')
+    def setUp(self, mock_rand):
+        mock_rand.return_value = 0.5
+        super().setUp()
+        self.box_env = TfEnv(DummyBoxEnv())
+        self.policy1 = GaussianMLPPolicy(
+            env_spec=self.box_env, init_std=1.0, name='P1')
+        self.policy2 = GaussianMLPPolicy(
+            env_spec=self.box_env, init_std=1.2, name='P2')
+        self.policy3 = GaussianMLPPolicyWithModel(
+            env_spec=self.box_env, init_std=1.0, name='P3')
+        self.policy4 = GaussianMLPPolicyWithModel(
+            env_spec=self.box_env, init_std=1.2, name='P4')
+
+        self.sess.run(tf.global_variables_initializer())
+
+        for a, b in zip(self.policy3.get_params(), self.policy1.get_params()):
+            self.sess.run(tf.assign(b, a))
+        for a, b in zip(self.policy4.get_params(), self.policy2.get_params()):
+            self.sess.run(tf.assign(b, a))
+
+        self.obs = [self.box_env.reset()]
+        self.obs_ph = tf.placeholder(
+            tf.float32, shape=(None, self.box_env.observation_space.flat_dim))
+        self.action_ph = tf.placeholder(
+            tf.float32, shape=(None, self.box_env.action_space.flat_dim))
+
+        self.dist1_sym = self.policy1.dist_info_sym(self.obs_ph, name='p1_sym')
+        self.dist2_sym = self.policy2.dist_info_sym(self.obs_ph, name='p2_sym')
+        self.dist3_sym = self.policy3.dist_info_sym(self.obs_ph, name='p3_sym')
+        self.dist4_sym = self.policy4.dist_info_sym(self.obs_ph, name='p4_sym')
+
+        assert self.policy1.vectorized == self.policy2.vectorized
+        assert self.policy3.vectorized == self.policy4.vectorized
+
+    def test_dist_info_sym_output(self):
+        dist1 = self.sess.run(
+            self.dist1_sym, feed_dict={self.obs_ph: self.obs})
+        dist2 = self.sess.run(
+            self.dist2_sym, feed_dict={self.obs_ph: self.obs})
+        dist3 = self.sess.run(
+            self.dist3_sym, feed_dict={self.obs_ph: self.obs})
+        dist4 = self.sess.run(
+            self.dist4_sym, feed_dict={self.obs_ph: self.obs})
+
+        assert np.array_equal(dist1['mean'], dist3['mean'])
+        assert np.array_equal(dist1['log_std'], dist3['log_std'])
+        assert np.array_equal(dist2['mean'], dist4['mean'])
+        assert np.array_equal(dist2['log_std'], dist4['log_std'])
+
+    @mock.patch('numpy.random.normal')
+    def test_get_action(self, mock_rand):
+        mock_rand.return_value = 0.5
+        action1, _ = self.policy1.get_action(self.obs)
+        action2, _ = self.policy2.get_action(self.obs)
+        action3, _ = self.policy3.get_action(self.obs)
+        action4, _ = self.policy4.get_action(self.obs)
+
+        assert np.array_equal(action1, action3)
+        assert np.array_equal(action2, action4)
+
+        actions1, dist_info1 = self.policy1.get_actions([self.obs])
+        actions2, dist_info2 = self.policy2.get_actions([self.obs])
+        actions3, dist_info3 = self.policy3.get_actions([self.obs])
+        actions4, dist_info4 = self.policy4.get_actions([self.obs])
+
+        assert np.array_equal(actions1, actions3)
+        assert np.array_equal(actions2, actions4)
+
+        assert np.array_equal(dist_info1['mean'], dist_info3['mean'])
+        assert np.array_equal(dist_info1['log_std'], dist_info3['log_std'])
+        assert np.array_equal(dist_info2['mean'], dist_info4['mean'])
+        assert np.array_equal(dist_info2['log_std'], dist_info4['log_std'])
+
+    def test_kl_sym(self):
+        kl_diff_sym1 = self.policy1.distribution.kl_sym(
+            self.dist1_sym, self.dist2_sym)
+        objective1 = tf.reduce_mean(kl_diff_sym1)
+
+        kl_func = tensor_utils.compile_function([self.obs_ph], objective1)
+        kl1 = kl_func(self.obs, self.obs)
+
+        kl_diff_sym2 = self.policy3.distribution.kl_sym(
+            self.dist3_sym, self.dist4_sym)
+        objective2 = tf.reduce_mean(kl_diff_sym2)
+
+        kl_func = tensor_utils.compile_function([self.obs_ph], objective2)
+        kl2 = kl_func(self.obs, self.obs)
+
+        assert np.array_equal(kl1, kl2)
+        self.assertAlmostEqual(kl1, kl2)
+
+    def test_log_likehihood_sym(self):
+        log_prob_sym1 = self.policy1.distribution.log_likelihood_sym(
+            self.action_ph, self.dist1_sym)
+        log_prob_func = tensor_utils.compile_function(
+            [self.obs_ph, self.action_ph], log_prob_sym1)
+        log_prob1 = log_prob_func(self.obs, [[1, 1]])
+
+        log_prob_sym2 = self.policy3.model.networks[
+            'default'].dist.log_likelihood_sym(self.action_ph, self.dist3_sym)
+        log_prob_func2 = tensor_utils.compile_function(
+            [self.obs_ph, self.action_ph], log_prob_sym2)
+        log_prob2 = log_prob_func2(self.obs, [[1, 1]])
+        assert log_prob1 == log_prob2
+
+        log_prob_sym1 = self.policy2.distribution.log_likelihood_sym(
+            self.action_ph, self.dist2_sym)
+        log_prob_func = tensor_utils.compile_function(
+            [self.obs_ph, self.action_ph], log_prob_sym1)
+        log_prob1 = log_prob_func(self.obs, [[1, 1]])
+
+        log_prob_sym2 = self.policy4.model.networks[
+            'default'].dist.log_likelihood_sym(self.action_ph, self.dist4_sym)
+        log_prob_func2 = tensor_utils.compile_function(
+            [self.obs_ph, self.action_ph], log_prob_sym2)
+        log_prob2 = log_prob_func2(self.obs, [[1, 1]])
+        assert log_prob1 == log_prob2
+
+    def test_policy_entropy_sym(self):
+        entropy_sym1 = self.policy1.distribution.entropy_sym(
+            self.dist1_sym, name='entropy_sym1')
+        entropy_func = tensor_utils.compile_function([self.obs_ph],
+                                                     entropy_sym1)
+        entropy1 = entropy_func(self.obs)
+
+        entropy_sym2 = self.policy3.distribution.entropy_sym(
+            self.dist3_sym, name='entropy_sym1')
+        entropy_func = tensor_utils.compile_function([self.obs_ph],
+                                                     entropy_sym2)
+        entropy2 = entropy_func(self.obs)
+        assert entropy1 == entropy2
+
+    def test_likelihood_ratio_sym(self):
+        likelihood_ratio_sym1 = self.policy1.distribution.likelihood_ratio_sym(
+            self.action_ph,
+            self.dist1_sym,
+            self.dist2_sym,
+            name='li_ratio_sym1')
+        likelihood_ratio_func = tensor_utils.compile_function(
+            [self.action_ph, self.obs_ph], likelihood_ratio_sym1)
+        likelihood_ratio1 = likelihood_ratio_func([[1, 1]], self.obs)
+
+        likelihood_ratio_sym2 = self.policy3.distribution.likelihood_ratio_sym(
+            self.action_ph,
+            self.dist3_sym,
+            self.dist4_sym,
+            name='li_ratio_sym2')
+        likelihood_ratio_func = tensor_utils.compile_function(
+            [self.action_ph, self.obs_ph], likelihood_ratio_sym2)
+        likelihood_ratio2 = likelihood_ratio_func([[1, 1]], self.obs)
+
+        assert likelihood_ratio1 == likelihood_ratio2


### PR DESCRIPTION
This PR does the following:
- Fix some detail in `GaussianMLPModel` to follow what's implemented in `GaussianMLPPolicy`, and the tests accordingly.
- Add test for the transition from `GaussianMLPPolicy` to `GaussianMLPPolicyWithModel`.
- Replace `GaussianMLPPolicy` to `GaussianMLPPolicyWithModel` on `PPO`.