### PR TITLE
Fix GaussianMLPRegressor

### DIFF
--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -276,7 +276,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             sess.run([
                 self._assign_x_mean,
                 self._assign_x_std,
-                ], feed_dict=feed_dict)  # yapf: disable
+            ], feed_dict=feed_dict)  # yapf: disable
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
             feed_dict = {

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -276,8 +276,7 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             sess.run([
                 self._assign_x_mean,
                 self._assign_x_std,
-            ],
-                     feed_dict=feed_dict)
+                ], feed_dict=feed_dict)  # yapf: disable
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
             feed_dict = {

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -235,21 +235,29 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             if self._normalize_inputs:
                 self._x_mean_var_ph = tf.placeholder(
                     shape=(1, ) + input_shape,
-                    dtype=tf.float32,)
+                    dtype=tf.float32,
+                )
                 self._x_std_var_ph = tf.placeholder(
                     shape=(1, ) + input_shape,
-                    dtype=tf.float32,)
-                self._assign_x_mean = tf.assign(self._x_mean_var, self._x_mean_var_ph)
-                self._assign_x_std = tf.assign(self._x_std_var, self._x_std_var_ph)
+                    dtype=tf.float32,
+                )
+                self._assign_x_mean = tf.assign(self._x_mean_var,
+                                                self._x_mean_var_ph)
+                self._assign_x_std = tf.assign(self._x_std_var,
+                                               self._x_std_var_ph)
             if self._normalize_outputs:
                 self._y_mean_var_ph = tf.placeholder(
                     shape=(1, output_dim),
-                    dtype=tf.float32,)
+                    dtype=tf.float32,
+                )
                 self._y_std_var_ph = tf.placeholder(
                     shape=(1, output_dim),
-                    dtype=tf.float32,)
-                self._assign_y_mean = tf.assign(self._y_mean_var, self._y_mean_var_ph)
-                self._assign_y_std = tf.assign(self._y_std_var, self._y_std_var_ph)
+                    dtype=tf.float32,
+                )
+                self._assign_y_mean = tf.assign(self._y_mean_var,
+                                                self._y_mean_var_ph)
+                self._assign_y_std = tf.assign(self._y_std_var,
+                                               self._y_std_var_ph)
 
     def fit(self, xs, ys):
         if self._subsample_factor < 1:
@@ -265,14 +273,19 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
                 self._x_mean_var_ph: np.mean(xs, axis=0, keepdims=True),
                 self._x_std_var_ph: np.std(xs, axis=0, keepdims=True) + 1e-8,
             }
-            sess.run([self._assign_x_mean, self._assign_x_std,], feed_dict=feed_dict)
+            sess.run([
+                self._assign_x_mean,
+                self._assign_x_std,
+            ],
+                     feed_dict=feed_dict)
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
             feed_dict = {
                 self._y_mean_var_ph: np.mean(ys, axis=0, keepdims=True),
                 self._y_std_var_ph: np.std(ys, axis=0, keepdims=True) + 1e-8,
             }
-            sess.run([self._assign_y_mean, self._assign_y_std], feed_dict=feed_dict)
+            sess.run([self._assign_y_mean, self._assign_y_std],
+                     feed_dict=feed_dict)
         if self._use_trust_region:
             old_means, old_log_stds = self._f_pdists(xs)
             inputs = [xs, ys, old_means, old_log_stds]

--- a/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -231,6 +231,26 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
             self._y_mean_var = y_mean_var
             self._y_std_var = y_std_var
 
+            # Optionally create assign operations for normalization
+            if self._normalize_inputs:
+                self._x_mean_var_ph = tf.placeholder(
+                    shape=(1, ) + input_shape,
+                    dtype=tf.float32,)
+                self._x_std_var_ph = tf.placeholder(
+                    shape=(1, ) + input_shape,
+                    dtype=tf.float32,)
+                self._assign_x_mean = tf.assign(self._x_mean_var, self._x_mean_var_ph)
+                self._assign_x_std = tf.assign(self._x_std_var, self._x_std_var_ph)
+            if self._normalize_outputs:
+                self._y_mean_var_ph = tf.placeholder(
+                    shape=(1, output_dim),
+                    dtype=tf.float32,)
+                self._y_std_var_ph = tf.placeholder(
+                    shape=(1, output_dim),
+                    dtype=tf.float32,)
+                self._assign_y_mean = tf.assign(self._y_mean_var, self._y_mean_var_ph)
+                self._assign_y_std = tf.assign(self._y_std_var, self._y_std_var_ph)
+
     def fit(self, xs, ys):
         if self._subsample_factor < 1:
             num_samples_tot = xs.shape[0]
@@ -241,20 +261,18 @@ class GaussianMLPRegressor(LayersPowered, Serializable, Parameterized):
         sess = tf.get_default_session()
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            sess.run([
-                tf.assign(self._x_mean_var, np.mean(xs, axis=0,
-                                                    keepdims=True)),
-                tf.assign(self._x_std_var,
-                          np.std(xs, axis=0, keepdims=True) + 1e-8),
-            ])
+            feed_dict = {
+                self._x_mean_var_ph: np.mean(xs, axis=0, keepdims=True),
+                self._x_std_var_ph: np.std(xs, axis=0, keepdims=True) + 1e-8,
+            }
+            sess.run([self._assign_x_mean, self._assign_x_std,], feed_dict=feed_dict)
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
-            sess.run([
-                tf.assign(self._y_mean_var, np.mean(ys, axis=0,
-                                                    keepdims=True)),
-                tf.assign(self._y_std_var,
-                          np.std(ys, axis=0, keepdims=True) + 1e-8),
-            ])
+            feed_dict = {
+                self._y_mean_var_ph: np.mean(ys, axis=0, keepdims=True),
+                self._y_std_var_ph: np.std(ys, axis=0, keepdims=True) + 1e-8,
+            }
+            sess.run([self._assign_y_mean, self._assign_y_std], feed_dict=feed_dict)
         if self._use_trust_region:
             old_means, old_log_stds = self._f_pdists(xs)
             inputs = [xs, ys, old_means, old_log_stds]

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
@@ -1,0 +1,41 @@
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.regressors import GaussianMLPRegressor
+from tests.fixtures import TfGraphTestCase
+
+
+class TestGaussianMlpRegressor(TfGraphTestCase):
+
+    def test_fit_normalized(self):
+        gmr = GaussianMLPRegressor(input_shape=(1, ), output_dim=1)
+        self.sess.run(tf.global_variables_initializer())
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        returns = returns.reshape((-1, 1))
+        for i in range(150):
+            gmr.fit(observations, returns)
+            # There will be assign operation in the first
+            # iteration so let's take the second one to check.
+            if i == 1:
+                assign_ops_counts = np.sum(np.array([
+                    'Assign' in n.name
+                    for n in tf.get_default_graph().as_graph_def().node
+                ]).astype(int))
+        assign_ops_counts_after = np.sum(np.array([
+            'Assign' in n.name
+            for n in tf.get_default_graph().as_graph_def().node
+        ]).astype(int))
+
+        assert assign_ops_counts == assign_ops_counts_after
+
+        paths = {
+            'observations': [[-np.pi], [-np.pi / 2], [-np.pi / 4], [0],
+                             [np.pi / 4], [np.pi / 2], [np.pi]]
+        }
+        prediction = gmr.predict(paths['observations'])
+        expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
@@ -6,7 +6,6 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestGaussianMlpRegressor(TfGraphTestCase):
-
     def test_fit_normalized(self):
         gmr = GaussianMLPRegressor(input_shape=(1, ), output_dim=1)
         self.sess.run(tf.global_variables_initializer())
@@ -21,14 +20,16 @@ class TestGaussianMlpRegressor(TfGraphTestCase):
             # There will be assign operation in the first
             # iteration so let's take the second one to check.
             if i == 1:
-                assign_ops_counts = np.sum(np.array([
-                    'Assign' in n.name
-                    for n in tf.get_default_graph().as_graph_def().node
-                ]).astype(int))
-        assign_ops_counts_after = np.sum(np.array([
-            'Assign' in n.name
-            for n in tf.get_default_graph().as_graph_def().node
-        ]).astype(int))
+                assign_ops_counts = np.sum(
+                    np.array([
+                        'Assign' in n.name
+                        for n in tf.get_default_graph().as_graph_def().node
+                    ]).astype(int))
+        assign_ops_counts_after = np.sum(
+            np.array([
+                'Assign' in n.name
+                for n in tf.get_default_graph().as_graph_def().node
+            ]).astype(int))
 
         assert assign_ops_counts == assign_ops_counts_after
 

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
@@ -17,7 +17,7 @@ class TestGaussianMlpRegressor(TfGraphTestCase):
         returns = returns.reshape((-1, 1))
         for i in range(150):
             gmr.fit(observations, returns)
-            # There will be assign operation in the first
+            # There will be new assign operations created in the first
             # iteration so let's take the second one to check.
             if i == 1:
                 assign_ops_counts = np.sum(


### PR DESCRIPTION
The `fit` method of GaussianMLPRegressor is creating new `tf.assign` operations every iteration. This will slow down the training. 

This is only a quick fix for `GaussianMLPRegressor` with tests for this bug so that embed2learn can use the new regressor/baseline. I will open an issue for other regressors. This bug also appears at new regressors that are implemented with `model`.