### PR TITLE
Fix some code inconsistencies

### DIFF
--- a/garage/tf/misc/tensor_utils.py
+++ b/garage/tf/misc/tensor_utils.py
@@ -170,10 +170,6 @@ def split_tensor_dict_list(tensor_dict):
     return ret
 
 
-def to_onehot_sym(inds, dim):
-    return tf.one_hot(inds, depth=dim, on_value=1, off_value=0)
-
-
 def pad_tensor(x, max_len):
     return np.concatenate([
         x,

--- a/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/garage/tf/regressors/categorical_mlp_regressor.py
@@ -104,8 +104,8 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
 
             loss = -tf.reduce_mean(dist.log_likelihood_sym(ys_var, info_vars))
 
-            predicted = tensor_utils.to_onehot_sym(
-                tf.argmax(prob_var, axis=1), output_dim)
+            predicted = tf.one_hot(
+                tf.argmax(prob_var, axis=1), depth=output_dim)
 
             self.prob_network = prob_network
             self.f_predict = tensor_utils.compile_function([xs_var], predicted)

--- a/garage/tf/regressors/continuous_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/continuous_mlp_regressor_with_model.py
@@ -42,7 +42,7 @@ class ContinuousMLPRegressorWithModel(Regressor2):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             tf.Tensor.
-        optimizer (tf.Optimizer): Optimizer for minimizing the negative
+        optimizer (garage.tf.Optimizer): Optimizer for minimizing the negative
             log-likelihood.
         optimizer_args (dict): Arguments for the optimizer. Default is None,
             which means no arguments.

--- a/garage/tf/regressors/continuous_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/continuous_mlp_regressor_with_model.py
@@ -66,8 +66,8 @@ class ContinuousMLPRegressorWithModel(Regressor2):
         super().__init__(input_shape, output_dim, name)
         self._normalize_inputs = normalize_inputs
 
-        with tf.variable_scope(
-                self._name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self._name, reuse=False) as vs:
+            self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
             if optimizer is None:

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -41,7 +41,7 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             tf.Tensor.
-        optimizer (tf.Optimizer): Optimizer for minimizing the negative
+        optimizer (garage,tf.Optimizer): Optimizer for minimizing the negative
             log-likelihood.
         optimizer_args (dict): Arguments for the optimizer. Default is None,
             which means no arguments.

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -41,7 +41,7 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             tf.Tensor.
-        optimizer (garage,tf.Optimizer): Optimizer for minimizing the negative
+        optimizer (garage.tf.Optimizer): Optimizer for minimizing the negative
             log-likelihood.
         optimizer_args (dict): Arguments for the optimizer. Default is None,
             which means no arguments.

--- a/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -97,8 +97,8 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         self._normalize_inputs = normalize_inputs
         self._normalize_outputs = normalize_outputs
 
-        with tf.variable_scope(
-                self._name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self._name, reuse=False) as vs:
+            self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
             if optimizer is None:

--- a/tests/fixtures/q_functions/simple_q_function.py
+++ b/tests/fixtures/q_functions/simple_q_function.py
@@ -19,7 +19,8 @@ class SimpleQFunction(QFunction2):
         obs_ph = tf.placeholder(
             tf.float32, (None, ) + self.obs_dim, name='obs')
 
-        with tf.variable_scope(self.name, reuse=False) as self._variable_scope:
+        with tf.variable_scope(self.name, reuse=False) as vs:
+            self._variable_scope = vs
             self.model.build(obs_ph)
 
     @property


### PR DESCRIPTION
This commit fixes the following things.

1. Removes `tensor_utils.to_onehot_sym` and replaces the calls with `tf.one_hot`. The idea was to replace all existing usages of the former API and use the TF API. Turns out there was only one file using that function.

2. There were a few instances were return value of a context manager was assigned to instance attributes which are now assigned to a temporary variable which is then assigned to the instance attribute.