### PR TITLE
Fix variable scope reentering

### DIFF
--- a/garage/tf/policies/base2.py
+++ b/garage/tf/policies/base2.py
@@ -1,5 +1,4 @@
 """Policy base classes without Parameterized."""
-import tensorflow as tf
 
 
 class Policy2:
@@ -15,7 +14,7 @@ class Policy2:
     def __init__(self, name, env_spec):
         self._name = name
         self._env_spec = env_spec
-        self._variable_scope = tf.VariableScope(reuse=False, name=name)
+        self._variable_scope = None
         self._models = []
 
     # Should be implemented by all policies

--- a/garage/tf/policies/categorical_conv_policy_with_model.py
+++ b/garage/tf/policies/categorical_conv_policy_with_model.py
@@ -107,8 +107,8 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, ) + self.obs_dim)
 
-        with tf.variable_scope(
-                name=self.name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self.name) as vs:
+            self._variable_scope = vs
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/categorical_conv_policy_with_model.py
+++ b/garage/tf/policies/categorical_conv_policy_with_model.py
@@ -107,7 +107,8 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, ) + self.obs_dim)
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.variable_scope(
+                name=self.name, reuse=False) as self._variable_scope:
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/categorical_mlp_policy_with_model.py
+++ b/garage/tf/policies/categorical_mlp_policy_with_model.py
@@ -81,8 +81,8 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(
-                name=self.name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self.name) as vs:
+            self._variable_scope = vs
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/categorical_mlp_policy_with_model.py
+++ b/garage/tf/policies/categorical_mlp_policy_with_model.py
@@ -81,7 +81,8 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.variable_scope(
+                name=self.name, reuse=False) as self._variable_scope:
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -84,7 +84,8 @@ class DeterministicMLPPolicyWithModel(Policy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.variable_scope(
+                reuse=False, name=self.name) as self._variable_scope:
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -84,8 +84,8 @@ class DeterministicMLPPolicyWithModel(Policy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(
-                reuse=False, name=self.name) as self._variable_scope:
+        with tf.variable_scope(self.name) as vs:
+            self._variable_scope = vs
             self.model.build(state_input)
 
         self._f_prob = tf.get_default_session().make_callable(

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -117,8 +117,8 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(
-                name=self.name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self.name) as vs:
+            self._variable_scope = vs
             self.model.build(state_input)
 
         self._f_dist = tf.get_default_session().make_callable(

--- a/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -117,7 +117,8 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
     def _initialize(self):
         state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.variable_scope(
+                name=self.name, reuse=False) as self._variable_scope:
             self.model.build(state_input)
 
         self._f_dist = tf.get_default_session().make_callable(

--- a/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -51,7 +51,7 @@ class DiscreteMLPQFunction:
         obs_dim = env_spec.observation_space.shape
         action_dim = env_spec.action_space.flat_dim
 
-        self._variable_scope = tf.VariableScope(reuse=False, name=name)
+        self._variable_scope = None
         self.model = MLPModel(
             output_dim=action_dim,
             name=name,
@@ -66,7 +66,7 @@ class DiscreteMLPQFunction:
 
         obs_ph = tf.placeholder(tf.float32, (None, ) + obs_dim, name='obs')
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.variable_scope(name=name, reuse=False) as self._variable_scope:
             self.model.build(obs_ph)
 
     @property

--- a/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -51,7 +51,6 @@ class DiscreteMLPQFunction:
         obs_dim = env_spec.observation_space.shape
         action_dim = env_spec.action_space.flat_dim
 
-        self._variable_scope = None
         self.model = MLPModel(
             output_dim=action_dim,
             name=name,
@@ -66,7 +65,8 @@ class DiscreteMLPQFunction:
 
         obs_ph = tf.placeholder(tf.float32, (None, ) + obs_dim, name='obs')
 
-        with tf.variable_scope(name=name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(name) as vs:
+            self._variable_scope = vs
             self.model.build(obs_ph)
 
     @property


### PR DESCRIPTION
Previously a `tf.VariableScope` object is created and cached. However, it will not create a `tf.variable_scope` object and add the scope to the graph.
This PR fixes variable scope reentering by following the TensorFlow suggested way.
(Reference: https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/python/ops/variable_scope.py#L1985)

This will close #609.