### PR TITLE
Move Snapshotter from .logger to .experiment

### DIFF
--- a/garage/experiment/__init__.py
+++ b/garage/experiment/__init__.py
@@ -3,9 +3,15 @@ from garage.experiment.experiment import run_experiment
 from garage.experiment.experiment import to_local_command
 from garage.experiment.experiment import variant
 from garage.experiment.experiment import VariantGenerator
-from garage.experiment.local_tf_runner import LocalRunner
+from garage.experiment.snapshotter import Snapshotter
+
+# LocalRunner needs snapshotter to be imported, so we have to use a strange
+# import order here
+snapshotter = Snapshotter()
+
+from garage.experiment.local_tf_runner import LocalRunner  # noqa: I100,E402,E501,I202 pylint: disable=wrong-import-position
 
 __all__ = [
-    "run_experiment", "to_local_command", "variant", "VariantGenerator",
-    "LocalRunner"
+    'run_experiment', 'to_local_command', 'variant', 'VariantGenerator',
+    'LocalRunner', 'Snapshotter', 'snapshotter'
 ]

--- a/garage/experiment/experiment_wrapper.py
+++ b/garage/experiment/experiment_wrapper.py
@@ -16,12 +16,11 @@ import dateutil.tz
 import psutil
 
 from garage import config
-from garage.experiment import deterministic
+from garage.experiment import deterministic, snapshotter
 from garage.experiment.experiment import concretize
 from garage.experiment.local_tf_runner import LocalRunner
 from garage.logger import CsvOutput
 from garage.logger import logger
-from garage.logger import snapshotter
 from garage.logger import StdOutput
 from garage.logger import TensorBoardOutput
 from garage.logger import TextOutput

--- a/garage/experiment/local_tf_runner.py
+++ b/garage/experiment/local_tf_runner.py
@@ -10,8 +10,8 @@ from types import SimpleNamespace
 
 import tensorflow as tf
 
+from garage.experiment import snapshotter
 from garage.logger import logger
-from garage.logger import snapshotter
 from garage.logger import tabular
 
 # Note: Optional module should be imported ad hoc to break circular dependency.

--- a/garage/experiment/snapshotter.py
+++ b/garage/experiment/snapshotter.py
@@ -122,3 +122,6 @@ class Snapshotter:
 
         with open(snapshot_file, 'rb') as file:
             return joblib.load(file)
+
+
+snapshotter = Snapshotter()

--- a/garage/logger/__init__.py
+++ b/garage/logger/__init__.py
@@ -7,15 +7,20 @@ from garage.logger.logger import Logger, LogOutput
 from garage.logger.simple_outputs import StdOutput, TextOutput
 from garage.logger.tabular_input import TabularInput
 from garage.logger.csv_output import CsvOutput  # noqa: I100
-from garage.logger.snapshotter import Snapshotter
 from garage.logger.tensor_board_output import TensorBoardOutput
 
 logger = Logger()
 tabular = TabularInput()
-snapshotter = Snapshotter()
 
 __all__ = [
-    'Histogram', 'Logger', 'CsvOutput', 'StdOutput', 'TextOutput', 'LogOutput',
-    'Snapshotter', 'TabularInput', 'TensorBoardOutput', 'logger', 'tabular',
-    'snapshotter'
+    'Histogram',
+    'Logger',
+    'CsvOutput',
+    'StdOutput',
+    'TextOutput',
+    'LogOutput',
+    'TabularInput',
+    'TensorBoardOutput',
+    'logger',
+    'tabular',
 ]

--- a/garage/np/algos/batch_polopt.py
+++ b/garage/np/algos/batch_polopt.py
@@ -1,4 +1,5 @@
-from garage.logger import logger, snapshotter, tabular
+from garage.experiment import snapshotter
+from garage.logger import logger, tabular
 from garage.np.algos.base import RLAlgorithm
 from garage.plotter import Plotter
 from garage.sampler import BatchSampler

--- a/tests/fixtures/algos/instrumented_batch_polopt.py
+++ b/tests/fixtures/algos/instrumented_batch_polopt.py
@@ -6,7 +6,8 @@ different stages in the experiment lifecycle.
 
 from multiprocessing.connection import Client
 
-from garage.logger import logger, snapshotter, tabular
+from garage.experiment import snapshotter
+from garage.logger import logger, tabular
 from garage.np.algos import BatchPolopt
 from garage.plotter import Plotter
 from tests.integration_tests.test_sigint import ExpLifecycle

--- a/tests/fixtures/tf/instrumented_batch_polopt.py
+++ b/tests/fixtures/tf/instrumented_batch_polopt.py
@@ -9,7 +9,8 @@ import time
 
 import tensorflow as tf
 
-from garage.logger import logger, snapshotter, tabular
+from garage.experiment import snapshotter
+from garage.logger import logger, tabular
 from garage.tf.algos import BatchPolopt
 from tests.integration_tests.test_sigint import ExpLifecycle
 
@@ -22,7 +23,7 @@ class InstrumentedBatchPolopt(BatchPolopt):
     """
 
     def train(self, sess=None):
-        address = ("localhost", 6000)
+        address = ('localhost', 6000)
         conn = Client(address)
         last_average_return = None
         try:
@@ -38,24 +39,24 @@ class InstrumentedBatchPolopt(BatchPolopt):
             for itr in range(self.start_itr, self.n_itr):
                 itr_start_time = time.time()
                 with logger.prefix('itr #%d | ' % itr):
-                    logger.log("Obtaining samples...")
+                    logger.log('Obtaining samples...')
                     conn.send(ExpLifecycle.OBTAIN_SAMPLES)
                     paths = self.obtain_samples(itr)
-                    logger.log("Processing samples...")
+                    logger.log('Processing samples...')
                     conn.send(ExpLifecycle.PROCESS_SAMPLES)
                     samples_data = self.process_samples(itr, paths)
-                    last_average_return = samples_data["average_return"]
-                    logger.log("Logging diagnostics...")
+                    last_average_return = samples_data['average_return']
+                    logger.log('Logging diagnostics...')
                     self.log_diagnostics(paths)
-                    logger.log("Optimizing policy...")
+                    logger.log('Optimizing policy...')
                     conn.send(ExpLifecycle.OPTIMIZE_POLICY)
                     self.optimize_policy(itr, samples_data)
-                    logger.log("Saving snapshot...")
+                    logger.log('Saving snapshot...')
                     params = self.get_itr_snapshot(itr)
                     if self.store_paths:
-                        params["paths"] = samples_data["paths"]
+                        params['paths'] = samples_data['paths']
                     snapshotter.save_itr_params(itr, params)
-                    logger.log("Saved")
+                    logger.log('Saved')
                     tabular.record('Time', time.time() - start_time)
                     tabular.record('ItrTime', time.time() - itr_start_time)
                     logger.log(tabular)
@@ -64,8 +65,8 @@ class InstrumentedBatchPolopt(BatchPolopt):
                         self.plotter.update_plot(self.policy,
                                                  self.max_path_length)
                         if self.pause_for_plot:
-                            input("Plotting evaluation run: Press Enter to "
-                                  "continue...")
+                            input('Plotting evaluation run: Press Enter to '
+                                  'continue...')
 
             conn.send(ExpLifecycle.SHUTDOWN)
             self.shutdown_worker()

--- a/tests/garage/experiment/test_resume.py
+++ b/tests/garage/experiment/test_resume.py
@@ -3,8 +3,7 @@ import tempfile
 
 import numpy as np
 
-from garage.experiment import LocalRunner
-from garage.logger import snapshotter
+from garage.experiment import LocalRunner, snapshotter
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import VPG
 from garage.tf.envs import TfEnv

--- a/tests/garage/experiment/test_snapshot.py
+++ b/tests/garage/experiment/test_snapshot.py
@@ -4,8 +4,8 @@ import tempfile
 import joblib
 import tensorflow as tf
 
-from garage.experiment import LocalRunner
-from garage.logger import logger, snapshotter
+from garage.experiment import LocalRunner, snapshotter
+from garage.logger import logger
 from garage.np.baselines import LinearFeatureBaseline
 from garage.sampler.utils import rollout
 from garage.tf.algos import TRPO

--- a/tests/garage/experiment/test_snapshotter.py
+++ b/tests/garage/experiment/test_snapshotter.py
@@ -5,7 +5,7 @@ import unittest
 
 from nose2 import tools
 
-from garage.logger import Snapshotter
+from garage.experiment import Snapshotter
 
 configurations = [('all', {
     'itr_1.pkl': 0,


### PR DESCRIPTION
The snapshotter is not really part of the logger API, it is really part
of the experiment runner subsystem.

This prepares the repo for removing the .logger package and replacing
it with dowel.