### PR TITLE
Refactor BernoulliMLPRegressor to use models

### DIFF
--- a/src/garage/tf/regressors/__init__.py
+++ b/src/garage/tf/regressors/__init__.py
@@ -3,6 +3,8 @@ from garage.tf.regressors.base2 import Regressor2
 from garage.tf.regressors.base2 import StochasticRegressor2
 from garage.tf.regressors.bernoulli_mlp_regressor import (
     BernoulliMLPRegressor)
+from garage.tf.regressors.bernoulli_mlp_regressor_with_model import (
+    BernoulliMLPRegressorWithModel)
 from garage.tf.regressors.categorical_mlp_regressor import (
     CategoricalMLPRegressor)
 from garage.tf.regressors.categorical_mlp_regressor_with_model import (
@@ -19,10 +21,10 @@ from garage.tf.regressors.gaussian_mlp_regressor_with_model import (
     GaussianMLPRegressorWithModel)
 
 __all__ = [
-    'BernoulliMLPRegressor', 'CategoricalMLPRegressor',
-    'CategoricalMLPRegressorWithModel', 'ContinuousMLPRegressor',
-    'ContinuousMLPRegressorWithModel', 'GaussianMLPRegressor',
-    'GaussianMLPRegressorModel', 'GaussianMLPRegressorWithModel',
-    'GaussianConvRegressor', 'Regressor2', 'StochasticRegressor',
-    'StochasticRegressor2'
+    'BernoulliMLPRegressor', 'BernoulliMLPRegressorWithModel',
+    'CategoricalMLPRegressor', 'CategoricalMLPRegressorWithModel',
+    'ContinuousMLPRegressor', 'ContinuousMLPRegressorWithModel',
+    'GaussianMLPRegressor', 'GaussianMLPRegressorModel',
+    'GaussianMLPRegressorWithModel', 'GaussianConvRegressor', 'Regressor2',
+    'StochasticRegressor', 'StochasticRegressor2'
 ]

--- a/src/garage/tf/regressors/bernoulli_mlp_regressor_with_model.py
+++ b/src/garage/tf/regressors/bernoulli_mlp_regressor_with_model.py
@@ -1,0 +1,241 @@
+"""Bernoulli MLP Regressor based on MLP with Normalized Inputs."""
+from dowel import tabular
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.distributions import Bernoulli
+from garage.tf.misc import tensor_utils
+from garage.tf.models import NormalizedInputMLPModel
+from garage.tf.optimizers import ConjugateGradientOptimizer, LbfgsOptimizer
+from garage.tf.regressors import StochasticRegressor2
+
+
+class BernoulliMLPRegressorWithModel(StochasticRegressor2):
+    """
+    BernoulliMLPRegressor with garage.tf.models.NormalizedInputMLPModel.
+
+    A class for performing regression by fitting a Bernoulli distribution to
+    the outputs.
+
+    Args:
+        input_shape (tuple[int]): Input shape of the training data. Since an
+            MLP model is used, implementation assumes flattened inputs. The
+            input shape of each data point should thus be of shape (x, ).
+        output_dim (int): Output dimension of the model.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for the network. For example, (32, 32) means the MLP
+            consists of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor. Default is Glorot uniform initializer.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor. Default is zero initializer.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor. Default is Glorot uniform initializer.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor. Default is zero initializer.
+        optimizer (garage.tf.Optimizer): Optimizer for minimizing the negative
+            log-likelihood. Defaults to LbsgsOptimizer
+        optimizer_args (dict): Arguments for the optimizer. Default is None,
+            which means no arguments.
+        tr_optimizer (garage.tf.Optimizer): Optimizer for trust region
+            approximation. Defaults to ConjugateGradientOptimizer.
+        tr_optimizer_args (dict): Arguments for the trust region optimizer.
+            Default is None, which means no arguments.
+        use_trust_region (bool): Whether to use trust region constraint.
+        max_kl_step (float): KL divergence constraint for each iteration.
+        normalize_inputs (bool): Bool for normalizing inputs or not.
+        layer_normalization (bool): Bool for using layer normalization or not.
+    """
+
+    def __init__(self,
+                 input_shape,
+                 output_dim,
+                 name='BernoulliMLPRegressorWithModel',
+                 hidden_sizes=(32, 32),
+                 hidden_nonlinearity=tf.nn.relu,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
+                 output_nonlinearity=tf.nn.sigmoid,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
+                 optimizer=None,
+                 optimizer_args=None,
+                 tr_optimizer=None,
+                 tr_optimizer_args=None,
+                 use_trust_region=True,
+                 max_kl_step=0.01,
+                 normalize_inputs=True,
+                 layer_normalization=False):
+
+        super().__init__(input_shape, output_dim, name)
+        self._use_trust_region = use_trust_region
+        self._max_kl_step = max_kl_step
+        self._normalize_inputs = normalize_inputs
+
+        with tf.variable_scope(self._name, reuse=False) as vs:
+            self._variable_scope = vs
+            if optimizer_args is None:
+                optimizer_args = dict()
+            if tr_optimizer_args is None:
+                tr_optimizer_args = dict()
+
+            if optimizer is None:
+                optimizer = LbfgsOptimizer(**optimizer_args)
+            else:
+                optimizer = optimizer(**optimizer_args)
+
+            if tr_optimizer is None:
+                tr_optimizer = ConjugateGradientOptimizer(**tr_optimizer_args)
+            else:
+                tr_optimizer = tr_optimizer(**tr_optimizer_args)
+
+            self._optimizer = optimizer
+            self._tr_optimizer = tr_optimizer
+
+        self.model = NormalizedInputMLPModel(
+            input_shape,
+            output_dim,
+            hidden_sizes=hidden_sizes,
+            hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
+            output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
+            layer_normalization=layer_normalization)
+
+        self._dist = Bernoulli(output_dim)
+
+        self._initialize()
+
+    def _initialize(self):
+        input_var = tf.placeholder(
+            tf.float32, shape=(None, ) + self._input_shape)
+
+        with tf.variable_scope(self._variable_scope):
+            self.model.build(input_var)
+
+            ys_var = tf.placeholder(
+                dtype=tf.float32, name='ys', shape=(None, self._output_dim))
+
+            old_prob_var = tf.placeholder(
+                dtype=tf.float32,
+                name='old_prob',
+                shape=(None, self._output_dim))
+
+            y_hat = self.model.networks['default'].y_hat
+
+            old_info_vars = dict(p=old_prob_var)
+            info_vars = dict(p=y_hat)
+
+            mean_kl = tf.reduce_mean(
+                self._dist.kl_sym(old_info_vars, info_vars))
+
+            loss = -tf.reduce_mean(
+                self._dist.log_likelihood_sym(ys_var, info_vars))
+
+            predicted = y_hat >= 0.5
+
+            self._f_predict = tensor_utils.compile_function([input_var],
+                                                            predicted)
+            self._f_prob = tensor_utils.compile_function([input_var], y_hat)
+
+            self._optimizer.update_opt(
+                loss=loss,
+                target=self,
+                network_output=[y_hat],
+                inputs=[input_var, ys_var])
+            self._tr_optimizer.update_opt(
+                loss=loss,
+                target=self,
+                network_output=[y_hat],
+                inputs=[input_var, ys_var, old_prob_var],
+                leq_constraint=(mean_kl, self._max_kl_step))
+            self._first_optimized = False
+
+    def fit(self, xs, ys):
+        """
+        Fit with input data xs and label ys.
+
+        Args:
+            xs (numpy.ndarray): Input data.
+            ys (numpy.ndarray): Label of input data.
+        """
+        if self._normalize_inputs:
+            # recompute normalizing constants for inputs
+            self.model.networks['default'].x_mean.load(
+                np.mean(xs, axis=0, keepdims=True))
+            self.model.networks['default'].x_std.load(
+                np.std(xs, axis=0, keepdims=True) + 1e-8)
+
+        if self._use_trust_region and self._first_optimized:
+            # To use trust region constraint and optimizer
+            old_prob = self._f_prob(xs)
+            inputs = [xs, ys, old_prob]
+            optimizer = self._tr_optimizer
+        else:
+            inputs = [xs, ys]
+            optimizer = self._optimizer
+        loss_before = optimizer.loss(inputs)
+        tabular.record('{}/LossBefore'.format(self._name), loss_before)
+        optimizer.optimize(inputs)
+        loss_after = optimizer.loss(inputs)
+        tabular.record('{}/LossAfter'.format(self._name), loss_after)
+        tabular.record('{}/dLoss'.format(self._name), loss_before - loss_after)
+        self._first_optimized = True
+
+    def predict(self, xs):
+        """
+        Predict ys based on input xs.
+
+        Args:
+            xs (numpy.ndarray): Input data.
+
+        Return:
+            The predicted ys (one hot vectors).
+        """
+        return self._f_predict(xs)
+
+    def log_likelihood_sym(self, x_var, y_var, name=None):
+        """
+        Symbolic graph of the log likelihood.
+
+        Args:
+            x_var (tf.Tensor): Input tf.Tensor for the input data.
+            y_var (tf.Tensor): Input tf.Tensor for the one hot label of data.
+            name (str): Name of the new graph.
+
+        Return:
+            tf.Tensor output of the symbolic log likelihood.
+        """
+        with tf.variable_scope(self._variable_scope):
+            prob, _, _ = self.model.build(x_var, name=name)
+
+        return self._dist.log_likelihood_sym(y_var, dict(p=prob))
+
+    def get_params_internal(self, **args):
+        """Get the params, which are the trainable variables."""
+        return self._variable_scope.trainable_variables()
+
+    def __getstate__(self):
+        """Object.__getstate__."""
+        new_dict = super().__getstate__()
+        del new_dict['_f_predict']
+        del new_dict['_f_prob']
+        return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__."""
+        super().__setstate__(state)
+        self._initialize()

--- a/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
@@ -16,7 +16,6 @@ def get_labels(input_shape, xs, output_dim):
         # [0, 1] if sign is positive else [1, 0]
         ys = 0 if np.sin(xs) <= 0 else 1
         label[ys] = 1
-
     elif input_shape == (2, ):
         ys = int(np.round(xs[0])) ^ int(np.round(xs[1]))
         if output_dim == 1:
@@ -36,7 +35,6 @@ def get_train_data(input_shape, output_dim):
             'observations': [[x]],
             'returns': [get_labels(input_shape, x, output_dim)]
         } for x in data]
-
     elif input_shape == (2, ):
         # Generate 1000 points with coordinates in [0, 1] for XOR data
         x = np.linspace(0, 1, 100)
@@ -59,7 +57,6 @@ def get_test_data(input_shape, output_dim):
                              [np.pi / 4], [np.pi / 3], [np.pi / 4]]
         }
         expected = [[1, 0], [1, 0], [1, 0], [0, 1], [0, 1], [0, 1]]
-
     elif input_shape == (2, ):
         paths = {'observations': [[0, 0], [0, 1], [1, 0], [1, 1]]}
         if output_dim == 1:

--- a/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
@@ -1,0 +1,233 @@
+import pickle
+from unittest import mock
+
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.optimizers import ConjugateGradientOptimizer, LbfgsOptimizer
+from garage.tf.regressors import BernoulliMLPRegressorWithModel
+from tests.fixtures import TfGraphTestCase
+
+
+def get_labels(input_shape, xs):
+    label = [0, 0]
+    if input_shape == (1, ):
+        ys = 0 if np.sin(xs) <= 0 else 1
+        label[ys] = 1
+
+    elif input_shape == (2, ):
+        ys = int(np.round(xs[0])) ^ int(np.round(xs[1]))
+        label[ys] = 1
+
+    return label
+
+
+def get_train_data(input_shape):
+    if input_shape == (1, ):
+        data = np.linspace(-np.pi, np.pi, 1000)
+        obs = [{
+            'observations': [[x]],
+            'returns': [get_labels(input_shape, x)]
+        } for x in data]
+
+    elif input_shape == (2, ):
+        data = [np.random.rand(2) for _ in range(1000)]
+        obs = [{
+            'observations': [x],
+            'returns': [get_labels(input_shape, x)]
+        } for x in data]
+    return obs
+
+
+def get_test_data(input_shape):
+    if input_shape == (1, ):
+        paths = {
+            'observations': [[-np.pi / 2], [-np.pi / 3], [-np.pi / 4],
+                             [np.pi / 4], [np.pi / 3], [np.pi / 4]]
+        }
+        expected = [[1, 0], [1, 0], [1, 0], [0, 1], [0, 1], [0, 1]]
+
+    elif input_shape == (2, ):
+        paths = {'observations': [[0, 0], [0, 1], [1, 0], [1, 1]]}
+        expected = [[1, 0], [0, 1], [0, 1], [1, 0]]
+
+    return paths, expected
+
+
+class TestBernoulliMLPRegressorWithModel(TfGraphTestCase):
+    @params(((1, ), 2), ((2, ), 2))
+    def test_fit_normalized(self, input_shape, output_dim):
+        bmr = BernoulliMLPRegressorWithModel(
+            input_shape=input_shape, output_dim=output_dim)
+        obs = get_train_data(input_shape)
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        returns = returns.reshape((-1, 2))
+
+        for _ in range(150):
+            bmr.fit(observations, returns)
+
+        paths, expected = get_test_data(input_shape)
+
+        prediction = bmr.predict(paths['observations'])
+
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean_expected = np.mean(observations, axis=0, keepdims=True)
+        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std_expected = np.std(observations, axis=0, keepdims=True)
+
+        assert np.allclose(x_mean, x_mean_expected)
+        assert np.allclose(x_std, x_std_expected)
+
+    @params(((1, ), 2), ((2, ), 2))
+    def test_fit_unnormalized(self, input_shape, output_dim):
+        bmr = BernoulliMLPRegressorWithModel(
+            input_shape=input_shape,
+            output_dim=output_dim,
+            normalize_inputs=False)
+        obs = get_train_data(input_shape)
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        returns = returns.reshape((-1, 2))
+
+        for _ in range(150):
+            bmr.fit(observations, returns)
+
+        paths, expected = get_test_data(input_shape)
+
+        prediction = bmr.predict(paths['observations'])
+
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean_expected = np.zeros_like(x_mean)
+        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std_expected = np.ones_like(x_std)
+
+        assert np.allclose(x_mean, x_mean_expected)
+        assert np.allclose(x_std, x_std_expected)
+
+    @params(((1, ), 2), ((2, ), 2))
+    def test_fit_with_no_trust_region(self, input_shape, output_dim):
+        bmr = BernoulliMLPRegressorWithModel(
+            input_shape=input_shape,
+            output_dim=output_dim,
+            use_trust_region=False)
+        obs = get_train_data(input_shape)
+
+        observations = np.concatenate([p['observations'] for p in obs])
+        returns = np.concatenate([p['returns'] for p in obs])
+        returns = returns.reshape((-1, 2))
+
+        for _ in range(150):
+            bmr.fit(observations, returns)
+
+        paths, expected = get_test_data(input_shape)
+
+        prediction = bmr.predict(paths['observations'])
+
+        assert np.allclose(prediction, expected, rtol=0, atol=0.1)
+
+        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean_expected = np.mean(observations, axis=0, keepdims=True)
+        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std_expected = np.std(observations, axis=0, keepdims=True)
+
+        assert np.allclose(x_mean, x_mean_expected)
+        assert np.allclose(x_std, x_std_expected)
+
+    @params((1, (1, 1)), (1, (2, 2)), (2, (3, 2)), (3, (2, 2)))
+    def test_log_likelihood_sym(self, output_dim, input_shape):
+        bmr = BernoulliMLPRegressorWithModel(
+            input_shape=(input_shape[1], ), output_dim=output_dim)
+
+        new_xs_var = tf.placeholder(tf.float32, input_shape)
+        new_ys_var = tf.placeholder(
+            dtype=tf.float32, name='ys', shape=(None, output_dim))
+
+        data = np.random.random(size=input_shape)
+        label = np.random.randint(0, output_dim, size=(input_shape[0]))
+        one_hot_label = np.zeros((input_shape[0], output_dim))
+        one_hot_label[np.arange(input_shape[0]), label] = 1
+
+        p = bmr._f_prob(np.asarray(data))
+        ll = bmr._dist.log_likelihood(np.asarray(one_hot_label), dict(p=p))
+
+        outputs = bmr.log_likelihood_sym(new_xs_var, new_ys_var, name='ll_sym')
+
+        ll_from_sym = self.sess.run(
+            outputs, feed_dict={
+                new_xs_var: data,
+                new_ys_var: one_hot_label
+            })
+
+        assert np.allclose(ll, ll_from_sym, rtol=0, atol=1e-5)
+
+    @mock.patch('tests.garage.tf.regressors.'
+                'test_bernoulli_mlp_regressor_with_model.'
+                'LbfgsOptimizer')
+    @mock.patch('tests.garage.tf.regressors.'
+                'test_bernoulli_mlp_regressor_with_model.'
+                'ConjugateGradientOptimizer')
+    def test_optimizer_args(self, mock_cg, mock_lbfgs):
+        lbfgs_args = dict(max_opt_itr=25)
+        cg_args = dict(cg_iters=15)
+        bmr = BernoulliMLPRegressorWithModel(
+            input_shape=(1, ),
+            output_dim=2,
+            optimizer=LbfgsOptimizer,
+            optimizer_args=lbfgs_args,
+            tr_optimizer=ConjugateGradientOptimizer,
+            tr_optimizer_args=cg_args,
+            use_trust_region=True)
+
+        assert mock_lbfgs.return_value is bmr._optimizer
+        assert mock_cg.return_value is bmr._tr_optimizer
+
+        mock_lbfgs.assert_called_with(max_opt_itr=25)
+        mock_cg.assert_called_with(cg_iters=15)
+
+    def test_is_pickleable(self):
+        bmr = BernoulliMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
+
+        with tf.variable_scope(
+                'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
+                reuse=True):
+            bias = tf.get_variable('mlp/hidden_0/bias')
+        bias.load(tf.ones_like(bias).eval())
+        bias1 = bias.eval()
+
+        result1 = bmr.predict(np.ones((1, 1)))
+        h = pickle.dumps(bmr)
+
+        with tf.Session(graph=tf.Graph()):
+            bmr_pickled = pickle.loads(h)
+            result2 = bmr_pickled.predict(np.ones((1, 1)))
+            assert np.array_equal(result1, result2)
+
+            with tf.variable_scope(
+                    'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
+                    reuse=True):
+                bias2 = tf.get_variable('mlp/hidden_0/bias').eval()
+
+            assert np.array_equal(bias1, bias2)
+
+    def test_is_pickleable2(self):
+        bmr = BernoulliMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
+
+        with tf.variable_scope(
+                'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
+                reuse=True):
+            x_mean = tf.get_variable('normalized_vars/x_mean')
+        x_mean.load(tf.ones_like(x_mean).eval())
+        x1 = bmr.model.networks['default'].x_mean.eval()
+        h = pickle.dumps(bmr)
+        with tf.Session(graph=tf.Graph()):
+            bmr_pickled = pickle.loads(h)
+            x2 = bmr_pickled.model.networks['default'].x_mean.eval()
+            assert np.array_equal(x1, x2)


### PR DESCRIPTION
Refactored `BernoulliMLPRegressor` to use `garage.tf.models`.
Added unit tests for the class `BernoulliMLPRegressorWithModel`.