### PR TITLE
Add pip to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
     - python==3.6.6
+    - pip # required so that conda doesn't complain
     - numpy==1.14.5 # pycma requires numpy to install (smh)
     - pre_commit  # See https://github.com/pre-commit/pre-commit/issues/701
     - pip:


### PR DESCRIPTION
A recent conda update requires that pip be listed in environment.yml in
order to use pip dependencies.

This PR updates environment.yml to list pip as a conda dependency, to
conform to the new style and avoid warnings from conda.