### PR TITLE
Fix GaussianMLPRegressor and baseline for pickling

### DIFF
--- a/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
+++ b/garage/tf/baselines/gaussian_mlp_baseline_with_model.py
@@ -18,12 +18,18 @@ class GaussianMLPBaselineWithModel(Baseline):
             name='GaussianMLPBaselineWithModel',
     ):
         """
-        Constructor.
+        Gaussian MLP Baseline with Model.
 
-        :param env_spec:
-        :param subsample_factor:
-        :param num_seq_inputs:
-        :param regressor_args:
+        It fits the input data to a gaussian distribution estimated by
+        a MLP.
+
+        Args:
+            env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+            subsample_factor (float): The factor to subsample the data. By
+                default it is 1.0, which means using all the data.
+            num_seq_inputs (float): Number of sequence per input. By default
+                it is 1.0, which means only one single sequence.
+            regressor_args (dict): Arguments for regressor.
         """
         super().__init__(env_spec)
         if regressor_args is None:

--- a/garage/tf/regressors/__init__.py
+++ b/garage/tf/regressors/__init__.py
@@ -1,4 +1,5 @@
 from garage.tf.regressors.base import StochasticRegressor
+from garage.tf.regressors.base2 import StochasticRegressor2
 from garage.tf.regressors.bernoulli_mlp_regressor import (
     BernoulliMLPRegressor)
 from garage.tf.regressors.categorical_mlp_regressor import (
@@ -16,5 +17,5 @@ __all__ = [
     'BernoulliMLPRegressor', 'CategoricalMLPRegressor',
     'DeterministicMLPRegressor', 'GaussianMLPRegressor',
     'GaussianMLPRegressorModel', 'GaussianMLPRegressorWithModel',
-    'GaussianConvRegressor', 'StochasticRegressor'
+    'GaussianConvRegressor', 'StochasticRegressor', 'StochasticRegressor2'
 ]

--- a/garage/tf/regressors/base.py
+++ b/garage/tf/regressors/base.py
@@ -41,7 +41,7 @@ class Regressor(Parameterized, abc.ABC):
         raise NotImplementedError
 
     def get_params_internal(self, **tags):
-        """Get trainable vars."""
+        """Get the list of parameters."""
         return self._variable_scope.trainable_variables()
 
 

--- a/garage/tf/regressors/base2.py
+++ b/garage/tf/regressors/base2.py
@@ -44,6 +44,9 @@ class Regressor2(abc.ABC):
 
         Args:
             xs: Input data.
+
+        Return:
+            The predicted ys.
         """
         raise NotImplementedError
 
@@ -158,9 +161,12 @@ class StochasticRegressor2(Regressor2):
         Symbolic graph of the log likelihood.
 
         Args:
-            x_var: Input tf.Tensor for the input data.
-            y_var: Input tf.Tensor for the label of data.
-            name: Name of the new graph.
+            x_var (tf.Tensor): Input tf.Tensor for the input data.
+            y_var (tf.Tensor): Input tf.Tensor for the label of data.
+            name (str): Name of the new graph.
+
+        Return:
+            tf.Tensor output of the symbolic log likelihood.
         """
         raise NotImplementedError
 
@@ -169,7 +175,10 @@ class StochasticRegressor2(Regressor2):
         Symbolic graph of the distribution.
 
         Args:
-            x_var: Input tf.Tensor for the input data.
-            name: Name of the new graph.
+            x_var (tf.Tensor): Input tf.Tensor for the input data.
+            name (str): Name of the new graph.
+
+        Return:
+            tf.Tensor output of the symbolic distribution.
         """
         raise NotImplementedError

--- a/garage/tf/regressors/base2.py
+++ b/garage/tf/regressors/base2.py
@@ -1,0 +1,175 @@
+"""Regressor base classes without Parameterized."""
+import abc
+
+import tensorflow as tf
+
+from garage.misc.tensor_utils import flatten_tensors
+from garage.misc.tensor_utils import unflatten_tensors
+
+
+class Regressor2(abc.ABC):
+    """
+    Regressor base class without Parameterized.
+
+    Args:
+        input_shape (tuple): Input shape.
+        output_dim (int): Output dimension.
+        name (str): Name of the regressor.
+    """
+
+    def __init__(self, input_shape, output_dim, name):
+        self._input_shape = input_shape
+        self._output_dim = output_dim
+        self._name = name
+        self._variable_scope = None
+        self._cached_params = {}
+        self._cached_param_dtypes = {}
+        self._cached_param_shapes = {}
+        self._cached_assign_ops = {}
+        self._cached_assign_placeholders = {}
+
+    def fit(self, xs, ys):
+        """
+        Fit with input data xs and label ys.
+
+        Args:
+            xs: Input data.
+            ys: Label of input data.
+        """
+        raise NotImplementedError
+
+    def predict(self, xs):
+        """
+        Predict ys based on input xs.
+
+        Args:
+            xs: Input data.
+        """
+        raise NotImplementedError
+
+    def get_params_internal(self, **tags):
+        """
+        Get the list of parameters.
+
+        This internal method does not perform caching, and should
+        be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def get_params(self, **tags):
+        """
+        Get the list of parameters, filtered by the provided tags.
+
+        Some common tags include 'regularizable' and 'trainable'
+        """
+        tag_tuple = tuple(sorted(list(tags.items()), key=lambda x: x[0]))
+        if tag_tuple not in self._cached_params:
+            self._cached_params[tag_tuple] = self.get_params_internal(**tags)
+        return self._cached_params[tag_tuple]
+
+    def get_param_dtypes(self, **tags):
+        """Get the list of dtypes for the parameters."""
+        tag_tuple = tuple(sorted(list(tags.items()), key=lambda x: x[0]))
+        if tag_tuple not in self._cached_param_dtypes:
+            params = self.get_params(**tags)
+            param_values = tf.get_default_session().run(params)
+            self._cached_param_dtypes[tag_tuple] = [
+                val.dtype for val in param_values
+            ]
+        return self._cached_param_dtypes[tag_tuple]
+
+    def get_param_shapes(self, **tags):
+        """Get the list of shapes for the parameters."""
+        tag_tuple = tuple(sorted(list(tags.items()), key=lambda x: x[0]))
+        if tag_tuple not in self._cached_param_shapes:
+            params = self.get_params(**tags)
+            param_values = tf.get_default_session().run(params)
+            self._cached_param_shapes[tag_tuple] = [
+                val.shape for val in param_values
+            ]
+        return self._cached_param_shapes[tag_tuple]
+
+    def get_param_values(self, **tags):
+        """Get the list of values for the parameters."""
+        params = self.get_params(**tags)
+        param_values = tf.get_default_session().run(params)
+        return flatten_tensors(param_values)
+
+    def set_param_values(self, flattened_params, name=None, **tags):
+        """Set the values for the parameters."""
+        with tf.name_scope(name, 'set_param_values', [flattened_params]):
+            debug = tags.pop('debug', False)
+            param_values = unflatten_tensors(flattened_params,
+                                             self.get_param_shapes(**tags))
+            ops = []
+            feed_dict = dict()
+            for param, dtype, value in zip(
+                    self.get_params(**tags), self.get_param_dtypes(**tags),
+                    param_values):
+                if param not in self._cached_assign_ops:
+                    assign_placeholder = tf.placeholder(
+                        dtype=param.dtype.base_dtype)
+                    assign_op = tf.assign(param, assign_placeholder)
+                    self._cached_assign_ops[param] = assign_op
+                    self._cached_assign_placeholders[
+                        param] = assign_placeholder
+                ops.append(self._cached_assign_ops[param])
+                feed_dict[self._cached_assign_placeholders[
+                    param]] = value.astype(dtype)
+                if debug:
+                    print('setting value of %s' % param.name)
+            tf.get_default_session().run(ops, feed_dict=feed_dict)
+
+    def __getstate__(self):
+        """Object.__getstate__."""
+        new_dict = self.__dict__.copy()
+        del new_dict['_cached_params']
+        del new_dict['_cached_param_dtypes']
+        del new_dict['_cached_param_shapes']
+        del new_dict['_cached_assign_ops']
+        del new_dict['_cached_assign_placeholders']
+        return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__."""
+        self._cached_params = {}
+        self._cached_param_dtypes = {}
+        self._cached_param_shapes = {}
+        self._cached_assign_ops = {}
+        self._cached_assign_placeholders = {}
+        self.__dict__.update(state)
+
+
+class StochasticRegressor2(Regressor2):
+    """
+    StochasticRegressor base class.
+
+    Args:
+        input_shape (tuple): Input shape.
+        output_dim (int): Output dimension.
+        name (str): Name of the regressor.
+    """
+
+    def __init__(self, input_shape, output_dim, name):
+        super().__init__(input_shape, output_dim, name)
+
+    def log_likelihood_sym(self, x_var, y_var, name=None):
+        """
+        Symbolic graph of the log likelihood.
+
+        Args:
+            x_var: Input tf.Tensor for the input data.
+            y_var: Input tf.Tensor for the label of data.
+            name: Name of the new graph.
+        """
+        raise NotImplementedError
+
+    def dist_info_sym(self, x_var, name=None):
+        """
+        Symbolic graph of the distribution.
+
+        Args:
+            x_var: Input tf.Tensor for the input data.
+            name: Name of the new graph.
+        """
+        raise NotImplementedError

--- a/garage/tf/regressors/base2.py
+++ b/garage/tf/regressors/base2.py
@@ -30,8 +30,8 @@ class Regressor2(abc.ABC):
         Fit with input data xs and label ys.
 
         Args:
-            xs: Input data.
-            ys: Label of input data.
+            xs (numpy.ndarray): Input data.
+            ys (numpy.ndarray): Label of input data.
         """
         raise NotImplementedError
 
@@ -40,7 +40,7 @@ class Regressor2(abc.ABC):
         Predict ys based on input xs.
 
         Args:
-            xs: Input data.
+            xs (numpy.ndarray): Input data.
 
         Return:
             The predicted ys.

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -6,10 +6,10 @@ from garage.logger import tabular
 from garage.tf.misc import tensor_utils
 from garage.tf.optimizers import LbfgsOptimizer, PenaltyLbfgsOptimizer
 from garage.tf.regressors import GaussianMLPRegressorModel
-from garage.tf.regressors import StochasticRegressor
+from garage.tf.regressors import StochasticRegressor2
 
 
-class GaussianMLPRegressorWithModel(StochasticRegressor):
+class GaussianMLPRegressorWithModel(StochasticRegressor2):
     """
     GaussianMLPRegressor with garage.tf.models.GaussianMLPRegressorModel.
 
@@ -272,3 +272,19 @@ class GaussianMLPRegressorWithModel(StochasticRegressor):
 
         return self.model.networks[name].dist.log_likelihood_sym(
             y_var, dict(mean=means_var, log_std=log_stds_var))
+
+    def get_params_internal(self, **args):
+        """Get the params, which are the trainable variables."""
+        return self._variable_scope.trainable_variables()
+
+    def __getstate__(self):
+        """Object.__getstate__."""
+        new_dict = super().__getstate__()
+        del new_dict['_f_predict']
+        del new_dict['_f_pdists']
+        return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__."""
+        super().__setstate__(state)
+        self._initialize()

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -213,23 +213,18 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
                 int(num_samples_tot * self._subsample_factor))
             xs, ys = xs[idx], ys[idx]
 
-        sess = tf.get_default_session()
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            sess.run([
-                tf.assign(self.model.networks['default'].x_mean,
-                          np.mean(xs, axis=0, keepdims=True)),
-                tf.assign(self.model.networks['default'].x_std,
-                          np.std(xs, axis=0, keepdims=True) + 1e-8),
-            ])
+            self.model.networks['default'].x_mean.load(
+                np.mean(xs, axis=0, keepdims=True))
+            self.model.networks['default'].x_std.load(
+                np.std(xs, axis=0, keepdims=True) + 1e-8)
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
-            sess.run([
-                tf.assign(self.model.networks['default'].y_mean,
-                          np.mean(ys, axis=0, keepdims=True)),
-                tf.assign(self.model.networks['default'].y_std,
-                          np.std(ys, axis=0, keepdims=True) + 1e-8),
-            ])
+            self.model.networks['default'].y_mean.load(
+                np.mean(ys, axis=0, keepdims=True))
+            self.model.networks['default'].y_std.load(
+                np.std(ys, axis=0, keepdims=True) + 1e-8)
         if self._use_trust_region:
             old_means, old_log_stds = self._f_pdists(xs)
             inputs = [xs, ys, old_means, old_log_stds]

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -205,7 +205,13 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
                 self._optimizer.update_opt(**optimizer_args)
 
     def fit(self, xs, ys):
-        """Fit with input data xs and label ys."""
+        """
+        Fit with input data xs and label ys.
+
+        Args:
+            xs (numpy.ndarray): Input data.
+            ys (numpy.ndarray): Label of input data.
+        """
         if self._subsample_factor < 1:
             num_samples_tot = xs.shape[0]
             idx = np.random.randint(
@@ -242,11 +248,13 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
 
     def predict(self, xs):
         """
-        Return the maximum likelihood estimate of the predicted y.
+        Predict ys based on input xs.
 
-        :param xs:
-        :return:
+        Args:
+            xs (numpy.ndarray): Input data.
 
+        Return:
+            The predicted ys.
         """
         return self._f_predict(xs)
 
@@ -255,9 +263,12 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         Symbolic graph of the log likelihood.
 
         Args:
-            x_var: Input tf.Tensor for the input data.
-            y_var: Input tf.Tensor for the label of data.
-            name: Name of the new graph.
+            x_var (tf.Tensor): Input tf.Tensor for the input data.
+            y_var (tf.Tensor): Input tf.Tensor for the label of data.
+            name (str): Name of the new graph.
+
+        Return:
+            tf.Tensor output of the symbolic log likelihood.
         """
         with tf.variable_scope(self._variable_scope):
             self.model.build(x_var, name=name)

--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -7,7 +7,11 @@ from garage.tf.models import Model
 class SimpleGaussianMLPModel(Model):
     """Simple GaussianMLPModel for testing."""
 
-    def __init__(self, name, output_dim, *args, **kwargs):
+    def __init__(self,
+                 output_dim,
+                 *args,
+                 name='SimpleGaussianMLPModel',
+                 **kwargs):
         super().__init__(name)
         self.output_dim = output_dim
 

--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -9,8 +9,8 @@ class SimpleGaussianMLPModel(Model):
 
     def __init__(self,
                  output_dim,
-                 *args,
                  name='SimpleGaussianMLPModel',
+                 *args,
                  **kwargs):
         super().__init__(name)
         self.output_dim = output_dim

--- a/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
@@ -30,9 +30,9 @@ class SimpleGaussianMLPRegressor(StochasticRegressor2):
             mean = tf.get_default_session().run(
                 self.model.networks['default'].mean,
                 feed_dict={self.model.networks['default'].input: xs})
-            return np.full((len(xs), 1), mean)
-        else:
-            return self.ys
+            self.ys = np.full((len(xs), 1), mean)
+
+        return self.ys
 
     def get_params_internal(self, *args, **kwargs):
         return self._variable_scope.trainable_variables()

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline_with_model.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline_with_model.py
@@ -1,3 +1,4 @@
+import pickle
 from unittest import mock
 
 from nose2.tools.params import params
@@ -11,7 +12,7 @@ from tests.fixtures.envs.dummy import DummyBoxEnv
 from tests.fixtures.regressors import SimpleGaussianMLPRegressor
 
 
-class TestGaussianMLPBaseline(TfGraphTestCase):
+class TestGaussianMLPBaselineWithModel(TfGraphTestCase):
     @params([1], [2], [1, 1], [2, 2])
     def test_fit(self, obs_dim):
         box_env = TfEnv(DummyBoxEnv(obs_dim=obs_dim))
@@ -43,6 +44,12 @@ class TestGaussianMLPBaseline(TfGraphTestCase):
             gmb = GaussianMLPBaselineWithModel(env_spec=box_env.spec)
             new_gmb = GaussianMLPBaselineWithModel(
                 env_spec=box_env.spec, name='GaussianMLPBaselineWithModel2')
+
+        # Manual change the parameter of GaussianMLPBaselineWithModel
+        with tf.variable_scope('GaussianMLPBaselineWithModel', reuse=True):
+            return_var = tf.get_variable('SimpleGaussianMLPModel/return_var')
+        return_var.load(1.0)
+
         old_param_values = gmb.get_param_values()
         new_param_values = new_gmb.get_param_values()
         assert not np.array_equal(old_param_values, new_param_values)
@@ -63,3 +70,26 @@ class TestGaussianMLPBaseline(TfGraphTestCase):
         trainable_params = tf.trainable_variables(
             scope='GaussianMLPBaselineWithModel')
         assert np.array_equal(params_interal, trainable_params)
+
+    def test_is_pickleable(self):
+        box_env = TfEnv(DummyBoxEnv(obs_dim=(1, )))
+        with mock.patch(('garage.tf.baselines.'
+                         'gaussian_mlp_baseline_with_model.'
+                         'GaussianMLPRegressorWithModel'),
+                        new=SimpleGaussianMLPRegressor):
+            gmb = GaussianMLPBaselineWithModel(env_spec=box_env.spec)
+        obs = {'observations': [np.full(1, 1), np.full(1, 1)]}
+
+        with tf.variable_scope('GaussianMLPBaselineWithModel', reuse=True):
+            return_var = tf.get_variable('SimpleGaussianMLPModel/return_var')
+        return_var.load(1.0)
+
+        prediction = gmb.predict(obs)
+
+        h = pickle.dumps(gmb)
+
+        with tf.Session(graph=tf.Graph()):
+            gmb_pickled = pickle.loads(h)
+            prediction2 = gmb_pickled.predict(obs)
+
+            assert np.array_equal(prediction, prediction2)


### PR DESCRIPTION
* New regressor base class which has the `get_params()` and `set_params()`. In the future, regressor should inherit from `Model` class and those methods should be put into `Model` class. For now I just put it in the regressor base class.
* Make `GaussianMLPRegressorWithModel` and `GaussianMLPBaselinesWithModel` pickleable, which will close #511.
* Modify `SimpleGaussianMLPRegressor` for testing.