### PR TITLE
Make off-policy sampler respect batch_size

### DIFF
--- a/garage/tf/samplers/off_policy_vectorized_sampler.py
+++ b/garage/tf/samplers/off_policy_vectorized_sampler.py
@@ -20,16 +20,15 @@ from garage.tf.samplers.batch_sampler import BatchSampler
 
 
 class OffPolicyVectorizedSampler(BatchSampler):
-    """This class implements OffPolicyVectorizedSampler."""
+    """This class implements OffPolicyVectorizedSampler.
+
+    Args:
+        algo(garage.np.RLAlgorithm): Algorithm.
+        env(garage.envs.GarageEnv): Environment.
+        n_envs(int): Number of parallel environments managed by sampler.
+    """
 
     def __init__(self, algo, env, n_envs=None, no_reset=True):
-        """
-        Construct an OffPolicyVectorizedSampler.
-
-        :param algo: Algorithms.
-        :param n_envs: Number of parallelized sampling envs.
-        :param no_reset: If True, don't reset environement after sampling.
-        """
         if n_envs is None:
             n_envs = int(algo.rollout_batch_size)
         super(OffPolicyVectorizedSampler, self).__init__(algo, env, n_envs)
@@ -57,12 +56,14 @@ class OffPolicyVectorizedSampler(BatchSampler):
 
     @overrides
     def obtain_samples(self, itr, batch_size):
-        """
-        Collect samples for the given iteration number.
+        """Collect samples for the given iteration number.
 
-        :param itr: Iteration number.
-        :param batch_size: Batch size.
-        :return: A list of paths.
+        Args:
+            itr(int): Iteration number.
+            batch_size(int): Number of environment interactions in one batch.
+
+        Returns:
+            list: A list of paths.
         """
         paths = []
         if not self.no_reset or self._last_obses is None:
@@ -183,12 +184,14 @@ class OffPolicyVectorizedSampler(BatchSampler):
 
     @overrides
     def process_samples(self, itr, paths):
-        """
-        Return processed sample data based on the collected paths.
+        """Return processed sample data based on the collected paths.
 
-        :param itr: Iteration number.
-        :param paths: A list of collected paths.
-        :return: Processed sample data.
+        Args:
+            itr(int): Iteration number.
+            paths(list): A list of collected paths.
+
+        Returns:
+            list: Processed sample data.
         """
         success_history = [
             path['success_count'] / path['running_length'] for path in paths

--- a/garage/tf/samplers/off_policy_vectorized_sampler.py
+++ b/garage/tf/samplers/off_policy_vectorized_sampler.py
@@ -28,7 +28,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
 
         :param algo: Algorithms.
         :param n_envs: Number of parallelized sampling envs.
-        :param no_reset: If Ture, don't reset environement after sampling.
+        :param no_reset: If True, don't reset environement after sampling.
         """
         if n_envs is None:
             n_envs = int(algo.rollout_batch_size)
@@ -80,9 +80,9 @@ class OffPolicyVectorizedSampler(BatchSampler):
         while n_samples < batch_size:
             policy.reset(dones)
             if self.algo.input_include_goal:
-                obs = [obs["observation"] for obs in obses]
-                d_g = [obs["desired_goal"] for obs in obses]
-                a_g = [obs["achieved_goal"] for obs in obses]
+                obs = [obs['observation'] for obs in obses]
+                d_g = [obs['desired_goal'] for obs in obses]
+                a_g = [obs['achieved_goal'] for obs in obses]
                 input_obses = np.concatenate((obs, d_g), axis=-1)
             else:
                 input_obses = obses
@@ -112,10 +112,10 @@ class OffPolicyVectorizedSampler(BatchSampler):
                     achieved_goal=a_g,
                     terminal=dones,
                     next_observation=[
-                        next_obs["observation"] for next_obs in next_obses
+                        next_obs['observation'] for next_obs in next_obses
                     ],
                     next_achieved_goal=[
-                        next_obs["achieved_goal"] for next_obs in next_obses
+                        next_obs['achieved_goal'] for next_obs in next_obses
                     ],
                 )
             else:
@@ -141,33 +141,33 @@ class OffPolicyVectorizedSampler(BatchSampler):
                         running_length=self._last_running_length[idx],
                         success_count=self._last_success_count[idx])
 
-                running_paths[idx]["rewards"].append(reward)
-                running_paths[idx]["env_infos"].append(env_info)
-                running_paths[idx]["dones"].append(done)
-                running_paths[idx]["running_length"] += 1
-                running_paths[idx]["undiscounted_return"] += reward
-                running_paths[idx]["success_count"] += env_info.get(
-                    "is_success") or 0
+                running_paths[idx]['rewards'].append(reward)
+                running_paths[idx]['env_infos'].append(env_info)
+                running_paths[idx]['dones'].append(done)
+                running_paths[idx]['running_length'] += 1
+                running_paths[idx]['undiscounted_return'] += reward
+                running_paths[idx]['success_count'] += env_info.get(
+                    'is_success') or 0
 
                 self._last_uncounted_discount[idx] += reward
                 self._last_success_count[idx] += env_info.get(
-                    "is_success") or 0
+                    'is_success') or 0
                 self._last_running_length[idx] += 1
 
                 if done or n_samples >= batch_size:
                     paths.append(
                         dict(
                             rewards=tensor_utils.stack_tensor_list(
-                                running_paths[idx]["rewards"]),
+                                running_paths[idx]['rewards']),
                             dones=tensor_utils.stack_tensor_list(
-                                running_paths[idx]["dones"]),
+                                running_paths[idx]['dones']),
                             env_infos=tensor_utils.stack_tensor_dict_list(
-                                running_paths[idx]["env_infos"]),
+                                running_paths[idx]['env_infos']),
                             running_length=running_paths[idx]
-                            ["running_length"],
+                            ['running_length'],
                             undiscounted_return=running_paths[idx]
-                            ["undiscounted_return"],
-                            success_count=running_paths[idx]["success_count"]))
+                            ['undiscounted_return'],
+                            success_count=running_paths[idx]['success_count']))
                     running_paths[idx] = None
 
                     if done:
@@ -190,15 +190,10 @@ class OffPolicyVectorizedSampler(BatchSampler):
         :param paths: A list of collected paths.
         :return: Processed sample data.
         """
-        success_history = []
-        for path in paths:
-            success_history.append(
-                path["success_count"] / path["running_length"])
-
         success_history = [
-            path["success_count"] / path["running_length"] for path in paths
+            path['success_count'] / path['running_length'] for path in paths
         ]
-        undiscounted_returns = [path["undiscounted_return"] for path in paths]
+        undiscounted_returns = [path['undiscounted_return'] for path in paths]
         samples_data = dict(
             undiscounted_returns=undiscounted_returns,
             success_history=success_history)

--- a/tests/fixtures/envs/dummy/dummy_dict_env.py
+++ b/tests/fixtures/envs/dummy/dummy_dict_env.py
@@ -36,8 +36,8 @@ class DummyDictEnv(DummyEnv):
 
     def reset(self):
         """Reset the environment."""
-        return np.ones(1)
+        return self.observation_space.sample()
 
     def step(self, action):
         """Step the environment."""
-        return np.ones(1), 0, True, dict()
+        return self.observation_space.sample(), 0, True, dict()

--- a/tests/fixtures/envs/dummy/dummy_dict_env.py
+++ b/tests/fixtures/envs/dummy/dummy_dict_env.py
@@ -15,13 +15,13 @@ class DummyDictEnv(DummyEnv):
         """Return an observation space."""
 
         return gym.spaces.Dict({
-            "achieved_goal":
+            'achieved_goal':
             gym.spaces.Box(
                 low=-200., high=200., shape=(3, ), dtype=np.float32),
-            "desired_goal":
+            'desired_goal':
             gym.spaces.Box(
                 low=-200., high=200., shape=(3, ), dtype=np.float32),
-            "observation":
+            'observation':
             gym.spaces.Box(
                 low=-200., high=200., shape=(25, ), dtype=np.float32)
         })
@@ -30,7 +30,7 @@ class DummyDictEnv(DummyEnv):
     def action_space(self):
         """Return an action space."""
         return gym.spaces.Dict({
-            "action":
+            'action':
             gym.spaces.Box(low=-5.0, high=5.0, shape=(1, ), dtype=np.float32)
         })
 

--- a/tests/fixtures/policies/dummy_policy.py
+++ b/tests/fixtures/policies/dummy_policy.py
@@ -22,6 +22,12 @@ class DummyPolicy(Policy, Serializable):
         """Return action."""
         return self.action_space.sample(), dict()
 
+    def get_actions(self, obses):
+        """Return actions."""
+        n = len(obses)
+        action, action_info = self.get_action(None)
+        return [action] * n, action_info
+
     @overrides
     def get_params_internal(self, **tags):
         """Return a list of policy internal params."""
@@ -31,6 +37,10 @@ class DummyPolicy(Policy, Serializable):
     def get_param_values(self, **tags):
         """Return values of params."""
         return np.random.uniform(-1, 1, 1000)
+
+    @overrides
+    def reset(self, *args, **kwargs):
+        pass
 
     @property
     def distribution(self):

--- a/tests/fixtures/tf/algos/dummy_off_policy_algo.py
+++ b/tests/fixtures/tf/algos/dummy_off_policy_algo.py
@@ -1,0 +1,6 @@
+from garage.tf.algos import OffPolicyRLAlgorithm
+
+
+class DummyOffPolicyAlgo(OffPolicyRLAlgorithm):
+    def init_opt(self):
+        pass

--- a/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
+++ b/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
@@ -54,15 +54,15 @@ class TestOffPolicyVectorizedSampler(TfGraphTestCase):
             paths1 = sampler.obtain_samples(0, 5)
             paths2 = sampler.obtain_samples(0, 5)
 
-            len1 = sum([len(path["rewards"]) for path in paths1])
-            len2 = sum([len(path["rewards"]) for path in paths2])
+            len1 = sum([len(path['rewards']) for path in paths1])
+            len2 = sum([len(path['rewards']) for path in paths2])
 
             assert len1 == 5 and len2 == 5, \
-                "Sampler should respect batch_size"
+                'Sampler should respect batch_size'
 
-            assert len1 + len2 == paths2[0]["running_length"], \
-                "Running length should be the length of full path"
+            assert len1 + len2 == paths2[0]['running_length'], \
+                'Running length should be the length of full path'
 
-            assert ((paths1[0]["rewards"] + paths2[0]["rewards"]).sum()
-                    == paths2[0]["undiscounted_return"]), \
-                "Undiscounted_return should be the sum of rewards of full path"
+            assert ((paths1[0]['rewards'] + paths2[0]['rewards']).sum()
+                    == paths2[0]['undiscounted_return']), \
+                'Undiscounted_return should be the sum of rewards of full path'

--- a/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
+++ b/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
@@ -1,0 +1,60 @@
+import gym
+import tensorflow as tf
+
+from garage.experiment import LocalRunner
+from garage.np.exploration_strategies import OUStrategy
+from garage.replay_buffer import SimpleReplayBuffer
+from garage.tf.algos import DDPG
+from garage.tf.envs import TfEnv
+from garage.tf.policies import ContinuousMLPPolicy
+from garage.tf.q_functions import ContinuousMLPQFunction
+from garage.tf.samplers import OffPolicyVectorizedSampler
+from tests.fixtures import TfGraphTestCase
+
+
+class TestOffPolicyVectorizedSampler(TfGraphTestCase):
+    def test_no_reset(self):
+        with LocalRunner(self.sess) as runner:
+            # This tests if off-policy sampler respect batch_size
+            # when no_reset is set to True
+            env = TfEnv(gym.make('InvertedDoublePendulum-v2'))
+            action_noise = OUStrategy(env.spec, sigma=0.2)
+            policy = ContinuousMLPPolicy(
+                env_spec=env.spec,
+                hidden_sizes=[64, 64],
+                hidden_nonlinearity=tf.nn.relu,
+                output_nonlinearity=tf.nn.tanh)
+            qf = ContinuousMLPQFunction(
+                env_spec=env.spec,
+                hidden_sizes=[64, 64],
+                hidden_nonlinearity=tf.nn.relu)
+            replay_buffer = SimpleReplayBuffer(
+                env_spec=env.spec,
+                size_in_transitions=int(1e6),
+                time_horizon=100)
+            algo = DDPG(
+                env_spec=env.spec,
+                policy=policy,
+                policy_lr=1e-4,
+                qf_lr=1e-3,
+                qf=qf,
+                replay_buffer=replay_buffer,
+                target_update_tau=1e-2,
+                n_train_steps=50,
+                discount=0.9,
+                min_buffer_size=int(1e4),
+                exploration_strategy=action_noise,
+            )
+
+            sampler = OffPolicyVectorizedSampler(algo, env, 1, no_reset=True)
+            sampler.start_worker()
+
+            runner.initialize_tf_vars()
+
+            paths1 = sampler.obtain_samples(0, 17)
+            paths2 = sampler.obtain_samples(0, 17)
+
+            len1 = sum([len(path['rewards']) for path in paths1])
+            len2 = sum([len(path['rewards']) for path in paths2])
+
+            assert len1 == 17 and len2 == 17

--- a/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
+++ b/tests/garage/tf/samplers/test_off_policy_vectorized_sampler.py
@@ -51,10 +51,18 @@ class TestOffPolicyVectorizedSampler(TfGraphTestCase):
 
             runner.initialize_tf_vars()
 
-            paths1 = sampler.obtain_samples(0, 17)
-            paths2 = sampler.obtain_samples(0, 17)
+            paths1 = sampler.obtain_samples(0, 5)
+            paths2 = sampler.obtain_samples(0, 5)
 
-            len1 = sum([len(path['rewards']) for path in paths1])
-            len2 = sum([len(path['rewards']) for path in paths2])
+            len1 = sum([len(path["rewards"]) for path in paths1])
+            len2 = sum([len(path["rewards"]) for path in paths2])
 
-            assert len1 == 17 and len2 == 17
+            assert len1 == 5 and len2 == 5, \
+                "Sampler should respect batch_size"
+
+            assert len1 + len2 == paths2[0]["running_length"], \
+                "Running length should be the length of full path"
+
+            assert ((paths1[0]["rewards"] + paths2[0]["rewards"]).sum()
+                    == paths2[0]["undiscounted_return"]), \
+                "Undiscounted_return should be the sum of rewards of full path"


### PR DESCRIPTION
Some off-policy algorithm such as DDPG and DQN require that environment
is not reset across batches. This PR adds `no_reset` parameter to
off-policy sampler that when it is set to True, the sampler will not
reset environment and the batch_size is strictly respected (previously
the sampler always returns full paths)

**Changelog**
- Add `no_reset` paramter to `OffPolicyVectoriedSampler` constructor. 
When set to `True`, the sampler will not reset environment across batches and 
the `batch_size` is strictly respected. 
- Add a field of boolean list `dones` in the return of `obtrain_samples()`

**Note**
The `return` of a path is currently computed in `process_samples()` in the sampler.
After this PR, the paths returned by `obtrain_samples()` are no longer guaranteed
to be full paths, so the `return` will not be correctly computed. 
The solution is to move `process_samples()` to algorithm and make algorithm responsible 
to compute `return`. This will be in another PR.