### PR TITLE
Remove conda from Dockerfiles and setup scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: "3.6.6"
+python: "3.5"
 
 services:
   - docker
@@ -22,6 +22,8 @@ jobs:
         - DEPLOY_FROM_THIS_JOB="true"
     - name: "Large tests"
       env: JOB_RUN_CMD="make ci-job-large"
+    - name: "Verify conda and pipenv installations"
+      env: JOB_RUN_CMD="make ci-job-verify-envs"
     - if: type = cron
       name: "Nightly tests"
       env: JOB_RUN_CMD="make ci-job-nightly"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@ After following the standard garage setup steps, make sure to run to install the
 
 To setup pre-commit in your repo:
 ```sh
-conda activate garage
+# make sure your Python environment is activated, e.g.
+# conda activate garage
+# pipenv shell
+# poetry shell
+# source venv/bin/activate
 pre-commit install -t pre-commit
 pre-commit install -t pre-push
 pre-commit install -t commit-msg

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -14,7 +14,7 @@ RUN \
   apt-get -y -q update && \
   # Prevents debconf from prompting for user input
   # See https://github.com/phusion/baseimage-docker/issues/58
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     # Dockerfile deps
     wget \
     bzip2 \
@@ -22,6 +22,7 @@ RUN \
     git \
     curl \
     # For building glfw
+    build-essential \
     cmake \
     xorg-dev \
     # mujoco_py
@@ -31,6 +32,7 @@ RUN \
     libglew-dev \
     libosmesa6-dev \
     patchelf \
+    python3-dev \
     # OpenAI gym
     # See https://github.com/openai/gym/blob/master/Dockerfile
     libpq-dev \
@@ -40,7 +42,12 @@ RUN \
     libsdl2-dev \
     # OpenAI baselines
     libopenmpi-dev \
-    openmpi-bin && \
+    openmpi-bin \
+    # virtualenv
+    python3 \
+    python3-pip \
+    python3-tk \
+    python3-virtualenv && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -58,7 +65,7 @@ RUN git clone https://github.com/glfw/glfw.git && \
   cd ../../ && \
   rm -rf glfw
 
-# MuJoCo 2.0 (for dm_control)
+# MuJoCo 2.0 (for dm_control and gym)
 RUN mkdir -p /root/.mujoco && \
   wget https://www.roboti.us/download/mujoco200_linux.zip -O mujoco.zip && \
   unzip mujoco.zip -d $HOME/.mujoco && \
@@ -66,17 +73,8 @@ RUN mkdir -p /root/.mujoco && \
   ln -s $HOME/.mujoco/mujoco200_linux $HOME/.mujoco/mujoco200
   ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco200/bin
 
-# conda
-RUN wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && \
-  bash miniconda.sh -b -p /opt/conda && \
-  rm miniconda.sh && \
-  ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
-ENV PATH=$PATH:/opt/conda/bin
-RUN conda update -q -y conda
-
-# conda environment
-# Copy over just environment.yml and setup.py first, so the Docker cache doesn't
-# expire until they change
+# Copy over just setup.py first, so the Docker cache doesn't expire until
+# dependencies change
 #
 # Files needed to run setup.py
 # - README.md
@@ -89,23 +87,28 @@ COPY VERSION /root/code/garage/VERSION
 COPY scripts/garage /root/code/garage/scripts/garage
 COPY src/garage/__init__.py /root/code/garage/src/garage/__init__.py
 COPY setup.py /root/code/garage/setup.py
-COPY environment.yml /root/code/garage/environment.yml
+WORKDIR /root/code/garage
+
+# Create virtualenv
+ENV VIRTUAL_ENV=/root/venv
+RUN python3 -m virtualenv --python=/usr/bin/python3 $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Prevent pip from complaining about available upgrades
+RUN pip install --upgrade pip
 
 # We need a MuJoCo key to install mujoco_py
 # In this step only the presence of the file mjkey.txt is required, so we only
 # create an empty file
-ARG MJKEY
 RUN touch /root/.mujoco/mjkey.txt && \
-  conda env create -f /root/code/garage/environment.yml && \
-  rm -rf /opt/conda/pkgs/* && \
+  # cma is dumb and requires numpy to run setup.py
+  pip install numpy==1.14.5 && \
+  pip install -e .[all,dev] && \
+  rm -r /root/.cache/pip && \
   rm /root/.mujoco/mjkey.txt
 
-# Extras
-# prevent pip from complaining about available upgrades
-RUN ["/bin/bash", "-c", "source activate garage && pip install --upgrade pip"]
-
 # Setup repo
-WORKDIR /root/code/garage
 # Pre-build pre-commit env
 COPY .pre-commit-config.yaml /root/code/garage
-RUN ["/bin/bash", "-c", "source activate garage && git init && pre-commit"]
+RUN git init && \
+  pre-commit

--- a/docker/entrypoint-headless.sh
+++ b/docker/entrypoint-headless.sh
@@ -28,9 +28,6 @@ if ! [ -e "$file" ]; then
   exit 1
 fi
 
-# Activate conda environment
-source activate garage
-
 # Fixes Segmentation Fault
 # See: https://github.com/openai/mujoco-py/pull/145#issuecomment-356938564
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLEW.so

--- a/docker/entrypoint-runtime.sh
+++ b/docker/entrypoint-runtime.sh
@@ -5,9 +5,6 @@ set -e
 # Get MuJoCo key from the environment
 echo "${MJKEY}" > /root/.mujoco/mjkey.txt
 
-# Activate conda environment
-source activate garage
-
 # Fixes Segmentation Fault
 # See: https://github.com/openai/mujoco-py/pull/145#issuecomment-356938564
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libGLEW.so

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -8,9 +8,12 @@ Installation
 Express Install
 ===============
 
+Install System Dependencies
+---------------------------
+
 The fastest way to set up dependencies for garage is via running the setup script.
 
-Clone our repo (https://github.com/rlworkgroup/garage) and navigate to its directory.
+Clone our repository (https://github.com/rlworkgroup/garage) and navigate to its directory.
 
 A MuJoCo key is required for installation. You can get one here: https://www.roboti.us/license.html
 
@@ -28,91 +31,92 @@ Make sure you run these scripts from the root directory of the repo, not from th
 
     ./scripts/setup_macos.sh --mjkey path-to-your-mjkey.txt --modify-bashrc
 
+Install Garage in a Python Environment
+--------------------------------------
 
-The script sets up a conda environment, which is similar to :code:`virtualenv`. To start using it, run the following:
+The script sets up pre-requisites for each platform, but does not install the Python package. We recommend you build your project using a Python environment manager which supports dependency resolution, such as `pipenv <https://docs.pipenv.org/en/latest/>`_, `conda <https://docs.conda.io/en/latest/>`_, or `poetry <https://poetry.eustace.io/>`_. We test against `pipenv` and `conda`.
 
+garage is also tested using `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, but we recommend against building your project using `virtualenv`, because it has difficulty resolving dependency conflicts which may arise between garage and other packages in your project. You are of course free to install garage as a system-wide Python package using `pip`, but we don't recommend this for the same reasons we recommend against using `virtualenv`.
+
+NOTE: garage only supports Python 3.5+, so make sure you Python environment is using this or a later version.
+
+- pipenv
 .. code-block:: bash
 
-    source activate garage
+    pipenv --three  # garage only supports Python 3.5+
+    pipenv run pip install numpy==1.14.5  # pycma requires numpy to install
+    pipenv install --pre garage  # --pre required because garage has some dependencies with verion numbers <1.0
 
 
-Optionally, if you would like to run experiments that depends on the MuJoCo environment, you can set it up by running the following command:
-
+- conda (environment named "myenv")
 .. code-block:: bash
 
-    ./scripts/setup_mujoco.sh
+    source activate myenv
+    pip install numpy==1.14.5
+    pip install garage
 
-and follow the instructions. You need to have the zip file for Mujoco v1.50 and the license file ready.
+Alternatively, you can add garage in the pip section of your `environment.yml`
+.. code-block:: yaml
+    name: myenv
+    channels:
+      - conda-forge
+    dependencies:
+    - python>=3.5
+    - pip
+    - numpy==1.14.5 # pycma requires numpy to install
+    - pip
+      - garage
 
-
-
-Manual Install
-==============
-
-Anaconda
-------------
-
-:code:`garage` assumes that you are using Anaconda Python distribution. You can download it from `https://www.continuum.io/downloads<https://www.continuum.io/downloads`.  Make sure to download the installer for Python 2.7.
-
-
-System dependencies for pygame
-------------------------------
-
-A few environments in garage are implemented using Box2D, which uses pygame for visualization.
-It requires a few system dependencies to be installed first.
-
-On Linux, run the following:
-
+- virtualenv (environment named "myenv")
 .. code-block:: bash
 
-  sudo apt-get install swig
-  sudo apt-get build-dep python-pygame
+    source myenv/bin/activate
+    pip install numpy==1.14.5  # pycma requires numpy to install
+    pip install garage
 
-On macOS, run the following:
 
+Extra Steps for Developers
+--------------------------
+
+If you plan on developing the garage repository, as opposed to simply using it as a library, you will probably prefer to install your copy of the garage repository as an editable library instead. After installing the pre-requisites using the instructions in `Install System Dependencies`_, you should install garage in your environment as below.
+
+- pipenv
 .. code-block:: bash
 
-  brew install swig sdl sdl_image sdl_mixer sdl_ttf portmidi
+    cd path/to/garage/repo
+    pipenv --three
+    pipenv run pip install numpy==1.14.5
+    pipenv install --pre -e .[all,dev]
 
-System dependencies for scipy
------------------------------
 
-This step is only needed under Linux:
-
+- conda
 .. code-block:: bash
 
-  sudo apt-get install build-dep python-scipy
+    source activate myenv
+    cd path/to/garage/repo
+    pip install numpy=1.14.5
+    pip install -e .[all,dev]
 
-Install Python modules
-----------------------
 
+- virtualenv
 .. code-block:: bash
 
-  conda env create -f environment.yml
+    source myenv/bin/activate
+    cd path/to/garage/repo
+    pip install numpy==1.14.5
+    pip install -e .[all,dev]
+
 
 GPU Support
 ===========
 
-To enable GPU support, you need to run the express installation script with the argument :code:`--gpu`. This options installs GPU-supported Tensorflow and modules needed by Theano.
+To enable GPU support, install the `garage[gpu]` extra package into your Python environment.
 
-Before you run garage, you need to specify the directory for the CUDA library in environment variable :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming to your CUDA version accordingly.
+Before you run garage, you need to specify the directory for the CUDA library in environment variable :code:`LD_LIBRARY_PATH`. You may need to replace the directory conforming to your CUDA version accordingly. We recommend you add this to your shell profile (e.g. `~/.bashrc`) for convenience.
 
 .. code-block:: bash
 
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-9.0/lib64
 
 
-You should now be able to use GPU in Tensorflow. For Theano, two additional steps are needed.
-
-* Specify CUDA root in :code:`~/.theanorc` (Create the file if it doesn't exist)
-
-.. code-block:: ini
-
-    [cuda]
-    root = /usr/local/cuda-9.0
-
-* | `Enable GPU for theano <http://deeplearning.net/software/theano/tutorial/using_gpu.html>`_ by
-
-.. code-block:: bash
-
-    export THEANO_FLAGS=device=cuda,floatX=float32,force_device=True
+You should now be able to use your GPU with TensorFlow and PyTorch.

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -216,56 +216,16 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
   echo "export ${LD_LIB_ENV_VAR}" >> "${BASH_PROF}"
 fi
 
-# Set up conda
-CONDA_SH="${HOME}/miniconda2/etc/profile.d/conda.sh"
-if [[ ! -d "${HOME}/miniconda2" ]]; then
-  CONDA_INSTALLER="$(mktemp -d)/miniconda.sh"
-  wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh \
-    -O "${CONDA_INSTALLER}"
-  chmod u+x "${CONDA_INSTALLER}"
-  bash "${CONDA_INSTALLER}" -b -u
-  if [[ "${_arg_modify_bashrc}" = on ]]; then
-    echo ". ${CONDA_SH}" >> "${BASH_PROF}"
-  fi
-fi
-# Export conda in this script
-. "${CONDA_SH}"
-conda update -q -y conda
-
 # We need a MuJoCo key to import mujoco_py
 cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
-
-# Create conda environment
-conda env create -f environment.yml
-if [[ "${?}" -ne 0 ]]; then
-  print_error "Error: conda environment could not be created"
-fi
-
-# Extras
-conda activate garage
-{
-  # Prevent pip from complaining about available upgrades
-  pip install --upgrade pip
-
-  # Install git hooks
-  pre-commit install -t pre-commit
-  pre-commit install -t pre-push
-  pre-commit install -t commit-msg
-
-  # Install a virtualenv for the hooks
-  pre-commit
-}
-conda deactivate
 
 # Add garage to python modules
 if [[ "${_arg_modify_bashrc}" != on ]]; then
   echo -e "\nRemember to execute the following commands before running garage:"
   echo "${LD_LIB_ENV_VAR}"
-  echo ". ${CONDA_SH}"
   echo "You may wish to edit your .bash_profile to prepend these commands."
 fi
 
-echo -e "\ngarage is installed! To make the changes take effect, work under" \
-  "a new terminal. Also, make sure to run \`conda activate garage\`" \
-  "whenever you open a new terminal and want to run programs under garage." \
+echo -e "\ngarage pre-requisites are installed! To make the changes take " \
+        "effect, open a new terminal or call 'source ~/.bash_profile'" \
   | fold -s

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+try:
+    # pylint: disable=unused-import
+    import numpy  # noqa: F401
+except ImportError:
+    raise RuntimeError(
+        'garage requires numpy in the environment to install. '
+        'Please install numpy==1.14.5 and try again. See '
+        'https://github.com/rlworkgroup/garage/issues/800 for more info.')
+
 # Required dependencies
 required = [
     # Please keep alphabetized
@@ -58,6 +67,7 @@ extras['dev'] = [
     'pylint==1.9.2',
     'pytest>=3.6',  # Required for pytest-cov on Python 3.6
     'pytest-cov',
+    'pytest-xdist',
     'sphinx',
     'sphinx_rtd_theme',
     'yapf',
@@ -79,6 +89,7 @@ setup(
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     scripts=['scripts/garage'],
+    python_requires='>=3.5',
     install_requires=required,
     extras_require=extras,
     license='MIT',

--- a/src/garage/np/algos/cem.py
+++ b/src/garage/np/algos/cem.py
@@ -68,7 +68,7 @@ class CEM(BatchPolopt):
         # fixed
         self.n_best = int(n_samples * best_frac)
         assert self.n_best >= 1, (
-            f'n_samples is too low. Make sure that n_samples * best_frac >= 1')
+            'n_samples is too low. Make sure that n_samples * best_frac >= 1')
         self.n_params = len(self.cur_mean)
 
     def sample_params(self, epoch):

--- a/tests/fixtures/experiment/fixture_experiment.py
+++ b/tests/fixtures/experiment/fixture_experiment.py
@@ -5,8 +5,8 @@ from garage.tf.envs import TfEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def fixture_exp(snapshot_config):
-    with LocalRunner(snapshot_config=snapshot_config) as runner:
+def fixture_exp(snapshot_config, sess):
+    with LocalRunner(snapshot_config=snapshot_config, sess=sess) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
         policy = CategoricalMLPPolicy(

--- a/tests/garage/experiment/test_snapshotter_integration.py
+++ b/tests/garage/experiment/test_snapshotter_integration.py
@@ -13,16 +13,20 @@ configurations = [('last', 4), ('first', 0), (3, 3)]
 
 
 class TestSnapshot(TfGraphTestCase):
-    temp_dir = tempfile.TemporaryDirectory()
-    snapshot_config = SnapshotConfig(
-        snapshot_dir=temp_dir.name, snapshot_mode='all', snapshot_gap=1)
+    def setup_method(self):
+        super().setup_method()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        snapshot_config = SnapshotConfig(
+            snapshot_dir=self.temp_dir.name,
+            snapshot_mode='all',
+            snapshot_gap=1)
+        fixture_exp(snapshot_config, self.sess)
+        for c in self.graph.collections:
+            self.graph.clear_collection(c)
 
-    @classmethod
-    def teardown_class(cls):
-        cls.temp_dir.cleanup()
-
-    def test_before_load(self):
-        fixture_exp(self.__class__.snapshot_config)
+    def teardown_method(self):
+        self.temp_dir.cleanup()
+        super().teardown_method()
 
     @pytest.mark.parametrize('load_mode, last_epoch', [*configurations])
     def test_load(self, load_mode, last_epoch):

--- a/tests/garage/sampler/test_is_sampler.py
+++ b/tests/garage/sampler/test_is_sampler.py
@@ -44,7 +44,7 @@ class TestISSampler(TfGraphTestCase):
                 mocked.assert_not_called()
 
                 assert runner.sampler.obtain_samples(3)
-                mocked.assert_called_once()
+                mocked.assert_called_once_with(3, None, True)
 
             # test importance sampling for first n_is_pretrain iterations
             with unittest.mock.patch.object(ISSampler,
@@ -53,7 +53,7 @@ class TestISSampler(TfGraphTestCase):
                 runner.sampler.n_backtrack = 'all'
                 runner.sampler.obtain_samples(4)
 
-                mocked.assert_called_once()
+                mocked.assert_called_once_with(4, None, True)
 
             runner.sampler.obtain_samples(5)
 

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -3,7 +3,6 @@ This script creates a test that fails when garage.tf.algos.PPO performance is
 too low.
 """
 import gym
-import pytest
 import tensorflow as tf
 
 from garage.envs import normalize
@@ -31,7 +30,8 @@ class TestPPO(TfGraphTestCase):
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_pendulum(self):
         """Test PPO with Pendulum environment."""
         with LocalRunner(sess=self.sess) as runner:
@@ -47,7 +47,8 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_pendulum_recurrent(self):
         """Test PPO with Pendulum environment and recurrent policy."""
         with LocalRunner() as runner:
@@ -64,7 +65,8 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_with_maximum_entropy(self):
         """Test PPO with maxium entropy method."""
         with LocalRunner(sess=self.sess) as runner:
@@ -84,7 +86,8 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_with_neg_log_likeli_entropy_estimation_and_max(self):
         """
         Test PPO with negative log likelihood entropy estimation and max
@@ -108,7 +111,8 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized(self):
         """
         Test PPO with negative log likelihood entropy estimation and
@@ -132,7 +136,8 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
-    @pytest.mark.large
+    # large marker removed to balance test jobs
+    # @pytest.mark.large
     def test_ppo_with_regularized_entropy(self):
         """Test PPO with regularized entropy method."""
         with LocalRunner(sess=self.sess) as runner:


### PR DESCRIPTION
This PR removes conda environments from the Dockerfiles and setup
scripts.
    
For the CI, we use a vanilla virtualenv to ensure that the garage
package installs in the lowest common-denonenator environment. We also
add a job to TravisCI to verify that conda can successfully build.
    
For the setup scripts, we remove the environment creation altogether and
assume that the user will install garage in her own environment of
choice. The scripts serve to only setup pre-requisities, not the Python
environment itself
    
Summary of changes:
* Remove conda environment from Dockerfiles and setup scripts
* Add virtualenv to Dockerfiles
* Add TravisCI job to build the conda environment
* Add pytest-xdist for parallel tests
* Update some tests and code to be Python 3.5 compliant

Fixes #444 
Fixes #666 