### PR TITLE
Fix flaky tests for runner and snapshot

### DIFF
--- a/tests/garage/experiment/test_local_tf_runner.py
+++ b/tests/garage/experiment/test_local_tf_runner.py
@@ -1,25 +1,16 @@
-import unittest
-
 import tensorflow as tf
 
 from garage.experiment import LocalRunner
-from garage.logger import logger
 from garage.np.baselines import LinearFeatureBaseline
 from garage.sampler import singleton_pool
 from garage.tf.algos import VPG
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.tf.samplers import BatchSampler
-from tests.fixtures.logger import NullOutput
+from tests.fixtures import TfGraphTestCase
 
 
-class TestLocalRunner(unittest.TestCase):
-    def setUp(self):
-        logger.add_output(NullOutput())
-
-    def tearDown(self):
-        logger.remove_all()
-
+class TestLocalRunner(TfGraphTestCase):
     def test_session(self):
         with LocalRunner():
             self.assertIsNotNone(

--- a/tests/garage/experiment/test_snapshot.py
+++ b/tests/garage/experiment/test_snapshot.py
@@ -1,6 +1,5 @@
 import os.path as osp
 import tempfile
-import unittest
 
 import joblib
 import tensorflow as tf
@@ -12,10 +11,11 @@ from garage.sampler.utils import rollout
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
+from tests.fixtures import TfGraphTestCase
 from tests.fixtures.logger import NullOutput
 
 
-class TestSnapshot(unittest.TestCase):
+class TestSnapshot(TfGraphTestCase):
     verifyItrs = 3
 
     @classmethod


### PR DESCRIPTION
Tests of `LocalRunner` and `Snapshotter` do not clear tensorflow graph. This is problematic when running `make test`, in which `TestSnapshot` and `TestLocalRunner` are tested back to back and tensorflow complaints of duplicate variables in the graph. This PR fixes this issue. 

This problem is not exposed earlier in CI because the order of tests was different, and those tests between `TestSnapshot` and `TestLocalRunner` clear the graph. 