### PR TITLE
Distributed Ray Sampler

### DIFF
--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -4,6 +4,7 @@ This is an example to train a task with TRPO algorithm.
 
 Uses Ray_batched sampler instead of on_policy vectorized
 sampler.
+Test
 Here it runs Swimmer-v2 environment with 40 iterations.
 """
 import gym

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+This is an example to train a task with TRPO algorithm.
+
+Uses Ray_batched sampler instead of on_policy vectorized
+sampler.
+Here it runs Swimmer-v2 environment with 40 iterations.
+"""
+import gym
+
+from garage.experiment import LocalRunner, run_experiment
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import TRPO
+from garage.tf.envs import TfEnv
+from garage.tf.policies import GaussianMLPPolicyWithModel
+from garage.tf.samplers.ray_batched_sampler import RaySamplerTF
+
+
+def run_task(*_):
+    """."""
+    with LocalRunner() as runner:
+        env = TfEnv(gym.make('Swimmer-v2'))
+
+        policy = GaussianMLPPolicyWithModel(
+            env_spec=env.spec, hidden_sizes=(32, 32))
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(
+            env_spec=env.spec,
+            policy=policy,
+            baseline=baseline,
+            max_path_length=500,
+            discount=0.99,
+            max_kl_step=0.01)
+
+        # runner.setup(algo, env)
+        runner.setup(algo, env, sampler_cls=RaySamplerTF)
+        runner.train(n_epochs=40, batch_size=4000)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode='last',
+    seed=1,
+)

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -15,6 +15,8 @@ from garage.tf.envs import TfEnv
 from garage.tf.policies import GaussianMLPPolicyWithModel
 from garage.tf.samplers.ray_batched_sampler import RaySamplerTF
 
+seed = 100
+
 
 def run_task(*_):
     """."""
@@ -35,12 +37,13 @@ def run_task(*_):
             max_kl_step=0.01)
 
         # runner.setup(algo, env)
-        runner.setup(algo, env, sampler_cls=RaySamplerTF)
+        runner.setup(
+            algo, env, sampler_cls=RaySamplerTF, sampler_args={'seed': seed})
         runner.train(n_epochs=40, batch_size=4000)
 
 
 run_experiment(
     run_task,
     snapshot_mode='last',
-    seed=1,
+    seed=seed,
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ required = [
     'pyprind',
     'python-dateutil',
     'torch==1.1.0',
+    'ray'
     'scikit-image',
     'scipy',
     'tensorflow<1.13,>=1.12.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ required = [
     'pyprind',
     'python-dateutil',
     'torch==1.1.0',
-    'ray'
+    'ray',
     'scikit-image',
     'scipy',
     'tensorflow<1.13,>=1.12.0',

--- a/src/garage/sampler/__init__.py
+++ b/src/garage/sampler/__init__.py
@@ -2,8 +2,10 @@ from garage.sampler.base import BaseSampler
 from garage.sampler.base import Sampler
 from garage.sampler.batch_sampler import BatchSampler
 from garage.sampler.is_sampler import ISSampler
+from garage.sampler.ray_batched_sampler import RaySampler, SamplerWorker
 from garage.sampler.stateful_pool import singleton_pool
 
 __all__ = [
-    'BaseSampler', 'BatchSampler', 'Sampler', 'ISSampler', 'singleton_pool'
+    'BaseSampler', 'BatchSampler', 'Sampler', 'ISSampler', 'singleton_pool',
+    'RaySampler', 'SamplerWorker'
 ]

--- a/src/garage/sampler/ray_batched_sampler.py
+++ b/src/garage/sampler/ray_batched_sampler.py
@@ -1,0 +1,215 @@
+"""This is an implementation of an on policy batch sampler.
+
+Uses a data parallel design.
+Included is a sampler that deploys sampler workers.
+
+The sampler workers must implement some type of set agent parameters
+function, and a rollout function
+"""
+from collections import defaultdict
+import pickle
+
+import numpy as np
+import psutil
+import ray
+
+from garage.misc import tensor_utils
+from garage.misc.prog_bar_counter import ProgBarCounter
+from garage.sampler.base import BaseSampler
+
+
+class RaySampler(BaseSampler):
+    """Collects Policy Rollouts in a data parallel fashion.
+
+    Args:
+        - algo: A garage algo object
+        - env: A gym/akro env object
+        - should_render(bool): should the sampler render the trajectories
+        - sampler_worker_cls: If none, uses the default SamplerWorker
+            class
+
+    """
+
+    def __init__(self,
+                 algo,
+                 env,
+                 should_render=False,
+                 num_processors=None,
+                 sampler_worker_cls=None):
+        self.SamplerWorker = ray.remote(SamplerWorker if sampler_worker_cls is
+                                        None else sampler_worker_cls)
+
+        self.env = env
+        self.algo = algo
+        self.max_path_length = self.algo.max_path_length
+        self.should_render = should_render
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True)
+        self.num_workers = num_processors if num_processors \
+            else psutil.cpu_count(logical=False)
+        self.all_workers = defaultdict(None)
+        self.active_workers = []
+        self.active_worker_ids = []
+
+    def start_worker(self):
+        """Initialize a new ray worker."""
+        env_pkl = pickle.dumps(self.env)
+        agent_pkl = pickle.dumps(self.algo.policy)
+        env_pkl_id, agent_pkl_id = ray.put(env_pkl), ray.put(agent_pkl)
+        for worker_id in range(self.num_workers):
+            self.all_workers[worker_id] = (self.SamplerWorker.remote(
+                worker_id, env_pkl_id, agent_pkl_id, self.max_path_length,
+                self.should_render))
+        self.idle_worker_ids = list(range(self.num_workers))
+
+    def obtain_samples(self, itr, num_samples):
+        """Sample the policy for new trajectories.
+
+        Args:
+            - itr(int): iteration number
+            - num_samples(int):number of steps the the sampler should collect
+        """
+        pbar = ProgBarCounter(num_samples)
+        completed_samples = 0
+        traj = []
+        updating_workers = []
+        self.idle_worker_ids = list(range(self.num_workers))
+
+        curr_policy_params = self.algo.policy.get_param_values()
+        params_id = ray.put(curr_policy_params)
+        while self.idle_worker_ids:
+            worker_id = self.idle_worker_ids.pop()
+            worker = self.all_workers[worker_id]
+            updating_workers.append(worker.set_agent.remote(params_id))
+
+        while completed_samples < num_samples:
+            updated, updating_workers = ray.wait(
+                updating_workers, num_returns=1, timeout=0.1)
+            upd = [ray.get(up) for up in updated]
+            self.idle_worker_ids.extend(upd)
+            while self.idle_worker_ids:
+                idle_worker_id = self.idle_worker_ids.pop()
+                self.active_worker_ids.append(idle_worker_id)
+                worker = self.all_workers[idle_worker_id]
+                self.active_workers.append(worker.rollout.remote())
+
+            ready, not_ready = ray.wait(
+                self.active_workers, num_returns=1, timeout=0.001)
+            self.active_workers = not_ready
+            for result in ready:
+                trajectory, num_returned_samples = self._process_trajectory(
+                    result)
+                completed_samples += num_returned_samples
+                pbar.inc(num_returned_samples)
+
+                traj.append(trajectory)
+        pbar.stop()
+        return traj
+
+    def shutdown_worker(self):
+        """Shuts down the worker."""
+        ray.shutdown()
+
+    def _process_trajectory(self, result):
+        trajectory = ray.get(result)
+        ready_worker_id = trajectory[0]
+        self.active_worker_ids.remove(ready_worker_id)
+        self.idle_worker_ids.append(ready_worker_id)
+        trajectory = dict(
+            observations=self.algo.env_spec.observation_space.flatten_n(
+                trajectory[1]),
+            actions=self.algo.env_spec.action_space.flatten_n(trajectory[2]),
+            rewards=tensor_utils.stack_tensor_list(trajectory[3]),
+            agent_infos=trajectory[4],
+            env_infos=trajectory[5])
+        num_returned_samples = len(trajectory['observations'])
+        return trajectory, num_returned_samples
+
+
+class SamplerWorker:
+    """Constructs a single sampler worker.
+
+    The worker can have its parameters updated, and sampler its policy for
+    trajectories or rollouts.
+
+    Args:
+        - worker_id(int): the id of the sampler_worker
+        - env: gym or akro env object
+        - max_path_length(int): max trajectory length
+        - should_render(bool): if true, renders trajectories after
+            sampling them
+
+    """
+
+    def __init__(self,
+                 worker_id,
+                 env,
+                 agent,
+                 max_path_length,
+                 should_render=False):
+        self.worker_id = worker_id
+        self.env = pickle.loads(env)
+        self.agent = pickle.loads(agent)
+        self.max_path_length = max_path_length
+        self.should_render = should_render
+        self.agent_updates = 0
+
+    def set_agent(self, flattened_params):
+        """Set the agent params.
+
+        Args:
+            - flattened_params(): model parameters in numpy format
+        """
+        self.agent.set_param_values(flattened_params)
+        self.agent_updates += 1
+        return self.worker_id
+
+    def rollout(self):
+        """Sample a single rollout from the agent/policy.
+
+        The following value for the following keys will be a 2D array,
+        with the first dimension corresponding to the time dimension.
+
+        - observations
+        - actions
+        - rewards
+        - next_observations
+        - terminals
+        The next two elements will be lists of dictionaries, with
+        the index into the list being the index into the time
+        - agent_infos
+        - env_infos
+        """
+        observations = []
+        actions = []
+        rewards = []
+        agent_infos = defaultdict(list)
+        env_infos = defaultdict(list)
+        o = self.env.reset()
+        self.agent.reset()
+        next_o = None
+        path_length = 0
+        while path_length < self.max_path_length:
+            a, agent_info = self.agent.get_action(o)
+            next_o, r, d, env_info = self.env.step(a)
+            observations.append(o)
+            rewards.append(r)
+            actions.append(a)
+            for k, v in agent_info.items():
+                agent_infos[k].append(v)
+            for k, v in env_info.items():
+                env_infos[k].append(v)
+            path_length += 1
+            if d:
+                break
+            o = next_o
+        for k, v in agent_infos.items():
+            agent_infos[k] = np.asarray(v)
+        for k, v in env_infos.items():
+            env_infos[k] = np.asarray(v)
+        return self.worker_id,\
+            np.array(observations),\
+            np.array(actions),\
+            np.array(rewards),\
+            dict(agent_infos),\
+            dict(env_infos)

--- a/src/garage/tf/samplers/__init__.py
+++ b/src/garage/tf/samplers/__init__.py
@@ -3,7 +3,10 @@ from garage.tf.samplers.off_policy_vectorized_sampler import (
     OffPolicyVectorizedSampler)
 from garage.tf.samplers.on_policy_vectorized_sampler import (
     OnPolicyVectorizedSampler)
+from garage.tf.samplers.ray_batched_sampler import (RaySamplerTF,
+                                                    SamplerWorkerTF)
 
 __all__ = [
-    'BatchSampler', 'OffPolicyVectorizedSampler', 'OnPolicyVectorizedSampler'
+    'BatchSampler', 'OffPolicyVectorizedSampler', 'OnPolicyVectorizedSampler',
+    'RaySamplerTF', 'SamplerWorkerTF'
 ]

--- a/src/garage/tf/samplers/ray_batched_sampler.py
+++ b/src/garage/tf/samplers/ray_batched_sampler.py
@@ -3,6 +3,7 @@
 Currently the same as garage.samplers.RaySampler but includes
 support for Tensorflow sessions
 """
+import ray
 import tensorflow as tf
 
 from garage.sampler import RaySampler, SamplerWorker
@@ -31,6 +32,14 @@ class RaySamplerTF(RaySampler):
             num_processors=None,
             sampler_worker_cls=SamplerWorkerTF)
 
+    def shutdown(self):
+        """Shuts down the worker."""
+        temp = []
+        for worker in self._all_workers.values():
+            temp.append(worker.shutdown.remote())
+        ray.get(temp)
+        ray.shutdown()
+
 
 class SamplerWorkerTF(SamplerWorker):
     """Sampler Worker for tensorflow on policy algorithms.
@@ -48,7 +57,8 @@ class SamplerWorkerTF(SamplerWorker):
                  seed,
                  max_path_length,
                  should_render=False):
-        self.sess = tf.InteractiveSession()
+        self.sess = tf.Session()
+        self.sess.__enter__()
         super().__init__(
             worker_id,
             env,
@@ -56,3 +66,7 @@ class SamplerWorkerTF(SamplerWorker):
             seed,
             max_path_length,
             should_render=should_render)
+
+    def shutdown(self):
+        """Perform shutdown processes for TF."""
+        self.sess.__exit__(None, None, None)

--- a/src/garage/tf/samplers/ray_batched_sampler.py
+++ b/src/garage/tf/samplers/ray_batched_sampler.py
@@ -1,0 +1,46 @@
+"""Ray Sampler, for tensorflow algorithms.
+
+Currently the same as garage.samplers.RaySampler but includes
+support for Tensorflow sessions
+"""
+import tensorflow as tf
+
+from garage.sampler import RaySampler, SamplerWorker
+
+
+class RaySamplerTF(RaySampler):
+    """Ray Sampler, for tensorflow algorithms.
+
+    Currently the same as garage.samplers.RaySampler
+
+    Args:
+        - Same as garage.samplers.RaySampler
+    """
+
+    def __init__(self, algo, env, should_render=False, num_processors=None):
+        super().__init__(
+            algo,
+            env,
+            should_render=False,
+            num_processors=None,
+            sampler_worker_cls=SamplerWorkerTF)
+
+
+class SamplerWorkerTF(SamplerWorker):
+    """Sampler Worker for tensorflow on policy algorithms.
+
+    - Same as garage.samplers.SamplerWorker, except it
+    initializes a tensorflow session, because each worker
+    is in a separate process.
+
+    """
+
+    def __init__(self,
+                 worker_id,
+                 env,
+                 agent,
+                 max_path_length,
+                 should_render=False):
+        self.sess = tf.InteractiveSession()
+        super().__init__(
+            worker_id, env, agent, max_path_length, should_render=False)

--- a/src/garage/tf/samplers/ray_batched_sampler.py
+++ b/src/garage/tf/samplers/ray_batched_sampler.py
@@ -17,10 +17,16 @@ class RaySamplerTF(RaySampler):
         - Same as garage.samplers.RaySampler
     """
 
-    def __init__(self, algo, env, should_render=False, num_processors=None):
+    def __init__(self,
+                 algo,
+                 env,
+                 seed,
+                 should_render=False,
+                 num_processors=None):
         super().__init__(
             algo,
             env,
+            seed,
             should_render=False,
             num_processors=None,
             sampler_worker_cls=SamplerWorkerTF)
@@ -39,8 +45,14 @@ class SamplerWorkerTF(SamplerWorker):
                  worker_id,
                  env,
                  agent,
+                 seed,
                  max_path_length,
                  should_render=False):
         self.sess = tf.InteractiveSession()
         super().__init__(
-            worker_id, env, agent, max_path_length, should_render=False)
+            worker_id,
+            env,
+            agent,
+            seed,
+            max_path_length,
+            should_render=should_render)

--- a/tests/fixtures/policies/__init__.py
+++ b/tests/fixtures/policies/__init__.py
@@ -1,8 +1,6 @@
 from tests.fixtures.policies.dummy_policy import DummyPolicy
 from tests.fixtures.policies.dummy_recurrent_policy import (
     DummyRecurrentPolicy)
+from tests.fixtures.policies.ray_sampler_utils import MockAlgo, ScriptedPolicy
 
-__all__ = [
-    "DummyPolicy",
-    "DummyRecurrentPolicy",
-]
+__all__ = ['DummyPolicy', 'DummyRecurrentPolicy', 'MockAlgo', 'ScriptedPolicy']

--- a/tests/fixtures/policies/ray_sampler_utils.py
+++ b/tests/fixtures/policies/ray_sampler_utils.py
@@ -1,0 +1,49 @@
+class MockAlgo():
+    def __init__(self, env_spec, policy, max_path_length=16):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.max_path_length = max_path_length
+
+
+class ScriptedPolicy():
+    """
+    A mock policy for 4x4 gridworldenv
+
+    '4x4': [
+        'SFFF',
+        'FHFH',
+        'FFFH',
+        'HFFG'
+    ]
+
+    0: left
+    1: down
+    2: right
+    3: up
+    -1: no move
+
+    'S' : starting point
+    'F' or '.': free space
+    'W' or 'x': wall
+    'H' or 'o': hole (terminates episode)
+    'G' : goal
+    [2,2,1,0,3,1,1,1,2,2,1,1,1,2,2,1]
+    """
+
+    def __init__(self):
+        self.scriptedActions = [2, 2, 1, 0, 3, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1]
+
+    def set_param_values(self, params):
+        return params
+
+    def get_param_values(self):
+        return 'ScriptedPolicy'
+
+    def reset(self, dones=None):
+        pass
+
+    def get_action(self, obs):
+        return self.scriptedActions[obs], {}
+
+    def get_actions(self, obses):
+        return [self.scriptedActions[obs] for obs in obses], {}

--- a/tests/garage/sampler/test_ray_sampler.py
+++ b/tests/garage/sampler/test_ray_sampler.py
@@ -1,53 +1,52 @@
-import gym
-import numpy as np
-import ray
+# import gym
+# import numpy as np
+# import ray
 
-from garage.sampler import RaySampler, SamplerWorker
-from garage.tf.envs import TfEnv
-from garage.tf.samplers.on_policy_vectorized_sampler \
-    import OnPolicyVectorizedSampler
-from tests.fixtures.policies.ray_sampler_utils import MockAlgo, ScriptedPolicy
+# from garage.sampler import RaySampler, SamplerWorker
+# from garage.tf.envs import TfEnv
+# from garage.tf.samplers.on_policy_vectorized_sampler \
+#     import OnPolicyVectorizedSampler
+# from tests.fixtures.policies.ray_sampler_utils import MockAlgo, \
+#                                               ScriptedPolicy
 
+# class TestSampler():
+#     @staticmethod
+#     def test_ray_batch_sampler():
+#         ray.init(
+#             ignore_reinit_error=True,
+#             object_store_memory=10000000,
+#             redis_max_memory=10000000)
+#         gym.envs.register(
+#             id='GridWorldEnv-v0',
+#             entry_point='garage.envs:GridWorldEnv',
+#             max_episode_steps=16,
+#             kwargs={'desc': '4x4'},
+#         )
 
-class TestSampler():
-    @staticmethod
-    def test_ray_batch_sampler():
-        ray.init(
-            ignore_reinit_error=True,
-            object_store_memory=10000000,
-            redis_max_memory=10000000)
-        gym.envs.register(
-            id='GridWorldEnv-v0',
-            entry_point='garage.envs:GridWorldEnv',
-            max_episode_steps=16,
-            kwargs={'desc': '4x4'},
-        )
+#         env = TfEnv(gym.make('GridWorldEnv-v0'))
 
-        env = TfEnv(gym.make('GridWorldEnv-v0'))
+#         policy = ScriptedPolicy()
 
-        policy = ScriptedPolicy()
+#         algo = MockAlgo(env.spec, policy)
+#         sampler1 = RaySampler(
+#             algo,
+#             env,
+#             seed=100,
+#             num_processors=1,
+#             sampler_worker_cls=SamplerWorker)
+#         sampler1.start_worker()
 
-        algo = MockAlgo(env.spec, policy)
-        sampler1 = RaySampler(
-            algo,
-            env,
-            seed=100,
-            num_processors=1,
-            sampler_worker_cls=SamplerWorker)
-        sampler1.start_worker()
+#         sampler2 = OnPolicyVectorizedSampler(algo, env)
+#         sampler2.start_worker()
 
-        sampler2 = OnPolicyVectorizedSampler(algo, env)
-        sampler2.start_worker()
+#         trajs1 = sampler1.obtain_samples(0, 16)[0]
+#         trajs2 = sampler2.obtain_samples(0, 1)[0]
 
-        trajs1 = sampler1.obtain_samples(0, 16)[0]
-        trajs2 = sampler2.obtain_samples(0, 1)[0]
+#         assert (trajs1['observations'].shape == np.array(
+#             trajs2['observations']).shape == (6, 16))
+#         traj2_action_shape = np.array(trajs2['actions']).shape
+#         assert (trajs1['actions'].shape == traj2_action_shape == (6, 4))
+#         assert (sum(trajs1['rewards']) == sum(trajs2['rewards']) == 1)
 
-        assert (trajs1['observations'].shape == np.array(
-            trajs2['observations']).shape == (6, 16))
-        traj2_action_shape = np.array(trajs2['actions']).shape
-        assert (trajs1['actions'].shape == traj2_action_shape == (6, 4))
-        assert (sum(trajs1['rewards']) == sum(trajs2['rewards']) == 1)
-
-
-if __name__ == '__main__':
-    TestSampler.test_ray_batch_sampler()
+# if __name__ == '__main__':
+#     TestSampler.test_ray_batch_sampler()

--- a/tests/garage/sampler/test_ray_sampler.py
+++ b/tests/garage/sampler/test_ray_sampler.py
@@ -1,0 +1,46 @@
+import gym
+import numpy as np
+import ray
+
+from garage.sampler import RaySampler, SamplerWorker
+from garage.tf.envs import TfEnv
+from garage.tf.samplers.on_policy_vectorized_sampler \
+    import OnPolicyVectorizedSampler
+from tests.fixtures.policies.ray_sampler_utils import MockAlgo, ScriptedPolicy
+
+
+class TestSampler():
+    @staticmethod
+    def test_ray_batch_sampler():
+        ray.init(local_mode=True, ignore_reinit_error=True)
+        gym.envs.register(
+            id='GridWorldEnv-v0',
+            entry_point='garage.envs:GridWorldEnv',
+            max_episode_steps=16,
+            kwargs={'desc': '4x4'},
+        )
+
+        env = TfEnv(gym.make('GridWorldEnv-v0'))
+
+        policy = ScriptedPolicy()
+
+        algo = MockAlgo(env.spec, policy)
+        sampler1 = RaySampler(
+            algo, env, num_processors=1, sampler_worker_cls=SamplerWorker)
+        sampler1.start_worker()
+
+        sampler2 = OnPolicyVectorizedSampler(algo, env)
+        sampler2.start_worker()
+
+        trajs1 = sampler1.obtain_samples(0, 16)[0]
+        trajs2 = sampler2.obtain_samples(0, 1)[0]
+
+        assert (trajs1['observations'].shape == np.array(
+            trajs2['observations']).shape == (6, 16))
+        traj2_action_shape = np.array(trajs2['actions']).shape
+        assert (trajs1['actions'].shape == traj2_action_shape == (6, 4))
+        assert (sum(trajs1['rewards']) == sum(trajs2['rewards']) == 1)
+
+
+if __name__ == '__main__':
+    TestSampler.test_ray_batch_sampler()

--- a/tests/garage/sampler/test_ray_sampler.py
+++ b/tests/garage/sampler/test_ray_sampler.py
@@ -29,7 +29,11 @@ class TestSampler():
 
         algo = MockAlgo(env.spec, policy)
         sampler1 = RaySampler(
-            algo, env, num_processors=1, sampler_worker_cls=SamplerWorker)
+            algo,
+            env,
+            seed=100,
+            num_processors=1,
+            sampler_worker_cls=SamplerWorker)
         sampler1.start_worker()
 
         sampler2 = OnPolicyVectorizedSampler(algo, env)

--- a/tests/garage/sampler/test_ray_sampler.py
+++ b/tests/garage/sampler/test_ray_sampler.py
@@ -12,7 +12,10 @@ from tests.fixtures.policies.ray_sampler_utils import MockAlgo, ScriptedPolicy
 class TestSampler():
     @staticmethod
     def test_ray_batch_sampler():
-        ray.init(local_mode=True, ignore_reinit_error=True)
+        ray.init(
+            ignore_reinit_error=True,
+            object_store_memory=10000000,
+            redis_max_memory=10000000)
         gym.envs.register(
             id='GridWorldEnv-v0',
             entry_point='garage.envs:GridWorldEnv',

--- a/tests/garage/sampler/test_ray_sampler.py
+++ b/tests/garage/sampler/test_ray_sampler.py
@@ -1,52 +1,46 @@
-# import gym
-# import numpy as np
-# import ray
+import numpy as np
+import ray
 
-# from garage.sampler import RaySampler, SamplerWorker
-# from garage.tf.envs import TfEnv
-# from garage.tf.samplers.on_policy_vectorized_sampler \
-#     import OnPolicyVectorizedSampler
-# from tests.fixtures.policies.ray_sampler_utils import MockAlgo, \
-#                                               ScriptedPolicy
+from garage.envs.grid_world_env import GridWorldEnv
+from garage.sampler import RaySampler, SamplerWorker
+from garage.tf.envs import TfEnv
+from garage.tf.samplers.on_policy_vectorized_sampler \
+    import OnPolicyVectorizedSampler
+from tests.fixtures.policies.ray_sampler_utils import MockAlgo, ScriptedPolicy
 
-# class TestSampler():
-#     @staticmethod
-#     def test_ray_batch_sampler():
-#         ray.init(
-#             ignore_reinit_error=True,
-#             object_store_memory=10000000,
-#             redis_max_memory=10000000)
-#         gym.envs.register(
-#             id='GridWorldEnv-v0',
-#             entry_point='garage.envs:GridWorldEnv',
-#             max_episode_steps=16,
-#             kwargs={'desc': '4x4'},
-#         )
 
-#         env = TfEnv(gym.make('GridWorldEnv-v0'))
+class TestSampler():
+    def setup_method(self):
+        ray.init(
+            ignore_reinit_error=True,
+            object_store_memory=10000000,
+            redis_max_memory=10000000)
 
-#         policy = ScriptedPolicy()
+        self.env = TfEnv(GridWorldEnv(desc='4x4'))
 
-#         algo = MockAlgo(env.spec, policy)
-#         sampler1 = RaySampler(
-#             algo,
-#             env,
-#             seed=100,
-#             num_processors=1,
-#             sampler_worker_cls=SamplerWorker)
-#         sampler1.start_worker()
+    def teardown_method(self):
+        self.env.close()
+        ray.shutdown()
 
-#         sampler2 = OnPolicyVectorizedSampler(algo, env)
-#         sampler2.start_worker()
+    def test_ray_batch_sampler(self):
+        policy = ScriptedPolicy()
+        algo = MockAlgo(self.env.spec, policy)
+        sampler1 = RaySampler(
+            algo,
+            self.env,
+            seed=100,
+            num_processors=1,
+            sampler_worker_cls=SamplerWorker)
+        sampler1.start_worker()
 
-#         trajs1 = sampler1.obtain_samples(0, 16)[0]
-#         trajs2 = sampler2.obtain_samples(0, 1)[0]
+        sampler2 = OnPolicyVectorizedSampler(algo, self.env)
+        sampler2.start_worker()
 
-#         assert (trajs1['observations'].shape == np.array(
-#             trajs2['observations']).shape == (6, 16))
-#         traj2_action_shape = np.array(trajs2['actions']).shape
-#         assert (trajs1['actions'].shape == traj2_action_shape == (6, 4))
-#         assert (sum(trajs1['rewards']) == sum(trajs2['rewards']) == 1)
+        trajs1 = sampler1.obtain_samples(0, 16)[0]
+        trajs2 = sampler2.obtain_samples(0, 1)[0]
 
-# if __name__ == '__main__':
-#     TestSampler.test_ray_batch_sampler()
+        assert (trajs1['observations'].shape == np.array(
+            trajs2['observations']).shape == (6, 16))
+        traj2_action_shape = np.array(trajs2['actions']).shape
+        assert (trajs1['actions'].shape == traj2_action_shape == (6, 4))
+        assert (sum(trajs1['rewards']) == sum(trajs2['rewards']) == 1)


### PR DESCRIPTION
- Built for parallel or distributed on policy batch sampling.
- Useful for if we want to run experiments with distributed sampling.
- Operates in a data parallel model (each processing element does the
  same operation, but with different inputs).
- Also works for local experiments well, but there is an overhead that
  presents itself when using tensorflow nn policies when sampling, as
  described in the next point.
- The first iteration of sampling is slightly slower than the on_policy_vectorized
  sampler on some examples (trpo_swimmer) because of a startup overhead that
  occurs because the first time we run new tf graphs for collecting
  samples. After the first iteration of the sampler, the
  sampler collects trajectories at the same speed as the on_policy_vectorized sampler.
  In the case of the trpo_swimmer example, there is an extra 10 second
  overhead due to the construction of new tensorflow graphs for
  sampling.

Reference to #31 