### PR TITLE
Lower threshold for flaky TRPO test

### DIFF
--- a/tests/garage/tf/algos/test_trpo_with_model.py
+++ b/tests/garage/tf/algos/test_trpo_with_model.py
@@ -36,6 +36,6 @@ class TestTRPO(TfGraphTestCase):
 
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 90
+            assert last_avg_ret > 85
 
             env.close()


### PR DESCRIPTION
`test_trpo_recurrent_cartpole` is flaky so the threshold for passing the test is lower to 85.