### PR TITLE
Conformance tests for DeterministicMLPPolicy

### DIFF
--- a/garage/tf/policies/deterministic_mlp_policy.py
+++ b/garage/tf/policies/deterministic_mlp_policy.py
@@ -13,7 +13,7 @@ from garage.tf.policies.base import Policy
 class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
     def __init__(self,
                  env_spec,
-                 name="DeterministicMLPPolicy",
+                 name='DeterministicMLPPolicy',
                  hidden_sizes=(32, 32),
                  hidden_nonlinearity=tf.nn.relu,
                  output_nonlinearity=tf.nn.tanh,
@@ -23,8 +23,8 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
 
         Serializable.quick_init(self, locals())
 
-        self._prob_network_name = "prob_network"
-        with tf.variable_scope(name, "DeterministicMLPPolicy"):
+        self._prob_network_name = 'prob_network'
+        with tf.variable_scope(name, 'DeterministicMLPPolicy'):
             if prob_network is None:
                 prob_network = MLP(
                     input_shape=(env_spec.observation_space.flat_dim, ),
@@ -33,7 +33,7 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
                     hidden_nonlinearity=hidden_nonlinearity,
                     output_nonlinearity=output_nonlinearity,
                     # batch_normalization=True,
-                    name="mlp_prob_network",
+                    name='mlp_prob_network',
                 )
 
             with tf.name_scope(self._prob_network_name):
@@ -62,7 +62,7 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
     @overrides
     def get_action(self, observation):
         flat_obs = self.observation_space.flatten(observation)
-        action = self._f_prob([flat_obs])
+        action = self._f_prob([flat_obs])[0]
         return action, dict()
 
     @overrides
@@ -72,6 +72,6 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
         return actions, dict()
 
     def get_action_sym(self, obs_var, name=None):
-        with tf.name_scope(name, "get_action_sym", values=[obs_var]):
+        with tf.name_scope(name, 'get_action_sym', values=[obs_var]):
             with tf.name_scope(self._prob_network_name, values=[obs_var]):
                 return L.get_output(self.prob_network.output_layer, obs_var)

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -96,7 +96,6 @@ class DeterministicMLPPolicyWithModel(Policy2):
         """Return action sym according to obs_var."""
         with tf.variable_scope(self._variable_scope):
             action = self.model.build(obs_var, name=name)
-            action = tf.reshape(action, self.action_space.shape)
             return action
 
     def get_params(self, trainable=True):

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -99,6 +99,10 @@ class DeterministicMLPPolicyWithModel(Policy2):
             action = tf.reshape(action, self.action_space.shape)
             return action
 
+    def get_params(self, trainable=True):
+        """Get the trainable variables."""
+        return self.get_trainable_vars()
+
     @overrides
     def get_action(self, observation):
         """Return a single action."""

--- a/garage/tf/policies/deterministic_mlp_policy_with_model.py
+++ b/garage/tf/policies/deterministic_mlp_policy_with_model.py
@@ -98,10 +98,6 @@ class DeterministicMLPPolicyWithModel(Policy2):
             action = self.model.build(obs_var, name=name)
             return action
 
-    def get_params(self, trainable=True):
-        """Get the trainable variables."""
-        return self.get_trainable_vars()
-
     @overrides
     def get_action(self, observation):
         """Return a single action."""

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
@@ -69,7 +69,7 @@ class TestDeterministicMLPPolicyWithModel(TfGraphTestCase):
 
         action = self.sess.run(
             action_sym, feed_dict={state_input: [obs.flatten()]})
-        action = np.reshape(action, action_dim)
+        action = policy.action_space.unflatten(action)
 
         assert np.array_equal(action, expected_action)
         assert env.action_space.contains(action)

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model.py
@@ -69,8 +69,10 @@ class TestDeterministicMLPPolicyWithModel(TfGraphTestCase):
 
         action = self.sess.run(
             action_sym, feed_dict={state_input: [obs.flatten()]})
-        assert env.action_space.contains(action)
+        action = np.reshape(action, action_dim)
+
         assert np.array_equal(action, expected_action)
+        assert env.action_space.contains(action)
 
     @params(
         ((1, ), (1, )),

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
@@ -40,9 +40,9 @@ class TestDeterministicMLPPolicyWithModelTransit(TfGraphTestCase):
 
         self.sess.run(tf.global_variables_initializer())
         for a, b in zip(self.policy3.get_params(), self.policy1.get_params()):
-            self.sess.run(b.assign(a))
+            self.sess.run(a.assign(b))
         for a, b in zip(self.policy4.get_params(), self.policy2.get_params()):
-            self.sess.run(b.assign(a))
+            self.sess.run(a.assign(b))
 
         self.obs = [self.box_env.reset()]
 

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
@@ -3,7 +3,7 @@ Unit test for DeterministicMLPPolicyWithModel.
 
 This test consists of four different DeterministicMLPPolicy: P1, P2, P3
 and P4. P1 and P2 are from DeterministicMLPPolicy, which does not use
-garage.tf.models.DeterministicMLPModel while P3 and P4 do use.
+garage.tf.models.MLPModel while P3 and P4 do use.
 
 This test ensures the outputs from all the policies are the same,
 for the transition from using DeterministicMLPPolicy to
@@ -40,9 +40,9 @@ class TestDeterministicMLPPolicyWithModelTransit(TfGraphTestCase):
 
         self.sess.run(tf.global_variables_initializer())
         for a, b in zip(self.policy3.get_params(), self.policy1.get_params()):
-            self.sess.run(tf.assign(b, a))
+            self.sess.run(b.assign(a))
         for a, b in zip(self.policy4.get_params(), self.policy2.get_params()):
-            self.sess.run(tf.assign(b, a))
+            self.sess.run(b.assign(a))
 
         self.obs = [self.box_env.reset()]
 

--- a/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_deterministic_mlp_policy_with_model_transit.py
@@ -1,0 +1,90 @@
+"""
+Unit test for DeterministicMLPPolicyWithModel.
+
+This test consists of four different DeterministicMLPPolicy: P1, P2, P3
+and P4. P1 and P2 are from DeterministicMLPPolicy, which does not use
+garage.tf.models.DeterministicMLPModel while P3 and P4 do use.
+
+This test ensures the outputs from all the policies are the same,
+for the transition from using DeterministicMLPPolicy to
+DeterministicMLPPolicyWithModel.
+
+It covers get_action, get_actions, get_action_sym.
+"""
+from unittest import mock
+
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.envs import TfEnv
+from garage.tf.policies import DeterministicMLPPolicy
+from garage.tf.policies import DeterministicMLPPolicyWithModel
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestDeterministicMLPPolicyWithModelTransit(TfGraphTestCase):
+    @mock.patch('tensorflow.random.normal')
+    def setUp(self, mock_rand):
+        mock_rand.return_value = 0.5
+        super().setUp()
+        self.box_env = TfEnv(DummyBoxEnv())
+        self.policy1 = DeterministicMLPPolicy(
+            env_spec=self.box_env, hidden_sizes=(32, 32), name='P1')
+        self.policy2 = DeterministicMLPPolicy(
+            env_spec=self.box_env, hidden_sizes=(64, 64), name='P2')
+        self.policy3 = DeterministicMLPPolicyWithModel(
+            env_spec=self.box_env, hidden_sizes=(32, 32), name='P3')
+        self.policy4 = DeterministicMLPPolicyWithModel(
+            env_spec=self.box_env, hidden_sizes=(64, 64), name='P4')
+
+        self.sess.run(tf.global_variables_initializer())
+        for a, b in zip(self.policy3.get_params(), self.policy1.get_params()):
+            self.sess.run(tf.assign(b, a))
+        for a, b in zip(self.policy4.get_params(), self.policy2.get_params()):
+            self.sess.run(tf.assign(b, a))
+
+        self.obs = [self.box_env.reset()]
+
+        assert self.policy1.vectorized == self.policy2.vectorized
+        assert self.policy3.vectorized == self.policy4.vectorized
+
+    @mock.patch('numpy.random.normal')
+    def test_get_action(self, mock_rand):
+        mock_rand.return_value = 0.5
+        action1, _ = self.policy1.get_action(self.obs)
+        action2, _ = self.policy2.get_action(self.obs)
+        action3, _ = self.policy3.get_action(self.obs)
+        action4, _ = self.policy4.get_action(self.obs)
+
+        assert np.array_equal(action1, action3)
+        assert np.array_equal(action2, action4)
+
+        actions1, _ = self.policy1.get_actions([self.obs, self.obs])
+        actions2, _ = self.policy2.get_actions([self.obs, self.obs])
+        actions3, _ = self.policy3.get_actions([self.obs, self.obs])
+        actions4, _ = self.policy4.get_actions([self.obs, self.obs])
+
+        assert np.array_equal(actions1, actions3)
+        assert np.array_equal(actions2, actions4)
+
+    def test_get_action_sym(self):
+        obs_dim = self.box_env.spec.observation_space.flat_dim
+        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+
+        action_sym1 = self.policy1.get_action_sym(
+            state_input, name='action_sym')
+        action_sym2 = self.policy2.get_action_sym(
+            state_input, name='action_sym')
+        action_sym3 = self.policy3.get_action_sym(
+            state_input, name='action_sym')
+        action_sym4 = self.policy4.get_action_sym(
+            state_input, name='action_sym')
+
+        action1 = self.sess.run(action_sym1, feed_dict={state_input: self.obs})
+        action2 = self.sess.run(action_sym2, feed_dict={state_input: self.obs})
+        action3 = self.sess.run(action_sym3, feed_dict={state_input: self.obs})
+        action4 = self.sess.run(action_sym4, feed_dict={state_input: self.obs})
+
+        assert np.array_equal(action1, action3)
+        assert np.array_equal(action2, action4)


### PR DESCRIPTION
Add tests to verify `DeterministicMLPPolicyWithModel` works exactly like `DeterministicMLPPolicy`. 

Fix some styling issues that flake/pylint insisted on fixing

In the other PR I was working from a fork and Travis had problems with Docker. Trying to see if this fixes the problem.