### PR TITLE
Fix gaussian recurrent policies implementation

### DIFF
--- a/src/garage/tf/core/parameter.py
+++ b/src/garage/tf/core/parameter.py
@@ -3,13 +3,7 @@
 import tensorflow as tf
 
 
-def parameter(input_var,
-              length,
-              batch_dim=None,
-              initializer=tf.zeros_initializer(),
-              dtype=tf.float32,
-              trainable=True,
-              name='parameter'):
+class Parameter:
     """
     Parameter layer.
 
@@ -21,6 +15,8 @@ def parameter(input_var,
     Args:
         input_var (tf.Tensor): Input tf.Tensor.
         length (int): Integer dimension of the variables.
+        param (tf.Tensor): tf.Tensor to be reused. If None, a new tf.Tensor
+            will be created.
         initializer (callable): Initializer of the variables. The function
             should return a tf.Tensor.
         dtype: Data type of the variables (default is tf.float32).
@@ -30,16 +26,36 @@ def parameter(input_var,
     Return:
         A tensor of the broadcasted variables.
     """
-    with tf.variable_scope(name):
-        p = tf.get_variable(
-            'parameter',
-            shape=(length, ),
-            dtype=dtype,
-            initializer=initializer,
-            trainable=trainable)
 
-        if batch_dim is None:
-            batch_dim = tf.shape(input_var)[:-1]
-        broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
-        p_broadcast = tf.broadcast_to(p, shape=broadcast_shape)
-        return p_broadcast
+    def __init__(self,
+                 input_var,
+                 length,
+                 param=None,
+                 batch_dim=None,
+                 initializer=tf.zeros_initializer(),
+                 dtype=tf.float32,
+                 trainable=True,
+                 name='parameter'):
+        with tf.variable_scope(name):
+            if param is None:
+                self._param = tf.get_variable(
+                    'parameter',
+                    shape=(length, ),
+                    dtype=dtype,
+                    initializer=initializer,
+                    trainable=trainable)
+            else:
+                self._param = param
+            if batch_dim is None:
+                batch_dim = tf.shape(input_var)[:-1]
+            broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
+            self._reshaped_param = tf.broadcast_to(
+                self._param, shape=broadcast_shape)
+
+    @property
+    def reshaped_param(self):
+        return self._reshaped_param
+
+    @property
+    def param(self):
+        return self._param

--- a/src/garage/tf/core/parameter.py
+++ b/src/garage/tf/core/parameter.py
@@ -3,10 +3,7 @@
 import tensorflow as tf
 
 
-def parameter(input_var,
-              length,
-              param=None,
-              batch_dim=None,
+def parameter(length,
               initializer=tf.zeros_initializer(),
               dtype=tf.float32,
               trainable=True,
@@ -14,34 +11,23 @@ def parameter(input_var,
     """
     Parameter layer.
 
-    Used as layer that could be broadcast to a certain shape to
-    match with input variable during training.
-    Example: A trainable parameter variable with shape (2,), it needs to be
-    broadcasted to (32, 2) when applied to a batch with size 32.
+    Helper function to create a tf.Variable under the scope name
 
     Args:
-        input_var (tf.Tensor): Input tf.Tensor.
-        length (int): Integer dimension of the variables.
-        param (tf.Tensor): tf.Tensor to be reused. If None, a new tf.Tensor
-            will be created.
-        initializer (callable): Initializer of the variables. The function
+        length (int): Integer dimension of the variable.
+        initializer (callable): Initializer of the variable. The function
             should return a tf.Tensor.
-        dtype: Data type of the variables (default is tf.float32).
-        trainable (bool): Whether these variables are trainable.
-        name (str): Variable scope of the variables.
+        dtype: Data type of the variable (default is tf.float32).
+        trainable (bool): Whether the variable is trainable.
+        name (str): Variable scope of the variable.
 
     Return:
-        A tensor of the broadcasted variables.
+        The tf.Tensor variable.
     """
     with tf.variable_scope(name):
-        if param is None:
-            param = tf.get_variable(
-                'parameter',
-                shape=(length, ),
-                dtype=dtype,
-                initializer=initializer,
-                trainable=trainable)
-        if batch_dim is None:
-            batch_dim = tf.shape(input_var)[:-1]
-        broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
-        return tf.broadcast_to(param, shape=broadcast_shape), param
+        return tf.get_variable(
+            'parameter',
+            shape=(length, ),
+            dtype=dtype,
+            initializer=initializer,
+            trainable=trainable)

--- a/src/garage/tf/core/parameter.py
+++ b/src/garage/tf/core/parameter.py
@@ -3,7 +3,14 @@
 import tensorflow as tf
 
 
-class Parameter:
+def parameter(input_var,
+              length,
+              param=None,
+              batch_dim=None,
+              initializer=tf.zeros_initializer(),
+              dtype=tf.float32,
+              trainable=True,
+              name='parameter'):
     """
     Parameter layer.
 
@@ -26,36 +33,15 @@ class Parameter:
     Return:
         A tensor of the broadcasted variables.
     """
-
-    def __init__(self,
-                 input_var,
-                 length,
-                 param=None,
-                 batch_dim=None,
-                 initializer=tf.zeros_initializer(),
-                 dtype=tf.float32,
-                 trainable=True,
-                 name='parameter'):
-        with tf.variable_scope(name):
-            if param is None:
-                self._param = tf.get_variable(
-                    'parameter',
-                    shape=(length, ),
-                    dtype=dtype,
-                    initializer=initializer,
-                    trainable=trainable)
-            else:
-                self._param = param
-            if batch_dim is None:
-                batch_dim = tf.shape(input_var)[:-1]
-            broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
-            self._reshaped_param = tf.broadcast_to(
-                self._param, shape=broadcast_shape)
-
-    @property
-    def reshaped_param(self):
-        return self._reshaped_param
-
-    @property
-    def param(self):
-        return self._param
+    with tf.variable_scope(name):
+        if param is None:
+            param = tf.get_variable(
+                'parameter',
+                shape=(length, ),
+                dtype=dtype,
+                initializer=initializer,
+                trainable=trainable)
+        if batch_dim is None:
+            batch_dim = tf.shape(input_var)[:-1]
+        broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
+        return tf.broadcast_to(param, shape=broadcast_shape), param

--- a/src/garage/tf/core/parameter.py
+++ b/src/garage/tf/core/parameter.py
@@ -3,7 +3,8 @@
 import tensorflow as tf
 
 
-def parameter(length,
+def parameter(input_var,
+              length,
               initializer=tf.zeros_initializer(),
               dtype=tf.float32,
               trainable=True,
@@ -11,9 +12,16 @@ def parameter(length,
     """
     Parameter layer.
 
-    Helper function to create a tf.Variable under the scope name
+    Used as layer that could be broadcast to a certain shape to
+    match with input variable during training.
+
+    For recurrent usage, use garage.tf.core.recurrent_parameter().
+
+    Example: A trainable parameter variable with shape (2,), it needs to be
+    broadcasted to (32, 2) when applied to a batch with size 32.
 
     Args:
+        input_var (tf.Tensor): Input tf.Tensor.
         length (int): Integer dimension of the variable.
         initializer (callable): Initializer of the variable. The function
             should return a tf.Tensor.
@@ -22,12 +30,64 @@ def parameter(length,
         name (str): Variable scope of the variable.
 
     Return:
-        The tf.Tensor variable.
+        A tensor of the broadcasted variables.
     """
     with tf.variable_scope(name):
-        return tf.get_variable(
+        p = tf.get_variable(
             'parameter',
             shape=(length, ),
             dtype=dtype,
             initializer=initializer,
             trainable=trainable)
+        batch_dim = tf.shape(input_var)[0]
+        broadcast_shape = tf.concat(axis=0, values=[[batch_dim], [length]])
+        p_broadcast = tf.broadcast_to(p, shape=broadcast_shape)
+        return p_broadcast
+
+
+def recurrent_parameter(input_var,
+                        step_input_var,
+                        length,
+                        initializer=tf.zeros_initializer(),
+                        dtype=tf.float32,
+                        trainable=True,
+                        name='recurrent_parameter'):
+    """
+    Parameter layer for recurrent networks.
+
+    Used as layer that could be broadcast to a certain shape to
+    match with input variable during training.
+
+    Example: A trainable parameter variable with shape (2,), it needs to be
+    broadcasted to (32, 4, 2) when applied to a batch with size 32 and
+    time-length 4.
+
+    Args:
+        input_var (tf.Tensor): Input tf.Tensor for full time-series inputs.
+        step_input_var (tf.Tensor): Input tf.Tensor for step inputs.
+        length (int): Integer dimension of the variable.
+        initializer (callable): Initializer of the variable. The function
+            should return a tf.Tensor.
+        dtype: Data type of the variable (default is tf.float32).
+        trainable (bool): Whether the variable is trainable.
+        name (str): Variable scope of the variable.
+
+    Return:
+        A tensor of the two broadcasted variables: one for full time-series
+            inputs, one for step inputs.
+    """
+    with tf.variable_scope(name):
+        p = tf.get_variable(
+            'parameter',
+            shape=(length, ),
+            dtype=dtype,
+            initializer=initializer,
+            trainable=trainable)
+        batch_dim = tf.shape(input_var)[:2]
+        step_batch_dim = tf.shape(step_input_var)[:1]
+        broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])
+        step_broadcast_shape = tf.concat(
+            axis=0, values=[step_batch_dim, [length]])
+        p_broadcast = tf.broadcast_to(p, shape=broadcast_shape)
+        step_p_broadcast = tf.broadcast_to(p, shape=step_broadcast_shape)
+        return p_broadcast, step_p_broadcast

--- a/src/garage/tf/misc/tensor_utils.py
+++ b/src/garage/tf/misc/tensor_utils.py
@@ -13,6 +13,22 @@ def compile_function(inputs, outputs, log_name=None):
     return run
 
 
+def broadcast(param, input_var, batch_dim=None):
+    """
+    Broadcast an existing variable to match input dimension.
+
+    Args:
+        param (tf.Tensor): Variable to broadcast.
+        input_var (tf.Tensor): Input variable to match dimension.
+        batch_dim (tf.Tensor): Batch dimension. If None, default to
+            be tf.shape(input_var)[:-1].
+    """
+    if batch_dim is None:
+        batch_dim = tf.shape(input_var)[:-1]
+    broadcast_shape = tf.concat(axis=0, values=[batch_dim, tf.shape(param)])
+    return tf.broadcast_to(param, shape=broadcast_shape)
+
+
 def get_target_ops(variables, target_variables, tau=None):
     """
     Get target variables update operations.

--- a/src/garage/tf/misc/tensor_utils.py
+++ b/src/garage/tf/misc/tensor_utils.py
@@ -13,22 +13,6 @@ def compile_function(inputs, outputs, log_name=None):
     return run
 
 
-def broadcast_with_batch(param, input_var, batch_dim=1):
-    """
-    Broadcast an existing variable to match input batch dimension.
-
-    Args:
-        param (tf.Tensor): Variable to broadcast.
-        input_var (tf.Tensor): Input batch variable.
-        batch_dim (int): Define the first `batch_dim` dimension as
-            Batch dimension. If None, default to be 1.
-    """
-    assert batch_dim > 0
-    batch_shape = tf.shape(input_var)[:batch_dim]
-    broadcast_shape = tf.concat(axis=0, values=[batch_shape, tf.shape(param)])
-    return tf.broadcast_to(param, shape=broadcast_shape)
-
-
 def get_target_ops(variables, target_variables, tau=None):
     """
     Get target variables update operations.

--- a/src/garage/tf/misc/tensor_utils.py
+++ b/src/garage/tf/misc/tensor_utils.py
@@ -13,19 +13,19 @@ def compile_function(inputs, outputs, log_name=None):
     return run
 
 
-def broadcast(param, input_var, batch_dim=None):
+def broadcast_with_batch(param, input_var, batch_dim=1):
     """
-    Broadcast an existing variable to match input dimension.
+    Broadcast an existing variable to match input batch dimension.
 
     Args:
         param (tf.Tensor): Variable to broadcast.
-        input_var (tf.Tensor): Input variable to match dimension.
-        batch_dim (tf.Tensor): Batch dimension. If None, default to
-            be tf.shape(input_var)[:-1].
+        input_var (tf.Tensor): Input batch variable.
+        batch_dim (int): Define the first `batch_dim` dimension as
+            Batch dimension. If None, default to be 1.
     """
-    if batch_dim is None:
-        batch_dim = tf.shape(input_var)[:-1]
-    broadcast_shape = tf.concat(axis=0, values=[batch_dim, tf.shape(param)])
+    assert batch_dim > 0
+    batch_shape = tf.shape(input_var)[:batch_dim]
+    broadcast_shape = tf.concat(axis=0, values=[batch_shape, tf.shape(param)])
     return tf.broadcast_to(param, shape=broadcast_shape)
 
 

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -6,7 +6,7 @@ from garage.tf.core.cnn import cnn
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast
+from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models.base import Model
 
 
@@ -270,15 +270,14 @@ class GaussianCNNModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    batch_dim = tf.shape(state_input)[0]
                     log_std_param = parameter(
                         length=action_dim,
                         initializer=tf.constant_initializer(
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
-                    log_std_network = broadcast(
-                        log_std_param, state_input, batch_dim=[batch_dim])
+                    log_std_network = broadcast_with_batch(
+                        log_std_param, state_input)
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -6,6 +6,7 @@ from garage.tf.core.cnn import cnn
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
+from garage.tf.misc.tensor_utils import broadcast
 from garage.tf.models.base import Model
 
 
@@ -270,14 +271,14 @@ class GaussianCNNModel(Model):
                         layer_normalization=self._layer_normalization)
                 else:
                     batch_dim = tf.shape(state_input)[0]
-                    log_std_network, _ = parameter(
-                        state_input,
+                    log_std_param = parameter(
                         length=action_dim,
-                        batch_dim=[batch_dim],
                         initializer=tf.constant_initializer(
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
+                    log_std_network = broadcast(
+                        log_std_param, state_input, batch_dim=[batch_dim])
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from garage.tf.core.cnn import cnn
 from garage.tf.core.mlp import mlp
-from garage.tf.core.parameter import Parameter
+from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models.base import Model
 
@@ -270,7 +270,7 @@ class GaussianCNNModel(Model):
                         layer_normalization=self._layer_normalization)
                 else:
                     batch_dim = tf.shape(state_input)[0]
-                    log_std_network = Parameter(
+                    log_std_network, _ = parameter(
                         state_input,
                         length=action_dim,
                         batch_dim=[batch_dim],
@@ -280,7 +280,7 @@ class GaussianCNNModel(Model):
                         name='log_std_network')
 
         mean_var = mean_network
-        std_param = log_std_network.reshaped_param
+        std_param = log_std_network
 
         with tf.variable_scope('std_limits'):
             if self._min_std_param is not None:

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from garage.tf.core.cnn import cnn
 from garage.tf.core.mlp import mlp
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import Parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models.base import Model
 
@@ -270,7 +270,7 @@ class GaussianCNNModel(Model):
                         layer_normalization=self._layer_normalization)
                 else:
                     batch_dim = tf.shape(state_input)[0]
-                    log_std_network = parameter(
+                    log_std_network = Parameter(
                         state_input,
                         length=action_dim,
                         batch_dim=[batch_dim],
@@ -280,7 +280,7 @@ class GaussianCNNModel(Model):
                         name='log_std_network')
 
         mean_var = mean_network
-        std_param = log_std_network
+        std_param = log_std_network.reshaped_param
 
         with tf.variable_scope('std_limits'):
             if self._min_std_param is not None:

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -6,7 +6,6 @@ from garage.tf.core.cnn import cnn
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models.base import Model
 
 
@@ -270,14 +269,13 @@ class GaussianCNNModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    log_std_param = parameter(
+                    log_std_network = parameter(
+                        input_var=state_input,
                         length=action_dim,
                         initializer=tf.constant_initializer(
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
-                    log_std_network = broadcast_with_batch(
-                        log_std_param, state_input)
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -3,9 +3,8 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.gru import gru
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import recurrent_parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models import Model
 
 
@@ -169,15 +168,13 @@ class GaussianGRUModel(Model):
                     _hidden_state_init_trainable,
                     output_nonlinearity_layer=self.
                     _mean_output_nonlinearity_layer)
-                log_std_param = parameter(
+                log_std_var, step_log_std_var = recurrent_parameter(
+                    input_var=state_input,
+                    step_input_var=step_input,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                log_std_var = broadcast_with_batch(
-                    log_std_param, state_input, batch_dim=2)
-                step_log_std_var = broadcast_with_batch(
-                    log_std_param, step_input, batch_dim=1)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from garage.tf.core.gru import gru
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
+from garage.tf.misc.tensor_utils import broadcast
 from garage.tf.models import Model
 
 
@@ -168,19 +169,13 @@ class GaussianGRUModel(Model):
                     _hidden_state_init_trainable,
                     output_nonlinearity_layer=self.
                     _mean_output_nonlinearity_layer)
-                log_std_var, log_std_var_param = parameter(
-                    state_input,
+                log_std_param = parameter(
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                step_log_std_var, _ = parameter(
-                    step_input,
-                    param=log_std_var_param,
-                    length=action_dim,
-                    initializer=tf.constant_initializer(self._init_std_param),
-                    trainable=self._learn_std,
-                    name='step_log_std_param')
+                log_std_var = broadcast(log_std_param, state_input)
+                step_log_std_var = broadcast(log_std_param, step_input)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.gru import gru
-from garage.tf.core.parameter import Parameter
+from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models import Model
 
@@ -168,15 +168,15 @@ class GaussianGRUModel(Model):
                     _hidden_state_init_trainable,
                     output_nonlinearity_layer=self.
                     _mean_output_nonlinearity_layer)
-                log_std_var = Parameter(
+                log_std_var, log_std_var_param = parameter(
                     state_input,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                step_log_std_var = Parameter(
+                step_log_std_var, _ = parameter(
                     step_input,
-                    param=log_std_var.param,
+                    param=log_std_var_param,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
@@ -184,12 +184,10 @@ class GaussianGRUModel(Model):
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])
-        action_var = rnd * tf.exp(
-            step_log_std_var.reshaped_param) + step_mean_var
+        action_var = rnd * tf.exp(step_log_std_var) + step_mean_var
 
-        return (action_var, mean_var, step_mean_var,
-                log_std_var.reshaped_param, step_log_std_var.reshaped_param,
-                step_hidden, hidden_init_var, dist)
+        return (action_var, mean_var, step_mean_var, log_std_var,
+                step_log_std_var, step_hidden, hidden_init_var, dist)
 
     def __getstate__(self):
         """Object.__getstate__."""

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from garage.tf.core.gru import gru
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast
+from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models import Model
 
 
@@ -174,8 +174,10 @@ class GaussianGRUModel(Model):
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                log_std_var = broadcast(log_std_param, state_input)
-                step_log_std_var = broadcast(log_std_param, step_input)
+                log_std_var = broadcast_with_batch(
+                    log_std_param, state_input, batch_dim=2)
+                step_log_std_var = broadcast_with_batch(
+                    log_std_param, step_input, batch_dim=1)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.lstm import lstm
-from garage.tf.core.parameter import Parameter
+from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models import Model
 
@@ -198,28 +198,27 @@ class GaussianLSTMModel(Model):
                      cell_state_init_trainable=self._cell_state_init_trainable,
                      output_nonlinearity_layer=self.
                      _mean_output_nonlinearity_layer)
-                log_std_var = Parameter(
+                log_std_var, log_std_var_param = parameter(
                     state_input,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                step_log_std_var = Parameter(
+                step_log_std_var, _ = parameter(
                     step_input,
                     length=action_dim,
-                    param=log_std_var.param,
+                    param=log_std_var_param,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='step_log_std_param')
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])
-        action_var = rnd * tf.exp(
-            step_log_std_var.reshaped_param) + step_mean_var
+        action_var = rnd * tf.exp(step_log_std_var) + step_mean_var
 
-        return (action_var, mean_var, step_mean_var,
-                log_std_var.reshaped_param, step_log_std_var.reshaped_param,
-                step_hidden, step_cell, hidden_init_var, cell_init_var, dist)
+        return (action_var, mean_var, step_mean_var, log_std_var,
+                step_log_std_var, step_hidden, step_cell, hidden_init_var,
+                cell_init_var, dist)
 
     def __getstate__(self):
         """Object.__getstate__."""

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from garage.tf.core.lstm import lstm
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
+from garage.tf.misc.tensor_utils import broadcast
 from garage.tf.models import Model
 
 
@@ -198,19 +199,13 @@ class GaussianLSTMModel(Model):
                      cell_state_init_trainable=self._cell_state_init_trainable,
                      output_nonlinearity_layer=self.
                      _mean_output_nonlinearity_layer)
-                log_std_var, log_std_var_param = parameter(
-                    state_input,
+                log_std_var_param = parameter(
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                step_log_std_var, _ = parameter(
-                    step_input,
-                    length=action_dim,
-                    param=log_std_var_param,
-                    initializer=tf.constant_initializer(self._init_std_param),
-                    trainable=self._learn_std,
-                    name='step_log_std_param')
+                log_std_var = broadcast(log_std_var_param, state_input)
+                step_log_std_var = broadcast(log_std_var_param, step_input)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from garage.tf.core.lstm import lstm
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast
+from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models import Model
 
 
@@ -204,8 +204,10 @@ class GaussianLSTMModel(Model):
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                log_std_var = broadcast(log_std_var_param, state_input)
-                step_log_std_var = broadcast(log_std_var_param, step_input)
+                log_std_var = broadcast_with_batch(
+                    log_std_var_param, state_input, batch_dim=2)
+                step_log_std_var = broadcast_with_batch(
+                    log_std_var_param, step_input, batch_dim=1)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -3,9 +3,8 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.lstm import lstm
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import recurrent_parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models import Model
 
 
@@ -199,15 +198,13 @@ class GaussianLSTMModel(Model):
                      cell_state_init_trainable=self._cell_state_init_trainable,
                      output_nonlinearity_layer=self.
                      _mean_output_nonlinearity_layer)
-                log_std_var_param = parameter(
+                log_std_var, step_log_std_var = recurrent_parameter(
+                    input_var=state_input,
+                    step_input_var=step_input,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                log_std_var = broadcast_with_batch(
-                    log_std_var_param, state_input, batch_dim=2)
-                step_log_std_var = broadcast_with_batch(
-                    log_std_var_param, step_input, batch_dim=1)
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.lstm import lstm
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import Parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models import Model
 
@@ -198,26 +198,28 @@ class GaussianLSTMModel(Model):
                      cell_state_init_trainable=self._cell_state_init_trainable,
                      output_nonlinearity_layer=self.
                      _mean_output_nonlinearity_layer)
-                log_std_var = parameter(
+                log_std_var = Parameter(
                     state_input,
                     length=action_dim,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='log_std_param')
-                step_log_std_var = parameter(
+                step_log_std_var = Parameter(
                     step_input,
                     length=action_dim,
+                    param=log_std_var.param,
                     initializer=tf.constant_initializer(self._init_std_param),
                     trainable=self._learn_std,
                     name='step_log_std_param')
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=step_mean_var.get_shape().as_list()[1:])
-        action_var = rnd * tf.exp(step_log_std_var) + step_mean_var
+        action_var = rnd * tf.exp(
+            step_log_std_var.reshaped_param) + step_mean_var
 
-        return (action_var, mean_var, step_mean_var, log_std_var,
-                step_log_std_var, step_hidden, step_cell, hidden_init_var,
-                cell_init_var, dist)
+        return (action_var, mean_var, step_mean_var,
+                log_std_var.reshaped_param, step_log_std_var.reshaped_param,
+                step_hidden, step_cell, hidden_init_var, cell_init_var, dist)
 
     def __getstate__(self):
         """Object.__getstate__."""

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast
+from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models.base import Model
 
 
@@ -202,7 +202,8 @@ class GaussianMLPModel(Model):
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
-                    log_std_network = broadcast(log_std_param, state_input)
+                    log_std_network = broadcast_with_batch(
+                        log_std_param, state_input)
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
-from garage.tf.misc.tensor_utils import broadcast_with_batch
 from garage.tf.models.base import Model
 
 
@@ -196,14 +195,13 @@ class GaussianMLPModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    log_std_param = parameter(
+                    log_std_network = parameter(
+                        input_var=state_input,
                         length=action_dim,
                         initializer=tf.constant_initializer(
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
-                    log_std_network = broadcast_with_batch(
-                        log_std_param, state_input)
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from garage.tf.core.mlp import mlp
 from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
+from garage.tf.misc.tensor_utils import broadcast
 from garage.tf.models.base import Model
 
 
@@ -195,13 +196,13 @@ class GaussianMLPModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    log_std_network, _ = parameter(
-                        state_input,
+                    log_std_param = parameter(
                         length=action_dim,
                         initializer=tf.constant_initializer(
                             self._init_std_param),
                         trainable=self._learn_std,
                         name='log_std_network')
+                    log_std_network = broadcast(log_std_param, state_input)
 
         mean_var = mean_network
         std_param = log_std_network

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.mlp import mlp
-from garage.tf.core.parameter import Parameter
+from garage.tf.core.parameter import parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models.base import Model
 
@@ -195,7 +195,7 @@ class GaussianMLPModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    log_std_network = Parameter(
+                    log_std_network, _ = parameter(
                         state_input,
                         length=action_dim,
                         initializer=tf.constant_initializer(
@@ -204,7 +204,7 @@ class GaussianMLPModel(Model):
                         name='log_std_network')
 
         mean_var = mean_network
-        std_param = log_std_network.reshaped_param
+        std_param = log_std_network
 
         with tf.variable_scope('std_limits'):
             if self._min_std_param is not None:

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.mlp import mlp
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import Parameter
 from garage.tf.distributions import DiagonalGaussian
 from garage.tf.models.base import Model
 
@@ -195,7 +195,7 @@ class GaussianMLPModel(Model):
                         name='log_std_network',
                         layer_normalization=self._layer_normalization)
                 else:
-                    log_std_network = parameter(
+                    log_std_network = Parameter(
                         state_input,
                         length=action_dim,
                         initializer=tf.constant_initializer(
@@ -204,7 +204,7 @@ class GaussianMLPModel(Model):
                         name='log_std_network')
 
         mean_var = mean_network
-        std_param = log_std_network
+        std_param = log_std_network.reshaped_param
 
         with tf.variable_scope('std_limits'):
             if self._min_std_param is not None:

--- a/tests/garage/tf/core/test_parameter.py
+++ b/tests/garage/tf/core/test_parameter.py
@@ -1,7 +1,7 @@
 import numpy as np
 import tensorflow as tf
 
-from garage.tf.core.parameter import Parameter
+from garage.tf.core.parameter import parameter
 from tests.fixtures import TfGraphTestCase
 
 
@@ -10,7 +10,7 @@ class TestParameter(TfGraphTestCase):
         input_vars = tf.placeholder(shape=[None, 2, 3, 4], dtype=tf.float32)
         initial_params = np.array([48, 21, 33])
 
-        params = Parameter(
+        reshaped_param, param = parameter(
             input_var=input_vars,
             length=3,
             initializer=tf.constant_initializer(initial_params))
@@ -21,12 +21,12 @@ class TestParameter(TfGraphTestCase):
         }
 
         self.sess.run(tf.global_variables_initializer())
-        p = self.sess.run(params.reshaped_param, feed_dict=feed_dict)
+        p = self.sess.run(reshaped_param, feed_dict=feed_dict)
 
         assert p.shape[:-1] == data.shape[:-1]
         assert np.all(p[0, 0, 0, :] == initial_params)
 
-        p = self.sess.run(params.param, feed_dict=feed_dict)
+        p = self.sess.run(param, feed_dict=feed_dict)
 
         assert p.shape == (3, )
         assert np.all(p == initial_params)

--- a/tests/garage/tf/core/test_parameter.py
+++ b/tests/garage/tf/core/test_parameter.py
@@ -29,7 +29,8 @@ class TestParameter(TfGraphTestCase):
         assert np.all(p == self.initial_params)
 
     def test_broadcast_with_batch(self):
-        broadcast_param = broadcast_with_batch(self.param, self.input_vars)
+        broadcast_param = broadcast_with_batch(
+            self.param, self.input_vars, batch_dim=3)
         p = self.sess.run(broadcast_param, feed_dict=self.feed_dict)
 
         assert p.shape[:-1] == self.data.shape[:-1]

--- a/tests/garage/tf/core/test_parameter.py
+++ b/tests/garage/tf/core/test_parameter.py
@@ -2,36 +2,44 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.parameter import parameter
-from garage.tf.misc.tensor_utils import broadcast_with_batch
+from garage.tf.core.parameter import recurrent_parameter
 from tests.fixtures import TfGraphTestCase
 
 
 class TestParameter(TfGraphTestCase):
     def setup_method(self):
         super().setup_method()
-        self.input_vars = tf.placeholder(
-            shape=[None, 2, 3, 4], dtype=tf.float32)
+        self.input_vars = tf.placeholder(shape=[None, 2, 5], dtype=tf.float32)
+        self.step_input_vars = tf.placeholder(
+            shape=[None, 5], dtype=tf.float32)
         self.initial_params = np.array([48, 21, 33])
 
-        self.param = parameter(
-            length=3, initializer=tf.constant_initializer(self.initial_params))
-
-        self.data = np.zeros(shape=[5, 2, 3, 4])
+        self.data = np.zeros(shape=[5, 2, 5])
+        self.step_data = np.zeros(shape=[5, 5])
         self.feed_dict = {
             self.input_vars: self.data,
+            self.step_input_vars: self.step_data
         }
-        self.sess.run(tf.global_variables_initializer())
 
     def test_param(self):
-        p = self.sess.run(self.param, feed_dict=self.feed_dict)
+        param = parameter(
+            input_var=self.input_vars,
+            length=3,
+            initializer=tf.constant_initializer(self.initial_params))
+        self.sess.run(tf.global_variables_initializer())
+        p = self.sess.run(param, feed_dict=self.feed_dict)
 
-        assert p.shape == (3, )
+        assert p.shape == (5, 3)
         assert np.all(p == self.initial_params)
 
-    def test_broadcast_with_batch(self):
-        broadcast_param = broadcast_with_batch(
-            self.param, self.input_vars, batch_dim=3)
-        p = self.sess.run(broadcast_param, feed_dict=self.feed_dict)
+    def test_recurrent_param(self):
+        param, step_param = recurrent_parameter(
+            input_var=self.input_vars,
+            step_input_var=self.step_input_vars,
+            length=3,
+            initializer=tf.constant_initializer(self.initial_params))
+        self.sess.run(tf.global_variables_initializer())
+        p = self.sess.run(param, feed_dict=self.feed_dict)
 
-        assert p.shape[:-1] == self.data.shape[:-1]
-        assert np.all(p[0, 0, 0, :] == self.initial_params)
+        assert p.shape == (5, 2, 3)
+        assert np.array_equal(p, np.full([5, 2, 3], self.initial_params))

--- a/tests/garage/tf/core/test_parameter.py
+++ b/tests/garage/tf/core/test_parameter.py
@@ -1,7 +1,7 @@
 import numpy as np
 import tensorflow as tf
 
-from garage.tf.core.parameter import parameter
+from garage.tf.core.parameter import Parameter
 from tests.fixtures import TfGraphTestCase
 
 
@@ -10,7 +10,7 @@ class TestParameter(TfGraphTestCase):
         input_vars = tf.placeholder(shape=[None, 2, 3, 4], dtype=tf.float32)
         initial_params = np.array([48, 21, 33])
 
-        params = parameter(
+        params = Parameter(
             input_var=input_vars,
             length=3,
             initializer=tf.constant_initializer(initial_params))
@@ -21,7 +21,12 @@ class TestParameter(TfGraphTestCase):
         }
 
         self.sess.run(tf.global_variables_initializer())
-        p = self.sess.run(params, feed_dict=feed_dict)
+        p = self.sess.run(params.reshaped_param, feed_dict=feed_dict)
 
         assert p.shape[:-1] == data.shape[:-1]
         assert np.all(p[0, 0, 0, :] == initial_params)
+
+        p = self.sess.run(params.param, feed_dict=feed_dict)
+
+        assert p.shape == (3, )
+        assert np.all(p == initial_params)

--- a/tests/garage/tf/core/test_parameter.py
+++ b/tests/garage/tf/core/test_parameter.py
@@ -2,7 +2,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.core.parameter import parameter
-from garage.tf.misc.tensor_utils import broadcast
+from garage.tf.misc.tensor_utils import broadcast_with_batch
 from tests.fixtures import TfGraphTestCase
 
 
@@ -28,8 +28,8 @@ class TestParameter(TfGraphTestCase):
         assert p.shape == (3, )
         assert np.all(p == self.initial_params)
 
-    def test_broadcast(self):
-        broadcast_param = broadcast(self.param, self.input_vars)
+    def test_broadcast_with_batch(self):
+        broadcast_param = broadcast_with_batch(self.param, self.input_vars)
         p = self.sess.run(broadcast_param, feed_dict=self.feed_dict)
 
         assert p.shape[:-1] == self.data.shape[:-1]

--- a/tests/garage/tf/models/test_gaussian_cnn_model.py
+++ b/tests/garage/tf/models/test_gaussian_cnn_model.py
@@ -564,7 +564,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             hidden_nonlinearity=None,
             std_parameterization='softplus',
             min_std=10,
-            hidden_w_init=tf.constant_initializer(0.01),
+            hidden_w_init=tf.constant_initializer(0.1),
             output_w_init=tf.constant_initializer(1))
         outputs = model.build(self._input_ph)
         action, mean, log_std, std_param = self.sess.run(
@@ -597,7 +597,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             hidden_nonlinearity=None,
             std_parameterization='softplus',
             max_std=1.0,
-            hidden_w_init=tf.constant_initializer(0.01),
+            hidden_w_init=tf.constant_initializer(0.1),
             output_w_init=tf.constant_initializer(1))
         outputs = model.build(self._input_ph)
         action, mean, log_std, std_param = self.sess.run(
@@ -606,8 +606,8 @@ class TestGaussianCNNModel(TfGraphTestCase):
         expected_log_std = np.full([1, output_dim], np.log(1))
         expected_std_param = np.full([1, output_dim], np.log(np.exp(1) - 1))
 
-        assert np.allclose(log_std, expected_log_std)
-        assert np.allclose(std_param, expected_std_param)
+        assert np.allclose(log_std, expected_log_std, rtol=0, atol=0.0001)
+        assert np.allclose(std_param, expected_std_param, rtol=0, atol=0.0001)
 
     def test_unknown_std_parameterization(self):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
When modeling `log_std` as a parameter, instead of creating two separate parameters for
`log_std` and `step_log_std`, they should share the same tf.Variable.

This PR fixed the bug and refactored parameter class to serve the purpose.



Attached the result of running `PPO` with `GaussianLSTMPolicy` (blue) and
`GaussianLSTMPolicyWithModel` (orange) on `InvertedDoublePendulum`.

<img width="360" alt="Screen Shot 2019-07-11 at 11 22 21 AM" src="https://user-images.githubusercontent.com/10270515/61075762-90898480-a3cf-11e9-9ed7-ab70cefddd46.png">
