### PR TITLE
Report the flake8 version in check_flake8.sh

### DIFF
--- a/scripts/travisci/check_flake8.sh
+++ b/scripts/travisci/check_flake8.sh
@@ -136,6 +136,8 @@ test_files_added="$(echo "${files_added}" |  grep "tests/*")"
 # Exit status of this script
 status=0
 
+flake8 --version
+
 # Check rules with flake8
 check_flake8() {
   flake8 --isolated \


### PR DESCRIPTION
This is important because the exact error messages caused vary
dramatically between flake8 versions (and the versions of its plugins).
In debugging why a CI run failed, having these versions is essential,
and they aren't easy to discover otherwise.