### PR TITLE
Fix flake8 failure by removing per-file-ignores

### DIFF
--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -143,7 +143,6 @@ check_flake8() {
   flake8 --isolated \
          --import-order-style=google \
          --application-import-names="${garage_packages}" \
-         --per-file-ignores="./src/garage/misc/krylov.py:N802,N803,N806" \
          "$@"
   status="$((${status} | ${?}))"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,6 @@ ignore = W503, D107
 ignore-names = setUp, tearDown, setUpClass,tearDownClass, setUpModule, tearDownModule
 import-order-style = google
 application-import-names = tests, sandbox, garage, examples
-per-file-ignores =
-    ./src/garage/misc/krylov.py:N802,N803,N806
 
 [pylint]
 #[MESSAGES CONTROL]


### PR DESCRIPTION
At least on my system, without this change I get this error:
```
./garage/misc/krylov.py:0:1: X100 Superfluous per-file-ignores for N802,N803,N806
```

It's possible that this fix won't work either, but if the CI says this change is good then I think we can submit it.