### PR TITLE
Fix recurrent policy bug

### DIFF
--- a/src/garage/tf/policies/gaussian_gru_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_gru_policy_with_model.py
@@ -175,6 +175,10 @@ class GaussianGRUPolicyWithModel(StochasticPolicy2):
         """
         Reset the policy.
 
+        If dones is None, it will be by default np.array([True]) which implies
+        the policy will not be "vectorized", i.e. number of parallel
+        environments for training data sampling = 1.
+
         Args:
             dones (numpy.ndarray): Bool that indicates terminal state(s).
 

--- a/src/garage/tf/policies/gaussian_gru_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_gru_policy_with_model.py
@@ -179,7 +179,7 @@ class GaussianGRUPolicyWithModel(StochasticPolicy2):
             dones (numpy.ndarray): Bool that indicates terminal state(s).
 
         """
-        if not dones:
+        if dones is None:
             dones = np.array([True])
         if self.prev_actions is None or len(dones) != len(self.prev_actions):
             self.prev_actions = np.zeros((len(dones),

--- a/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
@@ -196,6 +196,10 @@ class GaussianLSTMPolicyWithModel(StochasticPolicy2):
         """
         Reset the policy.
 
+        If dones is None, it will be by default np.array([True]) which implies
+        the policy will not be "vectorized", i.e. number of parallel
+        environments for training data sampling = 1.
+
         Args:
             dones (numpy.ndarray): Bool that indicates terminal state(s).
 

--- a/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
@@ -200,7 +200,7 @@ class GaussianLSTMPolicyWithModel(StochasticPolicy2):
             dones (numpy.ndarray): Bool that indicates terminal state(s).
 
         """
-        if not dones:
+        if dones is None:
             dones = np.array([True])
         if self.prev_actions is None or len(dones) != len(self.prev_actions):
             self.prev_actions = np.zeros((len(dones),

--- a/tests/garage/tf/algos/test_ppo_with_model.py
+++ b/tests/garage/tf/algos/test_ppo_with_model.py
@@ -39,12 +39,20 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 30
+            assert last_avg_ret > 60
 
             env.close()
 
@@ -64,12 +72,20 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 40
+            assert last_avg_ret > 80
 
             env.close()
 
@@ -89,11 +105,19 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 40
+            assert last_avg_ret > 80
 
             env.close()

--- a/tests/garage/tf/algos/test_ppo_with_model_baseline.py
+++ b/tests/garage/tf/algos/test_ppo_with_model_baseline.py
@@ -37,11 +37,20 @@ class TestPPO(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10))
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
+            )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 30
+            assert last_avg_ret > 100
 
             env.close()
 
@@ -61,10 +70,19 @@ class TestPPO(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10))
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
+            )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 30
+            assert last_avg_ret > 100
 
             env.close()

--- a/tests/garage/tf/algos/test_ppo_with_models.py
+++ b/tests/garage/tf/algos/test_ppo_with_models.py
@@ -39,12 +39,20 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 30
+            assert last_avg_ret > 60
 
             env.close()
 
@@ -64,17 +72,24 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 40
+            assert last_avg_ret > 80
 
             env.close()
 
-    test_ppo_pendulum_lstm_with_model.large = True
-
+    @pytest.mark.large
     def test_ppo_pendulum_gru_with_model(self):
         """Test PPO with model, with Pendulum environment."""
         with LocalRunner(sess=self.sess) as runner:
@@ -90,11 +105,19 @@ class TestPPOWithModel(TfGraphTestCase):
                 baseline=baseline,
                 max_path_length=100,
                 discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
+                gae_lambda=0.95,
+                lr_clip_range=0.2,
+                optimizer_args=dict(
+                    batch_size=32,
+                    max_epochs=10,
+                ),
+                stop_entropy_gradient=True,
+                entropy_method='max',
+                policy_ent_coeff=0.02,
+                center_adv=False,
             )
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
-            assert last_avg_ret > 40
+            assert last_avg_ret > 80
 
             env.close()


### PR DESCRIPTION
Checking whether dones is None by `if not dones` is error-prone, which makes
GaussianLSTMPolicyWithModel and GaussianGRUPolicyWithModel not working.

Also some tests should have higher thresholds in order to make sure the policies
are working properly.