### PR TITLE
CategoricalConvPolicy with model

### DIFF
--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -1,4 +1,4 @@
-"""CNN model in TensorFlow."""
+"""CNN in TensorFlow."""
 
 import tensorflow as tf
 
@@ -13,15 +13,23 @@ def cnn(input_var,
         hidden_w_init=tf.glorot_uniform_initializer(),
         hidden_b_init=tf.zeros_initializer()):
     """
-    CNN model. Based on 'NHWC' data format: [batch, height, width, channel].
+    CNN. Based on 'NHWC' data format: [batch, height, width, channel].
 
     Args:
         input_var: Input tf.Tensor to the CNN.
-        filter_dims: Dimension of the filters.
-        num_filters: Number of filters.
-        strides: The stride of the sliding window.
+        filter_dims(tuple[int]): Dimension of the filters. For example,
+            (3, 5) means there are two convolutional layers. The filter for
+            first layer is of dimension (3 x 3) and the second one is of
+            dimension (5 x 5).
+        num_filters(tuple[int]): Number of filters. For example, (3, 32) means
+            there are two convolutional layers. The filter for the first layer
+            has 3 channels and the second one with 32 channels.
+        strides(tuple[int]): The stride of the sliding window. For example,
+            (1, 2) means there are two convolutional layers. The stride of the
+            filter for first layer is 1 and that of the second layer is 2.
         name: Variable scope of the cnn.
-        padding: The type of padding algorithm to use, from "SAME", "VALID".
+        padding: The type of padding algorithm to use,
+            either 'SAME' or 'VALID'.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         hidden_w_init: Initializer function for the weight

--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -30,12 +30,15 @@ def cnn(input_var,
         name (str): Network name, also the variable scope.
         padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
 
     Return:
         The output tf.Tensor of the CNN.
@@ -90,12 +93,15 @@ def cnn_with_max_pooling(input_var,
             strides (2, 2).
         padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
 
     Return:
         The output tf.Tensor of the CNN.

--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -71,13 +71,25 @@ def cnn_with_max_pooling(input_var,
     Args:
         input_var: Input tf.Tensor to the CNN.
         output_dim: Dimension of the network output.
-        filter_dims: Dimension of the filters.
-        num_filters: Number of filters.
-        strides: The strides of the sliding window.
+        filter_dims(tuple[int]): Dimension of the filters. For example,
+            (3, 5) means there are two convolutional layers. The filter for
+            first layer is of dimension (3 x 3) and the second one is of
+            dimension (5 x 5).
+        num_filters(tuple[int]): Number of filters. For example, (3, 32) means
+            there are two convolutional layers. The filter for the first layer
+            has 3 channels and the second one with 32 channels.
+        strides(tuple[int]): The stride of the sliding window. For example,
+            (1, 2) means there are two convolutional layers. The stride of the
+            filter for first layer is 1 and that of the second layer is 2.
         name: Variable scope of the cnn.
-        pool_shapes: Dimension of the pooling layer(s).
-        pool_strides: The strides of the pooling layer(s).
-        padding: The type of padding algorithm to use, from "SAME", "VALID".
+        pool_shapes(tuple[int]): Dimension of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers have
+            shape (2, 2).
+        pool_strides(tuple[int]): The strides of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers have
+            strides (2, 2).
+        padding: The type of padding algorithm to use,
+            either 'SAME' or 'VALID'.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         hidden_w_init: Initializer function for the weight

--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -32,8 +32,6 @@ def cnn(input_var,
     Return:
         The output tf.Tensor of the CNN.
     """
-    if padding not in ['SAME', 'VALID']:
-        raise ValueError("Invalid padding: {}.".format(padding))
     with tf.variable_scope(name):
         h = input_var
         for index, (filter_dim, num_filter, stride) in enumerate(
@@ -82,8 +80,6 @@ def cnn_with_max_pooling(input_var,
     Return:
         The output tf.Tensor of the CNN.
     """
-    if padding not in ['SAME', 'VALID']:
-        raise ValueError("Invalid padding: {}.".format(padding))
     pool_strides = [1, pool_strides[0], pool_strides[1], 1]
     pool_shapes = [1, pool_shapes[0], pool_shapes[1], 1]
 
@@ -104,14 +100,8 @@ def cnn_with_max_pooling(input_var,
         return tf.reshape(h, [-1, dim])
 
 
-def _conv(input_var,
-          name,
-          filter_size,
-          num_filter,
-          strides,
-          hidden_w_init,
-          hidden_b_init,
-          padding="VALID"):
+def _conv(input_var, name, filter_size, num_filter, strides, hidden_w_init,
+          hidden_b_init, padding):
 
     # channel from input
     input_shape = input_var.get_shape()[-1].value

--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -4,27 +4,22 @@ import tensorflow as tf
 
 
 def cnn(input_var,
-        output_dim,
         filter_dims,
         num_filters,
-        stride,
+        strides,
         name,
-        padding="VALID",
+        padding,
         hidden_nonlinearity=tf.nn.relu,
-        hidden_w_init=tf.contrib.layers.xavier_initializer(),
-        hidden_b_init=tf.zeros_initializer(),
-        output_nonlinearity=None,
-        output_w_init=tf.contrib.layers.xavier_initializer(),
-        output_b_init=tf.zeros_initializer()):
+        hidden_w_init=tf.glorot_uniform_initializer(),
+        hidden_b_init=tf.zeros_initializer()):
     """
     CNN model. Based on 'NHWC' data format: [batch, height, width, channel].
 
     Args:
         input_var: Input tf.Tensor to the CNN.
-        output_dim: Dimension of the network output.
         filter_dims: Dimension of the filters.
         num_filters: Number of filters.
-        stride: The stride of the sliding window.
+        strides: The stride of the sliding window.
         name: Variable scope of the cnn.
         padding: The type of padding algorithm to use, from "SAME", "VALID".
         hidden_nonlinearity: Activation function for
@@ -33,56 +28,37 @@ def cnn(input_var,
                     of intermediate dense layer(s).
         hidden_b_init: Initializer function for the bias
                     of intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
-        output_w_init: Initializer function for the weight
-                    of output dense layer(s).
-        output_b_init: Initializer function for the bias
-                    of output dense layer(s).
 
     Return:
         The output tf.Tensor of the CNN.
     """
-    strides = [1, stride, stride, 1]
-
+    if padding not in ['SAME', 'VALID']:
+        raise ValueError("Invalid padding: {}.".format(padding))
     with tf.variable_scope(name):
         h = input_var
-        for index, (filter_dim, num_filter) in enumerate(
-                zip(filter_dims, num_filters)):
-            h = _conv(h, 'h{}'.format(index), filter_dim, num_filter, strides,
+        for index, (filter_dim, num_filter, stride) in enumerate(
+                zip(filter_dims, num_filters, strides)):
+            _stride = [1, stride, stride, 1]
+            h = _conv(h, 'h{}'.format(index), filter_dim, num_filter, _stride,
                       hidden_w_init, hidden_b_init, padding)
             if hidden_nonlinearity is not None:
                 h = hidden_nonlinearity(h)
-
-        # convert conv to dense
+        # flatten
         dim = tf.reduce_prod(h.get_shape()[1:].as_list())
-        h = tf.reshape(h, [-1, dim.eval()])
-        h = tf.layers.dense(
-            inputs=h,
-            units=output_dim,
-            activation=output_nonlinearity,
-            kernel_initializer=output_w_init,
-            bias_initializer=output_b_init,
-            name="output")
-
-        return h
+        return tf.reshape(h, [-1, dim])
 
 
 def cnn_with_max_pooling(input_var,
-                         output_dim,
                          filter_dims,
                          num_filters,
-                         stride,
+                         strides,
                          name,
-                         pool_shape,
-                         pool_stride,
-                         padding="VALID",
+                         pool_shapes,
+                         pool_strides,
+                         padding,
                          hidden_nonlinearity=tf.nn.relu,
-                         hidden_w_init=tf.contrib.layers.xavier_initializer(),
-                         hidden_b_init=tf.zeros_initializer(),
-                         output_nonlinearity=None,
-                         output_w_init=tf.contrib.layers.xavier_initializer(),
-                         output_b_init=tf.zeros_initializer()):
+                         hidden_w_init=tf.glorot_uniform_initializer(),
+                         hidden_b_init=tf.zeros_initializer()):
     """
     CNN model. Based on 'NHWC' data format: [batch, height, width, channel].
 
@@ -91,10 +67,10 @@ def cnn_with_max_pooling(input_var,
         output_dim: Dimension of the network output.
         filter_dims: Dimension of the filters.
         num_filters: Number of filters.
-        stride: The stride of the sliding window.
+        strides: The strides of the sliding window.
         name: Variable scope of the cnn.
-        pool_shape: Dimension of the pooling layer(s).
-        pool_stride: The stride of the pooling layer(s).
+        pool_shapes: Dimension of the pooling layer(s).
+        pool_strides: The strides of the pooling layer(s).
         padding: The type of padding algorithm to use, from "SAME", "VALID".
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
@@ -102,43 +78,30 @@ def cnn_with_max_pooling(input_var,
                     of intermediate dense layer(s).
         hidden_b_init: Initializer function for the bias
                     of intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
-        output_w_init: Initializer function for the weight
-                    of output dense layer(s).
-        output_b_init: Initializer function for the bias
-                    of output dense layer(s).
 
     Return:
         The output tf.Tensor of the CNN.
     """
-    strides = [1, stride, stride, 1]
-    pool_strides = [1, pool_stride[0], pool_stride[1], 1]
-    pool_shapes = [1, pool_shape[0], pool_shape[1], 1]
+    if padding not in ['SAME', 'VALID']:
+        raise ValueError("Invalid padding: {}.".format(padding))
+    pool_strides = [1, pool_strides[0], pool_strides[1], 1]
+    pool_shapes = [1, pool_shapes[0], pool_shapes[1], 1]
 
     with tf.variable_scope(name):
         h = input_var
-        for index, (filter_dim, num_filter) in enumerate(
-                zip(filter_dims, num_filters)):
-            h = _conv(h, 'h{}'.format(index), filter_dim, num_filter, strides,
+        for index, (filter_dim, num_filter, stride) in enumerate(
+                zip(filter_dims, num_filters, strides)):
+            _stride = [1, stride, stride, 1]
+            h = _conv(h, 'h{}'.format(index), filter_dim, num_filter, _stride,
                       hidden_w_init, hidden_b_init, padding)
             if hidden_nonlinearity is not None:
                 h = hidden_nonlinearity(h)
             h = tf.nn.max_pool(
                 h, ksize=pool_shapes, strides=pool_strides, padding=padding)
 
-        # convert conv to densevfxz
+        # flatten
         dim = tf.reduce_prod(h.get_shape()[1:].as_list())
-        h = tf.reshape(h, [-1, dim.eval()])
-        h = tf.layers.dense(
-            inputs=h,
-            units=output_dim,
-            activation=output_nonlinearity,
-            kernel_initializer=output_w_init,
-            bias_initializer=output_b_init,
-            name="output")
-
-        return h
+        return tf.reshape(h, [-1, dim])
 
 
 def _conv(input_var,

--- a/garage/tf/core/cnn.py
+++ b/garage/tf/core/cnn.py
@@ -16,19 +16,19 @@ def cnn(input_var,
     CNN. Based on 'NHWC' data format: [batch, height, width, channel].
 
     Args:
-        input_var: Input tf.Tensor to the CNN.
-        filter_dims(tuple[int]): Dimension of the filters. For example,
+        input_var (tf.Tensor): Input tf.Tensor to the CNN.
+        filter_dims (tuple[int]): Dimension of the filters. For example,
             (3, 5) means there are two convolutional layers. The filter for
             first layer is of dimension (3 x 3) and the second one is of
             dimension (5 x 5).
-        num_filters(tuple[int]): Number of filters. For example, (3, 32) means
+        num_filters (tuple[int]): Number of filters. For example, (3, 32) means
             there are two convolutional layers. The filter for the first layer
             has 3 channels and the second one with 32 channels.
-        strides(tuple[int]): The stride of the sliding window. For example,
+        strides (tuple[int]): The stride of the sliding window. For example,
             (1, 2) means there are two convolutional layers. The stride of the
             filter for first layer is 1 and that of the second layer is 2.
-        name: Variable scope of the cnn.
-        padding: The type of padding algorithm to use,
+        name (str): Network name, also the variable scope.
+        padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
@@ -69,26 +69,26 @@ def cnn_with_max_pooling(input_var,
     CNN model. Based on 'NHWC' data format: [batch, height, width, channel].
 
     Args:
-        input_var: Input tf.Tensor to the CNN.
-        output_dim: Dimension of the network output.
-        filter_dims(tuple[int]): Dimension of the filters. For example,
+        input_var (tf.Tensor): Input tf.Tensor to the CNN.
+        output_dim (int): Dimension of the network output.
+        filter_dims (tuple[int]): Dimension of the filters. For example,
             (3, 5) means there are two convolutional layers. The filter for
             first layer is of dimension (3 x 3) and the second one is of
             dimension (5 x 5).
-        num_filters(tuple[int]): Number of filters. For example, (3, 32) means
+        num_filters (tuple[int]): Number of filters. For example, (3, 32) means
             there are two convolutional layers. The filter for the first layer
             has 3 channels and the second one with 32 channels.
-        strides(tuple[int]): The stride of the sliding window. For example,
+        strides (tuple[int]): The stride of the sliding window. For example,
             (1, 2) means there are two convolutional layers. The stride of the
             filter for first layer is 1 and that of the second layer is 2.
-        name: Variable scope of the cnn.
-        pool_shapes(tuple[int]): Dimension of the pooling layer(s). For
+        name (str): Model name, also the variable scope of the cnn.
+        pool_shapes (tuple[int]): Dimension of the pooling layer(s). For
             example, (2, 2) means that all the pooling layers have
             shape (2, 2).
-        pool_strides(tuple[int]): The strides of the pooling layer(s). For
+        pool_strides (tuple[int]): The strides of the pooling layer(s). For
             example, (2, 2) means that all the pooling layers have
             strides (2, 2).
-        padding: The type of padding algorithm to use,
+        padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).

--- a/garage/tf/core/mlp.py
+++ b/garage/tf/core/mlp.py
@@ -20,10 +20,12 @@ def mlp(input_var,
     It maps real-valued inputs to real-valued outputs.
 
     Args:
-        input_var: Input tf.Tensor to the MLP.
-        output_dim: Dimension of the network output.
-        hidden_sizes: Output dimension of dense layer(s).
-        name: variable scope of the mlp.
+        input_var (tf.Tensor): Input tf.Tensor to the MLP.
+        output_dim (int): Dimension of the network output.
+        hidden_sizes (list[int]): Output dimension of dense layer(s).
+            For example, (32, 32) means this MLP consists of two
+            hidden layers, each with 32 hidden units.
+        name (str): Network name, also the variable scope.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         hidden_w_init: Initializer function for the weight
@@ -36,7 +38,7 @@ def mlp(input_var,
                     of output dense layer(s).
         output_b_init: Initializer function for the bias
                     of output dense layer(s).
-        layer_normalization: Bool for using layer normalization or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
 
     Return:
         The output tf.Tensor of the MLP

--- a/garage/tf/core/mlp.py
+++ b/garage/tf/core/mlp.py
@@ -1,4 +1,4 @@
-"""MLP model in TensorFlow."""
+"""MLP in TensorFlow."""
 
 import tensorflow as tf
 
@@ -15,7 +15,9 @@ def mlp(input_var,
         output_b_init=tf.zeros_initializer,
         layer_normalization=False):
     """
-    MLP model.
+    Multi-layer perceptron (MLP).
+
+    It maps real-valued inputs to real-valued outputs.
 
     Args:
         input_var: Input tf.Tensor to the MLP.

--- a/garage/tf/core/mlp.py
+++ b/garage/tf/core/mlp.py
@@ -8,11 +8,11 @@ def mlp(input_var,
         hidden_sizes,
         name,
         hidden_nonlinearity=tf.nn.relu,
-        hidden_w_init=tf.glorot_uniform_initializer,
-        hidden_b_init=tf.zeros_initializer,
+        hidden_w_init=tf.glorot_uniform_initializer(),
+        hidden_b_init=tf.zeros_initializer(),
         output_nonlinearity=None,
-        output_w_init=tf.glorot_uniform_initializer,
-        output_b_init=tf.zeros_initializer,
+        output_w_init=tf.glorot_uniform_initializer(),
+        output_b_init=tf.zeros_initializer(),
         layer_normalization=False):
     """
     Multi-layer perceptron (MLP).
@@ -26,18 +26,24 @@ def mlp(input_var,
             For example, (32, 32) means this MLP consists of two
             hidden layers, each with 32 hidden units.
         name (str): Network name, also the variable scope.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
-        output_w_init: Initializer function for the weight
-                    of output dense layer(s).
-        output_b_init: Initializer function for the bias
-                    of output dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
 
     Return:
@@ -52,7 +58,7 @@ def mlp(input_var,
                 activation=hidden_nonlinearity,
                 kernel_initializer=hidden_w_init,
                 bias_initializer=hidden_b_init,
-                name="hidden_{}".format(idx))
+                name='hidden_{}'.format(idx))
             if layer_normalization:
                 l_hid = tf.contrib.layers.layer_norm(l_hid)
 
@@ -62,5 +68,5 @@ def mlp(input_var,
             activation=output_nonlinearity,
             kernel_initializer=output_w_init,
             bias_initializer=output_b_init,
-            name="output")
+            name='output')
     return l_out

--- a/garage/tf/core/parameter.py
+++ b/garage/tf/core/parameter.py
@@ -19,12 +19,12 @@ def parameter(input_var,
     broadcasted to (32, 2) when applied to a batch with size 32.
 
     Args:
-        input_var: Input tf.Tensor.
-        length: Integer dimension of the variables.
+        input_var (tf.Tensor): Input tf.Tensor.
+        length (int): Integer dimension of the variables.
         initializer: Initializer of the variables.
         dtype: Data type of the variables.
-        trainable: Whether these variables are trainable.
-        name: variable scope of the variables.
+        trainable (bool): Whether these variables are trainable.
+        name (str): Variable scope of the variables.
 
     Return:
         A tensor of the broadcasted variables.

--- a/garage/tf/core/parameter.py
+++ b/garage/tf/core/parameter.py
@@ -21,8 +21,9 @@ def parameter(input_var,
     Args:
         input_var (tf.Tensor): Input tf.Tensor.
         length (int): Integer dimension of the variables.
-        initializer: Initializer of the variables.
-        dtype: Data type of the variables.
+        initializer (callable): Initializer of the variables. The function
+            should return a tf.Tensor.
+        dtype: Data type of the variables (default is tf.float32).
         trainable (bool): Whether these variables are trainable.
         name (str): Variable scope of the variables.
 

--- a/garage/tf/core/parameter.py
+++ b/garage/tf/core/parameter.py
@@ -9,7 +9,7 @@ def parameter(input_var,
               initializer=tf.zeros_initializer(),
               dtype=tf.float32,
               trainable=True,
-              name="parameter"):
+              name='parameter'):
     """
     Parameter layer.
 
@@ -31,7 +31,7 @@ def parameter(input_var,
     """
     with tf.variable_scope(name):
         p = tf.get_variable(
-            "parameter",
+            'parameter',
             shape=(length, ),
             dtype=dtype,
             initializer=initializer,

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -2,5 +2,6 @@ from garage.tf.models.base import Model
 from garage.tf.models.cnn_model import CNNModel
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
 from garage.tf.models.mlp_model import MLPModel
+from garage.tf.models.sequential import Sequential
 
-__all__ = ['CNNModel', 'Model', 'GaussianMLPModel', 'MLPModel']
+__all__ = ['CNNModel', 'Model', 'GaussianMLPModel', 'MLPModel', 'Sequential']

--- a/garage/tf/models/__init__.py
+++ b/garage/tf/models/__init__.py
@@ -1,5 +1,6 @@
 from garage.tf.models.base import Model
+from garage.tf.models.cnn_model import CNNModel
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
 from garage.tf.models.mlp_model import MLPModel
 
-__all__ = ['Model', 'GaussianMLPModel', 'MLPModel']
+__all__ = ['CNNModel', 'Model', 'GaussianMLPModel', 'MLPModel']

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -190,7 +190,6 @@ class Model(BaseModel):
 
         """
         network_name = name or 'default'
-
         if not self._networks:
             # First time building the model, so self._networks are empty
             # We store the variable_scope to reenter later when we reuse it
@@ -199,7 +198,7 @@ class Model(BaseModel):
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
-                    network._outputs = self._build(*inputs)
+                    network._outputs = self._build(*inputs, name)
                 variables = self._get_variables().values()
                 tf.get_default_session().run(
                     tf.variables_initializer(variables))
@@ -215,7 +214,7 @@ class Model(BaseModel):
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
-                    network._outputs = self._build(*inputs)
+                    network._outputs = self._build(*inputs, name)
         spec = self.network_output_spec()
         if spec:
             c = namedtuple(network_name,
@@ -232,9 +231,10 @@ class Model(BaseModel):
                     network.inputs, network.outputs)
         else:
             self._networks[network_name] = network
+
         return network.outputs
 
-    def _build(self, *inputs):
+    def _build(self, *inputs, name=None):
         """
         Output of the model given input placeholder(s).
 
@@ -245,6 +245,7 @@ class Model(BaseModel):
             inputs: Tensor input(s), recommended to be position arguments, e.g.
               def build(self, state_input=None, action_input=None, name=None).
               It would be usually same as the inputs in build().
+            name: Variable scope of the inner model, if exist.
         Return:
             output: Tensor output(s) of the model.
         """
@@ -287,6 +288,22 @@ class Model(BaseModel):
     def name(self):
         """Name of the model."""
         return self._name
+
+    @property
+    def input(self):
+        return self.networks['default'].input
+
+    @property
+    def output(self):
+        return self.networks['default'].output
+
+    @property
+    def inputs(self):
+        return self.networks['default'].inputs
+
+    @property
+    def outputs(self):
+        return self.networks['default'].outputs
 
     def _get_variables(self):
         if self._variable_scope:

--- a/garage/tf/models/base.py
+++ b/garage/tf/models/base.py
@@ -78,11 +78,6 @@ class Network:
     When a Network is built, it appears as a subgraph in the computation
     graphs, scoped by the Network name. All Networks built with the same
     model share the same parameters, i.e same inputs yield to same outputs.
-
-    Args:
-      model: The model building this network.
-      inputs: Input Tensor(s).
-      name: Name of the network, which is also the name scope.
     """
 
     @property
@@ -177,9 +172,9 @@ class Model(BaseModel):
         parameter sharing. Different Networks must have an unique name.
 
         Args:
-          inputs: Tensor input(s), recommended to be positional arguments, e.g.
-            def build(self, state_input, action_input, name=None).
-          name(str): Name of the model, which is also the name scope of the
+          inputs : Tensor input(s), recommended to be positional arguments,
+            e.g. def build(self, state_input, action_input, name=None).
+          name (str): Name of the model, which is also the name scope of the
             model.
 
         Raises:
@@ -243,9 +238,11 @@ class Model(BaseModel):
 
         Args:
             inputs: Tensor input(s), recommended to be position arguments, e.g.
-              def build(self, state_input=None, action_input=None, name=None).
+              def _build(self, state_input, action_input, name=None).
               It would be usually same as the inputs in build().
-            name: Variable scope of the inner model, if exist.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist.
+
         Return:
             output: Tensor output(s) of the model.
         """
@@ -256,7 +253,7 @@ class Model(BaseModel):
         Network output spec.
 
         Return:
-            *inputs: List of key(str) for the network outputs.
+            *inputs (list[str]): List of key(str) for the network outputs.
         """
         return []
 
@@ -286,23 +283,55 @@ class Model(BaseModel):
 
     @property
     def name(self):
-        """Name of the model."""
+        """
+        Name (str) of the model.
+
+        This is also the variable scope of the model.
+        """
         return self._name
 
     @property
     def input(self):
+        """
+        Default input (tf.Tensor) of the model.
+
+        When the model is built the first time, by default it
+        creates the 'default' network. This property creates
+        a reference to the input of the network.
+        """
         return self.networks['default'].input
 
     @property
     def output(self):
+        """
+        Default output (tf.Tensor) of the model.
+
+        When the model is built the first time, by default it
+        creates the 'default' network. This property creates
+        a reference to the output of the network.
+        """
         return self.networks['default'].output
 
     @property
     def inputs(self):
+        """
+        Default inputs (tf.Tensor) of the model.
+
+        When the model is built the first time, by default it
+        creates the 'default' network. This property creates
+        a reference to the inputs of the network.
+        """
         return self.networks['default'].inputs
 
     @property
     def outputs(self):
+        """
+        Default outputs (tf.Tensor) of the model.
+
+        When the model is built the first time, by default it
+        creates the 'default' network. This property creates
+        a reference to the outputs of the network.
+        """
         return self.networks['default'].outputs
 
     def _get_variables(self):

--- a/garage/tf/models/cnn_model.py
+++ b/garage/tf/models/cnn_model.py
@@ -23,12 +23,15 @@ class CNNModel(Model):
         name (str): Model name, also the variable scope.
         padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
     """
 
     def __init__(self,

--- a/garage/tf/models/cnn_model.py
+++ b/garage/tf/models/cnn_model.py
@@ -25,6 +25,8 @@ class CNNModel(Model):
                  strides,
                  padding,
                  name=None,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
                  hidden_nonlinearity=tf.nn.relu):
         super().__init__(name)
         self._filter_dims = filter_dims
@@ -32,12 +34,16 @@ class CNNModel(Model):
         self._strides = strides
         self._padding = padding
         self._hidden_nonlinearity = hidden_nonlinearity
+        self._hidden_w_init = hidden_w_init
+        self._hidden_b_init = hidden_b_init
 
     def _build(self, state_input):
         return cnn(
             input_var=state_input,
             filter_dims=self._filter_dims,
             hidden_nonlinearity=self._hidden_nonlinearity,
+            hidden_w_init=self._hidden_w_init,
+            hidden_b_init=self._hidden_b_init,
             num_filters=self._num_filters,
             strides=self._strides,
             padding=self._padding,

--- a/garage/tf/models/cnn_model.py
+++ b/garage/tf/models/cnn_model.py
@@ -1,0 +1,44 @@
+"""CNN Model."""
+import tensorflow as tf
+
+from garage.tf.core.cnn import cnn
+from garage.tf.models.base import Model
+
+
+class CNNModel(Model):
+    """
+    CNN Model.
+
+    Args:
+        filter_dims: Dimension of the filters.
+        num_filters: Number of filters.
+        strides: The stride of the sliding window.
+        name: Variable scope of the cnn.
+        padding: The type of padding algorithm to use, from "SAME", "VALID".
+        hidden_nonlinearity: Activation function for intermediate dense
+            layer(s).
+    """
+
+    def __init__(self,
+                 filter_dims,
+                 num_filters,
+                 strides,
+                 padding,
+                 name=None,
+                 hidden_nonlinearity=tf.nn.relu):
+        super().__init__(name)
+        self._filter_dims = filter_dims
+        self._num_filters = num_filters
+        self._strides = strides
+        self._padding = padding
+        self._hidden_nonlinearity = hidden_nonlinearity
+
+    def _build(self, state_input):
+        return cnn(
+            input_var=state_input,
+            filter_dims=self._filter_dims,
+            hidden_nonlinearity=self._hidden_nonlinearity,
+            num_filters=self._num_filters,
+            strides=self._strides,
+            padding=self._padding,
+            name="cnn")

--- a/garage/tf/models/cnn_model.py
+++ b/garage/tf/models/cnn_model.py
@@ -20,8 +20,8 @@ class CNNModel(Model):
         strides(tuple[int]): The stride of the sliding window. For example,
             (1, 2) means there are two convolutional layers. The stride of the
             filter for first layer is 1 and that of the second layer is 2.
-        name: Variable scope of the cnn model.
-        padding: The type of padding algorithm to use,
+        name (str): Model name, also the variable scope.
+        padding (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).

--- a/garage/tf/models/cnn_model.py
+++ b/garage/tf/models/cnn_model.py
@@ -10,13 +10,25 @@ class CNNModel(Model):
     CNN Model.
 
     Args:
-        filter_dims: Dimension of the filters.
-        num_filters: Number of filters.
-        strides: The stride of the sliding window.
-        name: Variable scope of the cnn.
-        padding: The type of padding algorithm to use, from "SAME", "VALID".
-        hidden_nonlinearity: Activation function for intermediate dense
-            layer(s).
+        filter_dims(tuple[int]): Dimension of the filters. For example,
+            (3, 5) means there are two convolutional layers. The filter
+            for first layer is of dimension (3 x 3) and the second one is of
+            dimension (5 x 5).
+        num_filters(tuple[int]): Number of filters. For example, (3, 32) means
+            there are two convolutional layers. The filter for the first layer
+            has 3 channels and the second one with 32 channels.
+        strides(tuple[int]): The stride of the sliding window. For example,
+            (1, 2) means there are two convolutional layers. The stride of the
+            filter for first layer is 1 and that of the second layer is 2.
+        name: Variable scope of the cnn model.
+        padding: The type of padding algorithm to use,
+            either 'SAME' or 'VALID'.
+        hidden_nonlinearity: Activation function for
+                    intermediate dense layer(s).
+        hidden_w_init: Initializer function for the weight
+                    of intermediate dense layer(s).
+        hidden_b_init: Initializer function for the bias
+                    of intermediate dense layer(s).
     """
 
     def __init__(self,
@@ -25,9 +37,9 @@ class CNNModel(Model):
                  strides,
                  padding,
                  name=None,
+                 hidden_nonlinearity=tf.nn.relu,
                  hidden_w_init=tf.glorot_uniform_initializer(),
-                 hidden_b_init=tf.zeros_initializer(),
-                 hidden_nonlinearity=tf.nn.relu):
+                 hidden_b_init=tf.zeros_initializer()):
         super().__init__(name)
         self._filter_dims = filter_dims
         self._num_filters = num_filters
@@ -37,7 +49,7 @@ class CNNModel(Model):
         self._hidden_w_init = hidden_w_init
         self._hidden_b_init = hidden_b_init
 
-    def _build(self, state_input):
+    def _build(self, state_input, name=None):
         return cnn(
             input_var=state_input,
             filter_dims=self._filter_dims,
@@ -47,4 +59,4 @@ class CNNModel(Model):
             num_filters=self._num_filters,
             strides=self._strides,
             padding=self._padding,
-            name="cnn")
+            name='cnn')

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -18,8 +18,24 @@ class GaussianMLPModel(Model):
         hidden_sizes (list[int]): Output dimension of dense layer(s) for
             the MLP for mean. For example, (32, 32) means the MLP consists
             of two hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Nonlinearity used for each hidden layer.
-        output_nonlinearity: Nonlinearity for the output layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         learn_std (bool): Is std trainable.
         init_std (float): Initial value for std.
         adaptive_std (bool): Is std a neural network. If False, it will be a
@@ -35,8 +51,11 @@ class GaussianMLPModel(Model):
             to avoid numerical issues.
         std_hidden_nonlinearity: Nonlinearity for each hidden layer in
             the std network.
-        std_output_nonlinearity: Nonlinearity for output layer in
-            the std network.
+        std_output_nonlinearity (callable): Activation function for output
+            dense layer in the std network. It should return a tf.Tensor. Set
+            it to None to maintain a linear activation.
+        std_output_w_init (callable): Initializer function for the weight
+            of output dense layer(s) in the std network.
         std_parametrization (str): How the std should be parametrized. There
             are two options:
             - exp: the logarithm of the std will be stored, and applied a
@@ -67,7 +86,6 @@ class GaussianMLPModel(Model):
                  std_hidden_b_init=tf.zeros_initializer(),
                  std_output_nonlinearity=None,
                  std_output_w_init=tf.glorot_uniform_initializer(),
-                 std_output_b_init=tf.zeros_initializer(),
                  std_parameterization='exp',
                  layer_normalization=False):
         # Network parameters
@@ -85,7 +103,6 @@ class GaussianMLPModel(Model):
         self._std_hidden_b_init = std_hidden_b_init
         self._std_output_nonlinearity = std_output_nonlinearity
         self._std_output_w_init = std_output_w_init
-        self._std_output_b_init = std_output_b_init
         self._std_parameterization = std_parameterization
         self._hidden_nonlinearity = hidden_nonlinearity
         self._hidden_w_init = hidden_w_init

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -13,33 +13,36 @@ class GaussianMLPModel(Model):
     GaussianMLPModel.
 
     Args:
-    :param output_dim: Output dimension of the model.
-    :param name: Name of the model.
-    :param hidden_sizes: List of sizes for the fully-connected hidden
-        layers.
-    :param learn_std: Is std trainable.
-    :param init_std: Initial value for std.
-    :param adaptive_std: Is std a neural network. If False, it will be a
-        parameter.
-    :param std_share_network: Boolean for whether mean and std share the same
-        network.
-    :param std_hidden_sizes: List of sizes for the fully-connected layers
-        for std.
-    :param min_std: Whether to make sure that the std is at least some
-        threshold value, to avoid numerical issues.
-    :param max_std: Whether to make sure that the std is at most some
-        threshold value, to avoid numerical issues.
-    :param std_hidden_nonlinearity: Nonlinearity for each hidden layer in
-        the std network.
-    :param std_output_nonlinearity: Nonlinearity for output layer in
-        the std network.
-    :param std_parametrization: How the std should be parametrized. There
-        are a few options:
-        - exp: the logarithm of the std will be stored, and applied a
-            exponential transformation
-        - softplus: the std will be computed as log(1+exp(x))
-    :param hidden_nonlinearity: Nonlinearity used for each hidden layer.
-    :param output_nonlinearity: Nonlinearity for the output layer.
+        output_dim (int): Output dimension of the model.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity: Nonlinearity used for each hidden layer.
+        output_nonlinearity: Nonlinearity for the output layer.
+        learn_std (bool): Is std trainable.
+        init_std (float): Initial value for std.
+        adaptive_std (bool): Is std a neural network. If False, it will be a
+            parameter.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        std_hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for std. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        min_std (float): If not None, the std is at least the value of min_std,
+            to avoid numerical issues.
+        max_std (float): If not None, the std is at most the value of max_std,
+            to avoid numerical issues.
+        std_hidden_nonlinearity: Nonlinearity for each hidden layer in
+            the std network.
+        std_output_nonlinearity: Nonlinearity for output layer in
+            the std network.
+        std_parametrization (str): How the std should be parametrized. There
+            are two options:
+            - exp: the logarithm of the std will be stored, and applied a
+               exponential transformation
+            - softplus: the std will be computed as log(1+exp(x))
+        layer_normalization (bool): Bool for using layer normalization or not.
     """
 
     def __init__(self,

--- a/garage/tf/models/gaussian_mlp_model.py
+++ b/garage/tf/models/gaussian_mlp_model.py
@@ -115,7 +115,7 @@ class GaussianMLPModel(Model):
         """Network output spec."""
         return ['sample', 'mean', 'log_std', 'std_param', 'dist']
 
-    def _build(self, state_input):
+    def _build(self, state_input, name=None):
         action_dim = self._output_dim
 
         with tf.variable_scope('dist_params'):

--- a/garage/tf/models/mlp_model.py
+++ b/garage/tf/models/mlp_model.py
@@ -55,7 +55,7 @@ class MLPModel(Model):
         self._output_b_init = output_b_init
         self._layer_normalization = layer_normalization
 
-    def _build(self, state_input):
+    def _build(self, state_input, name=None):
         return mlp(
             input_var=state_input,
             output_dim=self._output_dim,

--- a/garage/tf/models/mlp_model.py
+++ b/garage/tf/models/mlp_model.py
@@ -15,9 +15,11 @@ class MLPModel(Model):
     MLP Model.
 
     Args:
-        output_dim: Dimension of the network output.
-        name: variable scope of the mlp.
-        hidden_sizes: Output dimension of dense layer(s).
+        output_dim (int): Dimension of the network output.
+        hidden_sizes (list[int]): Output dimension of dense layer(s).
+            For example, (32, 32) means this MLP consists of two
+            hidden layers, each with 32 hidden units.
+        name (str): Model name, also the variable scope.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         hidden_w_init: Initializer function for the weight
@@ -30,7 +32,7 @@ class MLPModel(Model):
                     of output dense layer(s).
         output_b_init: Initializer function for the bias
                     of output dense layer(s).
-        layer_normalization: Bool for using layer normalization or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
     """
 
     def __init__(self,

--- a/garage/tf/models/mlp_model.py
+++ b/garage/tf/models/mlp_model.py
@@ -20,18 +20,24 @@ class MLPModel(Model):
             For example, (32, 32) means this MLP consists of two
             hidden layers, each with 32 hidden units.
         name (str): Model name, also the variable scope.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
-        output_w_init: Initializer function for the weight
-                    of output dense layer(s).
-        output_b_init: Initializer function for the bias
-                    of output dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
     """
 
@@ -62,7 +68,7 @@ class MLPModel(Model):
             input_var=state_input,
             output_dim=self._output_dim,
             hidden_sizes=self._hidden_sizes,
-            name="mlp",
+            name='mlp',
             hidden_nonlinearity=self._hidden_nonlinearity,
             hidden_w_init=self._hidden_w_init,
             hidden_b_init=self._hidden_b_init,

--- a/garage/tf/models/sequential.py
+++ b/garage/tf/models/sequential.py
@@ -13,7 +13,8 @@ class Sequential(Model):
 
     Args:
         name: Variable scope of the Sequential model.
-        models: The models to be connected in sequential order.
+        models (list[garage.Model]): The models to be connected
+            in sequential order.
     """
 
     def __init__(self, *models, name=None):

--- a/garage/tf/models/sequential.py
+++ b/garage/tf/models/sequential.py
@@ -13,7 +13,7 @@ class Sequential(Model):
 
     Args:
         name (str): Model name, also the variable scope.
-        models (list[garage.Model]): The models to be connected
+        models (list[garage.tf.models.Model]): The models to be connected
             in sequential order.
     """
 

--- a/garage/tf/models/sequential.py
+++ b/garage/tf/models/sequential.py
@@ -1,0 +1,48 @@
+"""
+Sequential Model.
+
+A model composed of one or more models which are connected sequential,
+according to the insertion order.
+"""
+from garage.tf.models.base import Model
+
+
+class Sequential(Model):
+    """
+    Sequential Model.
+
+    Args:
+        name: Variable scope of the Sequential model.
+        models: The models to be connected in sequential order.
+    """
+
+    def __init__(self, *models, name=None):
+        super().__init__(name)
+        self._models = models
+
+    def _build(self, input_var, name=None):
+        out = input_var
+        for model in self._models:
+            out = model.build(out, name=name)
+
+        return out
+
+    @property
+    def input(self):
+        """tf.Tensor input of the model by default."""
+        return self._models[0].networks['default'].input
+
+    @property
+    def output(self):
+        """tf.Tensor output of the model by default."""
+        return self._models[-1].networks['default'].output
+
+    @property
+    def inputs(self):
+        """tf.Tensor inputs of the model by default."""
+        return self._models[0].networks['default'].inputs
+
+    @property
+    def outputs(self):
+        """tf.Tensor outputs of the model by default."""
+        return self._models[-1].networks['default'].outputs

--- a/garage/tf/models/sequential.py
+++ b/garage/tf/models/sequential.py
@@ -12,7 +12,7 @@ class Sequential(Model):
     Sequential Model.
 
     Args:
-        name: Variable scope of the Sequential model.
+        name (str): Model name, also the variable scope.
         models (list[garage.Model]): The models to be connected
             in sequential order.
     """

--- a/garage/tf/policies/__init__.py
+++ b/garage/tf/policies/__init__.py
@@ -1,5 +1,8 @@
 from garage.tf.policies.base import Policy
 from garage.tf.policies.base import StochasticPolicy
+from garage.tf.policies.categorical_conv_policy import CategoricalConvPolicy
+from garage.tf.policies.categorical_conv_policy_with_model import (
+    CategoricalConvPolicyWithModel)
 from garage.tf.policies.categorical_gru_policy import CategoricalGRUPolicy
 from garage.tf.policies.categorical_lstm_policy import CategoricalLSTMPolicy
 from garage.tf.policies.categorical_mlp_policy import CategoricalMLPPolicy
@@ -20,6 +23,8 @@ from garage.tf.policies.gaussian_mlp_policy_with_model import (
 __all__ = [
     "Policy",
     "StochasticPolicy",
+    "CategoricalConvPolicy",
+    "CategoricalConvPolicyWithModel",
     "CategoricalGRUPolicy",
     "CategoricalLSTMPolicy",
     "CategoricalMLPPolicy",

--- a/garage/tf/policies/__init__.py
+++ b/garage/tf/policies/__init__.py
@@ -21,20 +21,11 @@ from garage.tf.policies.gaussian_mlp_policy_with_model import (
     GaussianMLPPolicyWithModel)
 
 __all__ = [
-    "Policy",
-    "StochasticPolicy",
-    "CategoricalConvPolicy",
-    "CategoricalConvPolicyWithModel",
-    "CategoricalGRUPolicy",
-    "CategoricalLSTMPolicy",
-    "CategoricalMLPPolicy",
-    "CategoricalMLPPolicyWithModel",
-    "ContinuousMLPPolicy",
-    "DiscreteQfDerivedPolicy",
-    "DeterministicMLPPolicy",
-    "DeterministicMLPPolicyWithModel",
-    "GaussianGRUPolicy",
-    "GaussianLSTMPolicy",
-    "GaussianMLPPolicy",
-    "GaussianMLPPolicyWithModel",
+    'Policy', 'StochasticPolicy', 'CategoricalConvPolicy',
+    'CategoricalConvPolicyWithModel', 'CategoricalGRUPolicy',
+    'CategoricalLSTMPolicy', 'CategoricalMLPPolicy',
+    'CategoricalMLPPolicyWithModel', 'ContinuousMLPPolicy',
+    'DiscreteQfDerivedPolicy', 'DeterministicMLPPolicy',
+    'DeterministicMLPPolicyWithModel', 'GaussianGRUPolicy',
+    'GaussianLSTMPolicy', 'GaussianMLPPolicy', 'GaussianMLPPolicyWithModel'
 ]

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -7,7 +7,8 @@ class Policy2:
     Policy base class without Parameterzied.
 
     Args:
-        env_spec: Environment specification.
+        name (str): Policy name, also the variable scope.
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
 
     """
 
@@ -117,10 +118,13 @@ class StochasticPolicy2(Policy2):
         Symbolic graph of the distribution.
 
         Return the symbolic distribution information about the actions.
-        :param obs_var: symbolic variable for observations
-        :param state_info_vars: a dictionary whose values should contain
-         information about the state of the policy at
-        the time it received the observation
+        Args:
+            obs_var (tf.Tensor): symbolic variable for observations
+            state_info_vars (dict): a dictionary whose values should contain
+                information about the state of the policy at the time it
+                received the observation.
+            name (str): Name of the symbolic graph.
+
         :return:
         """
         raise NotImplementedError
@@ -130,10 +134,11 @@ class StochasticPolicy2(Policy2):
         Distribution info.
 
         Return the distribution information about the actions.
-        :param obs_var: observation values
-        :param state_info_vars: a dictionary whose values should contain
-         information about the state of the policy at the time it received the
-         observation
-        :return:
+
+        Args:
+            obs_var (tf.Tensor): observation values
+            state_info_vars (dict): a dictionary whose values should contain
+                information about the state of the policy at the time it
+                received the observation
         """
         raise NotImplementedError

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -113,7 +113,7 @@ class StochasticPolicy2(Policy2):
         """Distribution."""
         raise NotImplementedError
 
-    def dist_info_sym(self, obs_var, state_info_vars, name="dist_info_sym"):
+    def dist_info_sym(self, obs_var, state_info_vars, name='dist_info_sym'):
         """
         Symbolic graph of the distribution.
 

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -108,22 +108,13 @@ class Policy2:
 
     def build_models(self, input_var, name=None):
         out = input_var
-        for model in self._models[:-1]:
+        for model in self._models:
             out = model.build(out, name=name)
-        self.model = self._models[-1]
-        return self.model.build(out, name=name)
+        return out
 
     @property
     def input(self):
         return self._models[0].networks['default'].input
-
-    @property
-    def inputs(self):
-        return self._models[0].networks['default'].inputs
-
-    @property
-    def output(self):
-        return self._models[-1].networks['default'].output
 
     @property
     def outputs(self):

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -103,23 +103,6 @@ class Policy2:
         """Get global vars."""
         return self._variable_scope.global_variables()
 
-    def add_model(self, model):
-        self._models.append(model)
-
-    def build_models(self, input_var, name=None):
-        out = input_var
-        for model in self._models:
-            out = model.build(out, name=name)
-        return out
-
-    @property
-    def input(self):
-        return self._models[0].networks['default'].input
-
-    @property
-    def outputs(self):
-        return self._models[-1].networks['default'].outputs
-
 
 class StochasticPolicy2(Policy2):
     """StochasticPolicy."""

--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -15,9 +15,9 @@ class Policy2:
         self._name = name
         self._env_spec = env_spec
         self._variable_scope = tf.VariableScope(reuse=False, name=name)
+        self._models = []
 
     # Should be implemented by all policies
-
     def get_action(self, observation):
         """Get action given observation."""
         raise NotImplementedError
@@ -102,6 +102,32 @@ class Policy2:
     def get_global_vars(self):
         """Get global vars."""
         return self._variable_scope.global_variables()
+
+    def add_model(self, model):
+        self._models.append(model)
+
+    def build_models(self, input_var, name=None):
+        out = input_var
+        for model in self._models[:-1]:
+            out = model.build(out, name=name)
+        self.model = self._models[-1]
+        return self.model.build(out, name=name)
+
+    @property
+    def input(self):
+        return self._models[0].networks['default'].input
+
+    @property
+    def inputs(self):
+        return self._models[0].networks['default'].inputs
+
+    @property
+    def output(self):
+        return self._models[-1].networks['default'].output
+
+    @property
+    def outputs(self):
+        return self._models[-1].networks['default'].outputs
 
 
 class StochasticPolicy2(Policy2):

--- a/garage/tf/policies/categorical_conv_policy_with_model.py
+++ b/garage/tf/policies/categorical_conv_policy_with_model.py
@@ -20,7 +20,7 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
     It only works with akro.tf.Discrete action space.
 
     Args:
-        env_spec: Environment specification.
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
         conv_filter_sizes(tuple[int]): Dimension of the filters. For example,
             (3, 5) means there are two convolutional layers. The filter for
             first layer is of dimension (3 x 3) and the second one is of
@@ -32,15 +32,17 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
             example, (1, 2) means there are two convolutional layers. The
             stride of the filter for first layer is 1 and that of the second
             layer is 2.
-        conv_pad: The type of padding algorithm to use,
+        conv_pad (str): The type of padding algorithm to use,
             either 'SAME' or 'VALID'.
-        name: Variable scope of the policy.
-        hidden_sizes: Output dimension of dense layer(s).
+        name (str): Policy name, also the variable scope of the policy.
+        hidden_sizes (list[int]): Output dimension of dense layer(s).
+            For example, (32, 32) means the MLP of this policy consists
+            of two hidden layers, each with 32 hidden units.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         output_nonlinearity: Activation function for
                     output dense layer.
-        layer_normalization: Bool for using layer normalization or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
 
     """
 

--- a/garage/tf/policies/categorical_conv_policy_with_model.py
+++ b/garage/tf/policies/categorical_conv_policy_with_model.py
@@ -38,10 +38,24 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
         hidden_sizes (list[int]): Output dimension of dense layer(s).
             For example, (32, 32) means the MLP of this policy consists
             of two hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
 
     """
@@ -55,7 +69,11 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
                  name='CategoricalConvPolicy',
                  hidden_sizes=[],
                  hidden_nonlinearity=tf.nn.relu,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
                  output_nonlinearity=tf.nn.softmax,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):
         assert isinstance(env_spec.action_space, Discrete), (
             'CategoricalConvPolicy only works with akro.tf.Discrete'
@@ -76,7 +94,11 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
                 output_dim=self.action_dim,
                 hidden_sizes=hidden_sizes,
                 hidden_nonlinearity=hidden_nonlinearity,
+                hidden_w_init=hidden_w_init,
+                hidden_b_init=hidden_b_init,
                 output_nonlinearity=output_nonlinearity,
+                output_w_init=output_w_init,
+                output_b_init=output_b_init,
                 layer_normalization=layer_normalization,
                 name='MLPModel'))
 

--- a/garage/tf/policies/categorical_mlp_policy.py
+++ b/garage/tf/policies/categorical_mlp_policy.py
@@ -21,14 +21,20 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
             prob_network=None,
     ):
         """
-        :param env_spec: A spec for the mdp.
-        :param hidden_sizes: list of sizes for the fully connected
-        hidden layers
-        :param hidden_nonlinearity: nonlinearity used for each hidden layer
-        :param prob_network: manually specified network for this policy, other
-         network params
-        are ignored
-        :return:
+        CategoricalMLPPolicy.
+
+        A policy that uses a MLP to estimate a categorical distribution.
+
+        Args:
+            env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+            hidden_sizes (list[int]): Output dimension of dense layer(s).
+                For example, (32, 32) means the MLP of this policy consists
+                of two hidden layers, each with 32 hidden units.
+            hidden_nonlinearity: Activation function for
+                        intermediate dense layer(s).
+            prob_network (tf.Tensor): manually specified network for this
+                policy. If None, a MLP with the network parameters will be
+                created. If not None, other network params are ignored.
         """
         assert isinstance(env_spec.action_space, Discrete)
 

--- a/garage/tf/policies/categorical_mlp_policy.py
+++ b/garage/tf/policies/categorical_mlp_policy.py
@@ -15,7 +15,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
     def __init__(
             self,
             env_spec,
-            name="CategoricalMLPPolicy",
+            name='CategoricalMLPPolicy',
             hidden_sizes=(32, 32),
             hidden_nonlinearity=tf.nn.tanh,
             prob_network=None,
@@ -31,7 +31,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                 For example, (32, 32) means the MLP of this policy consists
                 of two hidden layers, each with 32 hidden units.
             hidden_nonlinearity: Activation function for
-                        intermediate dense layer(s).
+                intermediate dense layer(s).
             prob_network (tf.Tensor): manually specified network for this
                 policy. If None, a MLP with the network parameters will be
                 created. If not None, other network params are ignored.
@@ -41,8 +41,8 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         Serializable.quick_init(self, locals())
 
         self.name = name
-        self._prob_network_name = "prob_network"
-        with tf.variable_scope(name, "CategoricalMLPPolicy"):
+        self._prob_network_name = 'prob_network'
+        with tf.variable_scope(name, 'CategoricalMLPPolicy'):
             if prob_network is None:
                 prob_network = MLP(
                     input_shape=(env_spec.observation_space.flat_dim, ),
@@ -71,7 +71,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
 
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
-        with tf.name_scope(name, "dist_info_sym", [obs_var, state_info_vars]):
+        with tf.name_scope(name, 'dist_info_sym', [obs_var, state_info_vars]):
             with tf.name_scope(self._prob_network_name, values=[obs_var]):
                 prob = L.get_output(
                     self._l_prob, {self._l_obs: tf.cast(obs_var, tf.float32)})

--- a/garage/tf/policies/categorical_mlp_policy_with_model.py
+++ b/garage/tf/policies/categorical_mlp_policy_with_model.py
@@ -23,25 +23,43 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
         hidden_sizes (list[int]): Output dimension of dense layer(s).
             For example, (32, 32) means the MLP of this policy consists of two
             hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
 
     """
 
     def __init__(self,
                  env_spec,
-                 name="CategoricalMLPPolicy",
+                 name='CategoricalMLPPolicy',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.tanh,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
                  output_nonlinearity=tf.nn.softmax,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):
         assert isinstance(
             env_spec.action_space,
-            Discrete), ("CategoricalMLPPolicy only works with akro.tf.Discrete"
-                        "action space.")
+            Discrete), ('CategoricalMLPPolicy only works with akro.tf.Discrete'
+                        'action space.')
         super().__init__(name, env_spec)
         self.obs_dim = env_spec.observation_space.flat_dim
         self.action_dim = env_spec.action_space.n
@@ -50,7 +68,11 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
             output_dim=self.action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
             output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
             layer_normalization=layer_normalization,
             name='MLPModel')
 

--- a/garage/tf/policies/categorical_mlp_policy_with_model.py
+++ b/garage/tf/policies/categorical_mlp_policy_with_model.py
@@ -12,17 +12,22 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
     """
     CategoricalMLPPolicy with model.
 
+    A policy that contains a MLP to make prediction based on
+    a categorical distribution.
+
     It only works with akro.tf.Discrete action space.
 
     Args:
-        env_spec: Environment specification.
-        name: variable scope of the mlp.
-        hidden_sizes: Output dimension of dense layer(s).
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        name (str): Policy name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s).
+            For example, (32, 32) means the MLP of this policy consists of two
+            hidden layers, each with 32 hidden units.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         output_nonlinearity: Activation function for
                     output dense layer.
-        layer_normalization: Bool for using layer normalization or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
 
     """
 

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -25,27 +25,45 @@ class DeterministicMLPPolicyWithModel(Policy2):
         hidden_sizes (list[int]): Output dimension of dense layer(s).
             For example, (32, 32) means the MLP of this policy consists of two
             hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         input_include_goal (bool): Include goal in the observation or not.
         layer_normalization (bool): Bool for using layer normalization or not.
     """
 
     def __init__(self,
                  env_spec,
-                 name="DeterministicMLPPolicy",
+                 name='DeterministicMLPPolicy',
                  hidden_sizes=(64, 64),
                  hidden_nonlinearity=tf.nn.relu,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
                  output_nonlinearity=tf.nn.tanh,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
                  input_include_goal=False,
                  layer_normalization=False):
         super().__init__(name, env_spec)
         action_dim = env_spec.action_space.flat_dim
         if input_include_goal:
             self.obs_dim = env_spec.observation_space.flat_dim_with_keys(
-                ["observation", "desired_goal"])
+                ['observation', 'desired_goal'])
         else:
             self.obs_dim = env_spec.observation_space.flat_dim
 
@@ -54,7 +72,11 @@ class DeterministicMLPPolicyWithModel(Policy2):
             name='MLPModel',
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
             output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
             layer_normalization=layer_normalization)
 
         self._initialize()

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -50,7 +50,7 @@ class DeterministicMLPPolicyWithModel(Policy2):
 
         self.model = MLPModel(
             output_dim=action_dim,
-            name=name,
+            name='MLPModel',
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
             output_nonlinearity=output_nonlinearity,

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -20,16 +20,17 @@ class DeterministicMLPPolicyWithModel(Policy2):
     It uses neural nets to fit the function of pi(s).
 
     Args:
-        env_spec: Environment specification.
-        name: Variable scope of the mlp.
-        hidden_sizes: Output dimension of dense layer(s).
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        name (str): Policy name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s).
+            For example, (32, 32) means the MLP of this policy consists of two
+            hidden layers, each with 32 hidden units.
         hidden_nonlinearity: Activation function for
                     intermediate dense layer(s).
         output_nonlinearity: Activation function for
                     output dense layer.
-        input_include_goal: Include goal or not.
-        layer_normalization: Bool for using layer normalization or not.
-
+        input_include_goal (bool): Include goal in the observation or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
     """
 
     def __init__(self,

--- a/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/garage/tf/policies/discrete_qf_derived_policy.py
@@ -17,8 +17,8 @@ class DiscreteQfDerivedPolicy(Policy, Serializable):
     DiscreteQfDerived policy.
 
     Args:
-        env_spec: Environment specification.
-        qf: The q-function used.
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        qf (garage.q_functions.QFunction): The q-function used.
     """
 
     def __init__(self, env_spec, qf):

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -10,27 +10,40 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     """
     GaussianMLPPolicy with GaussianMLPModel.
 
-    :param env_spec:
-    :param hidden_sizes: list of sizes for the fully-connected hidden
-    layers
-    :param learn_std: Is std trainable
-    :param init_std: Initial std
-    :param adaptive_std:
-    :param std_share_network:
-    :param std_hidden_sizes: list of sizes for the fully-connected layers
-     for std
-    :param min_std: whether to make sure that the std is at least some
-     threshold value, to avoid numerical issues
-    :param std_hidden_nonlinearity:
-    :param hidden_nonlinearity: nonlinearity used for each hidden layer
-    :param output_nonlinearity: nonlinearity for the output layer
-    :param mean_network: custom network for the output mean
-    :param std_network: custom network for the output log std
-    :param std_parametrization: how the std should be parametrized. There
-     are a few options:
+    A policy that contains a MLP to make prediction based on
+    a gaussian distribution.
+
+    Args:
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity: Nonlinearity used for each hidden layer.
+        output_nonlinearity: Nonlinearity for the output layer.
+        learn_std (bool): Is std trainable.
+        adaptive_std (bool): Is std a neural network. If False, it will be a
+            parameter.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        init_std (float): Initial value for std.
+        std_hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for std. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        min_std (float): If not None, the std is at least the value of min_std,
+            to avoid numerical issues.
+        max_std (float): If not None, the std is at most the value of max_std,
+            to avoid numerical issues.
+        std_hidden_nonlinearity: Nonlinearity for each hidden layer in
+            the std network.
+        std_output_nonlinearity: Nonlinearity for output layer in
+            the std network.
+        std_parametrization (str): How the std should be parametrized. There
+            are a few options:
         - exp: the logarithm of the std will be stored, and applied a
-         exponential transformation
+            exponential transformation
         - softplus: the std will be computed as log(1+exp(x))
+        layer_normalization (bool): Bool for using layer normalization or not.
     :return:
 
     """

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -19,8 +19,24 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
         hidden_sizes (list[int]): Output dimension of dense layer(s) for
             the MLP for mean. For example, (32, 32) means the MLP consists
             of two hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Nonlinearity used for each hidden layer.
-        output_nonlinearity: Nonlinearity for the output layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         learn_std (bool): Is std trainable.
         adaptive_std (bool): Is std a neural network. If False, it will be a
             parameter.
@@ -53,7 +69,11 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
                  name='GaussianMLPPolicyWithModel',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.tanh,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
                  output_nonlinearity=None,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
                  learn_std=True,
                  adaptive_std=False,
                  std_share_network=False,
@@ -74,7 +94,11 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
             output_dim=self.action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
             output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
             learn_std=learn_std,
             adaptive_std=adaptive_std,
             std_share_network=std_share_network,

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -58,7 +58,6 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
         self.action_dim = env_spec.action_space.flat_dim
 
         self.model = GaussianMLPModel(
-            name='GaussianMLPModel',
             output_dim=self.action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
@@ -73,7 +72,8 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
             std_hidden_nonlinearity=std_hidden_nonlinearity,
             std_output_nonlinearity=std_output_nonlinearity,
             std_parameterization=std_parameterization,
-            layer_normalization=layer_normalization)
+            layer_normalization=layer_normalization,
+            name='GaussianMLPModel')
 
         self._initialize()
 

--- a/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -16,24 +16,30 @@ class DiscreteMLPQFunction:
         env_spec: Environment specification.
         name: Name of the q-function, also serves as the variable scope.
         hidden_sizes: Output dimension of dense layer(s).
-        hidden_nonlinearity: Activation function for
-                    intermediate dense layer(s).
-        hidden_w_init: Initializer function for the weight
-                    of intermediate dense layer(s).
-        hidden_b_init: Initializer function for the bias
-                    of intermediate dense layer(s).
-        output_nonlinearity: Activation function for
-                    output dense layer.
-        output_w_init: Initializer function for the weight
-                    of output dense layer(s).
-        output_b_init: Initializer function for the bias
-                    of output dense layer(s).
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         layer_normalization: Bool for using layer normalization or not.
     """
 
     def __init__(self,
                  env_spec,
-                 name="discrete_mlp_q_function",
+                 name='discrete_mlp_q_function',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.relu,
                  hidden_w_init=tf.glorot_uniform_initializer(),
@@ -58,7 +64,7 @@ class DiscreteMLPQFunction:
             output_b_init=output_b_init,
             layer_normalization=layer_normalization)
 
-        obs_ph = tf.placeholder(tf.float32, (None, ) + obs_dim, name="obs")
+        obs_ph = tf.placeholder(tf.float32, (None, ) + obs_dim, name='obs')
 
         with tf.variable_scope(self._variable_scope):
             self.model.build(obs_ph)

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -20,7 +20,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
     def __init__(self,
                  input_shape,
                  output_dim,
-                 name="GaussianMLPRegressor",
+                 name='GaussianMLPRegressor',
                  mean_network=None,
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.tanh,
@@ -62,8 +62,8 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
         """
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
-        self._mean_network_name = "mean_network"
-        self._std_network_name = "std_network"
+        self._mean_network_name = 'mean_network'
+        self._std_network_name = 'std_network'
 
         with tf.variable_scope(name):
             if optimizer_args is None:
@@ -83,7 +83,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             if mean_network is None:
                 if std_share_network:
                     mean_network = MLP(
-                        name="mean_network",
+                        name='mean_network',
                         input_shape=input_shape,
                         output_dim=2 * output_dim,
                         hidden_sizes=hidden_sizes,
@@ -93,11 +93,11 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
                     l_mean = L.SliceLayer(
                         mean_network.output_layer,
                         slice(output_dim),
-                        name="mean_slice",
+                        name='mean_slice',
                     )
                 else:
                     mean_network = MLP(
-                        name="mean_network",
+                        name='mean_network',
                         input_shape=input_shape,
                         output_dim=output_dim,
                         hidden_sizes=hidden_sizes,
@@ -108,7 +108,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
 
             if adaptive_std:
                 l_log_std = MLP(
-                    name="log_std_network",
+                    name='log_std_network',
                     input_shape=input_shape,
                     input_var=mean_network.input_layer.input_var,
                     output_dim=output_dim,
@@ -120,14 +120,14 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
                 l_log_std = L.SliceLayer(
                     mean_network.output_layer,
                     slice(output_dim, 2 * output_dim),
-                    name="log_std_slice",
+                    name='log_std_slice',
                 )
             else:
                 l_log_std = L.ParamLayer(
                     mean_network.input_layer,
                     num_units=output_dim,
                     param=tf.constant_initializer(np.log(init_std)),
-                    name="output_log_std",
+                    name='output_log_std',
                     trainable=learn_std,
                 )
 
@@ -135,29 +135,29 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
 
             xs_var = mean_network.input_layer.input_var
             ys_var = tf.placeholder(
-                dtype=tf.float32, name="ys", shape=(None, output_dim))
+                dtype=tf.float32, name='ys', shape=(None, output_dim))
             old_means_var = tf.placeholder(
-                dtype=tf.float32, name="ys", shape=(None, output_dim))
+                dtype=tf.float32, name='ys', shape=(None, output_dim))
             old_log_stds_var = tf.placeholder(
                 dtype=tf.float32,
-                name="old_log_stds",
+                name='old_log_stds',
                 shape=(None, output_dim))
 
             x_mean_var = tf.Variable(
                 np.zeros((1, ) + input_shape, dtype=np.float32),
-                name="x_mean",
+                name='x_mean',
             )
             x_std_var = tf.Variable(
                 np.ones((1, ) + input_shape, dtype=np.float32),
-                name="x_std",
+                name='x_std',
             )
             y_mean_var = tf.Variable(
                 np.zeros((1, output_dim), dtype=np.float32),
-                name="y_mean",
+                name='y_mean',
             )
             y_std_var = tf.Variable(
                 np.ones((1, output_dim), dtype=np.float32),
-                name="y_std",
+                name='y_std',
             )
 
             normalized_xs_var = (xs_var - x_mean_var) / x_std_var
@@ -211,12 +211,12 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             )
 
             if use_trust_region:
-                optimizer_args["leq_constraint"] = (mean_kl, max_kl_step)
-                optimizer_args["inputs"] = [
+                optimizer_args['leq_constraint'] = (mean_kl, max_kl_step)
+                optimizer_args['inputs'] = [
                     xs_var, ys_var, old_means_var, old_log_stds_var
                 ]
             else:
-                optimizer_args["inputs"] = [xs_var, ys_var]
+                optimizer_args['inputs'] = [xs_var, ys_var]
 
             self._optimizer.update_opt(**optimizer_args)
 
@@ -292,9 +292,9 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             inputs = [xs, ys]
         loss_before = self._optimizer.loss(inputs)
         if self._name:
-            prefix = self._name + "/"
+            prefix = self._name + '/'
         else:
-            prefix = ""
+            prefix = ''
         tabular.record(prefix + 'LossBefore', loss_before)
         self._optimizer.optimize(inputs)
         loss_after = self._optimizer.loss(inputs)
@@ -327,7 +327,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             mean=means, log_std=log_stds))
 
     def log_likelihood_sym(self, x_var, y_var, name=None):
-        with tf.name_scope(name, "log_likelihood_sym", [x_var, y_var]):
+        with tf.name_scope(name, 'log_likelihood_sym', [x_var, y_var]):
             normalized_xs_var = (x_var - self._x_mean_var) / self._x_std_var
 
             with tf.name_scope(

--- a/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -13,33 +13,37 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
     distribution to the outputs.
 
     Args:
-    :param output_dim: Output dimension of the model.
-    :param name: Name of the model.
-    :param hidden_sizes: List of sizes for the fully-connected hidden
-        layers.
-    :param learn_std: Is std trainable.
-    :param init_std: Initial value for std.
-    :param adaptive_std: Is std a neural network. If False, it will be a
-        parameter.
-    :param std_share_network: Boolean for whether mean and std share the same
-        network.
-    :param std_hidden_sizes: List of sizes for the fully-connected layers
-        for std.
-    :param min_std: Whether to make sure that the std is at least some
-        threshold value, to avoid numerical issues.
-    :param max_std: Whether to make sure that the std is at most some
-        threshold value, to avoid numerical issues.
-    :param std_hidden_nonlinearity: Nonlinearity for each hidden layer in
-        the std network.
-    :param std_output_nonlinearity: Nonlinearity for output layer in
-        the std network.
-    :param std_parametrization: How the std should be parametrized. There
-        are a few options:
+        input_shape (tuple[int]): Input shape of the training data.
+        output_dim (int): Output dimension of the model.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity: Nonlinearity used for each hidden layer.
+        output_nonlinearity: Nonlinearity for the output layer.
+        learn_std (bool): Is std trainable.
+        init_std (float): Initial value for std.
+        adaptive_std (bool): Is std a neural network. If False, it will be a
+            parameter.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        std_hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for std. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        min_std (float): If not None, the std is at least the value of min_std,
+            to avoid numerical issues.
+        max_std (float): If not None, the std is at most the value of max_std,
+            to avoid numerical issues.
+        std_hidden_nonlinearity: Nonlinearity for each hidden layer in
+            the std network.
+        std_output_nonlinearity: Nonlinearity for output layer in
+            the std network.
+        std_parametrization (str): How the std should be parametrized. There
+            are a few options:
         - exp: the logarithm of the std will be stored, and applied a
             exponential transformation
         - softplus: the std will be computed as log(1+exp(x))
-    :param hidden_nonlinearity: Nonlinearity used for each hidden layer.
-    :param output_nonlinearity: Nonlinearity for the output layer.
+        layer_normalization (bool): Bool for using layer normalization or not.
     """
 
     def __init__(self,
@@ -47,7 +51,6 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
                  output_dim,
                  name='GaussianMLPRegressorModel',
                  **kwargs):
-        # Network parameters
         super().__init__(output_dim=output_dim, name=name, **kwargs)
         self._input_shape = input_shape
 

--- a/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -58,7 +58,7 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
             'normalized_log_stds', 'x_mean', 'x_std', 'y_mean', 'y_std', 'dist'
         ]
 
-    def _build(self, state_input):
+    def _build(self, state_input, name=None):
         with tf.variable_scope('normalized_vars'):
             x_mean_var = tf.get_variable(
                 name='x_mean',

--- a/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -19,8 +19,24 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
         hidden_sizes (list[int]): Output dimension of dense layer(s) for
             the MLP for mean. For example, (32, 32) means the MLP consists
             of two hidden layers, each with 32 hidden units.
-        hidden_nonlinearity: Nonlinearity used for each hidden layer.
-        output_nonlinearity: Nonlinearity for the output layer.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
         learn_std (bool): Is std trainable.
         init_std (float): Initial value for std.
         adaptive_std (bool): Is std a neural network. If False, it will be a

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -16,27 +16,53 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
     A class for performing regression by fitting a Gaussian distribution
     to the outputs.
 
-    :param input_shape: Shape of the input data.
-    :param output_dim: Dimension of output.
-    :param hidden_sizes: Number of hidden units of each layer of the mean
-     network.
-    :param hidden_nonlinearity: Non-linearity used for each layer of the
-     mean network.
-    :param optimizer: Optimizer for minimizing the negative log-likelihood.
-    :param use_trust_region: Whether to use trust region constraint.
-    :param max_kl_step: KL divergence constraint for each iteration
-    :param learn_std: Whether to learn the standard deviations. Only
-     effective if adaptive_std is False. If adaptive_std is True, this
-     parameter is ignored, and the weights for the std network are always
-     earned.
-    :param adaptive_std: Whether to make the std a function of the states.
-    :param std_share_network: Whether to use the same network as the mean.
-    :param std_hidden_sizes: Number of hidden units of each layer of the
-     std network. Only used if `std_share_network` is False. It defaults to
-     the same architecture as the mean.
-    :param std_nonlinearity: Non-linearity used for each layer of the std
-     network. Only used if `std_share_network` is False. It defaults to the
-     same non-linearity as the mean.
+    Args:
+        input_shape (tuple[int]): Input shape of the training data.
+        output_dim (int): Output dimension of the model.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        optimizer (tf.Optimizer): Optimizer for minimizing the negative
+            log-likelihood.
+        optimizer_args (dict): Arguments for the optimizer. Default is None,
+            which means no arguments.
+        use_trust_region (bool): Whether to use trust region constraint.
+        max_kl_step (float): KL divergence constraint for each iteration.
+        learn_std (bool): Is std trainable.
+        init_std (float): Initial value for std.
+        adaptive_std (bool): Is std a neural network. If False, it will be a
+            parameter.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        std_hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for std. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        std_nonlinearity: Nonlinearity for each hidden layer in
+            the std network.
+        layer_normalization (bool): Bool for using layer normalization or not.
+        normalize_inputs (bool): Bool for normalizing inputs or not.
+        normalize_outputs (bool): Bool for normalizing outputs or not.
+        subsample_factor (float): The factor to subsample the data. By default
+            it is 1.0, which means using all the data.
     """
 
     def __init__(self,
@@ -45,6 +71,11 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
                  name='GaussianMLPRegressorWithModel',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.tanh,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
+                 output_nonlinearity=None,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
                  optimizer=None,
                  optimizer_args=None,
                  use_trust_region=True,
@@ -84,7 +115,11 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
             output_dim=self._output_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
             output_nonlinearity=None,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
             learn_std=learn_std,
             adaptive_std=adaptive_std,
             std_share_network=std_share_network,

--- a/tests/fixtures/models/__init__.py
+++ b/tests/fixtures/models/__init__.py
@@ -1,8 +1,10 @@
+from tests.fixtures.models.simple_cnn_model import SimpleCNNModel
 from tests.fixtures.models.simple_gaussian_mlp_model import (
     SimpleGaussianMLPModel)
 from tests.fixtures.models.simple_mlp_model import SimpleMLPModel
 
 __all__ = [
+    "SimpleCNNModel",
     "SimpleGaussianMLPModel",
     "SimpleMLPModel",
 ]

--- a/tests/fixtures/models/__init__.py
+++ b/tests/fixtures/models/__init__.py
@@ -4,7 +4,7 @@ from tests.fixtures.models.simple_gaussian_mlp_model import (
 from tests.fixtures.models.simple_mlp_model import SimpleMLPModel
 
 __all__ = [
-    "SimpleCNNModel",
-    "SimpleGaussianMLPModel",
-    "SimpleMLPModel",
+    'SimpleCNNModel',
+    'SimpleGaussianMLPModel',
+    'SimpleMLPModel',
 ]

--- a/tests/fixtures/models/simple_cnn_model.py
+++ b/tests/fixtures/models/simple_cnn_model.py
@@ -9,8 +9,6 @@ class SimpleCNNModel(Model):
     def __init__(self, name, num_filters, filter_dims, strides, padding, *args,
                  **kwargs):
         super().__init__(name)
-        if padding not in ['SAME', 'VALID']:
-            raise ValueError("Invalid padding: {}.".format(padding))
         self.num_filters = num_filters
         self.filter_dims = filter_dims
         self.strides = strides

--- a/tests/fixtures/models/simple_cnn_model.py
+++ b/tests/fixtures/models/simple_cnn_model.py
@@ -1,0 +1,31 @@
+import tensorflow as tf
+
+from garage.tf.models import Model
+
+
+class SimpleCNNModel(Model):
+    """Simple CNNModel for testing."""
+
+    def __init__(self, name, num_filters, filter_dims, strides, padding, *args,
+                 **kwargs):
+        super().__init__(name)
+        if padding not in ['SAME', 'VALID']:
+            raise ValueError("Invalid padding: {}.".format(padding))
+        self.num_filters = num_filters
+        self.filter_dims = filter_dims
+        self.strides = strides
+        self.padding = padding
+
+    def _build(self, obs_input):
+        current_size = obs_input.get_shape().as_list()[1]
+        for filter_dim, stride in zip(self.filter_dims, self.strides):
+            if self.padding == 'SAME':
+                padded = int(filter_dim / 2) * 2
+                current_size = int(
+                    (current_size - filter_dim + padded) / stride) + 1
+            else:
+                current_size = int((current_size - filter_dim) / stride) + 1
+        flatten_shape = current_size * current_size * self.num_filters[-1]
+        return_var = tf.get_variable(
+            'return_var', (), initializer=tf.constant_initializer(0.5))
+        return tf.fill((tf.shape(obs_input)[0], flatten_shape), return_var)

--- a/tests/fixtures/models/simple_cnn_model.py
+++ b/tests/fixtures/models/simple_cnn_model.py
@@ -14,7 +14,7 @@ class SimpleCNNModel(Model):
         self.strides = strides
         self.padding = padding
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         current_size = obs_input.get_shape().as_list()[1]
         for filter_dim, stride in zip(self.filter_dims, self.strides):
             if self.padding == 'SAME':

--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -14,7 +14,7 @@ class SimpleGaussianMLPModel(Model):
     def network_output_spec(self):
         return ['sample', 'mean', 'log_std', 'std_param', 'dist']
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)
         log_std = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)
         action = mean + log_std * 0.5

--- a/tests/fixtures/models/simple_mlp_model.py
+++ b/tests/fixtures/models/simple_mlp_model.py
@@ -10,7 +10,7 @@ class SimpleMLPModel(Model):
         super().__init__(name)
         self.output_dim = output_dim
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         return_var = tf.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/fixtures/models/simple_mlp_model.py
+++ b/tests/fixtures/models/simple_mlp_model.py
@@ -11,4 +11,6 @@ class SimpleMLPModel(Model):
         self.output_dim = output_dim
 
     def _build(self, obs_input):
-        return tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)
+        return_var = tf.get_variable(
+            'return_var', (), initializer=tf.constant_initializer(0.5))
+        return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/garage/tf/core/test_cnn.py
+++ b/tests/garage/tf/core/test_cnn.py
@@ -1,3 +1,4 @@
+from nose2.tools.params import params
 import numpy as np
 import tensorflow as tf
 
@@ -10,7 +11,7 @@ from tests.helpers import max_pooling
 
 class TestCNN(TfGraphTestCase):
     def setUp(self):
-        super(TestCNN, self).setUp()
+        super().setUp()
         self.batch_size = 5
         self.input_width = 10
         self.input_height = 10
@@ -20,22 +21,79 @@ class TestCNN(TfGraphTestCase):
         input_shape = self.obs_input.shape[1:]  # height, width, channel
         self._input_ph = tf.placeholder(
             tf.float32, shape=(None, ) + input_shape, name="input")
-
-        self._output_shape = 2
-        self.filter_sizes = (3, 3)
-        self.in_channels = (3, 32)
-        self.out_channels = (32, 64)
-
         self.hidden_nonlinearity = tf.nn.relu
 
-    def test_output_shape(self):
+    @params(
+        ((1, ), (32, ), (1, )),
+        ((3, ), (32, ), (1, )),
+        ((3, ), (32, ), (2, )),
+        ((1, 1), (32, 64), (1, 1)),
+        ((3, 3), (32, 64), (1, 1)),
+        ((3, 3), (32, 64), (2, 2)),
+    )
+    def test_output_shape_same(self, filter_sizes, out_channels, strides):
         with tf.variable_scope("CNN"):
             self.cnn = cnn(
                 input_var=self._input_ph,
-                output_dim=self._output_shape,
-                filter_dims=self.filter_sizes,
-                num_filters=self.out_channels,
-                stride=1,
+                filter_dims=filter_sizes,
+                num_filters=out_channels,
+                strides=strides,
+                name="cnn",
+                padding="SAME",
+                hidden_w_init=tf.constant_initializer(1),
+                hidden_nonlinearity=self.hidden_nonlinearity)
+
+        self.sess.run(tf.global_variables_initializer())
+
+        result = self.sess.run(
+            self.cnn, feed_dict={self._input_ph: self.obs_input})
+
+        current_size = self.input_width
+        for filter_size, stride in zip(filter_sizes, strides):
+            padded = int(filter_size / 2) * 2
+            current_size = int(
+                (current_size - filter_size + padded) / stride) + 1
+        flatten_shape = current_size * current_size * out_channels[-1]
+        assert result.shape == (5, flatten_shape)
+
+    @params(((1, ), (32, ), (1, )), ((3, ), (32, ), (1, )),
+            ((3, ), (32, ), (2, )), ((1, 1), (32, 64), (1, 1)),
+            ((3, 3), (32, 64), (1, 1)), ((3, 3), (32, 64), (2, 2)))
+    def test_output_shape_valid(self, filter_sizes, out_channels, strides):
+        with tf.variable_scope("CNN"):
+            self.cnn = cnn(
+                input_var=self._input_ph,
+                filter_dims=filter_sizes,
+                num_filters=out_channels,
+                strides=strides,
+                name="cnn",
+                padding="VALID",
+                hidden_w_init=tf.constant_initializer(1),
+                hidden_nonlinearity=self.hidden_nonlinearity)
+
+        self.sess.run(tf.global_variables_initializer())
+
+        result = self.sess.run(
+            self.cnn, feed_dict={self._input_ph: self.obs_input})
+
+        current_size = self.input_width
+        for filter_size, stride in zip(filter_sizes, strides):
+            current_size = int((current_size - filter_size) / stride) + 1
+        flatten_shape = current_size * current_size * out_channels[-1]
+        assert result.shape == (5, flatten_shape)
+
+    @params(((1, ), (3, ), (32, ), (1, )), ((3, ), (3, ), (32, ), (1, )),
+            ((3, ), (3, ), (32, ), (2, )), ((1, 1), (3, 32), (32, 64), (1, 1)),
+            ((3, 3), (3, 32), (32, 64), (1, 1)), ((3, 3), (3, 32), (32, 64),
+                                                  (2, 2)))
+    def test_output_with_identity_filter(self, filter_sizes, in_channels,
+                                         out_channels, strides):
+        with tf.variable_scope("CNN"):
+            self.cnn = cnn(
+                input_var=self._input_ph,
+                filter_dims=filter_sizes,
+                num_filters=out_channels,
+                strides=strides,
                 name="cnn1",
                 padding="VALID",
                 hidden_w_init=tf.constant_initializer(1),
@@ -45,61 +103,36 @@ class TestCNN(TfGraphTestCase):
 
         result = self.sess.run(
             self.cnn, feed_dict={self._input_ph: self.obs_input})
-        assert result.shape[1] == self._output_shape
-
-    def test_output_with_identity_filter(self):
-        stride = 1
-        with tf.variable_scope("CNN"):
-            self.cnn = cnn(
-                input_var=self._input_ph,
-                output_dim=self._output_shape,
-                filter_dims=self.filter_sizes,
-                num_filters=self.out_channels,
-                stride=stride,
-                name="cnn1",
-                padding="VALID",
-                hidden_w_init=tf.constant_initializer(1),
-                hidden_nonlinearity=self.hidden_nonlinearity)
-
-        self.sess.run(tf.global_variables_initializer())
-
-        result = self.sess.run(
-            self.cnn, feed_dict={self._input_ph: self.obs_input})
-
-        # get weight values
-        with tf.variable_scope("CNN", reuse=True):
-            out_w = tf.get_variable("cnn1/output/kernel")
-            out_b = tf.get_variable("cnn1/output/bias")
 
         filter_sum = 1
         # filter value after 3 layers of conv
-        for filter_size, in_channel in zip(self.filter_sizes,
-                                           self.in_channels):
+        for filter_size, in_channel in zip(filter_sizes, in_channels):
             filter_sum *= filter_size * filter_size * in_channel
 
-        # input shape 10 * 10 * 3
-        # after two conv layer, we have filter
-        # with shape 6 * 6 * 32 (last channel)
+        current_size = self.input_width
+        for filter_size, stride in zip(filter_sizes, strides):
+            current_size = int((current_size - filter_size) / stride) + 1
+        flatten_shape = current_size * current_size * out_channels[-1]
 
         # flatten
-        h_out = np.full(
-            (self.batch_size, 6 * 6 * self.out_channels[-1]),
-            filter_sum,
-            dtype=np.float32)
-        # pass to a dense layer
-        dense_in = tf.matmul(h_out, out_w) + out_b
-        np.testing.assert_array_equal(dense_in.eval(), result)
+        h_out = np.full((self.batch_size, flatten_shape),
+                        filter_sum,
+                        dtype=np.float32)
+        np.testing.assert_array_equal(h_out, result)
 
-    def test_output_with_random_filter(self):
-        stride = 1
+    @params(((1, ), (3, ), (32, ), (1, )), ((3, ), (3, ), (32, ), (1, )),
+            ((3, ), (3, ), (32, ), (2, )), ((1, 1), (3, 32), (32, 64), (1, 1)),
+            ((3, 3), (3, 32), (32, 64), (1, 1)), ((3, 3), (3, 32), (32, 64),
+                                                  (2, 2)))
+    def test_output_with_random_filter(self, filter_sizes, in_channels,
+                                       out_channels, strides):
         # Build a cnn with random filter weights
         with tf.variable_scope("CNN"):
             self.cnn2 = cnn(
                 input_var=self._input_ph,
-                output_dim=self._output_shape,
-                filter_dims=self.filter_sizes,
-                num_filters=self.out_channels,
-                stride=stride,
+                filter_dims=filter_sizes,
+                num_filters=out_channels,
+                strides=strides,
                 name="cnn1",
                 padding="VALID",
                 hidden_nonlinearity=self.hidden_nonlinearity)
@@ -109,49 +142,52 @@ class TestCNN(TfGraphTestCase):
         result = self.sess.run(
             self.cnn2, feed_dict={self._input_ph: self.obs_input})
 
+        two_layer = len(filter_sizes) == 2
         # get weight values
         with tf.variable_scope("CNN", reuse=True):
             h0_w = tf.get_variable("cnn1/h0/weight").eval()
             h0_b = tf.get_variable("cnn1/h0/bias").eval()
-            h1_w = tf.get_variable("cnn1/h1/weight").eval()
-            h1_b = tf.get_variable("cnn1/h1/bias").eval()
-            out_w = tf.get_variable("cnn1/output/kernel")
-            out_b = tf.get_variable("cnn1/output/bias")
+            if two_layer:
+                h1_w = tf.get_variable("cnn1/h1/weight").eval()
+                h1_b = tf.get_variable("cnn1/h1/bias").eval()
 
-        filter_weights = (h0_w, h1_w)
-        filter_bias = (h0_b, h1_b)
+        filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
+        filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
 
         # convolution according to TensorFlow's approach
         input_val = convolve(
             _input=self.obs_input,
             filter_weights=filter_weights,
             filter_bias=filter_bias,
-            stride=stride,
-            filter_sizes=self.filter_sizes,
-            in_channels=self.in_channels,
+            strides=strides,
+            filter_sizes=filter_sizes,
+            in_channels=in_channels,
             hidden_nonlinearity=self.hidden_nonlinearity)
 
         # flatten
-        dense_in = input_val.reshape((self.batch_size, -1)).astype(np.float32)
-        # pass to a dense layer
-        dense_out = tf.matmul(dense_in, out_w) + out_b
-        np.testing.assert_array_almost_equal(dense_out.eval(), result)
+        dense_out = input_val.reshape((self.batch_size, -1)).astype(np.float32)
+        np.testing.assert_array_almost_equal(dense_out, result)
 
-    def test_output_with_max_pooling(self):
-        stride = 1
-        pool_shape = 2
-        pool_stride = 2
+    @params(
+        ((1, ), (3, ), (32, ), (1, ), 1, 1),
+        ((3, ), (3, ), (32, ), (1, ), 1, 1),
+        ((3, ), (3, ), (32, ), (2, ), 2, 2),
+        ((1, 1), (3, 32), (32, 64), (1, 1), 1, 1),
+        ((3, 3), (3, 32), (32, 64), (1, 1), 1, 1),
+    )
+    def test_output_with_max_pooling(self, filter_sizes, in_channels,
+                                     out_channels, strides, pool_shape,
+                                     pool_stride):
         # Build a cnn with random filter weights
         with tf.variable_scope("CNN"):
             self.cnn2 = cnn_with_max_pooling(
                 input_var=self._input_ph,
-                output_dim=self._output_shape,
-                filter_dims=self.filter_sizes,
-                num_filters=self.out_channels,
-                stride=stride,
+                filter_dims=filter_sizes,
+                num_filters=out_channels,
+                strides=strides,
                 name="cnn1",
-                pool_shape=(pool_shape, pool_shape),
-                pool_stride=(pool_stride, pool_stride),
+                pool_shapes=(pool_shape, pool_shape),
+                pool_strides=(pool_stride, pool_stride),
                 padding="VALID",
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
@@ -161,30 +197,29 @@ class TestCNN(TfGraphTestCase):
         result = self.sess.run(
             self.cnn2, feed_dict={self._input_ph: self.obs_input})
 
+        two_layer = len(filter_sizes) == 2
         # get weight values
         with tf.variable_scope("CNN", reuse=True):
             h0_w = tf.get_variable("cnn1/h0/weight").eval()
             h0_b = tf.get_variable("cnn1/h0/bias").eval()
-            h1_w = tf.get_variable("cnn1/h1/weight").eval()
-            h1_b = tf.get_variable("cnn1/h1/bias").eval()
-            out_w = tf.get_variable("cnn1/output/kernel")
-            out_b = tf.get_variable("cnn1/output/bias")
+            if two_layer:
+                h1_w = tf.get_variable("cnn1/h1/weight").eval()
+                h1_b = tf.get_variable("cnn1/h1/bias").eval()
 
-        filter_weights = (h0_w, h1_w)
-        filter_bias = (h0_b, h1_b)
+        filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
+        filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
 
         input_val = self.obs_input
 
         # convolution according to TensorFlow's approach
         # and perform max pooling on each layer
         for filter_size, filter_weight, _filter_bias, in_channel in zip(
-                self.filter_sizes, filter_weights, filter_bias,
-                self.in_channels):
+                filter_sizes, filter_weights, filter_bias, in_channels):
             input_val = convolve(
                 _input=input_val,
                 filter_weights=(filter_weight, ),
                 filter_bias=(_filter_bias, ),
-                stride=stride,
+                strides=strides,
                 filter_sizes=(filter_size, ),
                 in_channels=(in_channel, ),
                 hidden_nonlinearity=self.hidden_nonlinearity)
@@ -196,7 +231,29 @@ class TestCNN(TfGraphTestCase):
                 pool_stride=pool_stride)
 
         # flatten
-        dense_in = input_val.reshape((self.batch_size, -1)).astype(np.float32)
-        # pass to a dense layer
-        dense_out = tf.matmul(dense_in, out_w) + out_b
-        np.testing.assert_array_equal(dense_out.eval(), result)
+        dense_out = input_val.reshape((self.batch_size, -1)).astype(np.float32)
+        np.testing.assert_array_equal(dense_out, result)
+
+    def test_invalid_padding(self):
+        with self.assertRaises(ValueError):
+            with tf.variable_scope("CNN"):
+                self.cnn = cnn(
+                    input_var=self._input_ph,
+                    filter_dims=(3, ),
+                    num_filters=(32, ),
+                    strides=(1, ),
+                    name="cnn",
+                    padding="UNKNOWN")
+
+    def test_invalid_padding_max_pooling(self):
+        with self.assertRaises(ValueError):
+            with tf.variable_scope("CNN"):
+                self.cnn = cnn_with_max_pooling(
+                    input_var=self._input_ph,
+                    filter_dims=(3, ),
+                    num_filters=(32, ),
+                    strides=(1, ),
+                    name="cnn",
+                    pool_shapes=(1, 1),
+                    pool_strides=(1, 1),
+                    padding="UNKNOWN")

--- a/tests/garage/tf/core/test_cnn.py
+++ b/tests/garage/tf/core/test_cnn.py
@@ -20,7 +20,7 @@ class TestCNN(TfGraphTestCase):
 
         input_shape = self.obs_input.shape[1:]  # height, width, channel
         self._input_ph = tf.placeholder(
-            tf.float32, shape=(None, ) + input_shape, name="input")
+            tf.float32, shape=(None, ) + input_shape, name='input')
         self.hidden_nonlinearity = tf.nn.relu
 
     @params(
@@ -32,14 +32,14 @@ class TestCNN(TfGraphTestCase):
         ((3, 3), (32, 64), (2, 2)),
     )
     def test_output_shape_same(self, filter_sizes, out_channels, strides):
-        with tf.variable_scope("CNN"):
+        with tf.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
                 num_filters=out_channels,
                 strides=strides,
-                name="cnn",
-                padding="SAME",
+                name='cnn',
+                padding='SAME',
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
@@ -60,14 +60,14 @@ class TestCNN(TfGraphTestCase):
             ((3, ), (32, ), (2, )), ((1, 1), (32, 64), (1, 1)),
             ((3, 3), (32, 64), (1, 1)), ((3, 3), (32, 64), (2, 2)))
     def test_output_shape_valid(self, filter_sizes, out_channels, strides):
-        with tf.variable_scope("CNN"):
+        with tf.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
                 num_filters=out_channels,
                 strides=strides,
-                name="cnn",
-                padding="VALID",
+                name='cnn',
+                padding='VALID',
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
@@ -88,14 +88,14 @@ class TestCNN(TfGraphTestCase):
                                                   (2, 2)))
     def test_output_with_identity_filter(self, filter_sizes, in_channels,
                                          out_channels, strides):
-        with tf.variable_scope("CNN"):
+        with tf.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
                 num_filters=out_channels,
                 strides=strides,
-                name="cnn1",
-                padding="VALID",
+                name='cnn1',
+                padding='VALID',
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
@@ -127,14 +127,14 @@ class TestCNN(TfGraphTestCase):
     def test_output_with_random_filter(self, filter_sizes, in_channels,
                                        out_channels, strides):
         # Build a cnn with random filter weights
-        with tf.variable_scope("CNN"):
+        with tf.variable_scope('CNN'):
             self.cnn2 = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
                 num_filters=out_channels,
                 strides=strides,
-                name="cnn1",
-                padding="VALID",
+                name='cnn1',
+                padding='VALID',
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
         self.sess.run(tf.global_variables_initializer())
@@ -144,12 +144,12 @@ class TestCNN(TfGraphTestCase):
 
         two_layer = len(filter_sizes) == 2
         # get weight values
-        with tf.variable_scope("CNN", reuse=True):
-            h0_w = tf.get_variable("cnn1/h0/weight").eval()
-            h0_b = tf.get_variable("cnn1/h0/bias").eval()
+        with tf.variable_scope('CNN', reuse=True):
+            h0_w = tf.get_variable('cnn1/h0/weight').eval()
+            h0_b = tf.get_variable('cnn1/h0/bias').eval()
             if two_layer:
-                h1_w = tf.get_variable("cnn1/h1/weight").eval()
-                h1_b = tf.get_variable("cnn1/h1/bias").eval()
+                h1_w = tf.get_variable('cnn1/h1/weight').eval()
+                h1_b = tf.get_variable('cnn1/h1/bias').eval()
 
         filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
         filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
@@ -179,16 +179,16 @@ class TestCNN(TfGraphTestCase):
                                      out_channels, strides, pool_shape,
                                      pool_stride):
         # Build a cnn with random filter weights
-        with tf.variable_scope("CNN"):
+        with tf.variable_scope('CNN'):
             self.cnn2 = cnn_with_max_pooling(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
                 num_filters=out_channels,
                 strides=strides,
-                name="cnn1",
+                name='cnn1',
                 pool_shapes=(pool_shape, pool_shape),
                 pool_strides=(pool_stride, pool_stride),
-                padding="VALID",
+                padding='VALID',
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
@@ -199,12 +199,12 @@ class TestCNN(TfGraphTestCase):
 
         two_layer = len(filter_sizes) == 2
         # get weight values
-        with tf.variable_scope("CNN", reuse=True):
-            h0_w = tf.get_variable("cnn1/h0/weight").eval()
-            h0_b = tf.get_variable("cnn1/h0/bias").eval()
+        with tf.variable_scope('CNN', reuse=True):
+            h0_w = tf.get_variable('cnn1/h0/weight').eval()
+            h0_b = tf.get_variable('cnn1/h0/bias').eval()
             if two_layer:
-                h1_w = tf.get_variable("cnn1/h1/weight").eval()
-                h1_b = tf.get_variable("cnn1/h1/bias").eval()
+                h1_w = tf.get_variable('cnn1/h1/weight').eval()
+                h1_b = tf.get_variable('cnn1/h1/bias').eval()
 
         filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
         filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
@@ -236,24 +236,24 @@ class TestCNN(TfGraphTestCase):
 
     def test_invalid_padding(self):
         with self.assertRaises(ValueError):
-            with tf.variable_scope("CNN"):
+            with tf.variable_scope('CNN'):
                 self.cnn = cnn(
                     input_var=self._input_ph,
                     filter_dims=(3, ),
                     num_filters=(32, ),
                     strides=(1, ),
-                    name="cnn",
-                    padding="UNKNOWN")
+                    name='cnn',
+                    padding='UNKNOWN')
 
     def test_invalid_padding_max_pooling(self):
         with self.assertRaises(ValueError):
-            with tf.variable_scope("CNN"):
+            with tf.variable_scope('CNN'):
                 self.cnn = cnn_with_max_pooling(
                     input_var=self._input_ph,
                     filter_dims=(3, ),
                     num_filters=(32, ),
                     strides=(1, ),
-                    name="cnn",
+                    name='cnn',
                     pool_shapes=(1, 1),
                     pool_strides=(1, 1),
-                    padding="UNKNOWN")
+                    padding='UNKNOWN')

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -18,7 +18,7 @@ class TestCNNModel(TfGraphTestCase):
                                   self.input_height, 3))
         input_shape = self.obs_input.shape[1:]  # height, width, channel
         self._input_ph = tf.placeholder(
-            tf.float32, shape=(None, ) + input_shape, name="input")
+            tf.float32, shape=(None, ) + input_shape, name='input')
 
     @params(
         ((1, ), (3, ), (32, ), (1, )),
@@ -34,8 +34,8 @@ class TestCNNModel(TfGraphTestCase):
             filter_dims=filter_sizes,
             num_filters=out_channels,
             strides=strides,
-            name="cnn_model",
-            padding="VALID",
+            name='cnn_model',
+            padding='VALID',
             hidden_w_init=tf.constant_initializer(1),
             hidden_nonlinearity=None)
 
@@ -74,8 +74,8 @@ class TestCNNModel(TfGraphTestCase):
             filter_dims=filter_sizes,
             num_filters=out_channels,
             strides=strides,
-            name="cnn_model",
-            padding="VALID",
+            name='cnn_model',
+            padding='VALID',
             hidden_w_init=tf.constant_initializer(1),
             hidden_nonlinearity=None)
         outputs = model.build(self._input_ph)
@@ -90,7 +90,7 @@ class TestCNNModel(TfGraphTestCase):
             model_pickled = pickle.loads(h)
             input_shape = self.obs_input.shape[1:]  # height, width, channel
             input_ph = tf.placeholder(
-                tf.float32, shape=(None, ) + input_shape, name="input")
+                tf.float32, shape=(None, ) + input_shape, name='input')
             outputs = model_pickled.build(input_ph)
             output2 = sess.run(outputs, feed_dict={input_ph: self.obs_input})
 

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -1,0 +1,97 @@
+import pickle
+
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.models import CNNModel
+from tests.fixtures import TfGraphTestCase
+
+
+class TestCNNModel(TfGraphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.batch_size = 5
+        self.input_width = 10
+        self.input_height = 10
+        self.obs_input = np.ones((self.batch_size, self.input_width,
+                                  self.input_height, 3))
+        input_shape = self.obs_input.shape[1:]  # height, width, channel
+        self._input_ph = tf.placeholder(
+            tf.float32, shape=(None, ) + input_shape, name="input")
+
+    @params(
+        ((1, ), (3, ), (32, ), (1, )),
+        ((3, ), (3, ), (32, ), (1, )),
+        ((3, ), (3, ), (32, ), (2, )),
+        ((1, 1), (3, 32), (32, 64), (1, 1)),
+        ((3, 3), (3, 32), (32, 64), (1, 1)),
+        ((3, 3), (3, 32), (32, 64), (2, 2)),
+    )
+    def test_output_value(self, filter_sizes, in_channels, out_channels,
+                          strides):
+        model = CNNModel(
+            filter_dims=filter_sizes,
+            num_filters=out_channels,
+            strides=strides,
+            name="cnn_model",
+            padding="VALID",
+            hidden_w_init=tf.constant_initializer(1),
+            hidden_nonlinearity=None)
+
+        outputs = model.build(self._input_ph)
+        output = self.sess.run(
+            outputs, feed_dict={self._input_ph: self.obs_input})
+
+        filter_sum = 1
+        # filter value after 3 layers of conv
+        for filter_size, in_channel in zip(filter_sizes, in_channels):
+            filter_sum *= filter_size * filter_size * in_channel
+
+        current_size = self.input_width
+        for filter_size, stride in zip(filter_sizes, strides):
+            current_size = int((current_size - filter_size) / stride) + 1
+        flatten_shape = current_size * current_size * out_channels[-1]
+
+        # flatten
+        expected_output = np.full((self.batch_size, flatten_shape),
+                                  filter_sum,
+                                  dtype=np.float32)
+
+        assert np.array_equal(output, expected_output)
+
+    @params(
+        ((1, ), (3, ), (32, ), (1, )),
+        ((3, ), (3, ), (32, ), (1, )),
+        ((3, ), (3, ), (32, ), (2, )),
+        ((1, 1), (3, 32), (32, 64), (1, 1)),
+        ((3, 3), (3, 32), (32, 64), (1, 1)),
+        ((3, 3), (3, 32), (32, 64), (2, 2)),
+    )
+    def test_is_pickleable(self, filter_sizes, in_channels, out_channels,
+                           strides):
+        model = CNNModel(
+            filter_dims=filter_sizes,
+            num_filters=out_channels,
+            strides=strides,
+            name="cnn_model",
+            padding="VALID",
+            hidden_w_init=tf.constant_initializer(1),
+            hidden_nonlinearity=None)
+        outputs = model.build(self._input_ph)
+        with tf.variable_scope('cnn_model/cnn/h0', reuse=True):
+            bias = tf.get_variable('bias')
+        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+
+        output1 = self.sess.run(
+            outputs, feed_dict={self._input_ph: self.obs_input})
+        h = pickle.dumps(model)
+        with tf.Session(graph=tf.Graph()) as sess:
+            model_pickled = pickle.loads(h)
+            input_shape = self.obs_input.shape[1:]  # height, width, channel
+            input_ph = tf.placeholder(
+                tf.float32, shape=(None, ) + input_shape, name="input")
+            outputs = model_pickled.build(input_ph)
+            output2 = sess.run(outputs, feed_dict={input_ph: self.obs_input})
+
+            assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -17,7 +17,7 @@ class SimpleModel(Model):
     def network_output_spec(self):
         return ['state', 'action']
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         state = mlp(obs_input, self._output_dim, self._hidden_sizes, 'state')
         action = mlp(obs_input, self._output_dim, self._hidden_sizes, 'action')
         return state, action
@@ -30,7 +30,7 @@ class SimpleModel2(Model):
         self._output_dim = output_dim
         self._hidden_sizes = hidden_sizes
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         action = mlp(obs_input, self._output_dim, self._hidden_sizes, 'state')
         return action
 
@@ -46,7 +46,7 @@ class ComplicatedModel(Model):
     def network_output_spec(self):
         return ['action']
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         h1, _ = self._simple_model_1.build(obs_input)
         return self._simple_model_2.build(h1)
 
@@ -62,7 +62,7 @@ class ComplicatedModel2(Model):
     def network_output_spec(self):
         return ['action']
 
-    def _build(self, obs_input):
+    def _build(self, obs_input, name=None):
         h1, _ = self._parent_model.build(obs_input)
         return self._output_model.build(h1)
 

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -81,14 +81,14 @@ class TestModel(TfGraphTestCase):
 
     def test_model_creation_with_custom_name(self):
         input_var = tf.placeholder(tf.float32, shape=(None, 5))
-        model = SimpleModel(output_dim=2, name="MySimpleModel")
+        model = SimpleModel(output_dim=2, name='MySimpleModel')
         outputs = model.build(input_var, name='network_2')
         data = np.ones((3, 5))
         result, result2 = self.sess.run(
             [outputs, model.networks['network_2'].outputs],
             feed_dict={model.networks['network_2'].input: data})
         assert np.array_equal(result, result2)
-        assert model.name == "MySimpleModel"
+        assert model.name == 'MySimpleModel'
 
     def test_same_model_with_no_name(self):
         input_var = tf.placeholder(tf.float32, shape=(None, 5))

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -150,8 +150,8 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
 
         expected_prob = np.full(action_dim, 0.5)
 
-        obs_dim = env.spec.observation_space.flat_dim
-        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        obs_dim = env.spec.observation_space.shape
+        state_input = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
         dist1 = policy.dist_info_sym(state_input, name='policy2')
 
         prob = self.sess.run(dist1['prob'], feed_dict={state_input: [obs]})

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -189,13 +189,12 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
         # assign it to all one
         self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
         output1 = self.sess.run(
-            policy.model.networks['default'].outputs,
-            feed_dict={policy.input: [obs.flatten()]})
+            policy.outputs, feed_dict={policy.input: [obs.flatten()]})
         p = pickle.dumps(policy)
 
         with tf.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
-                policy_pickled.model.networks['default'].outputs,
+                policy_pickled.outputs,
                 feed_dict={policy_pickled.input: [obs.flatten()]})
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -1,0 +1,201 @@
+import pickle
+from unittest import mock
+
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.envs import TfEnv
+from garage.tf.policies import CategoricalConvPolicyWithModel
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
+from tests.fixtures.models import SimpleCNNModel
+from tests.fixtures.models import SimpleMLPModel
+
+
+class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
+    @params(
+        ((1, ), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, ), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+    )
+    @mock.patch('numpy.random.rand')
+    def test_get_action(self, obs_dim, action_dim, filter_dims, filter_sizes,
+                        strides, padding, hidden_sizes, mock_rand):
+        mock_rand.return_value = 0
+        env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_conv_policy_with_model.MLPModel'),
+                        new=SimpleMLPModel):
+            with mock.patch(('garage.tf.policies.'
+                             'categorical_conv_policy_with_model.CNNModel'),
+                            new=SimpleCNNModel):
+                policy = CategoricalConvPolicyWithModel(
+                    env_spec=env.spec,
+                    conv_filters=filter_dims,
+                    conv_filter_sizes=filter_sizes,
+                    conv_strides=strides,
+                    conv_pad=padding,
+                    hidden_sizes=hidden_sizes)
+
+        env.reset()
+        obs, _, _, _ = env.step(1)
+
+        action, prob = policy.get_action(obs)
+        expected_prob = np.full(action_dim, 0.5)
+
+        assert env.action_space.contains(action)
+        assert action == 0
+        assert np.array_equal(prob['prob'], expected_prob)
+
+        actions, probs = policy.get_actions([obs, obs, obs])
+        for action, prob in zip(actions, probs['prob']):
+            assert env.action_space.contains(action)
+            assert action == 0
+            assert np.array_equal(prob, expected_prob)
+
+    @params(
+        ((1, ), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, ), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+    )
+    def test_dist_info(self, obs_dim, action_dim, filter_dims, filter_sizes,
+                       strides, padding, hidden_sizes):
+        env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_conv_policy_with_model.MLPModel'),
+                        new=SimpleMLPModel):
+            with mock.patch(('garage.tf.policies.'
+                             'categorical_conv_policy_with_model.CNNModel'),
+                            new=SimpleCNNModel):
+                policy = CategoricalConvPolicyWithModel(
+                    env_spec=env.spec,
+                    conv_filters=filter_dims,
+                    conv_filter_sizes=filter_sizes,
+                    conv_strides=strides,
+                    conv_pad=padding,
+                    hidden_sizes=hidden_sizes)
+
+        env.reset()
+        obs, _, _, _ = env.step(1)
+
+        expected_prob = np.full(action_dim, 0.5)
+
+        policy_probs = policy.dist_info([obs.flatten()])
+        assert np.array_equal(policy_probs['prob'][0], expected_prob)
+
+    @params(
+        ((1, ), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'VALID', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'VALID', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'VALID', (4, 4)),
+        ((1, ), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, ), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, ), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+        ((1, 1), 1, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, ), (3, ), (1, ), 'SAME', (4, )),
+        ((2, 2), 2, (32, 64), (3, 3), (1, 1), 'SAME', (4, 4)),
+        ((2, 2), 2, (32, 64), (3, 3), (2, 2), 'SAME', (4, 4)),
+    )
+    def test_dist_info_sym(self, obs_dim, action_dim, filter_dims,
+                           filter_sizes, strides, padding, hidden_sizes):
+        env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_conv_policy_with_model.MLPModel'),
+                        new=SimpleMLPModel):
+            with mock.patch(('garage.tf.policies.'
+                             'categorical_conv_policy_with_model.CNNModel'),
+                            new=SimpleCNNModel):
+                policy = CategoricalConvPolicyWithModel(
+                    env_spec=env.spec,
+                    conv_filters=filter_dims,
+                    conv_filter_sizes=filter_sizes,
+                    conv_strides=strides,
+                    conv_pad=padding,
+                    hidden_sizes=hidden_sizes)
+
+        env.reset()
+        obs, _, _, _ = env.step(1)
+
+        expected_prob = np.full(action_dim, 0.5)
+
+        obs_dim = env.spec.observation_space.flat_dim
+        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        dist1 = policy.dist_info_sym(state_input, name="policy2")
+
+        prob = self.sess.run(
+            dist1['prob'], feed_dict={state_input: [obs.flatten()]})
+        assert np.array_equal(prob[0], expected_prob)
+
+    @params(
+        ((1, ), 1),
+        ((2, ), 2),
+        ((1, 1), 1),
+        ((2, 2), 2),
+    )
+    @mock.patch('numpy.random.rand')
+    def test_is_pickleable(self, obs_dim, action_dim, mock_rand):
+        mock_rand.return_value = 0
+        env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_conv_policy_with_model.MLPModel'),
+                        new=SimpleMLPModel):
+            with mock.patch(('garage.tf.policies.'
+                             'categorical_conv_policy_with_model.CNNModel'),
+                            new=SimpleCNNModel):
+                policy = CategoricalConvPolicyWithModel(
+                    env_spec=env.spec,
+                    conv_filters=(32, ),
+                    conv_filter_sizes=(3, ),
+                    conv_strides=(1, ),
+                    conv_pad='SAME',
+                    hidden_sizes=(4, ))
+        env.reset()
+        obs, _, _, _ = env.step(1)
+
+        with tf.variable_scope('CategoricalConvPolicy/MLPModel', reuse=True):
+            return_var = tf.get_variable('return_var')
+        # assign it to all one
+        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        output1 = self.sess.run(
+            policy.model.networks['default'].outputs,
+            feed_dict={policy.input: [obs.flatten()]})
+        p = pickle.dumps(policy)
+
+        with tf.Session(graph=tf.Graph()) as sess:
+            policy_pickled = pickle.loads(p)
+            output2 = sess.run(
+                policy_pickled.model.networks['default'].outputs,
+                feed_dict={policy_pickled.input: [obs.flatten()]})
+            assert np.array_equal(output1, output2)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -118,15 +118,15 @@ def max_pooling(_input, pool_shape, pool_stride):
 
 def write_file(result_json, algo):
     """Create new progress.json or append to existing one."""
-    latest_dir = "./latest_results"
-    latest_result = latest_dir + "/progress.json"
+    latest_dir = './latest_results'
+    latest_result = latest_dir + '/progress.json'
     res = {}
     if osp.exists(latest_result):
         res = json.loads(open(latest_result, 'r').read())
     elif not osp.exists(latest_dir):
         os.makedirs(latest_dir)
     res[algo] = result_json
-    result_file = open(latest_result, "w")
+    result_file = open(latest_result, 'w')
     result_file.write(json.dumps(res))
 
 
@@ -136,22 +136,22 @@ def create_json(b_csvs, g_csvs, trails, seeds, b_x, b_y, g_x, g_y, factor_g,
     task_result = {}
     for trail in range(trails):
         g_res, b_res = {}, {}
-        trail_seed = "trail_%d" % (trail + 1)
-        task_result["seed"] = seeds[trail]
+        trail_seed = 'trail_%d' % (trail + 1)
+        task_result['seed'] = seeds[trail]
         task_result[trail_seed] = {}
         df_g = json.loads(pd.read_csv(g_csvs[trail]).to_json())
         df_b = json.loads(pd.read_csv(b_csvs[trail]).to_json())
 
-        g_res["time_steps"] = list(
+        g_res['time_steps'] = list(
             map(lambda x: float(x) * factor_g, df_g[g_x].values()))
-        g_res["return"] = df_g[g_y]
+        g_res['return'] = df_g[g_y]
 
-        b_res["time_steps"] = list(
+        b_res['time_steps'] = list(
             map(lambda x: float(x) * factor_b, df_b[b_x].values()))
-        b_res["return"] = df_b[b_y]
+        b_res['return'] = df_b[b_y]
 
-        task_result[trail_seed]["garage"] = g_res
-        task_result[trail_seed]["baselines"] = b_res
+        task_result[trail_seed]['garage'] = g_res
+        task_result[trail_seed]['baselines'] = b_res
     return task_result
 
 
@@ -182,11 +182,11 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id,
         plt.plot(
             df_g[g_x],
             df_g[g_y],
-            label="garage_trial%d_seed%d" % (trial + 1, seed))
+            label='garage_trial%d_seed%d' % (trial + 1, seed))
         plt.plot(
             df_b[b_x],
             df_b[b_y],
-            label="baselines_trial%d_seed%d" % (trial + 1, seed))
+            label='baselines_trial%d_seed%d' % (trial + 1, seed))
 
     plt.legend()
     plt.xlabel(x_label)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -53,7 +53,7 @@ def step_env_with_gym_quirks(test_case,
         assert round_trip.env.spec == env.env.spec
 
 
-def convolve(_input, filter_weights, filter_bias, stride, filter_sizes,
+def convolve(_input, filter_weights, filter_bias, strides, filter_sizes,
              in_channels, hidden_nonlinearity):
     """Convolve."""
     # in_width = self.input_width
@@ -63,8 +63,8 @@ def convolve(_input, filter_weights, filter_bias, stride, filter_sizes,
     in_width = _input.shape[1]
     in_height = _input.shape[2]
 
-    for filter_size, in_shape, filter_weight, _filter_bias in zip(
-            filter_sizes, in_channels, filter_weights, filter_bias):
+    for filter_size, in_shape, filter_weight, _filter_bias, stride in zip(
+            filter_sizes, in_channels, filter_weights, filter_bias, strides):
         out_width = int((in_width - filter_size) / stride) + 1
         out_height = int((in_height - filter_size) / stride) + 1
         flatten_filter_size = filter_size * filter_size * in_shape


### PR DESCRIPTION
Time to work on CNN. This PR does the following:
- fix some small issue in cnn and removed the dense layer from it. Instead of having a "CNNnMLP", it's more reasonable to just do CNN -> MLP.
- Introduce the notion of `self.add_model()` and `self.build_models()` in policy. This is needed for stacking multiple models. In the future, when we eventually also make policy `is-a-model`, we will also put this notion into the rest of the models.
- and of course, categorical_conv_policy with model, and tests.
