### PR TITLE
update links in jupyter notebooks to point to rlworkgroup instead of …

### DIFF
--- a/examples/jupyter/custom_env.ipynb
+++ b/examples/jupyter/custom_env.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/shadiakiki1986/garage/blob/shadi-example_jupyter/examples/jupyter/custom_env.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/custom_env.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -73,10 +73,7 @@
         "echo \"abcd\" > mujoco_fake_key\n",
         "\n",
         "\n",
-        "# FIXME should be udpated to \"rlworkgroup\" once PR is merged\n",
-        "# https://github.com/rlworkgroup/garage/pull/476\n",
-        "# git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
-        "git clone --branch shadi-example_jupyter --depth 1 https://github.com/shadiakiki1986/garage.git\n",
+        "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
         "\n",
         "cd garage\n",
         "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"

--- a/examples/jupyter/trpo_gym_tf_cartpole.ipynb
+++ b/examples/jupyter/trpo_gym_tf_cartpole.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/shadiakiki1986/garage/blob/shadi-example_jupyter/examples/jupyter/trpo_gym_tf_cartpole.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/trpo_gym_tf_cartpole.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -65,10 +65,7 @@
         "echo \"abcd\" > mujoco_fake_key\n",
         "\n",
         "\n",
-        "# FIXME should be udpated to \"rlworkgroup\" once PR is merged\n",
-        "# https://github.com/rlworkgroup/garage/pull/476\n",
-        "# git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
-        "git clone --branch shadi-example_jupyter --depth 1 https://github.com/shadiakiki1986/garage.git\n",
+        "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
         "\n",
         "cd garage\n",
         "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"


### PR DESCRIPTION
…the forked repository

This is a follow-up PR after [PR#476](https://github.com/rlworkgroup/garage/pull/476) which was merged yesterday. Now that the `setup_colab.sh` file is merged into the upstream repository, the jupyter notebooks can be updated to point to the original upstream instead of the fork.