### PR TITLE
Remove nose2 and coverage from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,8 @@
 # Sphinx supports interpreting the arguments from the class docstring as the arguments for `__init__`.
 # We choose that as our convention and disable this rule.
 ignore = W503, D107
-ignore-names = setUp, tearDown, setUpClass,tearDownClass, setUpModule, tearDownModule
 import-order-style = google
-application-import-names = tests, sandbox, garage, examples
+application-import-names = tests, garage, examples
 per-file-ignores =
     ./src/garage/misc/krylov.py:N802,N803,N806
 
@@ -75,11 +74,6 @@ disable =
     not-context-manager,
     c-extension-no-member,
     wrong-import-order
-
-[unittest]
-plugins = nose2.plugins.attrib
-          nose2.plugins.layers
-          nose2.plugins.testid
 
 [tool:pytest]
 addopts = -rfE -s --strict-markers

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,9 @@ extras['intel'] = ['intel-tensorflow<1.13,>=1.12.0']
 extras['dev'] = [
     # Please keep alphabetized
     'baselines @ https://api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3',  # noqa: E501
-    'coverage',
     'flake8',
     'flake8-docstrings==1.3.0',
     'flake8-import-order',
-    'nose2',
     'pandas',
     'pep8-naming==0.7.0',
     'pre-commit',


### PR DESCRIPTION
These are obsolete, now that we use pytest.