### PR TITLE
GaussianGRUPolicy with model

### DIFF
--- a/src/garage/tf/models/__init__.py
+++ b/src/garage/tf/models/__init__.py
@@ -1,6 +1,7 @@
 from garage.tf.models.base import Model
 from garage.tf.models.cnn_model import CNNModel
 from garage.tf.models.cnn_model_max_pooling import CNNModelWithMaxPooling
+from garage.tf.models.gaussian_gru_model import GaussianGRUModel
 from garage.tf.models.gaussian_lstm_model import GaussianLSTMModel
 from garage.tf.models.gaussian_mlp_model import GaussianMLPModel
 from garage.tf.models.gru_model import GRUModel
@@ -13,6 +14,6 @@ from garage.tf.models.sequential import Sequential
 
 __all__ = [
     'CNNModel', 'CNNModelWithMaxPooling', 'LSTMModel', 'Model',
-    'GaussianLSTMModel', 'GaussianMLPModel', 'GRUModel', 'MLPDuelingModel',
-    'MLPModel', 'NormalizedInputMLPModel', 'Sequential'
+    'GaussianGRUModel', 'GaussianLSTMModel', 'GaussianMLPModel', 'GRUModel',
+    'MLPDuelingModel', 'MLPModel', 'NormalizedInputMLPModel', 'Sequential'
 ]

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -1,0 +1,203 @@
+"""GaussianGRUModel."""
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.core.gru import gru
+from garage.tf.core.parameter import parameter
+from garage.tf.distributions import DiagonalGaussian
+from garage.tf.models import Model
+
+
+class GaussianGRUModel(Model):
+    """
+    GaussianGRUModel.
+
+    Args:
+        output_dim (int): Output dimension of the model.
+        hidden_dim (int): Hidden dimension for GRU cell for mean.
+        name (str): Model name, also the variable scope.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        recurrent_nonlinearity (callable): Activation function for recurrent
+            layers. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        recurrent_w_init (callable): Initializer function for the weight
+            of recurrent layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_state_init (callable): Initializer function for the
+            initial hidden state. The functino should return a tf.Tensor.
+        hidden_state_init_trainable (bool): Bool for whether the initial
+            hidden state is trainable.
+        learn_std (bool): Is std trainable.
+        init_std (float): Initial value for std.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        layer_normalization (bool): Bool for using layer normalization or not.
+    """
+
+    def __init__(self,
+                 output_dim,
+                 hidden_dim=32,
+                 name=None,
+                 hidden_nonlinearity=tf.nn.tanh,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
+                 recurrent_nonlinearity=tf.nn.sigmoid,
+                 recurrent_w_init=tf.glorot_uniform_initializer(),
+                 output_nonlinearity=None,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
+                 hidden_state_init=tf.zeros_initializer(),
+                 hidden_state_init_trainable=False,
+                 learn_std=True,
+                 init_std=1.0,
+                 std_share_network=False,
+                 layer_normalization=False):
+        super().__init__(name)
+        self._output_dim = output_dim
+        self._hidden_dim = hidden_dim
+        self._hidden_nonlinearity = hidden_nonlinearity
+        self._hidden_w_init = hidden_w_init
+        self._hidden_b_init = hidden_b_init
+        self._recurrent_nonlinearity = recurrent_nonlinearity
+        self._recurrent_w_init = recurrent_w_init
+        self._output_nonlinearity = output_nonlinearity
+        self._output_w_init = output_w_init
+        self._output_b_init = output_b_init
+        self._hidden_state_init = hidden_state_init
+        self._hidden_state_init_trainable = hidden_state_init_trainable
+        self._layer_normalization = layer_normalization
+        self._learn_std = learn_std
+        self._std_share_network = std_share_network
+        self._init_std_param = np.log(init_std)
+        self._initialize()
+
+    def _initialize(self):
+        action_dim = self._output_dim
+        self._mean_std_gru_cell = tf.keras.layers.GRUCell(
+            units=self._hidden_dim,
+            activation=self._hidden_nonlinearity,
+            kernel_initializer=self._hidden_w_init,
+            bias_initializer=self._hidden_b_init,
+            recurrent_activation=self._recurrent_nonlinearity,
+            recurrent_initializer=self._recurrent_w_init,
+            name='mean_std_gru_layer')
+        self._mean_gru_cell = tf.keras.layers.GRUCell(
+            units=self._hidden_dim,
+            activation=self._hidden_nonlinearity,
+            kernel_initializer=self._hidden_w_init,
+            bias_initializer=self._hidden_b_init,
+            recurrent_activation=self._recurrent_nonlinearity,
+            recurrent_initializer=self._recurrent_w_init,
+            name='mean_gru_layer')
+        self._mean_std_output_nonlinearity_layer = tf.keras.layers.Dense(
+            units=action_dim * 2,
+            activation=self._output_nonlinearity,
+            kernel_initializer=self._output_w_init,
+            bias_initializer=self._output_b_init,
+            name='mean_std_output_layer')
+        self._mean_output_nonlinearity_layer = tf.keras.layers.Dense(
+            units=action_dim,
+            activation=self._output_nonlinearity,
+            kernel_initializer=self._output_w_init,
+            bias_initializer=self._output_b_init,
+            name='mean_output_layer')
+
+    def network_input_spec(self):
+        """Network input spec."""
+        return ['full_input', 'step_input', 'step_hidden_input']
+
+    def network_output_spec(self):
+        """Network output spec."""
+        return [
+            'sample', 'mean', 'step_mean', 'log_std', 'step_log_std',
+            'step_hidden', 'init_hidden', 'dist'
+        ]
+
+    def _build(self, state_input, step_input, hidden_input, name=None):
+        action_dim = self._output_dim
+
+        with tf.variable_scope('dist_params'):
+            if self._std_share_network:
+                # mean and std networks share an MLP
+                (outputs, step_outputs, step_hidden, hidden_init_var) = gru(
+                    name='mean_std_network',
+                    gru_cell=self._mean_std_gru_cell,
+                    all_input_var=state_input,
+                    step_input_var=step_input,
+                    step_hidden_var=hidden_input,
+                    hidden_state_init=self._hidden_state_init,
+                    hidden_state_init_trainable=self.
+                    _hidden_state_init_trainable,
+                    output_nonlinearity_layer=self.
+                    _mean_std_output_nonlinearity_layer)
+                with tf.variable_scope('mean_network'):
+                    mean_var = outputs[..., :action_dim]
+                    step_mean_var = step_outputs[..., :action_dim]
+                with tf.variable_scope('log_std_network'):
+                    log_std_var = outputs[..., action_dim:]
+                    step_log_std_var = step_outputs[..., action_dim:]
+
+            else:
+                # separate MLPs for mean and std networks
+                # mean network
+                (mean_var, step_mean_var, step_hidden, hidden_init_var) = gru(
+                    name='mean_network',
+                    gru_cell=self._mean_gru_cell,
+                    all_input_var=state_input,
+                    step_input_var=step_input,
+                    step_hidden_var=hidden_input,
+                    hidden_state_init=self._hidden_state_init,
+                    hidden_state_init_trainable=self.
+                    _hidden_state_init_trainable,
+                    output_nonlinearity_layer=self.
+                    _mean_output_nonlinearity_layer)
+                log_std_var = parameter(
+                    state_input,
+                    length=action_dim,
+                    initializer=tf.constant_initializer(self._init_std_param),
+                    trainable=self._learn_std,
+                    name='log_std_param')
+                step_log_std_var = parameter(
+                    step_input,
+                    length=action_dim,
+                    initializer=tf.constant_initializer(self._init_std_param),
+                    trainable=self._learn_std,
+                    name='step_log_std_param')
+
+        dist = DiagonalGaussian(self._output_dim)
+        rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])
+        action_var = rnd * tf.exp(step_log_std_var) + step_mean_var
+
+        return (action_var, mean_var, step_mean_var, log_std_var,
+                step_log_std_var, step_hidden, hidden_init_var, dist)
+
+    def __getstate__(self):
+        """Object.__getstate__."""
+        new_dict = super().__getstate__()
+        del new_dict['_mean_std_gru_cell']
+        del new_dict['_mean_gru_cell']
+        del new_dict['_mean_std_output_nonlinearity_layer']
+        del new_dict['_mean_output_nonlinearity_layer']
+        return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__."""
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/__init__.py
+++ b/src/garage/tf/policies/__init__.py
@@ -19,6 +19,8 @@ from garage.tf.policies.deterministic_mlp_policy_with_model import (
 from garage.tf.policies.discrete_qf_derived_policy import (
     DiscreteQfDerivedPolicy)
 from garage.tf.policies.gaussian_gru_policy import GaussianGRUPolicy
+from garage.tf.policies.gaussian_gru_policy_with_model import (
+    GaussianGRUPolicyWithModel)
 from garage.tf.policies.gaussian_lstm_policy import GaussianLSTMPolicy
 from garage.tf.policies.gaussian_lstm_policy_with_model import (
     GaussianLSTMPolicyWithModel)
@@ -34,6 +36,7 @@ __all__ = [
     'CategoricalMLPPolicyWithModel', 'ContinuousMLPPolicy',
     'DiscreteQfDerivedPolicy', 'DeterministicMLPPolicy',
     'DeterministicMLPPolicyWithModel', 'GaussianGRUPolicy',
-    'GaussianLSTMPolicy', 'GaussianLSTMPolicyWithModel', 'GaussianMLPPolicy',
+    'GaussianLSTMPolicy', 'GaussianGRUPolicyWithModel',
+    'GaussianLSTMPolicyWithModel', 'GaussianMLPPolicy',
     'GaussianMLPPolicyWithModel'
 ]

--- a/src/garage/tf/policies/gaussian_gru_policy.py
+++ b/src/garage/tf/policies/gaussian_gru_policy.py
@@ -19,13 +19,17 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
             env_spec,
             name='GaussianGRUPolicy',
             hidden_dim=32,
+            hidden_nonlinearity=tf.tanh,
+            recurrent_nonlinearity=tf.nn.sigmoid,
+            recurrent_w_x_init=L.XavierUniformInitializer(),
+            recurrent_w_h_init=L.OrthogonalInitializer(),
+            output_nonlinearity=None,
+            output_w_init=L.XavierUniformInitializer(),
             feature_network=None,
             state_include_action=True,
-            hidden_nonlinearity=tf.tanh,
             gru_layer_cls=L.GRULayer,
             learn_std=True,
             init_std=1.0,
-            output_nonlinearity=None,
             std_share_network=False,
     ):
         """
@@ -80,7 +84,11 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                     output_dim=2 * action_dim,
                     hidden_dim=hidden_dim,
                     hidden_nonlinearity=hidden_nonlinearity,
+                    recurrent_nonlinearity=recurrent_nonlinearity,
+                    recurrent_w_x_init=recurrent_w_x_init,
+                    recurrent_w_h_init=recurrent_w_h_init,
                     output_nonlinearity=output_nonlinearity,
+                    output_w_init=output_w_init,
                     gru_layer_cls=gru_layer_cls,
                     name='gru_mean_network')
 
@@ -110,7 +118,11 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
                     output_dim=action_dim,
                     hidden_dim=hidden_dim,
                     hidden_nonlinearity=hidden_nonlinearity,
+                    recurrent_nonlinearity=recurrent_nonlinearity,
+                    recurrent_w_x_init=recurrent_w_x_init,
+                    recurrent_w_h_init=recurrent_w_h_init,
                     output_nonlinearity=output_nonlinearity,
+                    output_w_init=output_w_init,
                     gru_layer_cls=gru_layer_cls,
                     name='gru_mean_network')
 

--- a/src/garage/tf/policies/gaussian_gru_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_gru_policy_with_model.py
@@ -1,0 +1,278 @@
+"""GaussianGRUPolicy with GaussianGRUModel."""
+import akro.tf
+import numpy as np
+import tensorflow as tf
+
+from garage.misc.overrides import overrides
+from garage.tf.models import GaussianGRUModel
+from garage.tf.policies.base2 import StochasticPolicy2
+
+
+class GaussianGRUPolicyWithModel(StochasticPolicy2):
+    """
+    GaussianGRUPolicy with GaussianGRUModel.
+
+    A policy that contains a GRU to make prediction based on
+    a gaussian distribution.
+
+    Args:
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        name (str): Model name, also the variable scope.
+        hidden_dim (int): Hidden dimension for GRU cell for mean.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        recurrent_nonlinearity (callable): Activation function for recurrent
+            layers. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        recurrent_w_init (callable): Initializer function for the weight
+            of recurrent layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_state_init (callable): Initializer function for the
+            initial hidden state. The functino should return a tf.Tensor.
+        hidden_state_init_trainable (bool): Bool for whether the initial
+            hidden state is trainable.
+        learn_std (bool): Is std trainable.
+        std_share_network (bool): Boolean for whether mean and std share
+            the same network.
+        init_std (float): Initial value for std.
+        layer_normalization (bool): Bool for using layer normalization or not.
+        state_include_action (bool): Whether the state includes action.
+            If True, input dimension will be
+            (observation dimension + action dimension).
+    """
+
+    def __init__(self,
+                 env_spec,
+                 hidden_dim=32,
+                 name='GaussianGRUPolicyWithModel',
+                 hidden_nonlinearity=tf.nn.tanh,
+                 hidden_w_init=tf.glorot_uniform_initializer(),
+                 hidden_b_init=tf.zeros_initializer(),
+                 recurrent_nonlinearity=tf.nn.sigmoid,
+                 recurrent_w_init=tf.glorot_uniform_initializer(),
+                 output_nonlinearity=None,
+                 output_w_init=tf.glorot_uniform_initializer(),
+                 output_b_init=tf.zeros_initializer(),
+                 hidden_state_init=tf.zeros_initializer(),
+                 hidden_state_init_trainable=False,
+                 learn_std=True,
+                 std_share_network=False,
+                 init_std=1.0,
+                 layer_normalization=False,
+                 state_include_action=True):
+        if not isinstance(env_spec.action_space, akro.tf.Box):
+            raise ValueError('GaussianGRUPolicy only works with '
+                             'akro.tf.Box action space, but not {}'.format(
+                                 env_spec.action_space))
+        super().__init__(name, env_spec)
+        self._obs_dim = env_spec.observation_space.flat_dim
+        self._action_dim = env_spec.action_space.flat_dim
+        self._hidden_dim = hidden_dim
+        self._state_include_action = state_include_action
+
+        if state_include_action:
+            self._input_dim = self._obs_dim + self._action_dim
+        else:
+            self._input_dim = self._obs_dim
+
+        self.model = GaussianGRUModel(
+            output_dim=self._action_dim,
+            hidden_dim=hidden_dim,
+            name='GaussianGRUModel',
+            hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
+            recurrent_nonlinearity=recurrent_nonlinearity,
+            recurrent_w_init=recurrent_w_init,
+            output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
+            hidden_state_init=hidden_state_init,
+            hidden_state_init_trainable=hidden_state_init_trainable,
+            layer_normalization=layer_normalization,
+            learn_std=learn_std,
+            std_share_network=std_share_network,
+            init_std=init_std)
+
+        self._initialize()
+
+    def _initialize(self):
+        obs_ph = tf.placeholder(
+            tf.float32, shape=(None, None, self._input_dim))
+        step_input_var = tf.placeholder(
+            shape=(None, self._input_dim), name='step_input', dtype=tf.float32)
+        step_hidden_var = tf.placeholder(
+            shape=(None, self._hidden_dim),
+            name='step_hidden_input',
+            dtype=tf.float32)
+
+        with tf.variable_scope(self.name) as vs:
+            self._variable_scope = vs
+            self.model.build(obs_ph, step_input_var, step_hidden_var)
+
+        self._f_step_mean_std = tf.get_default_session().make_callable(
+            [
+                self.model.networks['default'].sample,
+                self.model.networks['default'].step_mean,
+                self.model.networks['default'].step_log_std,
+                self.model.networks['default'].step_hidden
+            ],
+            feed_list=[step_input_var, step_hidden_var])
+
+        self.prev_actions = None
+        self.prev_hiddens = None
+
+    @property
+    def vectorized(self):
+        """Vectorized or not."""
+        return True
+
+    def dist_info_sym(self, obs_var, state_info_vars, name=None):
+        """
+        Symbolic graph of the distribution.
+
+        Args:
+            obs_var (tf.Tensor): Tensor input for symbolic graph.
+            state_info_vars (dict): Extra state information, e.g.
+                previous action.
+            name (str): Name for symbolic graph.
+
+        """
+        if self._state_include_action:
+            prev_action_var = state_info_vars['prev_action']
+            prev_action_var = tf.cast(prev_action_var, tf.float32)
+            all_input_var = tf.concat(
+                axis=2, values=[obs_var, prev_action_var])
+        else:
+            all_input_var = obs_var
+
+        with tf.variable_scope(self._variable_scope):
+            _, mean_var, _, log_std_var, _, _, _, _ = self.model.build(
+                all_input_var,
+                self.model.networks['default'].step_input,
+                self.model.networks['default'].step_hidden_input,
+                name=name)
+
+        return dict(mean=mean_var, log_std=log_std_var)
+
+    def reset(self, dones=None):
+        """
+        Reset the policy.
+
+        Args:
+            dones (numpy.ndarray): Bool that indicates terminal state(s).
+
+        """
+        if not dones:
+            dones = np.array([True])
+        if self.prev_actions is None or len(dones) != len(self.prev_actions):
+            self.prev_actions = np.zeros((len(dones),
+                                          self.action_space.flat_dim))
+            self.prev_hiddens = np.zeros((len(dones), self._hidden_dim))
+
+        self.prev_actions[dones] = 0.
+        self.prev_hiddens[dones] = self.model.networks[
+            'default'].init_hidden.eval()
+
+    @overrides
+    def get_action(self, observation):
+        """
+        Get single action from this policy for the input observation.
+
+        Args:
+            observation (numpy.ndarray): Observation from environment.
+
+        Returns:
+            action (numpy.ndarray): Predicted action.
+            agent_info (dict): Distribution obtained after observing the
+                given observation, with keys
+                * mean: (numpy.ndarray)
+                * log_std: (numpy.ndarray)
+                * prev_action: (numpy.ndarray), only present if
+                    self._state_include_action is True.
+
+        """
+        actions, agent_infos = self.get_actions([observation])
+        return actions[0], {k: v[0] for k, v in agent_infos.items()}
+
+    @overrides
+    def get_actions(self, observations):
+        """
+        Get multiple actions from this policy for the input observations.
+
+        Args:
+            observations (numpy.ndarray): Observations from environment.
+
+        Returns:
+            actions (numpy.ndarray): Predicted actions.
+            agent_infos (dict): Distribution obtained after observing the
+                given observation, with keys
+                * mean: (numpy.ndarray)
+                * log_std: (numpy.ndarray)
+                * prev_action: (numpy.ndarray), only present if
+                    self._state_include_action is True.
+
+        """
+        flat_obs = self.observation_space.flatten_n(observations)
+        if self._state_include_action:
+            assert self.prev_actions is not None
+            all_input = np.concatenate([flat_obs, self.prev_actions], axis=-1)
+        else:
+            all_input = flat_obs
+        samples, means, log_stds, hidden_vec = self._f_step_mean_std(
+            all_input, self.prev_hiddens)
+        samples = self.action_space.unflatten_n(samples)
+        prev_actions = self.prev_actions
+        self.prev_actions = samples
+        self.prev_hiddens = hidden_vec
+        agent_infos = dict(mean=means, log_std=log_stds)
+        if self._state_include_action:
+            agent_infos['prev_action'] = np.copy(prev_actions)
+        return samples, agent_infos
+
+    @property
+    def recurrent(self):
+        """Recurrent or not."""
+        return True
+
+    @property
+    def distribution(self):
+        """Policy distribution."""
+        return self.model.networks['default'].dist
+
+    @property
+    def state_info_specs(self):
+        """State info specification."""
+        if self._state_include_action:
+            return [
+                ('prev_action', (self._action_dim, )),
+            ]
+        else:
+            return []
+
+    def __getstate__(self):
+        """Object.__getstate__."""
+        new_dict = super().__getstate__()
+        del new_dict['_f_step_mean_std']
+        return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__."""
+        super().__setstate__(state)
+        self._initialize()

--- a/tests/fixtures/models/__init__.py
+++ b/tests/fixtures/models/__init__.py
@@ -1,6 +1,8 @@
 from tests.fixtures.models.simple_cnn_model import SimpleCNNModel
 from tests.fixtures.models.simple_cnn_model_with_max_pooling import (
     SimpleCNNModelWithMaxPooling)
+from tests.fixtures.models.simple_gaussian_gru_model import (
+    SimpleGaussianGRUModel)
 from tests.fixtures.models.simple_gaussian_lstm_model import (
     SimpleGaussianLSTMModel)
 from tests.fixtures.models.simple_gaussian_mlp_model import (
@@ -12,6 +14,7 @@ from tests.fixtures.models.simple_mlp_model import SimpleMLPModel
 __all__ = [
     'SimpleCNNModel',
     'SimpleCNNModelWithMaxPooling',
+    'SimpleGaussianGRUModel',
     'SimpleGaussianLSTMModel',
     'SimpleGaussianMLPModel',
     'SimpleGRUModel',

--- a/tests/fixtures/models/simple_gaussian_gru_model.py
+++ b/tests/fixtures/models/simple_gaussian_gru_model.py
@@ -1,0 +1,56 @@
+import tensorflow as tf
+
+from garage.tf.distributions import DiagonalGaussian
+from garage.tf.models import Model
+
+
+class SimpleGaussianGRUModel(Model):
+    """Simple GaussianGRUModel for testing."""
+
+    def __init__(self,
+                 output_dim,
+                 hidden_dim,
+                 name='SimpleGaussianGRUModel',
+                 *args,
+                 **kwargs):
+        super().__init__(name)
+        self.output_dim = output_dim
+        self.hidden_dim = hidden_dim
+
+    def network_input_spec(self):
+        """Network input spec."""
+        return ['full_input', 'step_input', 'step_hidden_input']
+
+    def network_output_spec(self):
+        """Network output spec."""
+        return [
+            'sample', 'mean', 'step_mean', 'log_std', 'step_log_std',
+            'step_hidden', 'init_hidden', 'dist'
+        ]
+
+    def _build(self,
+               obs_input,
+               step_obs_input,
+               step_hidden,
+               step_cell,
+               name=None):
+        return_var = tf.get_variable(
+            'return_var', (), initializer=tf.constant_initializer(0.5))
+        mean = log_std = tf.fill(
+            (tf.shape(obs_input)[0], tf.shape(obs_input)[1], self.output_dim),
+            return_var)
+        step_mean = step_log_std = tf.fill(
+            (tf.shape(step_obs_input)[0], self.output_dim), return_var)
+
+        hidden_init_var = tf.get_variable(
+            name='initial_hidden',
+            shape=(self.hidden_dim, ),
+            initializer=tf.zeros_initializer(),
+            trainable=False,
+            dtype=tf.float32)
+
+        sample = 0.5 * step_mean + step_log_std
+        dist = DiagonalGaussian(self.output_dim)
+        # sample = 0.5 * 0.5 + 0.5 = 0.75
+        return (sample, mean, step_mean, log_std, step_log_std, step_hidden,
+                hidden_init_var, dist)

--- a/tests/garage/tf/algos/test_ppo_with_model.py
+++ b/tests/garage/tf/algos/test_ppo_with_model.py
@@ -10,6 +10,7 @@ from garage.experiment import LocalRunner
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianGRUPolicyWithModel
 from garage.tf.policies import GaussianLSTMPolicyWithModel
 from garage.tf.policies import GaussianMLPPolicyWithModel
 from tests.fixtures import TfGraphTestCase
@@ -47,8 +48,8 @@ class TestPPOWithModel(TfGraphTestCase):
 
     test_ppo_pendulum_with_model.large = True
 
-    def test_ppo_pendulum_recurrent_with_model(self):
-        """Test PPO with Pendulum environment and recurrent policy."""
+    def test_ppo_pendulum_lstm_with_model(self):
+        """Test PPO with Pendulum environment and LSTM policy."""
         with LocalRunner() as runner:
             env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
             policy = GaussianLSTMPolicyWithModel(env_spec=env.spec, )
@@ -71,4 +72,30 @@ class TestPPOWithModel(TfGraphTestCase):
 
             env.close()
 
-    test_ppo_pendulum_recurrent_with_model.large = True
+    test_ppo_pendulum_lstm_with_model.large = True
+
+    def test_ppo_pendulum_gru_with_model(self):
+        """Test PPO with Pendulum environment and GRU policy."""
+        with LocalRunner() as runner:
+            env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
+            policy = GaussianGRUPolicyWithModel(env_spec=env.spec, )
+            baseline = GaussianMLPBaseline(
+                env_spec=env.spec,
+                regressor_args=dict(hidden_sizes=(32, 32)),
+            )
+            algo = PPO(
+                env_spec=env.spec,
+                policy=policy,
+                baseline=baseline,
+                max_path_length=100,
+                discount=0.99,
+                lr_clip_range=0.01,
+                optimizer_args=dict(batch_size=32, max_epochs=10),
+            )
+            runner.setup(algo, env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            assert last_avg_ret > 40
+
+            env.close()
+
+    test_ppo_pendulum_gru_with_model.large = True

--- a/tests/garage/tf/models/test_gaussian_gru_model.py
+++ b/tests/garage/tf/models/test_gaussian_gru_model.py
@@ -1,0 +1,375 @@
+import pickle
+from unittest import mock
+
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.models import GaussianGRUModel
+from tests.fixtures import TfGraphTestCase
+from tests.helpers import recurrent_step_gru
+
+
+class TestGaussianGRUModel(TfGraphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.batch_size = 1
+        self.time_step = 2
+        self.feature_shape = 2
+        self.default_initializer = tf.constant_initializer(0.1)
+
+        self.obs_inputs = np.full(
+            (self.batch_size, self.time_step, self.feature_shape), 1.)
+        self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
+
+        self.input_var = tf.placeholder(
+            tf.float32, shape=(None, None, self.feature_shape), name='input')
+        self.step_input_var = tf.placeholder(
+            tf.float32, shape=(None, self.feature_shape), name='step_input')
+
+    # yapf: disable
+    @params(
+        (1, 1),
+        (2, 2),
+        (3, 3))
+    # yapf: enable
+    @mock.patch('tensorflow.random.normal')
+    def test_std_share_network_output_values(self, output_dim, hidden_dim,
+                                             mock_normal):
+        mock_normal.return_value = 0.5
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=True,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (action_var, mean_var, step_mean_var, log_std_var, step_log_std_var,
+         step_hidden, hidden_init_var, dist) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
+                                    hidden_init_var.eval())
+
+        mean, log_std = self.sess.run(
+            [mean_var, log_std_var],
+            feed_dict={self.input_var: self.obs_inputs})
+
+        for i in range(self.time_step):
+            action, mean1, log_std1, hidden1 = self.sess.run(
+                [action_var, step_mean_var, step_log_std_var, step_hidden],
+                feed_dict={
+                    self.step_input_var: self.obs_input,
+                    step_hidden_var: hidden1
+                })
+
+            hidden2 = recurrent_step_gru(
+                input_val=self.obs_input,
+                num_units=hidden_dim,
+                step_hidden=hidden2,
+                w_x_init=0.1,
+                w_h_init=0.1,
+                b_init=0.,
+                nonlinearity=None,
+                gate_nonlinearity=None)
+
+            output_nonlinearity = np.full(
+                (np.prod(hidden2.shape[1:]), output_dim), 0.1)
+            output2 = np.matmul(hidden2, output_nonlinearity)
+            assert np.allclose(mean1, output2)
+            assert np.allclose(log_std1, output2)
+            assert np.allclose(hidden1, hidden2)
+
+            expected_action = 0.5 * np.exp(log_std1) + mean1
+            assert np.allclose(action, expected_action)
+
+    # yapf: disable
+    @params(
+        (1, 1),
+        (2, 2),
+        (3, 3))
+    # yapf: enable
+    def test_std_share_network_shapes(self, output_dim, hidden_dim):
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=True,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (action_var, mean_var, step_mean_var, log_std_var, step_log_std_var,
+         step_hidden, hidden_init_var, dist) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        # output layer is a tf.keras.layers.Dense object,
+        # which cannot be access by tf.variable_scope.
+        # A workaround is to access in tf.global_variables()
+        for var in tf.global_variables():
+            if 'output_layer/kernel' in var.name:
+                std_share_output_weights = var
+            if 'output_layer/bias' in var.name:
+                std_share_output_bias = var
+        assert std_share_output_weights.shape[1] == output_dim * 2
+        assert std_share_output_bias.shape == output_dim * 2
+
+    @params((1, 1, 1), (1, 1, 2), (1, 2, 1), (1, 2, 2), (3, 3, 1), (3, 3, 2))
+    @mock.patch('tensorflow.random.normal')
+    def test_without_std_share_network_output_values(
+            self, output_dim, hidden_dim, init_std, mock_normal):
+        mock_normal.return_value = 0.5
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=False,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer,
+            init_std=init_std)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (action_var, mean_var, step_mean_var, log_std_var, step_log_std_var,
+         step_hidden, hidden_init_var, dist) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
+                                    hidden_init_var.eval())
+
+        mean, log_std = self.sess.run(
+            [mean_var, log_std_var],
+            feed_dict={self.input_var: self.obs_inputs})
+
+        for i in range(self.time_step):
+            action, mean1, log_std1, hidden1 = self.sess.run(
+                [action_var, step_mean_var, step_log_std_var, step_hidden],
+                feed_dict={
+                    self.step_input_var: self.obs_input,
+                    step_hidden_var: hidden1
+                })
+
+            hidden2 = recurrent_step_gru(
+                input_val=self.obs_input,
+                num_units=hidden_dim,
+                step_hidden=hidden2,
+                w_x_init=0.1,
+                w_h_init=0.1,
+                b_init=0.,
+                nonlinearity=None,
+                gate_nonlinearity=None)
+
+            output_nonlinearity = np.full(
+                (np.prod(hidden2.shape[1:]), output_dim), 0.1)
+            output2 = np.matmul(hidden2, output_nonlinearity)
+            assert np.allclose(mean1, output2)
+            expected_log_std = np.full((self.batch_size, output_dim),
+                                       np.log(init_std))
+            assert np.allclose(log_std1, expected_log_std)
+            assert np.allclose(hidden1, hidden2)
+
+            expected_action = 0.5 * np.exp(log_std1) + mean1
+            assert np.allclose(action, expected_action)
+
+    # yapf: disable
+    @params(
+        (1, 1),
+        (2, 2),
+        (3, 3))
+    # yapf: enable
+    def test_without_std_share_network_shapes(self, output_dim, hidden_dim):
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=False,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (action_var, mean_var, step_mean_var, log_std_var, step_log_std_var,
+         step_hidden, hidden_init_var, dist) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        # output layer is a tf.keras.layers.Dense object,
+        # which cannot be access by tf.variable_scope.
+        # A workaround is to access in tf.global_variables()
+        for var in tf.global_variables():
+            if 'output_layer/kernel' in var.name:
+                std_share_output_weights = var
+            if 'output_layer/bias' in var.name:
+                std_share_output_bias = var
+            if 'log_std_param/parameter' in var.name:
+                log_std_param = var
+        assert std_share_output_weights.shape[1] == output_dim
+        assert std_share_output_bias.shape == output_dim
+        assert log_std_param.shape == output_dim
+
+    # yapf: disable
+    @params(
+        (1, 1),
+        (2, 2),
+        (3, 3))
+    # yapf: enable
+    @mock.patch('tensorflow.random.normal')
+    def test_std_share_network_is_pickleable(self, output_dim, hidden_dim,
+                                             mock_normal):
+        mock_normal.return_value = 0.5
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=True,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (_, mean_var, step_mean_var, log_std_var,
+         step_log_std_var, step_hidden, _, _) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        # output layer is a tf.keras.layers.Dense object,
+        # which cannot be access by tf.variable_scope.
+        # A workaround is to access in tf.global_variables()
+        for var in tf.global_variables():
+            if 'output_layer/bias' in var.name:
+                var.load(tf.ones_like(var).eval())
+
+        hidden = np.zeros((self.batch_size, hidden_dim))
+
+        outputs1 = self.sess.run([mean_var, log_std_var],
+                                 feed_dict={self.input_var: self.obs_inputs})
+        output1 = self.sess.run([step_mean_var, step_log_std_var, step_hidden],
+                                feed_dict={
+                                    self.step_input_var: self.obs_input,
+                                    step_hidden_var: hidden
+                                })  # noqa: E126
+
+        h = pickle.dumps(model)
+        with tf.Session(graph=tf.Graph()) as sess:
+            model_pickled = pickle.loads(h)
+
+            input_var = tf.placeholder(
+                tf.float32,
+                shape=(None, None, self.feature_shape),
+                name='input')
+            step_input_var = tf.placeholder(
+                tf.float32,
+                shape=(None, self.feature_shape),
+                name='step_input')
+            step_hidden_var = tf.placeholder(
+                shape=(self.batch_size, hidden_dim),
+                name='initial_hidden',
+                dtype=tf.float32)
+
+            (_, mean_var2, step_mean_var2, log_std_var2,
+             step_log_std_var2, step_hidden2, _, _) = model_pickled.build(
+                 input_var, step_input_var, step_hidden_var)
+
+            outputs2 = sess.run([mean_var2, log_std_var2],
+                                feed_dict={input_var: self.obs_inputs})
+            output2 = sess.run(
+                [step_mean_var2, step_log_std_var2, step_hidden2],
+                feed_dict={
+                    step_input_var: self.obs_input,
+                    step_hidden_var: hidden
+                })
+            assert np.array_equal(outputs1, outputs2)
+            assert np.array_equal(output1, output2)
+
+    # yapf: disable
+    @params(
+        (1, 1),
+        (2, 2),
+        (3, 3))
+    # yapf: enable
+    @mock.patch('tensorflow.random.normal')
+    def test_without_std_share_network_is_pickleable(self, output_dim,
+                                                     hidden_dim, mock_normal):
+        mock_normal.return_value = 0.5
+        model = GaussianGRUModel(
+            output_dim=output_dim,
+            hidden_dim=hidden_dim,
+            std_share_network=False,
+            hidden_nonlinearity=None,
+            recurrent_nonlinearity=None,
+            hidden_w_init=self.default_initializer,
+            recurrent_w_init=self.default_initializer,
+            output_w_init=self.default_initializer)
+        step_hidden_var = tf.placeholder(
+            shape=(self.batch_size, hidden_dim),
+            name='step_hidden',
+            dtype=tf.float32)
+        (_, mean_var, step_mean_var, log_std_var,
+         step_log_std_var, step_hidden, _, _) = model.build(
+             self.input_var, self.step_input_var, step_hidden_var)
+
+        # output layer is a tf.keras.layers.Dense object,
+        # which cannot be access by tf.variable_scope.
+        # A workaround is to access in tf.global_variables()
+        for var in tf.global_variables():
+            if 'output_layer/bias' in var.name:
+                var.load(tf.ones_like(var).eval())
+
+        hidden = np.zeros((self.batch_size, hidden_dim))
+
+        outputs1 = self.sess.run([mean_var, log_std_var],
+                                 feed_dict={self.input_var: self.obs_inputs})
+        output1 = self.sess.run([step_mean_var, step_log_std_var, step_hidden],
+                                feed_dict={
+                                    self.step_input_var: self.obs_input,
+                                    step_hidden_var: hidden
+                                })  # noqa: E126
+
+        h = pickle.dumps(model)
+        with tf.Session(graph=tf.Graph()) as sess:
+            model_pickled = pickle.loads(h)
+
+            input_var = tf.placeholder(
+                tf.float32,
+                shape=(None, None, self.feature_shape),
+                name='input')
+            step_input_var = tf.placeholder(
+                tf.float32,
+                shape=(None, self.feature_shape),
+                name='step_input')
+            step_hidden_var = tf.placeholder(
+                shape=(self.batch_size, hidden_dim),
+                name='initial_hidden',
+                dtype=tf.float32)
+
+            (_, mean_var2, step_mean_var2, log_std_var2,
+             step_log_std_var2, step_hidden2, _, _) = model_pickled.build(
+                 input_var, step_input_var, step_hidden_var)
+
+            outputs2 = sess.run([mean_var2, log_std_var2],
+                                feed_dict={input_var: self.obs_inputs})
+            output2 = sess.run(
+                [step_mean_var2, step_log_std_var2, step_hidden2],
+                feed_dict={
+                    step_input_var: self.obs_input,
+                    step_hidden_var: hidden
+                })
+            assert np.array_equal(outputs1, outputs2)
+            assert np.array_equal(output1, output2)

--- a/tests/garage/tf/policies/test_gaussian_gru_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy_with_model.py
@@ -1,0 +1,217 @@
+import pickle
+from unittest import mock
+
+from nose2.tools.params import params
+import numpy as np
+import tensorflow as tf
+
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianGRUPolicyWithModel
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
+from tests.fixtures.models import SimpleGaussianGRUModel
+
+
+class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
+    @params(
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4),
+    )
+    def test_dist_info_sym(self, obs_dim, action_dim, hidden_dim):
+        env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+
+        obs_ph = tf.placeholder(
+            tf.float32, shape=(None, None, env.observation_space.flat_dim))
+
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=False)
+
+            policy.reset()
+            obs = env.reset()
+
+            dist_sym = policy.dist_info_sym(
+                obs_var=obs_ph, state_info_vars=None, name='p2_sym')
+
+        dist = self.sess.run(
+            dist_sym, feed_dict={obs_ph: [[obs.flatten()], [obs.flatten()]]})
+
+        assert np.array_equal(dist['mean'], np.full((2, 1) + action_dim, 0.5))
+        assert np.array_equal(dist['log_std'], np.full((2, 1) + action_dim,
+                                                       0.5))
+
+    @params(
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4),
+    )
+    def test_dist_info_sym_include_action(self, obs_dim, action_dim,
+                                          hidden_dim):
+        env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+
+        obs_ph = tf.placeholder(
+            tf.float32, shape=(None, None, env.observation_space.flat_dim))
+
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=True)
+
+            policy.reset()
+            obs = env.reset()
+            dist_sym = policy.dist_info_sym(
+                obs_var=obs_ph,
+                state_info_vars={'prev_action': np.zeros((2, 1) + action_dim)},
+                name='p2_sym')
+        dist = self.sess.run(
+            dist_sym, feed_dict={obs_ph: [[obs.flatten()], [obs.flatten()]]})
+
+        assert np.array_equal(dist['mean'], np.full((2, 1) + action_dim, 0.5))
+        assert np.array_equal(dist['log_std'], np.full((2, 1) + action_dim,
+                                                       0.5))
+
+    def test_dist_info_sym_wrong_input(self):
+        env = TfEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
+
+        obs_ph = tf.placeholder(
+            tf.float32, shape=(None, None, env.observation_space.flat_dim))
+
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=True)
+
+            policy.reset()
+            obs = env.reset()
+
+            policy.dist_info_sym(
+                obs_var=obs_ph,
+                state_info_vars={'prev_action': np.zeros((3, 1, 1))},
+                name='p2_sym')
+        # observation batch size = 2 but prev_action batch size = 3
+        with self.assertRaises(tf.errors.InvalidArgumentError):
+            self.sess.run(
+                policy.model.networks['p2_sym'].input,
+                feed_dict={obs_ph: [[obs.flatten()], [obs.flatten()]]})
+
+    def test_invalid_env(self):
+        env = TfEnv(DummyDiscreteEnv())
+        with self.assertRaises(ValueError):
+            GaussianGRUPolicyWithModel(env_spec=env.spec)
+
+    # yapf: disable
+    @params(
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4))
+    # yapf: enable
+    def test_get_action_state_include_action(self, obs_dim, action_dim,
+                                             hidden_dim):
+
+        env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=True)
+
+        policy.reset()
+        obs = env.reset()
+
+        action, agent_info = policy.get_action(obs)
+        assert env.action_space.contains(action)
+        assert np.array_equal(action, np.full(action_dim, 0.75))
+        expected_mean = np.full(action_dim, 0.5)
+        assert np.array_equal(agent_info['mean'], expected_mean)
+        expected_log_std = np.full(action_dim, 0.5)
+        assert np.array_equal(agent_info['log_std'], expected_log_std)
+        expected_prev_action = np.full(action_dim, 0)
+        assert np.array_equal(agent_info['prev_action'], expected_prev_action)
+
+        policy.reset()
+
+        actions, agent_infos = policy.get_actions([obs])
+        for action, mean, log_std, prev_action in zip(
+                actions, agent_infos['mean'], agent_infos['log_std'],
+                agent_infos['prev_action']):
+            assert env.action_space.contains(action)
+            assert np.array_equal(action, np.full(action_dim, 0.75))
+            assert np.array_equal(mean, expected_mean)
+            assert np.array_equal(log_std, expected_log_std)
+            assert np.array_equal(prev_action, expected_prev_action)
+
+    # yapf: disable
+    @params(
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4))
+    # yapf: enable
+    def test_get_action(self, obs_dim, action_dim, hidden_dim):
+        env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=False)
+
+        policy.reset()
+        obs = env.reset()
+
+        action, agent_info = policy.get_action(obs)
+        assert env.action_space.contains(action)
+        assert np.array_equal(action, np.full(action_dim, 0.75))
+        expected_mean = np.full(action_dim, 0.5)
+        assert np.array_equal(agent_info['mean'], expected_mean)
+        expected_log_std = np.full(action_dim, 0.5)
+        assert np.array_equal(agent_info['log_std'], expected_log_std)
+
+        actions, agent_infos = policy.get_actions([obs])
+        for action, mean, log_std in zip(actions, agent_infos['mean'],
+                                         agent_infos['log_std']):
+            assert env.action_space.contains(action)
+            assert np.array_equal(action, np.full(action_dim, 0.75))
+            assert np.array_equal(mean, expected_mean)
+            assert np.array_equal(log_std, expected_log_std)
+
+    def test_is_pickleable(self):
+        env = TfEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
+        with mock.patch(('garage.tf.policies.'
+                         'gaussian_gru_policy_with_model.GaussianGRUModel'),
+                        new=SimpleGaussianGRUModel):
+            policy = GaussianGRUPolicyWithModel(
+                env_spec=env.spec, state_include_action=False)
+
+        env.reset()
+        obs = env.reset()
+
+        with tf.variable_scope(
+                'GaussianGRUPolicyWithModel/GaussianGRUModel', reuse=True):
+            return_var = tf.get_variable('return_var')
+        # assign it to all one
+        return_var.load(tf.ones_like(return_var).eval())
+
+        output1 = self.sess.run(
+            policy.model.networks['default'].mean,
+            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+
+        p = pickle.dumps(policy)
+
+        with tf.Session(graph=tf.Graph()) as sess:
+            policy_pickled = pickle.loads(p)
+            output2 = sess.run(
+                policy_pickled.model.networks['default'].mean,
+                feed_dict={
+                    policy_pickled.model.input: [[obs.flatten()],
+                                                 [obs.flatten()]]
+                })
+            assert np.array_equal(output1, output2)

--- a/tests/garage/tf/policies/test_gaussian_gru_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy_with_model_transit.py
@@ -1,13 +1,13 @@
 """
-Unit test for GaussianLSTMPolicy with Model.
+Unit test for GaussianGRUPolicy with Model.
 
-This test consists of four different GaussianLSTMPolicy: P1, P2, P3
-and P4. P1 and P2 are from GaussianLSTMPolicy, which does not use
-garage.tf.models.LSTMModel while P3 and P4 do use.
+This test consists of four different GaussianGRUPolicy: P1, P2, P3
+and P4. P1 and P2 are from GaussianGRUPolicy, which does not use
+garage.tf.models.GRUModel while P3 and P4 do use.
 
 This test ensures the outputs from all the policies are the same,
-for the transition from using GaussianLSTMPolicy to
-GaussianLSTMPolicyWithModel.
+for the transition from using GaussianGRUPolicy to
+GaussianGRUPolicyWithModel.
 
 It covers get_action, get_actions, dist_info_sym, kl_sym,
 log_likelihood_sym, entropy_sym and likelihood_ratio_sym.
@@ -19,13 +19,13 @@ import tensorflow as tf
 
 from garage.tf.envs import TfEnv
 from garage.tf.misc import tensor_utils
-from garage.tf.policies import GaussianLSTMPolicy
-from garage.tf.policies import GaussianLSTMPolicyWithModel
+from garage.tf.policies import GaussianGRUPolicy
+from garage.tf.policies import GaussianGRUPolicyWithModel
 from tests.fixtures import TfGraphTestCase
 from tests.fixtures.envs.dummy import DummyBoxEnv
 
 
-class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
+class TestGaussianGRUPolicyWithModelTransit(TfGraphTestCase):
     @mock.patch('tensorflow.random.normal')
     def setUp(self, mock_rand):
         mock_rand.return_value = 0.5
@@ -37,7 +37,7 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
         self.default_output_nonlinearity = None
         self.time_step = 1
 
-        self.policy1 = GaussianLSTMPolicy(
+        self.policy1 = GaussianGRUPolicy(
             env_spec=env.spec,
             hidden_dim=4,
             hidden_nonlinearity=self.default_hidden_nonlinearity,
@@ -48,7 +48,7 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
             output_w_init=self.default_initializer,
             state_include_action=True,
             name='P1')
-        self.policy2 = GaussianLSTMPolicy(
+        self.policy2 = GaussianGRUPolicy(
             env_spec=env.spec,
             hidden_dim=4,
             hidden_nonlinearity=self.default_hidden_nonlinearity,
@@ -62,7 +62,7 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
 
         self.sess.run(tf.global_variables_initializer())
 
-        self.policy3 = GaussianLSTMPolicyWithModel(
+        self.policy3 = GaussianGRUPolicyWithModel(
             env_spec=env.spec,
             hidden_dim=4,
             hidden_nonlinearity=self.default_hidden_nonlinearity,
@@ -73,7 +73,7 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
             output_w_init=self.default_initializer,
             state_include_action=True,
             name='P3')
-        self.policy4 = GaussianLSTMPolicyWithModel(
+        self.policy4 = GaussianGRUPolicyWithModel(
             env_spec=env.spec,
             hidden_dim=4,
             hidden_nonlinearity=self.default_hidden_nonlinearity,


### PR DESCRIPTION
Added GaussianGRUModel and GaussianGRUPolicyWithModel.

Added test for PPO with GaussianGRUPolicyWithModel.

Apart from testing functionality of GaussianGRUPolicyWithModel
in test_gaussian_gru_policy_with_model.py, transitions from the
old policy (GaussianGRUPolicy) to the new policy
(GaussianGRUPolicyWithModel) are also tested in
test_gaussian_gru_policy_with_model_transit.py, to make sure
they have the same API.