### PR TITLE
Re-enable explicit docker caching from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  # Pull cached docker image
+  - docker pull rlworkgroup/garage-ci:latest
 
 install:
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
@@ -52,6 +54,13 @@ before_script:
 
 script:
   - ADD_ARGS="${ci_env}" TAG="${tag}" make run-ci RUN_CMD="${JOB_RUN_CMD}"
+
+deploy:
+  provider: script
+  script: TAG="${tag}" make ci-deploy-docker
+  on:
+    branch: master
+    condition: $DEPLOY_FROM_THIS_JOB = true
 
 git:
   depth: false


### PR DESCRIPTION
The previous change did not work as-expected because of how our
docker-compose layers are setup. We will test more and try again later.