### PR TITLE
Add SOA entropy regularization methods to tf/NPO

### DIFF
--- a/src/garage/tf/algos/erwr.py
+++ b/src/garage/tf/algos/erwr.py
@@ -1,4 +1,3 @@
-from garage.tf.algos.npo import PGLoss
 from garage.tf.algos.vpg import VPG
 from garage.tf.optimizers import LbfgsOptimizer
 
@@ -38,18 +37,29 @@ class ERWR(VPG):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): Objective.
+        pg_loss (str): A string from: 'vanilla', 'surrogate',
+            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
             policies, as in TRPO.
-        optimizer (float): The optimizer of the algorithm.
-        optimizer_args (dict): Optimizer args.
+        optimizer (object): The optimizer of the algorithm. Should be the
+            optimizers in garage.tf.optimizers.
+        optimizer_args (dict): The arguments of the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
-        use_softplus_entropy (bool): Whether to use softplus entropy.
-        stop_entropy_gradient (bool): Whether to stop entropy gradient.
+            Setting it to zero would mean no entropy regularization.
+        use_softplus_entropy (bool): Whether to estimate the softmax
+            distribution of the entropy to prevent the entropy from being
+            negative.
+        use_neg_logli_entropy (bool): Whether to estimate the entropy as the
+            negative log likelihood of the action.
+        stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        entropy_method (str): A string from: 'max', 'regularized',
+            'no_entropy'. The type of entropy method to use. 'max' adds the
+            dense entropy to the reward for each time step. 'regularized' adds
+            the mean entropy to the surrogate objective. See
+            https://arxiv.org/abs/1805.00909 for more details.
         name (str): The name of the algorithm.
-
     """
 
     def __init__(self,
@@ -63,7 +73,7 @@ class ERWR(VPG):
                  center_adv=True,
                  positive_adv=True,
                  fixed_horizon=False,
-                 pg_loss=PGLoss.VANILLA,
+                 pg_loss='vanilla',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -72,29 +82,31 @@ class ERWR(VPG):
                  use_softplus_entropy=False,
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
+                 entropy_method='no_entropy',
                  name='ERWR'):
         if optimizer is None:
             optimizer = LbfgsOptimizer
             if optimizer_args is None:
                 optimizer_args = dict()
-        super(ERWR, self).__init__(
+        super().__init__(
             env_spec=env_spec,
             policy=policy,
             baseline=baseline,
             scope=scope,
-            gae_lambda=gae_lambda,
             max_path_length=max_path_length,
             discount=discount,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
+            gae_lambda=gae_lambda,
             center_adv=center_adv,
             positive_adv=positive_adv,
             fixed_horizon=fixed_horizon,
+            pg_loss=pg_loss,
+            lr_clip_range=lr_clip_range,
+            max_kl_step=max_kl_step,
+            optimizer=optimizer,
+            optimizer_args=optimizer_args,
             policy_ent_coeff=policy_ent_coeff,
             use_softplus_entropy=use_softplus_entropy,
             use_neg_logli_entropy=use_neg_logli_entropy,
             stop_entropy_gradient=stop_entropy_gradient,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
+            entropy_method=entropy_method,
             name=name)

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -1,5 +1,4 @@
 from garage.tf.algos.npo import NPO
-from garage.tf.algos.npo import PGLoss
 from garage.tf.optimizers import FirstOrderOptimizer
 
 
@@ -27,18 +26,29 @@ class PPO(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): Objective.
+        pg_loss (str): A string from: 'vanilla', 'surrogate',
+            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
             policies, as in TRPO.
-        optimizer (float): The optimizer of the algorithm.
-        optimizer_args (dict): Optimizer args.
+        optimizer (object): The optimizer of the algorithm. Should be the
+            optimizers in garage.tf.optimizers.
+        optimizer_args (dict): The arguments of the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
-        use_softplus_entropy (bool): Whether to use softplus entropy.
-        stop_entropy_gradient (bool): Whether to stop entropy gradient.
+            Setting it to zero would mean no entropy regularization.
+        use_softplus_entropy (bool): Whether to estimate the softmax
+            distribution of the entropy to prevent the entropy from being
+            negative.
+        use_neg_logli_entropy (bool): Whether to estimate the entropy as the
+            negative log likelihood of the action.
+        stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        entropy_method (str): A string from: 'max', 'regularized',
+            'no_entropy'. The type of entropy method to use. 'max' adds the
+            dense entropy to the reward for each time step. 'regularized' adds
+            the mean entropy to the surrogate objective. See
+            https://arxiv.org/abs/1805.00909 for more details.
         name (str): The name of the algorithm.
-
     """
 
     def __init__(self,
@@ -52,7 +62,7 @@ class PPO(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss=PGLoss.SURROGATE_CLIP,
+                 pg_loss='surrogate_clip',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -61,29 +71,31 @@ class PPO(NPO):
                  use_softplus_entropy=False,
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
+                 entropy_method='no_entropy',
                  name='PPO'):
         if optimizer is None:
             optimizer = FirstOrderOptimizer
             if optimizer_args is None:
                 optimizer_args = dict()
-        super(PPO, self).__init__(
+        super().__init__(
             env_spec=env_spec,
             policy=policy,
             baseline=baseline,
             scope=scope,
-            gae_lambda=gae_lambda,
             max_path_length=max_path_length,
             discount=discount,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
+            gae_lambda=gae_lambda,
             center_adv=center_adv,
             positive_adv=positive_adv,
             fixed_horizon=fixed_horizon,
+            pg_loss=pg_loss,
+            lr_clip_range=lr_clip_range,
+            max_kl_step=max_kl_step,
+            optimizer=optimizer,
+            optimizer_args=optimizer_args,
             policy_ent_coeff=policy_ent_coeff,
             use_softplus_entropy=use_softplus_entropy,
             use_neg_logli_entropy=use_neg_logli_entropy,
             stop_entropy_gradient=stop_entropy_gradient,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
+            entropy_method=entropy_method,
             name=name)

--- a/src/garage/tf/algos/tnpg.py
+++ b/src/garage/tf/algos/tnpg.py
@@ -1,4 +1,4 @@
-from garage.tf.algos.npo import NPO, PGLoss
+from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import ConjugateGradientOptimizer
 
 
@@ -26,31 +26,43 @@ class TNPG(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): Objective.
+        pg_loss (str): A string from: 'vanilla', 'surrogate',
+            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
-            policies.
+            policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
-            policies.
-        optimizer (float): The optimizer of the algorithm.
-        optimizer_args (dict): Optimizer args.
+            policies, as in TRPO.
+        optimizer (object): The optimizer of the algorithm. Should be the
+            optimizers in garage.tf.optimizers.
+        optimizer_args (dict): The arguments of the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
-        use_softplus_entropy (bool): Whether to use softplus entropy.
-        stop_entropy_gradient (bool): Whether to stop entropy gradient.
+            Setting it to zero would mean no entropy regularization.
+        use_softplus_entropy (bool): Whether to estimate the softmax
+            distribution of the entropy to prevent the entropy from being
+            negative.
+        use_neg_logli_entropy (bool): Whether to estimate the entropy as the
+            negative log likelihood of the action.
+        stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        entropy_method (str): A string from: 'max', 'regularized',
+            'no_entropy'. The type of entropy method to use. 'max' adds the
+            dense entropy to the reward for each time step. 'regularized' adds
+            the mean entropy to the surrogate objective. See
+            https://arxiv.org/abs/1805.00909 for more details.
         name (str): The name of the algorithm.
-
     """
 
     def __init__(self,
                  env_spec,
                  policy,
                  baseline,
+                 scope=None,
                  max_path_length=500,
                  discount=0.99,
                  gae_lambda=0.98,
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss=PGLoss.SURROGATE,
+                 pg_loss='surrogate',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -59,6 +71,7 @@ class TNPG(NPO):
                  use_softplus_entropy=False,
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
+                 entropy_method='no_entropy',
                  name='TNPG'):
         if optimizer is None:
             optimizer = ConjugateGradientOptimizer
@@ -67,10 +80,11 @@ class TNPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super(TNPG, self).__init__(
+        super().__init__(
             env_spec=env_spec,
             policy=policy,
             baseline=baseline,
+            scope=scope,
             max_path_length=max_path_length,
             discount=discount,
             gae_lambda=gae_lambda,
@@ -79,11 +93,12 @@ class TNPG(NPO):
             fixed_horizon=fixed_horizon,
             pg_loss=pg_loss,
             lr_clip_range=lr_clip_range,
+            max_kl_step=max_kl_step,
             optimizer=optimizer,
             optimizer_args=optimizer_args,
             policy_ent_coeff=policy_ent_coeff,
-            max_kl_step=max_kl_step,
             use_softplus_entropy=use_softplus_entropy,
             use_neg_logli_entropy=use_neg_logli_entropy,
             stop_entropy_gradient=stop_entropy_gradient,
+            entropy_method=entropy_method,
             name=name)

--- a/src/garage/tf/algos/vpg.py
+++ b/src/garage/tf/algos/vpg.py
@@ -1,5 +1,4 @@
 from garage.tf.algos.npo import NPO
-from garage.tf.algos.npo import PGLoss
 from garage.tf.optimizers import FirstOrderOptimizer
 
 
@@ -25,18 +24,29 @@ class VPG(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): Objective.
+        pg_loss (str): A string from: 'vanilla', 'surrogate',
+            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
             policies, as in TRPO.
-        optimizer (float): The optimizer of the algorithm.
-        optimizer_args (dict): Optimizer args.
+        optimizer (object): The optimizer of the algorithm. Should be the
+            optimizers in garage.tf.optimizers.
+        optimizer_args (dict): The arguments of the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
-        use_softplus_entropy (bool): Whether to use softplus entropy.
-        stop_entropy_gradient (bool): Whether to stop entropy gradient.
+            Setting it to zero would mean no entropy regularization.
+        use_softplus_entropy (bool): Whether to estimate the softmax
+            distribution of the entropy to prevent the entropy from being
+            negative.
+        use_neg_logli_entropy (bool): Whether to estimate the entropy as the
+            negative log likelihood of the action.
+        stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        entropy_method (str): A string from: 'max', 'regularized',
+            'no_entropy'. The type of entropy method to use. 'max' adds the
+            dense entropy to the reward for each time step. 'regularized' adds
+            the mean entropy to the surrogate objective. See
+            https://arxiv.org/abs/1805.00909 for more details.
         name (str): The name of the algorithm.
-
     """
 
     def __init__(self,
@@ -50,7 +60,7 @@ class VPG(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss=PGLoss.VANILLA,
+                 pg_loss='vanilla',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -59,6 +69,7 @@ class VPG(NPO):
                  use_softplus_entropy=False,
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
+                 entropy_method='no_entropy',
                  name='VPG'):
         if optimizer is None:
             default_args = dict(
@@ -70,24 +81,25 @@ class VPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super(VPG, self).__init__(
+        super().__init__(
             env_spec=env_spec,
             policy=policy,
             baseline=baseline,
             scope=scope,
-            gae_lambda=gae_lambda,
             max_path_length=max_path_length,
             discount=discount,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
+            gae_lambda=gae_lambda,
             center_adv=center_adv,
             positive_adv=positive_adv,
             fixed_horizon=fixed_horizon,
+            pg_loss=pg_loss,
+            lr_clip_range=lr_clip_range,
+            max_kl_step=max_kl_step,
+            optimizer=optimizer,
+            optimizer_args=optimizer_args,
             policy_ent_coeff=policy_ent_coeff,
             use_softplus_entropy=use_softplus_entropy,
             use_neg_logli_entropy=use_neg_logli_entropy,
             stop_entropy_gradient=stop_entropy_gradient,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
+            entropy_method=entropy_method,
             name=name)

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -15,56 +15,88 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestNPO(TfGraphTestCase):
-    def test_npo_pendulum(self):
-        """Test NPO with Pendulum environment."""
-        with LocalRunner(self.sess) as runner:
-            env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-            policy = GaussianMLPPolicy(
-                env_spec=env.spec,
-                hidden_sizes=(64, 64),
-                hidden_nonlinearity=tf.nn.tanh,
-                output_nonlinearity=None,
-            )
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(hidden_sizes=(32, 32)),
-            )
-            algo = NPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                policy_ent_coeff=0.0)
-            runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 20
-
-            env.close()
-
-    test_npo_pendulum.large = True
-
-    def test_npo_unknown_pg_loss(self):
-        """Test NPO with unkown policy gradient loss."""
-        env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-        policy = GaussianMLPPolicy(
-            env_spec=env.spec,
+    def setUp(self):
+        super().setUp()
+        self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
+        self.policy = GaussianMLPPolicy(
+            env_spec=self.env.spec,
             hidden_sizes=(64, 64),
             hidden_nonlinearity=tf.nn.tanh,
             output_nonlinearity=None,
         )
-        baseline = GaussianMLPBaseline(
-            env_spec=env.spec,
+        self.baseline = GaussianMLPBaseline(
+            env_spec=self.env.spec,
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
-        with self.assertRaises(NotImplementedError) as context:
+
+    def test_npo_pendulum(self):
+        """Test NPO with Pendulum Environment."""
+        with LocalRunner(self.sess) as runner:
+            algo = NPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                gae_lambda=0.98,
+                policy_ent_coeff=0.0)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 20
+
+    def test_npo_with_unknown_pg_loss(self):
+        """Test NPO with unkown pg loss."""
+        with self.assertRaises(ValueError, msg='Invalid pg_loss'):
             NPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
                 pg_loss='random pg_loss',
             )
-        assert 'Unknown PGLoss' in str(context.exception)
 
-        env.close()
+    def test_npo_with_invalid_entropy_method(self):
+        """Test NPO with invalid entropy method."""
+        with self.assertRaises(ValueError, msg='Invalid entropy_method'):
+            NPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                entropy_method=None,
+            )
+
+    def test_npo_with_max_entropy_and_center_adv(self):
+        """Test NPO with max entropy and center_adv."""
+        with self.assertRaises(ValueError):
+            NPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                entropy_method='max',
+                center_adv=True,
+            )
+
+    def test_npo_with_max_entropy_and_no_stop_entropy_gradient(self):
+        """Test NPO with max entropy and false stop_entropy_gradient."""
+        with self.assertRaises(ValueError):
+            NPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                entropy_method='max',
+                stop_entropy_gradient=False,
+            )
+
+    def test_npo_with_invalid_no_entropy_configuration(self):
+        """Test NPO with invalid no entropy configuration."""
+        with self.assertRaises(ValueError):
+            NPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                entropy_method='no_entropy',
+                policy_ent_coeff=0.02,
+            )
+
+    def tearDown(self):
+        self.env.close()
+        super().tearDown()

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -30,7 +30,7 @@ class TestNPO(TfGraphTestCase):
         )
 
     def test_npo_pendulum(self):
-        """Test NPO with Pendulum Environment."""
+        """Test NPO with Pendulum environment."""
         with LocalRunner(self.sess) as runner:
             algo = NPO(
                 env_spec=self.env.spec,

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -31,7 +31,7 @@ class TestPPO(TfGraphTestCase):
         )
 
     def test_ppo_pendulum(self):
-        """Test PPO with Pendulum Environment."""
+        """Test PPO with Pendulum environment."""
         with LocalRunner(self.sess) as runner:
             algo = PPO(
                 env_spec=self.env.spec,
@@ -48,7 +48,7 @@ class TestPPO(TfGraphTestCase):
     test_ppo_pendulum.large = True
 
     def test_ppo_pendulum_recurrent(self):
-        """Test PPO with Pendulum Environment and recurrent policy."""
+        """Test PPO with Pendulum environment and recurrent policy."""
         with LocalRunner() as runner:
             algo = PPO(
                 env_spec=self.env.spec,
@@ -109,8 +109,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    test_ppo_with_neg_log_likeli_entropy_estimation_and_max.large = True
-
     def test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized(self):
         """
         Test PPO with negative log likelihood entropy estimation and
@@ -134,8 +132,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized.large = True  # noqa: E501
-
     def test_ppo_with_regularized_entropy(self):
         """Test PPO with regularized entropy method."""
         with LocalRunner(self.sess) as runner:
@@ -154,8 +150,6 @@ class TestPPO(TfGraphTestCase):
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
-
-    test_ppo_with_regularized_entropy.large = True
 
     def tearDown(self):
         self.env.close()

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -15,57 +15,148 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestPPO(TfGraphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
+        self.policy = GaussianMLPPolicy(
+            env_spec=self.env.spec,
+            hidden_sizes=(64, 64),
+            hidden_nonlinearity=tf.nn.tanh,
+            output_nonlinearity=None,
+        )
+        self.recurrent_policy = GaussianLSTMPolicy(env_spec=self.env.spec, )
+        self.baseline = GaussianMLPBaseline(
+            env_spec=self.env.spec,
+            regressor_args=dict(hidden_sizes=(32, 32)),
+        )
+
     def test_ppo_pendulum(self):
-        """Test PPO with Pendulum environment."""
+        """Test PPO with Pendulum Environment."""
         with LocalRunner(self.sess) as runner:
-            env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-            policy = GaussianMLPPolicy(
-                env_spec=env.spec,
-                hidden_sizes=(64, 64),
-                hidden_nonlinearity=tf.nn.tanh,
-                output_nonlinearity=None,
-            )
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(hidden_sizes=(32, 32)),
-            )
             algo = PPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
                 max_path_length=100,
                 discount=0.99,
                 lr_clip_range=0.01,
                 optimizer_args=dict(batch_size=32, max_epochs=10))
-            runner.setup(algo, env)
+            runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
-
-            env.close()
 
     test_ppo_pendulum.large = True
 
     def test_ppo_pendulum_recurrent(self):
-        """Test PPO with Pendulum environment and recurrent policy."""
+        """Test PPO with Pendulum Environment and recurrent policy."""
         with LocalRunner() as runner:
-            env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-            policy = GaussianLSTMPolicy(env_spec=env.spec, )
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(hidden_sizes=(32, 32)),
-            )
             algo = PPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
+                env_spec=self.env.spec,
+                policy=self.recurrent_policy,
+                baseline=self.baseline,
                 max_path_length=100,
                 discount=0.99,
                 lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10))
-            runner.setup(algo, env)
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+            )
+            runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-            env.close()
-
     test_ppo_pendulum_recurrent.large = True
+
+    def test_ppo_with_maximum_entropy(self):
+        """Test PPO with maxium entropy method."""
+        with LocalRunner(self.sess) as runner:
+            algo = PPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 40
+
+    test_ppo_with_maximum_entropy.large = True
+
+    def test_ppo_with_neg_log_likeli_entropy_estimation_and_max(self):
+        """
+        Test PPO with negative log likelihood entropy estimation and max
+        entropy method.
+        """
+        with LocalRunner(self.sess) as runner:
+            algo = PPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+                stop_entropy_gradient=True,
+                use_neg_logli_entropy=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 40
+
+    test_ppo_with_neg_log_likeli_entropy_estimation_and_max.large = True
+
+    def test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized(self):
+        """
+        Test PPO with negative log likelihood entropy estimation and
+        regularized entropy method.
+        """
+        with LocalRunner(self.sess) as runner:
+            algo = PPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+                stop_entropy_gradient=True,
+                use_neg_logli_entropy=True,
+                entropy_method='regularized',
+                policy_ent_coeff=0.0,
+                center_adv=True)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 40
+
+    test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized.large = True  # noqa: E501
+
+    def test_ppo_with_regularized_entropy(self):
+        """Test PPO with regularized entropy method."""
+        with LocalRunner(self.sess) as runner:
+            algo = PPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+                stop_entropy_gradient=False,
+                entropy_method='regularized',
+                policy_ent_coeff=0.02,
+                center_adv=True)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 40
+
+    test_ppo_with_regularized_entropy.large = True
+
+    def tearDown(self):
+        self.env.close()
+        super().tearDown()

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -15,60 +15,65 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestTRPO(TfGraphTestCase):
-    def test_trpo_pendulum(self):
-        """Test TRPO with Pendulum environment."""
-        with LocalRunner(self.sess) as runner:
-            env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-            policy = GaussianMLPPolicy(
-                env_spec=env.spec,
-                hidden_sizes=(64, 64),
-                hidden_nonlinearity=tf.nn.tanh,
-                output_nonlinearity=None,
-            )
-            baseline = GaussianMLPBaseline(
-                env_spec=env.spec,
-                regressor_args=dict(hidden_sizes=(32, 32)),
-            )
-            algo = TRPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                policy_ent_coeff=0.0)
-            runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 80
-
-            env.close()
-
-    test_trpo_pendulum.large = True
-
-    def test_trpo_unknown_kl_constraint(self):
-        """Test TRPO with unkown KL constraints."""
-        env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
-        policy = GaussianMLPPolicy(
-            env_spec=env.spec,
+    def setUp(self):
+        super().setUp()
+        self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
+        self.policy = GaussianMLPPolicy(
+            env_spec=self.env.spec,
             hidden_sizes=(64, 64),
             hidden_nonlinearity=tf.nn.tanh,
             output_nonlinearity=None,
         )
-        baseline = GaussianMLPBaseline(
-            env_spec=env.spec,
+        self.baseline = GaussianMLPBaseline(
+            env_spec=self.env.spec,
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
-        with self.assertRaises(NotImplementedError) as context:
+
+    def test_trpo_pendulum(self):
+        """Test TRPO with Pendulum environment."""
+        with LocalRunner(self.sess) as runner:
+            algo = TRPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                gae_lambda=0.98,
+                policy_ent_coeff=0.0)
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 50
+
+    def test_trpo_unknown_kl_constraint(self):
+        """Test TRPO with unkown KL constraints."""
+        with self.assertRaises(ValueError, msg='Invalid kl_constraint'):
             TRPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
                 max_path_length=100,
                 discount=0.99,
                 gae_lambda=0.98,
                 policy_ent_coeff=0.0,
                 kl_constraint='random kl_constraint',
             )
-        assert 'Unknown KLConstraint' in str(context.exception)
 
-        env.close()
+    def test_trpo_soft_kl_constraint(self):
+        """Test TRPO with unkown KL constraints."""
+        with LocalRunner(self.sess) as runner:
+            algo = TRPO(
+                env_spec=self.env.spec,
+                policy=self.policy,
+                baseline=self.baseline,
+                max_path_length=100,
+                discount=0.99,
+                gae_lambda=0.98,
+                policy_ent_coeff=0.0,
+                kl_constraint='soft')
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 50
+
+    def tearDown(self):
+        self.env.close()
+        super().tearDown()


### PR DESCRIPTION
* Add max entropy method to tf/NPO.
* Fix the neg_log_likeli entropy estimation in tf/NPO.
* Add documentation of sane entropy regularization default.
* Replace Enum params with strings.