### PR TITLE
Remove explicit docker caching from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,6 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  # Pull cached docker image
-  - docker pull rlworkgroup/garage-ci:latest
 
 install:
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
@@ -54,13 +52,6 @@ before_script:
 
 script:
   - ADD_ARGS="${ci_env}" TAG="${tag}" make run-ci RUN_CMD="${JOB_RUN_CMD}"
-
-deploy:
-  provider: script
-  script: TAG="${tag}" make ci-deploy-docker
-  on:
-    branch: master
-    condition: $DEPLOY_FROM_THIS_JOB = true
 
 git:
   depth: false


### PR DESCRIPTION
In principle, this should be handled by automatic builds on Docker Hub
(which builds master) and docker-compose using caching. 

We can disable this now, and watch to make sure that cachine still
works. It will be obvious, because build times will increase.