### PR TITLE
Fix pickle tests

### DIFF
--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -15,7 +15,9 @@ class SimpleGaussianMLPModel(Model):
         return ['sample', 'mean', 'log_std', 'std_param', 'dist']
 
     def _build(self, obs_input, name=None):
-        mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)
+        return_var = tf.get_variable(
+            'return_var', (), initializer=tf.constant_initializer(0.5))
+        mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)
         log_std = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)
         action = mean + log_std * 0.5
         dist = DiagonalGaussian(self.output_dim)

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -81,7 +81,7 @@ class TestCNNModel(TfGraphTestCase):
         outputs = model.build(self._input_ph)
         with tf.variable_scope('cnn_model/cnn/h0', reuse=True):
             bias = tf.get_variable('bias')
-        bias.load(np.ones_like(bias))
+        bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(
             outputs, feed_dict={self._input_ph: self.obs_input})

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -81,7 +81,7 @@ class TestCNNModel(TfGraphTestCase):
         outputs = model.build(self._input_ph)
         with tf.variable_scope('cnn_model/cnn/h0', reuse=True):
             bias = tf.get_variable('bias')
-        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+        bias.load(np.ones_like(bias))
 
         output1 = self.sess.run(
             outputs, feed_dict={self._input_ph: self.obs_input})

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -195,7 +195,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_std_network/output/bias')
         # assign it to all ones
-        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+        bias.load(np.ones_like(bias))
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
@@ -229,7 +229,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_network/output/bias')
         # assign it to all ones
-        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+        bias.load(np.ones_like(bias))
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
@@ -266,7 +266,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_network/output/bias')
         # assign it to all ones
-        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+        bias.load(np.ones_like(bias))
 
         h = pickle.dumps(model)
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -195,7 +195,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_std_network/output/bias')
         # assign it to all ones
-        bias.load(np.ones_like(bias))
+        bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
@@ -229,7 +229,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_network/output/bias')
         # assign it to all ones
-        bias.load(np.ones_like(bias))
+        bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
@@ -266,7 +266,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
         with tf.variable_scope('GaussianMLPModel', reuse=True):
             bias = tf.get_variable('dist_params/mean_network/output/bias')
         # assign it to all ones
-        bias.load(np.ones_like(bias))
+        bias.load(tf.ones_like(bias).eval())
 
         h = pickle.dumps(model)
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})

--- a/tests/garage/tf/models/test_mlp_model.py
+++ b/tests/garage/tf/models/test_mlp_model.py
@@ -39,13 +39,20 @@ class TestMLPModel(TfGraphTestCase):
             hidden_nonlinearity=None,
             hidden_w_init=tf.ones_initializer(),
             output_w_init=tf.ones_initializer())
-        model_pickled = pickle.loads(pickle.dumps(model))
+        outputs = model.build(self.input_var)
+
+        # assign bias to all one
+        with tf.variable_scope('MLPModel/mlp', reuse=True):
+            bias = tf.get_variable('hidden_0/bias')
+        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+
+        output1 = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
+
+        h = pickle.dumps(model)
         with tf.Session(graph=tf.Graph()) as sess:
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
+            model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
-            output = sess.run(outputs, feed_dict={input_var: self.obs})
+            output2 = sess.run(outputs, feed_dict={input_var: self.obs})
 
-            expected_output = np.full([1, output_dim],
-                                      5 * np.prod(hidden_sizes))
-
-            assert np.array_equal(output, expected_output)
+            assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_mlp_model.py
+++ b/tests/garage/tf/models/test_mlp_model.py
@@ -44,7 +44,8 @@ class TestMLPModel(TfGraphTestCase):
         # assign bias to all one
         with tf.variable_scope('MLPModel/mlp', reuse=True):
             bias = tf.get_variable('hidden_0/bias')
-        bias.load(np.ones_like(bias))
+
+        bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
 

--- a/tests/garage/tf/models/test_mlp_model.py
+++ b/tests/garage/tf/models/test_mlp_model.py
@@ -44,7 +44,7 @@ class TestMLPModel(TfGraphTestCase):
         # assign bias to all one
         with tf.variable_scope('MLPModel/mlp', reuse=True):
             bias = tf.get_variable('hidden_0/bias')
-        self.sess.run(tf.assign(bias, tf.ones_like(bias)))
+        bias.load(np.ones_like(bias))
 
         output1 = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
 

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -164,7 +164,7 @@ class TestModel(TfGraphTestCase):
             # assign bias to all one
             with tf.variable_scope('SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            sess.run(tf.assign(bias, tf.ones_like(bias)))
+            bias.load(np.ones_like(bias))
 
             results = sess.run(
                 model.networks['default'].outputs,
@@ -200,7 +200,7 @@ class TestModel(TfGraphTestCase):
             with tf.variable_scope(
                     'ComplicatedModel/SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            sess.run(tf.assign(bias, tf.ones_like(bias)))
+            bias.load(np.ones_like(bias))
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})
@@ -231,7 +231,7 @@ class TestModel(TfGraphTestCase):
             with tf.variable_scope(
                     'ComplicatedModel2/SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            sess.run(tf.assign(bias, tf.ones_like(bias)))
+            bias.load(np.ones_like(bias))
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -164,7 +164,7 @@ class TestModel(TfGraphTestCase):
             # assign bias to all one
             with tf.variable_scope('SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            bias.load(np.ones_like(bias))
+            bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
                 model.networks['default'].outputs,
@@ -200,7 +200,7 @@ class TestModel(TfGraphTestCase):
             with tf.variable_scope(
                     'ComplicatedModel/SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            bias.load(np.ones_like(bias))
+            bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})
@@ -231,7 +231,7 @@ class TestModel(TfGraphTestCase):
             with tf.variable_scope(
                     'ComplicatedModel2/SimpleModel/state', reuse=True):
                 bias = tf.get_variable('hidden_0/bias')
-            bias.load(np.ones_like(bias))
+            bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -161,6 +161,11 @@ class TestModel(TfGraphTestCase):
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
             model.build(input_var)
 
+            # assign bias to all one
+            with tf.variable_scope('SimpleModel/state', reuse=True):
+                bias = tf.get_variable('hidden_0/bias')
+            sess.run(tf.assign(bias, tf.ones_like(bias)))
+
             results = sess.run(
                 model.networks['default'].outputs,
                 feed_dict={model.networks['default'].input: data})
@@ -191,6 +196,12 @@ class TestModel(TfGraphTestCase):
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
             outputs = model.build(input_var)
 
+            # assign bias to all one
+            with tf.variable_scope(
+                    'ComplicatedModel/SimpleModel/state', reuse=True):
+                bias = tf.get_variable('hidden_0/bias')
+            sess.run(tf.assign(bias, tf.ones_like(bias)))
+
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})
             model_data = pickle.dumps(model)
@@ -215,6 +226,12 @@ class TestModel(TfGraphTestCase):
         with tf.Session(graph=tf.Graph()) as sess:
             input_var = tf.placeholder(tf.float32, shape=(None, 5))
             outputs = model.build(input_var)
+
+            # assign bias to all one
+            with tf.variable_scope(
+                    'ComplicatedModel2/SimpleModel/state', reuse=True):
+                bias = tf.get_variable('hidden_0/bias')
+            sess.run(tf.assign(bias, tf.ones_like(bias)))
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -187,7 +187,7 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
                 'CategoricalConvPolicy/Sequential/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        return_var.load(np.ones_like(return_var))
+        return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
             policy.model.outputs, feed_dict={policy.model.input: [obs]})
         p = pickle.dumps(policy)

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -187,7 +187,7 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
                 'CategoricalConvPolicy/Sequential/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        return_var.load(np.ones_like(return_var))
         output1 = self.sess.run(
             policy.model.outputs, feed_dict={policy.model.input: [obs]})
         p = pickle.dumps(policy)

--- a/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
@@ -112,7 +112,7 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
         with tf.variable_scope('CategoricalMLPPolicy/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        return_var.load(np.ones_like(return_var))
+        return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
             policy.model.outputs,
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
@@ -112,7 +112,7 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
         with tf.variable_scope('CategoricalMLPPolicy/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        return_var.load(np.ones_like(return_var))
         output1 = self.sess.run(
             policy.model.outputs,
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
@@ -85,7 +85,7 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
 
         obs_dim = env.spec.observation_space.flat_dim
         state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
-        dist1 = policy.dist_info_sym(state_input, name="policy2")
+        dist1 = policy.dist_info_sym(state_input, name='policy2')
 
         prob = self.sess.run(
             dist1['prob'], feed_dict={state_input: [obs.flatten()]})
@@ -109,18 +109,19 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        expected_prob = np.full(action_dim, 0.5)
+        with tf.variable_scope('CategoricalMLPPolicy/MLPModel', reuse=True):
+            return_var = tf.get_variable('return_var')
+        # assign it to all one
+        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        output1 = self.sess.run(
+            policy.model.outputs,
+            feed_dict={policy.model.input: [obs.flatten()]})
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            action, prob = policy_pickled.get_action(obs)
-            assert env.action_space.contains(action)
-            assert action == 0
-            assert np.array_equal(prob['prob'], expected_prob)
-
-            prob1 = policy.dist_info([obs.flatten()])
-            prob2 = policy_pickled.dist_info([obs.flatten()])
-            assert np.array_equal(prob1['prob'], prob2['prob'])
-            assert np.array_equal(prob2['prob'][0], expected_prob)
+            output2 = sess.run(
+                policy_pickled.model.outputs,
+                feed_dict={policy_pickled.model.input: [obs.flatten()]})
+            assert np.array_equal(output1, output2)

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
@@ -93,7 +93,7 @@ class TestDeterministicMLPPolicyWithModel(TfGraphTestCase):
         with tf.variable_scope('DeterministicMLPPolicy/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        return_var.load(np.ones_like(return_var))
         output1 = self.sess.run(
             policy.model.outputs,
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
@@ -93,7 +93,7 @@ class TestDeterministicMLPPolicyWithModel(TfGraphTestCase):
         with tf.variable_scope('DeterministicMLPPolicy/MLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        return_var.load(np.ones_like(return_var))
+        return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
             policy.model.outputs,
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -105,7 +105,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
                 'GaussianMLPPolicyWithModel/GaussianMLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        return_var.load(np.ones_like(return_var))
+        return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
             policy.model.outputs[:-1],
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -105,7 +105,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
                 'GaussianMLPPolicyWithModel/GaussianMLPModel', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        return_var.load(np.ones_like(return_var))
         output1 = self.sess.run(
             policy.model.outputs[:-1],
             feed_dict={policy.model.input: [obs.flatten()]})

--- a/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
@@ -101,7 +101,7 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
                 'discrete_mlp_q_function/discrete_mlp_q_function', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        return_var.load(np.ones_like(return_var))
+        return_var.load(tf.ones_like(return_var).eval())
 
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 

--- a/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
@@ -74,7 +74,7 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 
         input_var = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
-        q_vals = qf.get_qval_sym(input_var, "another")
+        q_vals = qf.get_qval_sym(input_var, 'another')
         output2 = self.sess.run(q_vals, feed_dict={input_var: [obs]})
 
         expected_output = np.full(action_dim, 0.5)
@@ -97,6 +97,12 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
+        with tf.variable_scope(
+                'discrete_mlp_q_function/discrete_mlp_q_function', reuse=True):
+            return_var = tf.get_variable('return_var')
+        # assign it to all one
+        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 
         h_data = pickle.dumps(qf)
@@ -104,7 +110,7 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
             qf_pickled = pickle.loads(h_data)
             input_var = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
 
-            q_vals = qf_pickled.get_qval_sym(input_var, "another")
+            q_vals = qf_pickled.get_qval_sym(input_var, 'another')
             output2 = sess.run(q_vals, feed_dict={input_var: [obs]})
 
         assert np.array_equal(output1, output2)

--- a/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
@@ -101,7 +101,7 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
                 'discrete_mlp_q_function/discrete_mlp_q_function', reuse=True):
             return_var = tf.get_variable('return_var')
         # assign it to all one
-        self.sess.run(tf.assign(return_var, tf.ones_like(return_var)))
+        return_var.load(np.ones_like(return_var))
 
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 


### PR DESCRIPTION
Previously pickling test is done with default parameters. It work even if it does not pickle the weights correctly. This PR fixed the issue by manually assigning weights to some variables so as to make sure the pickling is done correctly. 
This PR will also close #608.