### PR TITLE
Use name_scope in FirstOrderOptimizer

### DIFF
--- a/garage/tf/optimizers/first_order_optimizer.py
+++ b/garage/tf/optimizers/first_order_optimizer.py
@@ -66,7 +66,7 @@ class FirstOrderOptimizer(Serializable):
         :param inputs: A list of symbolic variables as inputs
         :return: No return value.
         """
-        with tf.variable_scope(
+        with tf.name_scope(
                 self._name,
                 values=[
                     loss,


### PR DESCRIPTION
Using variable_scope will messup the `get_params`.