### PR TITLE
Update TensorFlow to 1.14.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: pylint
         name: pylint
         entry: pylint
-        args: ['-j 0', '--rcfile=setup.cfg']
+        args: ['-j 2', '--rcfile=setup.cfg']
         stages: [commit, push]
         language: system
         files: \.py$

--- a/docs/user/implement_algo_advanced.rst
+++ b/docs/user/implement_algo_advanced.rst
@@ -92,7 +92,7 @@ extra diagnostic information as well as supporting recurrent policies):
             'action',
             batch_dims=1,
         )
-        advantage_var = tf.placeholder('advantage')
+        advantage_var = tf.compat.v1.placeholder('advantage')
         dist = self.policy.distribution
         old_dist_info_vars = {
             k: TT.matrix('old_%s' % k)

--- a/docs/user/implement_algo_basic.rst
+++ b/docs/user/implement_algo_basic.rst
@@ -207,7 +207,7 @@ First, we construct symbolic variables for the input data:
         name='actions',
         batch_dims=1
     )
-    returns_var = tf.placeholder(name='returns')
+    returns_var = tf.compat.v1.placeholder(name='returns')
 
 Note that we can transform the policy gradient formula as
 

--- a/examples/jupyter/custom_env.ipynb
+++ b/examples/jupyter/custom_env.ipynb
@@ -452,7 +452,7 @@
         "sess = tf.InteractiveSession()\n",
         "\n",
         "# no need to initialize\n",
-        "sess.run(tf.global_variables_initializer())\n"
+        "sess.run(tf.compat.v1.global_variables_initializer())\n"
       ],
       "execution_count": 0,
       "outputs": []

--- a/examples/jupyter/trpo_gym_tf_cartpole.ipynb
+++ b/examples/jupyter/trpo_gym_tf_cartpole.ipynb
@@ -350,7 +350,7 @@
       "cell_type": "code",
       "source": [
         "# initialize\n",
-        "sess.run(tf.global_variables_initializer())"
+        "sess.run(tf.compat.v1.global_variables_initializer())"
       ],
       "execution_count": 0,
       "outputs": []

--- a/examples/sim_policy.py
+++ b/examples/sim_policy.py
@@ -22,9 +22,9 @@ if __name__ == '__main__':
 
     # If the snapshot file use tensorflow, do:
     # import tensorflow as tf
-    # with tf.Session():
+    # with tf.compat.v1.Session():
     #     [rest of the code]
-    with tf.Session() as sess:
+    with tf.compat.v1.Session() as sess:
         data = joblib.load(args.file)
         policy = data['algo'].policy
         env = data['env']

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ required = [
     'torch==1.1.0',
     'scikit-image',
     'scipy',
-    'tensorflow<1.13,>=1.12.0',
-    'tensorflow-probability<0.6.0,>=0.5.0',  # for tensorflow 1.12
+    'tensorflow<1.15,>=1.14.0',
+    'tensorflow-probability<0.8.0,>=0.7.0',  # for tensorflow 1.12
     'torchvision==0.3.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ except ImportError:
         'Please install numpy==1.14.5 and try again. See '
         'https://github.com/rlworkgroup/garage/issues/800 for more info.')
 
+TF_VERSION = '<1.15,>=1.14.0'
+
 # Required dependencies
 required = [
     # Please keep alphabetized
@@ -38,7 +40,7 @@ required = [
     'torch==1.1.0',
     'scikit-image',
     'scipy',
-    'tensorflow<1.15,>=1.14.0',
+    'tensorflow' + TF_VERSION,
     'tensorflow-probability<0.8.0,>=0.7.0',  # for tensorflow 1.12
     'torchvision==0.3.0'
 ]
@@ -48,7 +50,7 @@ extras = {}
 extras['all'] = list(set(sum(extras.values(), [])))
 
 # Intel dependencies not included in all
-extras['intel'] = ['intel-tensorflow<1.13,>=1.12.0']
+extras['intel'] = ['intel-tensorflow' + TF_VERSION]
 
 # Development dependencies (*not* included in "all")
 extras['dev'] = [

--- a/src/garage/experiment/deterministic.py
+++ b/src/garage/experiment/deterministic.py
@@ -21,7 +21,7 @@ def set_seed(seed):
     np.random.seed(seed)
     if 'tensorflow' in sys.modules:
         import tensorflow as tf
-        tf.set_random_seed(seed)
+        tf.compat.v1.set_random_seed(seed)
 
 
 def get_seed():

--- a/src/garage/experiment/local_tf_runner.py
+++ b/src/garage/experiment/local_tf_runner.py
@@ -74,7 +74,7 @@ class LocalRunner:
         if max_cpus > 1:
             from garage.sampler import singleton_pool
             singleton_pool.initialize(max_cpus)
-        self.sess = sess or tf.Session()
+        self.sess = sess or tf.compat.v1.Session()
         self.sess_entered = False
         self.has_setup = False
         self.plot = False
@@ -89,14 +89,15 @@ class LocalRunner:
             This local runner.
 
         """
-        if tf.get_default_session() is not self.sess:
+        if tf.compat.v1.get_default_session() is not self.sess:
             self.sess.__enter__()
             self.sess_entered = True
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Leave session."""
-        if tf.get_default_session() is self.sess and self.sess_entered:
+        if tf.compat.v1.get_default_session(
+        ) is self.sess and self.sess_entered:
             self.sess.__exit__(exc_type, exc_val, exc_tb)
             self.sess_entered = False
 
@@ -150,12 +151,12 @@ class LocalRunner:
         """Initialize all uninitialized variables in session."""
         with tf.name_scope('initialize_tf_vars'):
             uninited_set = [
-                e.decode()
-                for e in self.sess.run(tf.report_uninitialized_variables())
+                e.decode() for e in self.sess.run(
+                    tf.compat.v1.report_uninitialized_variables())
             ]
             self.sess.run(
-                tf.variables_initializer([
-                    v for v in tf.global_variables()
+                tf.compat.v1.variables_initializer([
+                    v for v in tf.compat.v1.global_variables()
                     if v.name.split(':')[0] in uninited_set
                 ]))
 

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -75,8 +75,8 @@ class DDPG(OffPolicyRLAlgorithm):
                  discount=0.99,
                  policy_weight_decay=0,
                  qf_weight_decay=0,
-                 policy_optimizer=tf.train.AdamOptimizer,
-                 qf_optimizer=tf.train.AdamOptimizer,
+                 policy_optimizer=tf.compat.v1.train.AdamOptimizer,
+                 qf_optimizer=tf.compat.v1.train.AdamOptimizer,
                  clip_pos_returns=False,
                  clip_return=np.inf,
                  max_action=None,
@@ -157,12 +157,13 @@ class DDPG(OffPolicyRLAlgorithm):
                         flat_dim_with_keys(['observation', 'desired_goal'])
                 else:
                     obs_dim = self.env_spec.observation_space.flat_dim
-                y = tf.placeholder(tf.float32, shape=(None, 1), name='input_y')
-                obs = tf.placeholder(
+                y = tf.compat.v1.placeholder(
+                    tf.float32, shape=(None, 1), name='input_y')
+                obs = tf.compat.v1.placeholder(
                     tf.float32,
                     shape=(None, obs_dim),
                     name='input_observation')
-                actions = tf.placeholder(
+                actions = tf.compat.v1.placeholder(
                     tf.float32,
                     shape=(None, self.env_spec.action_space.flat_dim),
                     name='input_action')
@@ -189,7 +190,8 @@ class DDPG(OffPolicyRLAlgorithm):
             # Set up qf training function
             qval = self.qf.get_qval_sym(obs, actions, name='q_value')
             with tf.name_scope('qval_loss'):
-                qval_loss = tf.reduce_mean(tf.squared_difference(y, qval))
+                qval_loss = tf.reduce_mean(
+                    tf.compat.v1.squared_difference(y, qval))
                 if self.qf_weight_decay > 0.:
                     qf_reg = tc.layers.apply_regularization(
                         tc.layers.l2_regularizer(self.qf_weight_decay),

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -61,7 +61,7 @@ class DQN(OffPolicyRLAlgorithm):
                  n_train_steps=50,
                  max_path_length=None,
                  qf_lr=0.001,
-                 qf_optimizer=tf.train.AdamOptimizer,
+                 qf_optimizer=tf.compat.v1.train.AdamOptimizer,
                  discount=1.0,
                  target_network_update_freq=5,
                  grad_norm_clipping=None,
@@ -112,9 +112,11 @@ class DQN(OffPolicyRLAlgorithm):
 
         # build q networks
         with tf.name_scope(self.name, 'DQN'):
-            action_t_ph = tf.placeholder(tf.int32, None, name='action')
-            reward_t_ph = tf.placeholder(tf.float32, None, name='reward')
-            done_t_ph = tf.placeholder(tf.float32, None, name='done')
+            action_t_ph = tf.compat.v1.placeholder(
+                tf.int32, None, name='action')
+            reward_t_ph = tf.compat.v1.placeholder(
+                tf.float32, None, name='reward')
+            done_t_ph = tf.compat.v1.placeholder(tf.float32, None, name='done')
 
             with tf.name_scope('update_ops'):
                 target_update_op = tensor_utils.get_target_ops(
@@ -152,8 +154,8 @@ class DQN(OffPolicyRLAlgorithm):
                 target_q_values = (reward_t_ph + self.discount * q_best_masked)
 
                 # td_error = q_selected - tf.stop_gradient(target_q_values)
-                loss = tf.losses.huber_loss(q_selected,
-                                            tf.stop_gradient(target_q_values))
+                loss = tf.compat.v1.losses.huber_loss(
+                    q_selected, tf.stop_gradient(target_q_values))
                 loss = tf.reduce_mean(loss)
 
             with tf.name_scope('optimize_ops'):

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -198,13 +198,13 @@ class NPO(BatchPolopt):
                 name='action', batch_dims=2)
             reward_var = tensor_utils.new_tensor(
                 name='reward', ndim=2, dtype=tf.float32)
-            valid_var = tf.placeholder(
+            valid_var = tf.compat.v1.placeholder(
                 tf.float32, shape=[None, None], name='valid')
             baseline_var = tensor_utils.new_tensor(
                 name='baseline', ndim=2, dtype=tf.float32)
 
             policy_state_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32, shape=[None] * 2 + list(shape), name=k)
                 for k, shape in self.policy.state_info_specs
             }
@@ -214,7 +214,7 @@ class NPO(BatchPolopt):
 
             # old policy distribution
             policy_old_dist_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32,
                     shape=[None] * 2 + list(shape),
                     name='policy_old_%s' % k)

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -233,7 +233,7 @@ class REPS(BatchPolopt):
                 ndim=0,
                 dtype=tf.float32)   # yapf: disable
             policy_state_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32,
                     shape=[None] * 2 + list(shape),
                     name=k)
@@ -245,7 +245,7 @@ class REPS(BatchPolopt):
             ]   # yapf: disable
 
             policy_old_dist_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32,
                     shape=[None] * 2 + list(shape),
                     name='policy_old_%s' % k)
@@ -391,7 +391,7 @@ class REPS(BatchPolopt):
             pol_mean_kl = tf.reduce_mean(kl)
 
         with tf.name_scope('dual'):
-            dual_loss = i.param_eta * self.epsilon + i.param_eta * tf.log(
+            dual_loss = i.param_eta * self.epsilon + i.param_eta * tf.math.log(
                 tf.reduce_mean(
                     tf.exp(delta_v / i.param_eta -
                            tf.reduce_max(delta_v / i.param_eta)))

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -167,8 +167,7 @@ class REPS(BatchPolopt):
             x0=x0,
             fprime=eval_dual_grad,
             bounds=bounds,
-            **self.dual_optimizer_args,
-        )
+            **self.dual_optimizer_args)
 
         logger.log('Computing dual after')
         self.param_eta, self.param_v = params_ast[0], params_ast[1:]

--- a/src/garage/tf/core/cnn.py
+++ b/src/garage/tf/core/cnn.py
@@ -43,7 +43,7 @@ def cnn(input_var,
     Return:
         The output tf.Tensor of the CNN.
     """
-    with tf.variable_scope(name):
+    with tf.compat.v1.variable_scope(name):
         h = input_var
         for index, (filter_dim, num_filter, stride) in enumerate(
                 zip(filter_dims, num_filters, strides)):
@@ -110,7 +110,7 @@ def cnn_with_max_pooling(input_var,
     pool_strides = [1, pool_strides[0], pool_strides[1], 1]
     pool_shapes = [1, pool_shapes[0], pool_shapes[1], 1]
 
-    with tf.variable_scope(name):
+    with tf.compat.v1.variable_scope(name):
         h = input_var
         for index, (filter_dim, num_filter, stride) in enumerate(
                 zip(filter_dims, num_filters, strides)):
@@ -119,7 +119,7 @@ def cnn_with_max_pooling(input_var,
                       hidden_w_init, hidden_b_init, padding)
             if hidden_nonlinearity is not None:
                 h = hidden_nonlinearity(h)
-            h = tf.nn.max_pool(
+            h = tf.nn.max_pool2d(
                 h, ksize=pool_shapes, strides=pool_strides, padding=padding)
 
         # flatten
@@ -135,9 +135,11 @@ def _conv(input_var, name, filter_size, num_filter, strides, hidden_w_init,
     w_shape = [filter_size, filter_size, input_shape, num_filter]
     b_shape = [1, 1, 1, num_filter]
 
-    with tf.variable_scope(name):
-        weight = tf.get_variable('weight', w_shape, initializer=hidden_w_init)
-        bias = tf.get_variable('bias', b_shape, initializer=hidden_b_init)
+    with tf.compat.v1.variable_scope(name):
+        weight = tf.compat.v1.get_variable(
+            'weight', w_shape, initializer=hidden_w_init)
+        bias = tf.compat.v1.get_variable(
+            'bias', b_shape, initializer=hidden_b_init)
 
         return tf.nn.conv2d(
             input_var, weight, strides=strides, padding=padding) + bias

--- a/src/garage/tf/core/gru.py
+++ b/src/garage/tf/core/gru.py
@@ -34,12 +34,12 @@ def gru(name,
         hidden (tf.Tensor): Step hidden state.
         hidden_init_var (tf.Tensor): Initial hidden state.
     """
-    with tf.variable_scope(name):
+    with tf.compat.v1.variable_scope(name):
         hidden_dim = gru_cell.units
         output, [hidden] = gru_cell(step_input_var, states=[step_hidden_var])
         output = output_nonlinearity_layer(output)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(hidden_dim, ),
             initializer=hidden_state_init,

--- a/src/garage/tf/core/lstm.py
+++ b/src/garage/tf/core/lstm.py
@@ -44,19 +44,19 @@ def lstm(name,
         hidden_init_var (tf.Tensor): Initial hidden state.
         cell_init_var (tf.Tensor): Initial cell state.
     """
-    with tf.variable_scope(name):
+    with tf.compat.v1.variable_scope(name):
         hidden_dim = lstm_cell.units
         output, [hidden, cell] = lstm_cell(
             step_input_var, states=(step_hidden_var, step_cell_var))
         output = output_nonlinearity_layer(output)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(hidden_dim, ),
             initializer=hidden_state_init,
             trainable=hidden_state_init_trainable,
             dtype=tf.float32)
-        cell_init_var = tf.get_variable(
+        cell_init_var = tf.compat.v1.get_variable(
             name='initial_cell',
             shape=(hidden_dim, ),
             initializer=cell_state_init,

--- a/src/garage/tf/core/mlp.py
+++ b/src/garage/tf/core/mlp.py
@@ -70,7 +70,7 @@ def mlp(input_var,
         else:
             _concat_layer = 0
 
-    with tf.variable_scope(name):
+    with tf.compat.v1.variable_scope(name):
         l_hid = input_var
         for idx, hidden_size in enumerate(hidden_sizes):
             if _merge_inputs and idx == _concat_layer:

--- a/src/garage/tf/core/network.py
+++ b/src/garage/tf/core/network.py
@@ -27,7 +27,7 @@ class MLP(LayersPowered, Serializable):
 
         Serializable.quick_init(self, locals())
 
-        with tf.variable_scope(name, 'MLP'):
+        with tf.compat.v1.variable_scope(name, 'MLP'):
             if input_layer is None:
                 l_in = ly.InputLayer(
                     shape=(None, ) + input_shape,
@@ -120,7 +120,7 @@ class ConvNetwork(LayersPowered, Serializable):
          fc layers
         hidden_sizes: a list of numbers of hidden units for all fc layers
         """
-        with tf.variable_scope(name, 'ConvNetwork'):
+        with tf.compat.v1.variable_scope(name, 'ConvNetwork'):
             if input_layer is not None:
                 l_in = input_layer
                 l_hid = l_in
@@ -233,7 +233,7 @@ class GRUNetwork:
                  input_var=None,
                  input_layer=None,
                  layer_args=None):
-        with tf.variable_scope(name, 'GRUNetwork'):
+        with tf.compat.v1.variable_scope(name, 'GRUNetwork'):
             if input_layer is None:
                 l_in = ly.InputLayer(
                     shape=(None, None) + input_shape,
@@ -368,7 +368,7 @@ class LSTMNetwork:
                  forget_bias=1.0,
                  use_peepholes=False,
                  layer_args=None):
-        with tf.variable_scope(name, 'LSTMNetwork'):
+        with tf.compat.v1.variable_scope(name, 'LSTMNetwork'):
             if input_layer is None:
                 l_in = ly.InputLayer(
                     shape=(None, None) + input_shape,
@@ -538,7 +538,7 @@ class ConvMergeNetwork(LayersPowered, Serializable):
         if extra_hidden_sizes is None:
             extra_hidden_sizes = []
 
-        with tf.variable_scope(name, 'ConvMergeNetwork'):
+        with tf.compat.v1.variable_scope(name, 'ConvMergeNetwork'):
 
             input_flat_dim = np.prod(input_shape)
             extra_input_flat_dim = np.prod(extra_input_shape)

--- a/src/garage/tf/core/parameter.py
+++ b/src/garage/tf/core/parameter.py
@@ -32,8 +32,8 @@ def parameter(input_var,
     Return:
         A tensor of the broadcasted variables.
     """
-    with tf.variable_scope(name):
-        p = tf.get_variable(
+    with tf.compat.v1.variable_scope(name):
+        p = tf.compat.v1.get_variable(
             'parameter',
             shape=(length, ),
             dtype=dtype,

--- a/src/garage/tf/distributions/bernoulli.py
+++ b/src/garage/tf/distributions/bernoulli.py
@@ -20,9 +20,11 @@ class Bernoulli(Distribution):
                            [old_dist_info_vars, new_dist_info_vars]):
             old_p = old_dist_info_vars['p']
             new_p = new_dist_info_vars['p']
-            kl = old_p * (tf.log(old_p + TINY) - tf.log(new_p + TINY)) \
-                + (1 - old_p) \
-                * (tf.log(1 - old_p + TINY) - tf.log(1 - new_p + TINY))
+            kl = (
+                old_p * (tf.math.log(old_p + TINY) - tf.math.log(new_p + TINY))
+                + (1 - old_p) *
+                (tf.math.log(1 - old_p + TINY) - tf.math.log(1 - new_p + TINY))
+            )
             ndims = kl.get_shape().ndims
             return tf.reduce_sum(kl, axis=ndims - 1)
 
@@ -60,7 +62,8 @@ class Bernoulli(Distribution):
             p = dist_info_vars['p']
             ndims = p.get_shape().ndims
             return tf.reduce_sum(
-                x_var * tf.log(p + TINY) + (1 - x_var) * tf.log(1 - p + TINY),
+                x_var * tf.math.log(p + TINY) +
+                (1 - x_var) * tf.math.log(1 - p + TINY),
                 axis=ndims - 1)
 
     def log_likelihood(self, xs, dist_info):

--- a/src/garage/tf/distributions/categorical.py
+++ b/src/garage/tf/distributions/categorical.py
@@ -16,15 +16,15 @@ def from_onehot(x_var):
 
 class Categorical(Distribution):
     def __init__(self, dim, name=None):
-        with tf.variable_scope(name, 'Categorical'):
+        with tf.compat.v1.variable_scope(name, 'Categorical'):
             self._dim = dim
             self._name = name
-            weights_var = tf.placeholder(
+            weights_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, dim), name='weights')
             self._f_sample = compile_function(
                 inputs=[weights_var],
-                outputs=tf.multinomial(
-                    tf.log(weights_var + 1e-8), num_samples=1)[:, 0],
+                outputs=tf.random.categorical(
+                    tf.math.log(weights_var + 1e-8), num_samples=1)[:, 0],
             )
 
     @property
@@ -42,8 +42,8 @@ class Categorical(Distribution):
             ndims = old_prob_var.get_shape().ndims
             # Assume layout is N * A
             return tf.reduce_sum(
-                old_prob_var *
-                (tf.log(old_prob_var + TINY) - tf.log(new_prob_var + TINY)),
+                old_prob_var * (tf.math.log(old_prob_var + TINY) -
+                                tf.math.log(new_prob_var + TINY)),
                 axis=ndims - 1)
 
     def kl(self, old_dist_info, new_dist_info):
@@ -74,7 +74,7 @@ class Categorical(Distribution):
     def entropy_sym(self, dist_info_vars, name=None):
         with tf.name_scope(name, 'entropy_sym', [dist_info_vars]):
             probs = dist_info_vars['prob']
-            return -tf.reduce_sum(probs * tf.log(probs + TINY), axis=1)
+            return -tf.reduce_sum(probs * tf.math.log(probs + TINY), axis=1)
 
     def cross_entropy_sym(self,
                           old_dist_info_vars,
@@ -87,7 +87,8 @@ class Categorical(Distribution):
             ndims = old_prob_var.get_shape().ndims
             # Assume layout is N * A
             return tf.reduce_sum(
-                old_prob_var * (-tf.log(new_prob_var + TINY)), axis=ndims - 1)
+                old_prob_var * (-tf.math.log(new_prob_var + TINY)),
+                axis=ndims - 1)
 
     def entropy(self, info):
         probs = info['prob']
@@ -98,7 +99,7 @@ class Categorical(Distribution):
                            [x_var, dist_info_vars]):
             probs = dist_info_vars['prob']
             ndims = probs.get_shape().ndims
-            return tf.log(
+            return tf.math.log(
                 tf.reduce_sum(probs * tf.cast(x_var, tf.float32), ndims - 1) +
                 TINY)
 
@@ -117,7 +118,8 @@ class Categorical(Distribution):
     def sample_sym(self, dist_info, name=None):
         with tf.name_scope(name, 'sample_sym', [dist_info]):
             probs = dist_info['prob']
-            samples = tf.multinomial(tf.log(probs + 1e-8), num_samples=1)[:, 0]
+            samples = tf.multinomial(
+                tf.math.log(probs + 1e-8), num_samples=1)[:, 0]
 
             return tf.nn.embedding_lookup(
                 np.eye(self.dim, dtype=np.float32), samples)

--- a/src/garage/tf/distributions/recurrent_categorical.py
+++ b/src/garage/tf/distributions/recurrent_categorical.py
@@ -27,8 +27,8 @@ class RecurrentCategorical(Distribution):
             new_prob_var = new_dist_info_vars['prob']
             # Assume layout is N * T * A
             return tf.reduce_sum(
-                old_prob_var *
-                (tf.log(old_prob_var + TINY) - tf.log(new_prob_var + TINY)),
+                old_prob_var * (tf.math.log(old_prob_var + TINY) -
+                                tf.math.log(new_prob_var + TINY)),
                 axis=2)
 
     def kl(self, old_dist_info, new_dist_info):
@@ -65,7 +65,7 @@ class RecurrentCategorical(Distribution):
     def entropy_sym(self, dist_info_vars, name=None):
         with tf.name_scope(name, 'entropy_sym', [dist_info_vars]):
             probs = dist_info_vars['prob']
-            return -tf.reduce_sum(probs * tf.log(probs + TINY), 2)
+            return -tf.reduce_sum(probs * tf.math.log(probs + TINY), 2)
 
     def log_likelihood_sym(self, xs, dist_info_vars, name=None):
         with tf.name_scope(name, 'log_likelihood_sym', [xs, dist_info_vars]):

--- a/src/garage/tf/models/base.py
+++ b/src/garage/tf/models/base.py
@@ -230,7 +230,8 @@ class Model(BaseModel):
             out_args.extend(network.outputs)
 
         c = namedtuple(network_name, [*in_spec, *out_spec])
-        self._networks[network_name] = c(*in_args, *out_args)
+        all_args = in_args + out_args
+        self._networks[network_name] = c(*all_args)
 
         return network.outputs
 

--- a/src/garage/tf/models/base.py
+++ b/src/garage/tf/models/base.py
@@ -13,14 +13,14 @@ class BaseModel(abc.ABC):
     A Model contains the structure/configuration of a set of computation
     graphs, or can be understood as a set of networks. Using a model
     requires calling `build()` with given input placeholder, which can be
-    either tf.placeholder, or the output from another model. This makes
-    composition of complex models with simple models much easier.
+    either tf.compat.v1.placeholder, or the output from another model. This
+    makes composition of complex models with simple models much easier.
 
     Examples:
         model = SimpleModel(output_dim=2)
         # To use a model, first create a placeholder.
-        # In the case of TensorFlow, we create a tf.placeholder.
-        input_ph = tf.placeholder(tf.float32, shape=(None, 2))
+        # In the case of TensorFlow, we create a tf.compat.v1.placeholder.
+        input_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 2))
 
         # Building the model
         output = model.build(input_ph)
@@ -190,22 +190,22 @@ class Model(BaseModel):
         if not self._networks:
             # First time building the model, so self._networks are empty
             # We store the variable_scope to reenter later when we reuse it
-            with tf.variable_scope(self._name) as vs:
+            with tf.compat.v1.variable_scope(self._name) as vs:
                 self._variable_scope = vs
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
                     network._outputs = self._build(*inputs, name)
                 variables = self._get_variables().values()
-                tf.get_default_session().run(
-                    tf.variables_initializer(variables))
+                tf.compat.v1.get_default_session().run(
+                    tf.compat.v1.variables_initializer(variables))
                 if self._default_parameters:
                     self.parameters = self._default_parameters
         else:
             if network_name in self._networks:
                 raise ValueError(
                     'Network {} already exists!'.format(network_name))
-            with tf.variable_scope(
+            with tf.compat.v1.variable_scope(
                     self._variable_scope, reuse=True,
                     auxiliary_name_scope=False):
                 with tf.name_scope(name=network_name):
@@ -282,7 +282,7 @@ class Model(BaseModel):
         """Parameters of the model."""
         _variables = self._get_variables()
         if _variables:
-            return tf.get_default_session().run(_variables)
+            return tf.compat.v1.get_default_session().run(_variables)
         else:
             return _variables
 

--- a/src/garage/tf/models/gaussian_cnn_model.py
+++ b/src/garage/tf/models/gaussian_cnn_model.py
@@ -180,7 +180,7 @@ class GaussianCNNModel(Model):
     def _build(self, state_input, name=None):
         action_dim = self._output_dim
 
-        with tf.variable_scope('dist_params'):
+        with tf.compat.v1.variable_scope('dist_params'):
             if self._std_share_network:
                 # mean and std networks share an CNN
                 b = np.concatenate([
@@ -210,9 +210,9 @@ class GaussianCNNModel(Model):
                     output_b_init=tf.constant_initializer(b),
                     name='mean_std_network',
                     layer_normalization=self._layer_normalization)
-                with tf.variable_scope('mean_network'):
+                with tf.compat.v1.variable_scope('mean_network'):
                     mean_network = mean_std_network[..., :action_dim]
-                with tf.variable_scope('log_std_network'):
+                with tf.compat.v1.variable_scope('log_std_network'):
                     log_std_network = mean_std_network[..., action_dim:]
 
             else:
@@ -280,18 +280,18 @@ class GaussianCNNModel(Model):
         mean_var = mean_network
         std_param = log_std_network
 
-        with tf.variable_scope('std_limits'):
+        with tf.compat.v1.variable_scope('std_limits'):
             if self._min_std_param is not None:
                 std_param = tf.maximum(std_param, self._min_std_param)
             if self._max_std_param is not None:
                 std_param = tf.minimum(std_param, self._max_std_param)
 
-        with tf.variable_scope('std_parameterization'):
+        with tf.compat.v1.variable_scope('std_parameterization'):
             # build std_var with std parameterization
             if self._std_parameterization == 'exp':
                 log_std_var = std_param
             else:  # we know it must be softplus here
-                log_std_var = tf.log(tf.log(1. + tf.exp(std_param)))
+                log_std_var = tf.math.log(tf.math.log(1. + tf.exp(std_param)))
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/gaussian_gru_model.py
+++ b/src/garage/tf/models/gaussian_gru_model.py
@@ -133,7 +133,7 @@ class GaussianGRUModel(Model):
     def _build(self, state_input, step_input, hidden_input, name=None):
         action_dim = self._output_dim
 
-        with tf.variable_scope('dist_params'):
+        with tf.compat.v1.variable_scope('dist_params'):
             if self._std_share_network:
                 # mean and std networks share an MLP
                 (outputs, step_outputs, step_hidden, hidden_init_var) = gru(
@@ -147,10 +147,10 @@ class GaussianGRUModel(Model):
                     _hidden_state_init_trainable,
                     output_nonlinearity_layer=self.
                     _mean_std_output_nonlinearity_layer)
-                with tf.variable_scope('mean_network'):
+                with tf.compat.v1.variable_scope('mean_network'):
                     mean_var = outputs[..., :action_dim]
                     step_mean_var = step_outputs[..., :action_dim]
-                with tf.variable_scope('log_std_network'):
+                with tf.compat.v1.variable_scope('log_std_network'):
                     log_std_var = outputs[..., action_dim:]
                     step_log_std_var = step_outputs[..., action_dim:]
 

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -155,7 +155,7 @@ class GaussianLSTMModel(Model):
                name=None):
         action_dim = self._output_dim
 
-        with tf.variable_scope('dist_params'):
+        with tf.compat.v1.variable_scope('dist_params'):
             if self._std_share_network:
                 # mean and std networks share an MLP
                 (outputs, step_outputs, step_hidden, step_cell,
@@ -173,10 +173,10 @@ class GaussianLSTMModel(Model):
                      cell_state_init_trainable=self._cell_state_init_trainable,
                      output_nonlinearity_layer=self.
                      _mean_std_output_nonlinearity_layer)
-                with tf.variable_scope('mean_network'):
+                with tf.compat.v1.variable_scope('mean_network'):
                     mean_var = outputs[..., :action_dim]
                     step_mean_var = step_outputs[..., :action_dim]
-                with tf.variable_scope('log_std_network'):
+                with tf.compat.v1.variable_scope('log_std_network'):
                     log_std_var = outputs[..., action_dim:]
                     step_log_std_var = step_outputs[..., action_dim:]
 

--- a/src/garage/tf/models/gaussian_mlp_model.py
+++ b/src/garage/tf/models/gaussian_mlp_model.py
@@ -138,7 +138,7 @@ class GaussianMLPModel(Model):
     def _build(self, state_input, name=None):
         action_dim = self._output_dim
 
-        with tf.variable_scope('dist_params'):
+        with tf.compat.v1.variable_scope('dist_params'):
             if self._std_share_network:
                 # mean and std networks share an MLP
                 b = np.concatenate([
@@ -158,9 +158,9 @@ class GaussianMLPModel(Model):
                     output_b_init=tf.constant_initializer(b),
                     name='mean_std_network',
                     layer_normalization=self._layer_normalization)
-                with tf.variable_scope('mean_network'):
+                with tf.compat.v1.variable_scope('mean_network'):
                     mean_network = mean_std_network[..., :action_dim]
-                with tf.variable_scope('log_std_network'):
+                with tf.compat.v1.variable_scope('log_std_network'):
                     log_std_network = mean_std_network[..., action_dim:]
 
             else:
@@ -206,18 +206,18 @@ class GaussianMLPModel(Model):
         mean_var = mean_network
         std_param = log_std_network
 
-        with tf.variable_scope('std_limits'):
+        with tf.compat.v1.variable_scope('std_limits'):
             if self._min_std_param is not None:
                 std_param = tf.maximum(std_param, self._min_std_param)
             if self._max_std_param is not None:
                 std_param = tf.minimum(std_param, self._max_std_param)
 
-        with tf.variable_scope('std_parameterization'):
+        with tf.compat.v1.variable_scope('std_parameterization'):
             # build std_var with std parameterization
             if self._std_parameterization == 'exp':
                 log_std_var = std_param
             else:  # we know it must be softplus here
-                log_std_var = tf.log(tf.log(1. + tf.exp(std_param)))
+                log_std_var = tf.math.log(tf.math.log(1. + tf.exp(std_param)))
 
         dist = DiagonalGaussian(self._output_dim)
         rnd = tf.random.normal(shape=mean_var.get_shape().as_list()[1:])

--- a/src/garage/tf/models/normalized_input_mlp_model.py
+++ b/src/garage/tf/models/normalized_input_mlp_model.py
@@ -70,14 +70,14 @@ class NormalizedInputMLPModel(MLPModel):
         return ['y_hat', 'x_mean', 'x_std']
 
     def _build(self, state_input, name=None):
-        with tf.variable_scope('normalized_vars'):
-            x_mean_var = tf.get_variable(
+        with tf.compat.v1.variable_scope('normalized_vars'):
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std_var',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,

--- a/src/garage/tf/optimizers/first_order_optimizer.py
+++ b/src/garage/tf/optimizers/first_order_optimizer.py
@@ -43,7 +43,7 @@ class FirstOrderOptimizer(Serializable):
         self._target = None
         self._callback = callback
         if tf_optimizer_cls is None:
-            tf_optimizer_cls = tf.train.AdamOptimizer
+            tf_optimizer_cls = tf.compat.v1.train.AdamOptimizer
         if tf_optimizer_args is None:
             tf_optimizer_args = dict(learning_rate=1e-3)
         self._tf_optimizer = tf_optimizer_cls(**tf_optimizer_args)
@@ -111,7 +111,7 @@ class FirstOrderOptimizer(Serializable):
         dataset = BatchDataset(
             inputs, self._batch_size, extra_inputs=extra_inputs)
 
-        sess = tf.get_default_session()
+        sess = tf.compat.v1.get_default_session()
 
         for epoch in range(self._max_epochs):
             if self._verbose:

--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -38,8 +38,10 @@ class Plotter:
         Plotter.__plotters.append(self)
         self.env = env
         self.policy = policy
-        self.sess = tf.get_default_session() if sess is None else sess
-        self.graph = tf.get_default_graph() if graph is None else graph
+        self.sess = tf.compat.v1.get_default_session(
+        ) if sess is None else sess
+        self.graph = tf.compat.v1.get_default_graph(
+        ) if graph is None else graph
         self.rollout = rollout
         self.worker_thread = Thread(target=self._start_worker, daemon=True)
         self.queue = Queue()
@@ -124,7 +126,7 @@ class Plotter:
         if not Plotter.enable:
             return
         if not self.worker_thread.is_alive():
-            tf.get_variable_scope().reuse_variables()
+            tf.compat.v1.get_variable_scope().reuse_variables()
             self.worker_thread.start()
             self.queue.put(
                 Message(

--- a/src/garage/tf/policies/categorical_conv_policy.py
+++ b/src/garage/tf/policies/categorical_conv_policy.py
@@ -43,7 +43,7 @@ class CategoricalConvPolicy(StochasticPolicy, LayersPowered, Serializable):
         self._env_spec = env_spec
         self._prob_network_name = 'prob_network'
 
-        with tf.variable_scope(name, 'CategoricalConvPolicy'):
+        with tf.compat.v1.variable_scope(name, 'CategoricalConvPolicy'):
             if prob_network is None:
                 prob_network = ConvNetwork(
                     input_shape=env_spec.observation_space.shape,

--- a/src/garage/tf/policies/categorical_conv_policy_with_model.py
+++ b/src/garage/tf/policies/categorical_conv_policy_with_model.py
@@ -105,13 +105,14 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        state_input = tf.placeholder(tf.float32, shape=(None, ) + self.obs_dim)
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + self.obs_dim)
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(state_input)
 
-        self._f_prob = tf.get_default_session().make_callable(
+        self._f_prob = tf.compat.v1.get_default_session().make_callable(
             self.model.outputs, feed_list=[self.model.input])
 
     @property
@@ -122,7 +123,7 @@ class CategoricalConvPolicyWithModel(StochasticPolicy2):
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
         """Symbolic graph of the distribution."""
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             prob = self.model.build(obs_var, name=name)
         return dict(prob=prob)
 

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -35,7 +35,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
         assert isinstance(env_spec.action_space, akro.Discrete)
 
         self._prob_network_name = 'prob_network'
-        with tf.variable_scope(name, 'CategoricalGRUPolicy'):
+        with tf.compat.v1.variable_scope(name, 'CategoricalGRUPolicy'):
             Serializable.quick_init(self, locals())
             super(CategoricalGRUPolicy, self).__init__(env_spec)
 
@@ -88,7 +88,7 @@ class CategoricalGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
             self.l_input = l_input
             self.state_include_action = state_include_action
 
-            flat_input_var = tf.placeholder(
+            flat_input_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, input_dim), name='flat_input')
             if feature_network is None:
                 feature_var = flat_input_var

--- a/src/garage/tf/policies/categorical_gru_policy_with_model.py
+++ b/src/garage/tf/policies/categorical_gru_policy_with_model.py
@@ -109,20 +109,20 @@ class CategoricalGRUPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self._input_dim))
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             shape=(None, self._input_dim), name='step_input', dtype=tf.float32)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_hidden_input',
             dtype=tf.float32)
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph, step_input_var, step_hidden_var)
 
-        self._f_step_prob = tf.get_default_session().make_callable(
+        self._f_step_prob = tf.compat.v1.get_default_session().make_callable(
             [
                 self.model.networks['default'].step_output,
                 self.model.networks['default'].step_hidden
@@ -148,7 +148,7 @@ class CategoricalGRUPolicyWithModel(StochasticPolicy2):
         else:
             all_input_var = obs_var
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             outputs, _, _, _ = self.model.build(
                 all_input_var,
                 self.model.networks['default'].step_input,

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -38,7 +38,7 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
         assert isinstance(env_spec.action_space, akro.Discrete)
 
         self._prob_network_name = 'prob_network'
-        with tf.variable_scope(name, 'CategoricalLSTMPolicy'):
+        with tf.compat.v1.variable_scope(name, 'CategoricalLSTMPolicy'):
             Serializable.quick_init(self, locals())
             super(CategoricalLSTMPolicy, self).__init__(env_spec)
 
@@ -94,7 +94,7 @@ class CategoricalLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
             self.l_input = l_input
             self.state_include_action = state_include_action
 
-            flat_input_var = tf.placeholder(
+            flat_input_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, input_dim), name='flat_input')
             if feature_network is None:
                 feature_var = flat_input_var

--- a/src/garage/tf/policies/categorical_lstm_policy_with_model.py
+++ b/src/garage/tf/policies/categorical_lstm_policy_with_model.py
@@ -123,25 +123,25 @@ class CategoricalLSTMPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self._input_dim))
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             shape=(None, self._input_dim), name='step_input', dtype=tf.float32)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_hidden_input',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_cell_input',
             dtype=tf.float32)
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph, step_input_var, step_hidden_var,
                              step_cell_var)
 
-        self._f_step_prob = tf.get_default_session().make_callable(
+        self._f_step_prob = tf.compat.v1.get_default_session().make_callable(
             [
                 self.model.networks['default'].step_output,
                 self.model.networks['default'].step_hidden,
@@ -168,7 +168,7 @@ class CategoricalLSTMPolicyWithModel(StochasticPolicy2):
         else:
             all_input_var = obs_var
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             outputs, _, _, _, _, _ = self.model.build(
                 all_input_var,
                 self.model.networks['default'].step_input,

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -42,7 +42,7 @@ class CategoricalMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
 
         self.name = name
         self._prob_network_name = 'prob_network'
-        with tf.variable_scope(name, 'CategoricalMLPPolicy'):
+        with tf.compat.v1.variable_scope(name, 'CategoricalMLPPolicy'):
             if prob_network is None:
                 prob_network = MLP(
                     input_shape=(env_spec.observation_space.flat_dim, ),

--- a/src/garage/tf/policies/categorical_mlp_policy_with_model.py
+++ b/src/garage/tf/policies/categorical_mlp_policy_with_model.py
@@ -78,13 +78,14 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(state_input)
 
-        self._f_prob = tf.get_default_session().make_callable(
+        self._f_prob = tf.compat.v1.get_default_session().make_callable(
             self.model.networks['default'].outputs,
             feed_list=[self.model.networks['default'].input])
 
@@ -96,7 +97,7 @@ class CategoricalMLPPolicyWithModel(StochasticPolicy2):
     @overrides
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
         """Symbolic graph of the distribution."""
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             prob = self.model.build(obs_var, name=name)
         return dict(prob=prob)
 

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -83,7 +83,7 @@ class ContinuousMLPPolicy(Policy, LayersPowered, Serializable):
             reuse: A bool indicates whether reuse variables in the same scope.
             trainable: A bool indicates whether variables are trainable.
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             l_in = layers.InputLayer(shape=(None, self._obs_dim), name='obs')
 
             l_hidden = l_in

--- a/src/garage/tf/policies/continuous_mlp_policy_with_model.py
+++ b/src/garage/tf/policies/continuous_mlp_policy_with_model.py
@@ -91,13 +91,14 @@ class ContinuousMLPPolicyWithModel(Policy2):
         self._initialize()
 
     def _initialize(self):
-        state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(state_input)
 
-        self._f_prob = tf.get_default_session().make_callable(
+        self._f_prob = tf.compat.v1.get_default_session().make_callable(
             self.model.networks['default'].outputs,
             feed_list=[self.model.networks['default'].input])
 
@@ -110,7 +111,7 @@ class ContinuousMLPPolicyWithModel(Policy2):
             name (str): Name for symbolic graph.
 
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             return self.model.build(obs_var, name=name)
 
     @overrides

--- a/src/garage/tf/policies/deterministic_mlp_policy.py
+++ b/src/garage/tf/policies/deterministic_mlp_policy.py
@@ -24,7 +24,7 @@ class DeterministicMLPPolicy(Policy, LayersPowered, Serializable):
         Serializable.quick_init(self, locals())
 
         self._prob_network_name = 'prob_network'
-        with tf.variable_scope(name, 'DeterministicMLPPolicy'):
+        with tf.compat.v1.variable_scope(name, 'DeterministicMLPPolicy'):
             if prob_network is None:
                 prob_network = MLP(
                     input_shape=(env_spec.observation_space.flat_dim, ),

--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -31,7 +31,7 @@ class DiscreteQfDerivedPolicy(Policy2):
         self._initialize()
 
     def _initialize(self):
-        self._f_qval = tf.get_default_session().make_callable(
+        self._f_qval = tf.compat.v1.get_default_session().make_callable(
             self._qf.q_vals,
             feed_list=[self._qf.model.networks['default'].input])
 

--- a/src/garage/tf/policies/gaussian_gru_policy.py
+++ b/src/garage/tf/policies/gaussian_gru_policy.py
@@ -43,7 +43,7 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
         self._mean_network_name = 'mean_network'
         self._std_network_name = 'std_network'
 
-        with tf.variable_scope(name, 'GaussianGRUPolicy'):
+        with tf.compat.v1.variable_scope(name, 'GaussianGRUPolicy'):
             Serializable.quick_init(self, locals())
             super(GaussianGRUPolicy, self).__init__(env_spec)
 
@@ -151,7 +151,7 @@ class GaussianGRUPolicy(StochasticPolicy, LayersPowered, Serializable):
             self.l_input = l_input
             self.state_include_action = state_include_action
 
-            flat_input_var = tf.placeholder(
+            flat_input_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, input_dim), name='flat_input')
             if feature_network is None:
                 feature_var = flat_input_var

--- a/src/garage/tf/policies/gaussian_gru_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_gru_policy_with_model.py
@@ -113,27 +113,28 @@ class GaussianGRUPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self._input_dim))
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             shape=(None, self._input_dim), name='step_input', dtype=tf.float32)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_hidden_input',
             dtype=tf.float32)
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph, step_input_var, step_hidden_var)
 
-        self._f_step_mean_std = tf.get_default_session().make_callable(
-            [
-                self.model.networks['default'].sample,
-                self.model.networks['default'].step_mean,
-                self.model.networks['default'].step_log_std,
-                self.model.networks['default'].step_hidden
-            ],
-            feed_list=[step_input_var, step_hidden_var])
+        self._f_step_mean_std = (
+            tf.compat.v1.get_default_session().make_callable(
+                [
+                    self.model.networks['default'].sample,
+                    self.model.networks['default'].step_mean,
+                    self.model.networks['default'].step_log_std,
+                    self.model.networks['default'].step_hidden
+                ],
+                feed_list=[step_input_var, step_hidden_var]))
 
         self.prev_actions = None
         self.prev_hiddens = None
@@ -162,7 +163,7 @@ class GaussianGRUPolicyWithModel(StochasticPolicy2):
         else:
             all_input_var = obs_var
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             _, mean_var, _, log_std_var, _, _, _, _ = self.model.build(
                 all_input_var,
                 self.model.networks['default'].step_input,

--- a/src/garage/tf/policies/gaussian_lstm_policy.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy.py
@@ -42,7 +42,7 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
 
         self._mean_network_name = 'mean_network'
         self._std_network_name = 'std_network'
-        with tf.variable_scope(name, 'GaussianLSTMPolicy'):
+        with tf.compat.v1.variable_scope(name, 'GaussianLSTMPolicy'):
             Serializable.quick_init(self, locals())
             super(GaussianLSTMPolicy, self).__init__(env_spec)
 
@@ -159,7 +159,7 @@ class GaussianLSTMPolicy(StochasticPolicy, LayersPowered, Serializable):
             self.state_include_action = state_include_action
             self.name = name
 
-            flat_input_var = tf.placeholder(
+            flat_input_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, input_dim), name='flat_input')
             if feature_network is None:
                 feature_var = flat_input_var

--- a/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy_with_model.py
@@ -126,25 +126,26 @@ class GaussianLSTMPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self._input_dim))
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             shape=(None, self._input_dim), name='step_input', dtype=tf.float32)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_hidden_input',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(None, self._hidden_dim),
             name='step_cell_input',
             dtype=tf.float32)
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph, step_input_var, step_hidden_var,
                              step_cell_var)
 
-        self._f_step_mean_std = tf.get_default_session().make_callable(
+        self._f_step_mean_std = tf.compat.v1.get_default_session(
+        ).make_callable(
             [
                 self.model.networks['default'].sample,
                 self.model.networks['default'].step_mean,
@@ -182,7 +183,7 @@ class GaussianLSTMPolicyWithModel(StochasticPolicy2):
         else:
             all_input_var = obs_var
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             _, mean_var, _, log_std_var, _, _, _, _, _, _ = self.model.build(
                 all_input_var,
                 self.model.networks['default'].step_input,

--- a/src/garage/tf/policies/gaussian_mlp_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy.py
@@ -61,7 +61,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
         self._mean_network_name = 'mean_network'
         self._std_network_name = 'std_network'
 
-        with tf.variable_scope(name, 'GaussianMLPPolicy'):
+        with tf.compat.v1.variable_scope(name, 'GaussianMLPPolicy'):
 
             obs_dim = env_spec.observation_space.flat_dim
             action_dim = env_spec.action_space.flat_dim
@@ -79,7 +79,7 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                                         np.full(action_dim, init_std_param)),
                                        axis=0)
                     b = tf.constant_initializer(b)
-                    with tf.variable_scope(self._mean_network_name):
+                    with tf.compat.v1.variable_scope(self._mean_network_name):
                         mean_network = MLP(
                             name='mlp',
                             input_shape=(obs_dim, ),
@@ -132,14 +132,14 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
                     )
                     l_std_param = std_network.output_layer
                 elif std_share_network:
-                    with tf.variable_scope(self._std_network_name):
+                    with tf.compat.v1.variable_scope(self._std_network_name):
                         l_std_param = L.SliceLayer(
                             mean_network.output_layer,
                             slice(action_dim, 2 * action_dim),
                             name='std_slice',
                         )
                 else:
-                    with tf.variable_scope(self._std_network_name):
+                    with tf.compat.v1.variable_scope(self._std_network_name):
                         l_std_param = L.ParamLayer(
                             mean_network.input_layer,
                             num_units=action_dim,
@@ -200,7 +200,8 @@ class GaussianMLPPolicy(StochasticPolicy, LayersPowered, Serializable):
             if self.std_parametrization == 'exp':
                 log_std_var = std_param_var
             elif self.std_parametrization == 'softplus':
-                log_std_var = tf.log(tf.log(1. + tf.exp(std_param_var)))
+                log_std_var = tf.math.log(
+                    tf.math.log(1. + tf.exp(std_param_var)))
             else:
                 raise NotImplementedError
             return dict(mean=mean_var, log_std=log_std_var)

--- a/src/garage/tf/policies/gaussian_mlp_policy_with_model.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy_with_model.py
@@ -115,13 +115,14 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
         self._initialize()
 
     def _initialize(self):
-        state_input = tf.placeholder(tf.float32, shape=(None, self.obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, self.obs_dim))
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(state_input)
 
-        self._f_dist = tf.get_default_session().make_callable(
+        self._f_dist = tf.compat.v1.get_default_session().make_callable(
             [
                 self.model.networks['default'].sample,
                 self.model.networks['default'].mean,
@@ -136,7 +137,7 @@ class GaussianMLPPolicyWithModel(StochasticPolicy2):
 
     def dist_info_sym(self, obs_var, state_info_vars=None, name='default'):
         """Symbolic graph of the distribution."""
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             _, mean_var, log_std_var, _, _ = self.model.build(
                 obs_var, name=name)
         return dict(mean=mean_var, log_std=log_std_var)

--- a/src/garage/tf/q_functions/base.py
+++ b/src/garage/tf/q_functions/base.py
@@ -15,11 +15,13 @@ class QFunction(Parameterized):
 
     def get_trainable_vars(self, scope=None):
         scope = scope if scope else self.name
-        return tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, scope=scope)
+        return tf.compat.v1.get_collection(
+            tf.compat.v1.GraphKeys.TRAINABLE_VARIABLES, scope=scope)
 
     def get_global_vars(self, scope=None):
         scope = scope if scope else self.name
-        return tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope=scope)
+        return tf.compat.v1.get_collection(
+            tf.compat.v1.GraphKeys.GLOBAL_VARIABLES, scope=scope)
 
     def get_regularizable_vars(self, scope=None):
         scope = scope if scope else self.name

--- a/src/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/src/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -68,7 +68,7 @@ class ContinuousMLPQFunction(QFunction, LayersPowered, Serializable):
             reuse: A bool indicates whether reuse variables in the same scope.
             trainable: A bool indicates whether variables are trainable.
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             l_obs = L.InputLayer(shape=(None, self._obs_dim), name='obs')
             l_action = L.InputLayer(
                 shape=(None, self._action_dim), name='actions')

--- a/src/garage/tf/q_functions/continuous_mlp_q_function_with_model.py
+++ b/src/garage/tf/q_functions/continuous_mlp_q_function_with_model.py
@@ -97,15 +97,16 @@ class ContinuousMLPQFunctionWithModel(QFunction2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(tf.float32, (None, self._obs_dim), name='obs')
-        action_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
+            tf.float32, (None, self._obs_dim), name='obs')
+        action_ph = tf.compat.v1.placeholder(
             tf.float32, (None, self._action_dim), name='act')
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph, action_ph)
 
-        self._f_qval = tf.get_default_session().make_callable(
+        self._f_qval = tf.compat.v1.get_default_session().make_callable(
             self.model.networks['default'].outputs,
             feed_list=[obs_ph, action_ph])
 
@@ -130,7 +131,7 @@ class ContinuousMLPQFunctionWithModel(QFunction2):
         Return:
             The tf.Tensor output of Discrete MLP QFunction.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             return self.model.build(state_input, action_input, name=name)
 
     def clone(self, name):

--- a/src/garage/tf/q_functions/discrete_cnn_q_function.py
+++ b/src/garage/tf/q_functions/discrete_cnn_q_function.py
@@ -155,9 +155,9 @@ class DiscreteCNNQFunction(QFunction2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, (None, ) + self.obs_dim, name='obs')
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph)
 
@@ -182,7 +182,7 @@ class DiscreteCNNQFunction(QFunction2):
         Return:
             The tf.Tensor output of Discrete CNN QFunction.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             return self.model.build(state_input, name=name)
 
     def clone(self, name):

--- a/src/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/src/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -95,10 +95,10 @@ class DiscreteMLPQFunction(QFunction2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, (None, ) + self.obs_dim, name='obs')
 
-        with tf.variable_scope(self.name) as vs:
+        with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph)
 
@@ -122,7 +122,7 @@ class DiscreteMLPQFunction(QFunction2):
         Return:
             The tf.Tensor output of Discrete MLP QFunction.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             return self.model.build(state_input, name=name)
 
     def clone(self, name):

--- a/src/garage/tf/regressors/bernoulli_mlp_regressor.py
+++ b/src/garage/tf/regressors/bernoulli_mlp_regressor.py
@@ -45,7 +45,7 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
 
             if optimizer is None:
                 optimizer = LbfgsOptimizer()
@@ -69,16 +69,16 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
             LayersPowered.__init__(self, [l_p])
 
             xs_var = p_network.input_layer.input_var
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, output_dim), name='ys')
-            old_p_var = tf.placeholder(
+            old_p_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=(None, output_dim), name='old_p')
 
-            x_mean_var = tf.get_variable(
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 initializer=tf.zeros_initializer(),
                 shape=(1, ) + input_shape)
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std',
                 initializer=tf.ones_initializer(),
                 shape=(1, ) + input_shape)
@@ -128,10 +128,10 @@ class BernoulliMLPRegressor(LayersPowered, Serializable, Parameterized):
             # recompute normalizing constants for inputs
             new_mean = np.mean(xs, axis=0, keepdims=True)
             new_std = np.std(xs, axis=0, keepdims=True) + 1e-8
-            tf.get_default_session().run(
+            tf.compat.v1.get_default_session().run(
                 tf.group(
-                    tf.assign(self.x_mean_var, new_mean),
-                    tf.assign(self.x_std_var, new_std),
+                    tf.compat.v1.assign(self.x_mean_var, new_mean),
+                    tf.compat.v1.assign(self.x_std_var, new_std),
                 ))
             # self._x_mean_var.set_value(np.mean(xs, axis=0, keepdims=True))
             # self._x_std_var.set_value(

--- a/src/garage/tf/regressors/bernoulli_mlp_regressor_with_model.py
+++ b/src/garage/tf/regressors/bernoulli_mlp_regressor_with_model.py
@@ -83,7 +83,7 @@ class BernoulliMLPRegressorWithModel(StochasticRegressor2):
         self._max_kl_step = max_kl_step
         self._normalize_inputs = normalize_inputs
 
-        with tf.variable_scope(self._name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self._name, reuse=False) as vs:
             self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
@@ -120,16 +120,16 @@ class BernoulliMLPRegressorWithModel(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(input_var)
 
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
 
-            old_prob_var = tf.placeholder(
+            old_prob_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_prob',
                 shape=(None, self._output_dim))
@@ -219,7 +219,7 @@ class BernoulliMLPRegressorWithModel(StochasticRegressor2):
         Return:
             tf.Tensor output of the symbolic log likelihood.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             prob, _, _ = self.model.build(x_var, name=name)
 
         return self._dist.log_likelihood_sym(y_var, dict(p=prob))

--- a/src/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor.py
@@ -49,7 +49,7 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
-        with tf.variable_scope(name, 'CategoricalMLPRegressor'):
+        with tf.compat.v1.variable_scope(name, 'CategoricalMLPRegressor'):
             if optimizer is None:
                 optimizer = LbfgsOptimizer()
             if tr_optimizer is None:
@@ -74,16 +74,16 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
             LayersPowered.__init__(self, [l_prob])
 
             xs_var = prob_network.input_layer.input_var
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=[None, output_dim], name='ys')
-            old_prob_var = tf.placeholder(
+            old_prob_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=[None, output_dim], name='old_prob')
 
-            x_mean_var = tf.get_variable(
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 shape=(1, ) + input_shape,
                 initializer=tf.constant_initializer(0., dtype=tf.float32))
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std',
                 shape=(1, ) + input_shape,
                 initializer=tf.constant_initializer(1., dtype=tf.float32))
@@ -137,10 +137,10 @@ class CategoricalMLPRegressor(LayersPowered, Serializable, Parameterized):
             # recompute normalizing constants for inputs
             new_mean = np.mean(xs, axis=0, keepdims=True)
             new_std = np.std(xs, axis=0, keepdims=True) + 1e-8
-            tf.get_default_session().run(
+            tf.compat.v1.get_default_session().run(
                 tf.group(
-                    tf.assign(self.x_mean_var, new_mean),
-                    tf.assign(self.x_std_var, new_std),
+                    tf.compat.v1.assign(self.x_mean_var, new_mean),
+                    tf.compat.v1.assign(self.x_std_var, new_std),
                 ))
         if self.use_trust_region and self.first_optimized:
             old_prob = self.f_prob(xs)

--- a/src/garage/tf/regressors/categorical_mlp_regressor_with_model.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor_with_model.py
@@ -84,7 +84,7 @@ class CategoricalMLPRegressorWithModel(StochasticRegressor2):
         self._max_kl_step = max_kl_step
         self._normalize_inputs = normalize_inputs
 
-        with tf.variable_scope(self._name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self._name, reuse=False) as vs:
             self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
@@ -119,16 +119,16 @@ class CategoricalMLPRegressorWithModel(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(input_var)
 
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
 
-            old_prob_var = tf.placeholder(
+            old_prob_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_prob',
                 shape=(None, self._output_dim))
@@ -233,7 +233,7 @@ class CategoricalMLPRegressorWithModel(StochasticRegressor2):
         Return:
             tf.Tensor output of the symbolic graph of the distribution.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             prob, _, _ = self.model.build(x_var, name=name)
 
         return dict(prob=prob)
@@ -250,7 +250,7 @@ class CategoricalMLPRegressorWithModel(StochasticRegressor2):
         Return:
             tf.Tensor output of the symbolic log likelihood.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             prob, _, _ = self.model.build(x_var, name=name)
 
         return self._dist.log_likelihood_sym(y_var, dict(prob=prob))

--- a/src/garage/tf/regressors/continuous_mlp_regressor.py
+++ b/src/garage/tf/regressors/continuous_mlp_regressor.py
@@ -42,7 +42,7 @@ class ContinuousMLPRegressor(LayersPowered, Serializable, Parameterized):
         Parameterized.__init__(self)
         Serializable.quick_init(self, locals())
 
-        with tf.variable_scope(name, 'ContinuousMLPRegressor'):
+        with tf.compat.v1.variable_scope(name, 'ContinuousMLPRegressor'):
             if optimizer_args is None:
                 optimizer_args = dict()
 
@@ -69,14 +69,14 @@ class ContinuousMLPRegressor(LayersPowered, Serializable, Parameterized):
             LayersPowered.__init__(self, [l_out])
 
             xs_var = network.input_layer.input_var
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, shape=[None, output_dim], name='ys')
 
-            x_mean_var = tf.get_variable(
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 shape=(1, ) + input_shape,
                 initializer=tf.constant_initializer(0., dtype=tf.float32))
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std',
                 shape=(1, ) + input_shape,
                 initializer=tf.constant_initializer(1., dtype=tf.float32))
@@ -118,10 +118,10 @@ class ContinuousMLPRegressor(LayersPowered, Serializable, Parameterized):
             # recompute normalizing constants for inputs
             new_mean = np.mean(xs, axis=0, keepdims=True)
             new_std = np.std(xs, axis=0, keepdims=True) + 1e-8
-            tf.get_default_session().run(
+            tf.compat.v1.get_default_session().run(
                 tf.group(
-                    tf.assign(self.x_mean_var, new_mean),
-                    tf.assign(self.x_std_var, new_std),
+                    tf.compat.v1.assign(self.x_mean_var, new_mean),
+                    tf.compat.v1.assign(self.x_std_var, new_std),
                 ))
         inputs = [xs, ys]
         loss_before = self.optimizer.loss(inputs)

--- a/src/garage/tf/regressors/continuous_mlp_regressor_with_model.py
+++ b/src/garage/tf/regressors/continuous_mlp_regressor_with_model.py
@@ -66,7 +66,7 @@ class ContinuousMLPRegressorWithModel(Regressor2):
         super().__init__(input_shape, output_dim, name)
         self._normalize_inputs = normalize_inputs
 
-        with tf.variable_scope(self._name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self._name, reuse=False) as vs:
             self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
@@ -90,13 +90,13 @@ class ContinuousMLPRegressorWithModel(Regressor2):
         self._initialize()
 
     def _initialize(self):
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
 
-        with tf.variable_scope(self._name) as vs:
+        with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
             self.model.build(input_var)
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
 
             y_hat = self.model.networks['default'].y_hat
@@ -154,7 +154,7 @@ class ContinuousMLPRegressorWithModel(Regressor2):
         Return:
             tf.Tensor output of the symbolic prediction.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             y_hat, _, _ = self.model.build(xs, name=name)
 
         return y_hat

--- a/src/garage/tf/regressors/gaussian_cnn_regressor_model.py
+++ b/src/garage/tf/regressors/gaussian_cnn_regressor_model.py
@@ -104,26 +104,26 @@ class GaussianCNNRegressorModel(GaussianCNNModel):
         ]
 
     def _build(self, state_input, name=None):
-        with tf.variable_scope('normalized_vars'):
-            x_mean_var = tf.get_variable(
+        with tf.compat.v1.variable_scope('normalized_vars'):
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std_var',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.ones_initializer(),
                 trainable=False)
-            y_mean_var = tf.get_variable(
+            y_mean_var = tf.compat.v1.get_variable(
                 name='y_mean_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
-            y_std_var = tf.get_variable(
+            y_std_var = tf.compat.v1.get_variable(
                 name='y_std_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
@@ -139,7 +139,7 @@ class GaussianCNNRegressorModel(GaussianCNNModel):
             means_var = normalized_mean * y_std_var + y_mean_var
 
         with tf.name_scope('std_network'):
-            log_stds_var = normalized_log_std + tf.log(y_std_var)
+            log_stds_var = normalized_log_std + tf.math.log(y_std_var)
 
         return (sample, means_var, log_stds_var, std_param, normalized_mean,
                 normalized_log_std, x_mean_var, x_std_var, y_mean_var,

--- a/src/garage/tf/regressors/gaussian_cnn_regressor_with_model.py
+++ b/src/garage/tf/regressors/gaussian_cnn_regressor_with_model.py
@@ -145,7 +145,7 @@ class GaussianCNNRegressorWithModel(StochasticRegressor2):
         self._normalize_inputs = normalize_inputs
         self._normalize_outputs = normalize_outputs
 
-        with tf.variable_scope(self._name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self._name, reuse=False) as vs:
             self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
@@ -190,18 +190,18 @@ class GaussianCNNRegressorWithModel(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(input_var)
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
-            old_means_var = tf.placeholder(
+            old_means_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_means',
                 shape=(None, self._output_dim))
-            old_log_stds_var = tf.placeholder(
+            old_log_stds_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_log_stds',
                 shape=(None, self._output_dim))
@@ -218,7 +218,8 @@ class GaussianCNNRegressorWithModel(StochasticRegressor2):
             normalized_ys_var = (ys_var - y_mean_var) / y_std_var
 
             normalized_old_means_var = (old_means_var - y_mean_var) / y_std_var
-            normalized_old_log_stds_var = old_log_stds_var - tf.log(y_std_var)
+            normalized_old_log_stds_var = (
+                old_log_stds_var - tf.math.log(y_std_var))
 
             normalized_dist_info_vars = dict(
                 mean=normalized_means_var, log_std=normalized_log_stds_var)
@@ -325,7 +326,7 @@ class GaussianCNNRegressorWithModel(StochasticRegressor2):
         Return:
             tf.Tensor output of the symbolic log likelihood.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(x_var, name=name)
 
         means_var = self.model.networks[name].means

--- a/src/garage/tf/regressors/gaussian_mlp_regressor_model.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor_model.py
@@ -78,26 +78,26 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
         ]
 
     def _build(self, state_input, name=None):
-        with tf.variable_scope('normalized_vars'):
-            x_mean_var = tf.get_variable(
+        with tf.compat.v1.variable_scope('normalized_vars'):
+            x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
-            x_std_var = tf.get_variable(
+            x_std_var = tf.compat.v1.get_variable(
                 name='x_std_var',
                 shape=(1, ) + self._input_shape,
                 dtype=np.float32,
                 initializer=tf.ones_initializer(),
                 trainable=False)
-            y_mean_var = tf.get_variable(
+            y_mean_var = tf.compat.v1.get_variable(
                 name='y_mean_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
                 initializer=tf.zeros_initializer(),
                 trainable=False)
-            y_std_var = tf.get_variable(
+            y_std_var = tf.compat.v1.get_variable(
                 name='y_std_var',
                 shape=(1, self._output_dim),
                 dtype=np.float32,
@@ -113,7 +113,7 @@ class GaussianMLPRegressorModel(GaussianMLPModel):
             means_var = normalized_mean * y_std_var + y_mean_var
 
         with tf.name_scope('std_network'):
-            log_stds_var = normalized_log_std + tf.log(y_std_var)
+            log_stds_var = normalized_log_std + tf.math.log(y_std_var)
 
         return (sample, means_var, log_stds_var, std_param, normalized_mean,
                 normalized_log_std, x_mean_var, x_std_var, y_mean_var,

--- a/src/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor_with_model.py
@@ -97,7 +97,7 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         self._normalize_inputs = normalize_inputs
         self._normalize_outputs = normalize_outputs
 
-        with tf.variable_scope(self._name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self._name, reuse=False) as vs:
             self._variable_scope = vs
             if optimizer_args is None:
                 optimizer_args = dict()
@@ -135,18 +135,18 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
 
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(input_var)
-            ys_var = tf.placeholder(
+            ys_var = tf.compat.v1.placeholder(
                 dtype=tf.float32, name='ys', shape=(None, self._output_dim))
-            old_means_var = tf.placeholder(
+            old_means_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_means',
                 shape=(None, self._output_dim))
-            old_log_stds_var = tf.placeholder(
+            old_log_stds_var = tf.compat.v1.placeholder(
                 dtype=tf.float32,
                 name='old_log_stds',
                 shape=(None, self._output_dim))
@@ -163,7 +163,8 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
             normalized_ys_var = (ys_var - y_mean_var) / y_std_var
 
             normalized_old_means_var = (old_means_var - y_mean_var) / y_std_var
-            normalized_old_log_stds_var = old_log_stds_var - tf.log(y_std_var)
+            normalized_old_log_stds_var = (
+                old_log_stds_var - tf.math.log(y_std_var))
 
             normalized_dist_info_vars = dict(
                 mean=normalized_means_var, log_std=normalized_log_stds_var)
@@ -270,7 +271,7 @@ class GaussianMLPRegressorWithModel(StochasticRegressor2):
         Return:
             tf.Tensor output of the symbolic log likelihood.
         """
-        with tf.variable_scope(self._variable_scope):
+        with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(x_var, name=name)
 
         means_var = self.model.networks[name].means

--- a/src/garage/tf/samplers/batch_sampler.py
+++ b/src/garage/tf/samplers/batch_sampler.py
@@ -6,12 +6,12 @@ from garage.sampler.utils import truncate_paths
 
 
 def worker_init_tf(g):
-    g.sess = tf.Session()
+    g.sess = tf.compat.v1.Session()
     g.sess.__enter__()
 
 
 def worker_init_tf_vars(g):
-    g.sess.run(tf.global_variables_initializer())
+    g.sess.run(tf.compat.v1.global_variables_initializer())
 
 
 class BatchSampler(BaseSampler):

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -199,7 +199,7 @@ def run_baselines(env, seed, log_dir):
         allow_soft_placement=True,
         intra_op_parallelism_threads=ncpu,
         inter_op_parallelism_threads=ncpu)
-    tf.Session(config=config).__enter__()
+    tf.compat.v1.Session(config=config).__enter__()
 
     # Set up logger for baselines
     configure(dir=log_dir, format_strs=['stdout', 'log', 'csv', 'tensorboard'])

--- a/tests/benchmarks/test_benchmark_trpo.py
+++ b/tests/benchmarks/test_benchmark_trpo.py
@@ -178,7 +178,7 @@ def run_baselines(env, seed, log_dir):
     :param log_dir: Log dir path.
     :return
     '''
-    with tf.Session().as_default():
+    with tf.compat.v1.Session().as_default():
         baselines_logger.configure(log_dir)
 
         def policy_fn(name, ob_space, ac_space):

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -9,7 +9,7 @@ from tests.fixtures.logger import NullOutput
 
 class TfTestCase:
     def setup_method(self):
-        self.sess = tf.Session()
+        self.sess = tf.compat.v1.Session()
         self.sess.__enter__()
 
     def teardown_method(self):

--- a/tests/fixtures/models/simple_cnn_model.py
+++ b/tests/fixtures/models/simple_cnn_model.py
@@ -30,6 +30,6 @@ class SimpleCNNModel(Model):
             else:
                 current_size = int((current_size - filter_dim) / stride) + 1
         flatten_shape = current_size * current_size * self.num_filters[-1]
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], flatten_shape), return_var)

--- a/tests/fixtures/models/simple_cnn_model_with_max_pooling.py
+++ b/tests/fixtures/models/simple_cnn_model_with_max_pooling.py
@@ -36,6 +36,6 @@ class SimpleCNNModelWithMaxPooling(Model):
             new_size = current_size - self.pool_shapes[0]
             current_size = int(new_size / self.pool_strides[0]) + 1
         flatten_shape = current_size * current_size * self.num_filters[-1]
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], flatten_shape), return_var)

--- a/tests/fixtures/models/simple_gaussian_cnn_model.py
+++ b/tests/fixtures/models/simple_gaussian_cnn_model.py
@@ -19,7 +19,7 @@ class SimpleGaussianCNNModel(Model):
         return ['sample', 'mean', 'log_std', 'std_param', 'dist']
 
     def _build(self, obs_input, name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)
         log_std = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)

--- a/tests/fixtures/models/simple_gaussian_gru_model.py
+++ b/tests/fixtures/models/simple_gaussian_gru_model.py
@@ -34,7 +34,7 @@ class SimpleGaussianGRUModel(Model):
                step_hidden,
                step_cell,
                name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = log_std = tf.fill(
             (tf.shape(obs_input)[0], tf.shape(obs_input)[1], self.output_dim),
@@ -42,7 +42,7 @@ class SimpleGaussianGRUModel(Model):
         step_mean = step_log_std = tf.fill(
             (tf.shape(step_obs_input)[0], self.output_dim), return_var)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),

--- a/tests/fixtures/models/simple_gaussian_lstm_model.py
+++ b/tests/fixtures/models/simple_gaussian_lstm_model.py
@@ -36,7 +36,7 @@ class SimpleGaussianLSTMModel(Model):
                step_hidden,
                step_cell,
                name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = log_std = tf.fill(
             (tf.shape(obs_input)[0], tf.shape(obs_input)[1], self.output_dim),
@@ -44,13 +44,13 @@ class SimpleGaussianLSTMModel(Model):
         step_mean = step_log_std = tf.fill(
             (tf.shape(step_obs_input)[0], self.output_dim), return_var)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),
             trainable=False,
             dtype=tf.float32)
-        cell_init_var = tf.get_variable(
+        cell_init_var = tf.compat.v1.get_variable(
             name='initial_cell',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),

--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -19,7 +19,7 @@ class SimpleGaussianMLPModel(Model):
         return ['sample', 'mean', 'log_std', 'std_param', 'dist']
 
     def _build(self, obs_input, name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)
         log_std = tf.fill((tf.shape(obs_input)[0], self.output_dim), 0.5)

--- a/tests/fixtures/models/simple_gru_model.py
+++ b/tests/fixtures/models/simple_gru_model.py
@@ -25,7 +25,7 @@ class SimpleGRUModel(Model):
         return ['all_output', 'step_output', 'step_hidden', 'init_hidden']
 
     def _build(self, obs_input, step_obs_input, step_hidden, name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         outputs = tf.fill(
             (tf.shape(obs_input)[0], tf.shape(obs_input)[1], self.output_dim),
@@ -33,7 +33,7 @@ class SimpleGRUModel(Model):
         output = tf.fill((tf.shape(step_obs_input)[0], self.output_dim),
                          return_var)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),

--- a/tests/fixtures/models/simple_lstm_model.py
+++ b/tests/fixtures/models/simple_lstm_model.py
@@ -35,7 +35,7 @@ class SimpleLSTMModel(Model):
                step_hidden,
                step_cell,
                name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         outputs = tf.fill(
             (tf.shape(obs_input)[0], tf.shape(obs_input)[1], self.output_dim),
@@ -43,13 +43,13 @@ class SimpleLSTMModel(Model):
         output = tf.fill((tf.shape(step_obs_input)[0], self.output_dim),
                          return_var)
 
-        hidden_init_var = tf.get_variable(
+        hidden_init_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),
             trainable=False,
             dtype=tf.float32)
-        cell_init_var = tf.get_variable(
+        cell_init_var = tf.compat.v1.get_variable(
             name='initial_cell',
             shape=(self.hidden_dim, ),
             initializer=tf.zeros_initializer(),

--- a/tests/fixtures/models/simple_mlp_merge_model.py
+++ b/tests/fixtures/models/simple_mlp_merge_model.py
@@ -15,6 +15,6 @@ class SimpleMLPMergeModel(Model):
         return ['input_var1', 'input_var2']
 
     def _build(self, obs_input, act_input, name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/fixtures/models/simple_mlp_model.py
+++ b/tests/fixtures/models/simple_mlp_model.py
@@ -11,6 +11,6 @@ class SimpleMLPModel(Model):
         self.output_dim = output_dim
 
     def _build(self, obs_input, name=None):
-        return_var = tf.get_variable(
+        return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/fixtures/q_functions/simple_q_function.py
+++ b/tests/fixtures/q_functions/simple_q_function.py
@@ -16,10 +16,10 @@ class SimpleQFunction(QFunction2):
         self._initialize()
 
     def _initialize(self):
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, (None, ) + self.obs_dim, name='obs')
 
-        with tf.variable_scope(self.name, reuse=False) as vs:
+        with tf.compat.v1.variable_scope(self.name, reuse=False) as vs:
             self._variable_scope = vs
             self.model.build(obs_ph)
 

--- a/tests/fixtures/regressors/simple_gaussian_cnn_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_cnn_regressor.py
@@ -16,9 +16,9 @@ class SimpleGaussianCNNRegressor(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_ph = tf.placeholder(
+        input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
-        with tf.variable_scope(self._name) as vs:
+        with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
             self.model.build(input_ph)
         self.ys = None
@@ -28,7 +28,7 @@ class SimpleGaussianCNNRegressor(StochasticRegressor2):
 
     def predict(self, xs):
         if self.ys is None:
-            mean = tf.get_default_session().run(
+            mean = tf.compat.v1.get_default_session().run(
                 self.model.networks['default'].mean,
                 feed_dict={self.model.networks['default'].input: xs})
             self.ys = np.full((len(xs), 1), mean)

--- a/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
@@ -16,9 +16,9 @@ class SimpleGaussianMLPRegressor(StochasticRegressor2):
         self._initialize()
 
     def _initialize(self):
-        input_ph = tf.placeholder(
+        input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
-        with tf.variable_scope(self._name) as vs:
+        with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
             self.model.build(input_ph)
         self.ys = None
@@ -28,7 +28,7 @@ class SimpleGaussianMLPRegressor(StochasticRegressor2):
 
     def predict(self, xs):
         if self.ys is None:
-            mean = tf.get_default_session().run(
+            mean = tf.compat.v1.get_default_session().run(
                 self.model.networks['default'].mean,
                 feed_dict={self.model.networks['default'].input: xs})
             self.ys = np.full((len(xs), 1), mean)

--- a/tests/fixtures/regressors/simple_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_mlp_regressor.py
@@ -16,9 +16,9 @@ class SimpleMLPRegressor(Regressor2):
         self._initialize()
 
     def _initialize(self):
-        input_ph = tf.placeholder(
+        input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + self._input_shape)
-        with tf.variable_scope(self._name) as vs:
+        with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
             self.model.build(input_ph)
         self.ys = None
@@ -28,7 +28,7 @@ class SimpleMLPRegressor(Regressor2):
 
     def predict(self, xs):
         if self.ys is None:
-            outputs = tf.get_default_session().run(
+            outputs = tf.compat.v1.get_default_session().run(
                 self.model.networks['default'].outputs,
                 feed_dict={self.model.networks['default'].input: xs})
             self.ys = outputs

--- a/tests/fixtures/tf/instrumented_batch_polopt.py
+++ b/tests/fixtures/tf/instrumented_batch_polopt.py
@@ -29,10 +29,10 @@ class InstrumentedBatchPolopt(BatchPolopt):
         try:
             created_session = True if (sess is None) else False
             if sess is None:
-                sess = tf.Session()
+                sess = tf.compat.v1.Session()
                 sess.__enter__()
 
-            sess.run(tf.global_variables_initializer())
+            sess.run(tf.compat.v1.global_variables_initializer())
             conn.send(ExpLifecycle.START)
             self.start_worker(sess)
             start_time = time.time()

--- a/tests/fixtures/tf/instrumented_npo.py
+++ b/tests/fixtures/tf/instrumented_npo.py
@@ -132,13 +132,13 @@ class InstrumentedNPO(InstrumentedBatchPolopt):
                 name='action', batch_dims=2)
             reward_var = tensor_utils.new_tensor(
                 name='reward', ndim=2, dtype=tf.float32)
-            valid_var = tf.placeholder(
+            valid_var = tf.compat.v1.placeholder(
                 tf.float32, shape=[None, None], name='valid')
             baseline_var = tensor_utils.new_tensor(
                 name='baseline', ndim=2, dtype=tf.float32)
 
             policy_state_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32, shape=[None] * 2 + list(shape), name=k)
                 for k, shape in self.policy.state_info_specs
             }
@@ -148,7 +148,7 @@ class InstrumentedNPO(InstrumentedBatchPolopt):
 
             # old policy distribution
             policy_old_dist_info_vars = {
-                k: tf.placeholder(
+                k: tf.compat.v1.placeholder(
                     tf.float32,
                     shape=[None] * 2 + list(shape),
                     name='policy_old_%s' % k)

--- a/tests/garage/experiment/test_local_tf_runner.py
+++ b/tests/garage/experiment/test_local_tf_runner.py
@@ -14,12 +14,12 @@ from tests.fixtures import TfGraphTestCase
 class TestLocalRunner(TfGraphTestCase):
     def test_session(self):
         with LocalRunner():
-            assert tf.get_default_session is not None, (
+            assert tf.compat.v1.get_default_session is not None, (
                 'LocalRunner() should provide a default tf session.')
 
-        sess = tf.Session()
+        sess = tf.compat.v1.Session()
         with LocalRunner(sess=sess):
-            assert tf.get_default_session() is sess, (
+            assert tf.compat.v1.get_default_session() is sess, (
                 'LocalRunner(sess) should use sess as default session.')
 
     def test_singleton_pool(self):
@@ -50,7 +50,7 @@ class TestLocalRunner(TfGraphTestCase):
             runner.train(n_epochs=1, batch_size=100)
 
     def test_external_sess(self):
-        with tf.Session() as sess:
+        with tf.compat.v1.Session() as sess:
             with LocalRunner(sess=sess):
                 pass
             # sess should still be the default session here.

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -192,20 +192,20 @@ class TestDQN(TfGraphTestCase):
                 target_network_update_freq=1,
                 buffer_batch_size=32)
             runner.setup(algo, env)
-            with tf.variable_scope(
+            with tf.compat.v1.variable_scope(
                     'DiscreteMLPQFunction/MLPModel/mlp/hidden_0', reuse=True):
-                bias = tf.get_variable('bias')
+                bias = tf.compat.v1.get_variable('bias')
                 # assign it to all one
                 old_bias = tf.ones_like(bias).eval()
                 bias.load(old_bias)
                 h = pickle.dumps(algo)
 
-            with tf.Session(graph=tf.Graph()):
+            with tf.compat.v1.Session(graph=tf.Graph()):
                 pickle.loads(h)
-                with tf.variable_scope(
+                with tf.compat.v1.variable_scope(
                         'DiscreteMLPQFunction/MLPModel/mlp/hidden_0',
                         reuse=True):
-                    new_bias = tf.get_variable('bias')
+                    new_bias = tf.compat.v1.get_variable('bias')
                     new_bias = new_bias.eval()
                     assert np.array_equal(old_bias, new_bias)
 

--- a/tests/garage/tf/baselines/test_baselines.py
+++ b/tests/garage/tf/baselines/test_baselines.py
@@ -31,7 +31,7 @@ class TestTfBaselines(TfGraphTestCase):
                 conv_pads=['VALID', 'VALID'],
                 hidden_sizes=(32, 32)))
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
         deterministic_mlp_baseline.get_param_values(trainable=True)
         gaussian_mlp_baseline.get_param_values(trainable=True)
         gaussian_conv_baseline.get_param_values(trainable=True)

--- a/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model.py
+++ b/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model.py
@@ -46,8 +46,9 @@ class TestContinuousMLPBaselineWithModel(TfGraphTestCase):
                 env_spec=box_env.spec, name='ContinuousMLPBaselineWithModel2')
 
         # Manual change the parameter of ContinuousMLPBaselineWithModel
-        with tf.variable_scope('ContinuousMLPBaselineWithModel2', reuse=True):
-            return_var = tf.get_variable('SimpleMLPModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'ContinuousMLPBaselineWithModel2', reuse=True):
+            return_var = tf.compat.v1.get_variable('SimpleMLPModel/return_var')
         return_var.load(1.0)
 
         old_param_values = cmb.get_param_values()
@@ -66,7 +67,7 @@ class TestContinuousMLPBaselineWithModel(TfGraphTestCase):
                         new=SimpleMLPRegressor):
             cmb = ContinuousMLPBaselineWithModel(env_spec=box_env.spec)
         params_interal = cmb.get_params_internal()
-        trainable_params = tf.trainable_variables(
+        trainable_params = tf.compat.v1.trainable_variables(
             scope='ContinuousMLPBaselineWithModel')
         assert np.array_equal(params_interal, trainable_params)
 
@@ -79,15 +80,16 @@ class TestContinuousMLPBaselineWithModel(TfGraphTestCase):
             cmb = ContinuousMLPBaselineWithModel(env_spec=box_env.spec)
         obs = {'observations': [np.full(1, 1), np.full(1, 1)]}
 
-        with tf.variable_scope('ContinuousMLPBaselineWithModel', reuse=True):
-            return_var = tf.get_variable('SimpleMLPModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'ContinuousMLPBaselineWithModel', reuse=True):
+            return_var = tf.compat.v1.get_variable('SimpleMLPModel/return_var')
         return_var.load(1.0)
 
         prediction = cmb.predict(obs)
 
         h = pickle.dumps(cmb)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             cmb_pickled = pickle.loads(h)
             prediction2 = cmb_pickled.predict(obs)
 

--- a/tests/garage/tf/baselines/test_gaussian_cnn_baseline_with_model.py
+++ b/tests/garage/tf/baselines/test_gaussian_cnn_baseline_with_model.py
@@ -46,8 +46,10 @@ class TestGaussianCNNBaselineWithModel(TfGraphTestCase):
                 env_spec=box_env.spec, name='GaussianCNNBaselineWithModel2')
 
         # Manual change the parameter of GaussianCNNBaselineWithModel
-        with tf.variable_scope('GaussianCNNBaselineWithModel', reuse=True):
-            return_var = tf.get_variable('SimpleGaussianCNNModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'GaussianCNNBaselineWithModel', reuse=True):
+            return_var = tf.compat.v1.get_variable(
+                'SimpleGaussianCNNModel/return_var')
         return_var.load(1.0)
 
         old_param_values = gcb.get_param_values()
@@ -67,7 +69,7 @@ class TestGaussianCNNBaselineWithModel(TfGraphTestCase):
             gcb = GaussianCNNBaselineWithModel(
                 env_spec=box_env.spec, regressor_args=dict())
         params_interal = gcb.get_params_internal()
-        trainable_params = tf.trainable_variables(
+        trainable_params = tf.compat.v1.trainable_variables(
             scope='GaussianCNNBaselineWithModel')
         assert np.array_equal(params_interal, trainable_params)
 
@@ -80,15 +82,17 @@ class TestGaussianCNNBaselineWithModel(TfGraphTestCase):
             gcb = GaussianCNNBaselineWithModel(env_spec=box_env.spec)
         obs = {'observations': [np.full(1, 1), np.full(1, 1)]}
 
-        with tf.variable_scope('GaussianCNNBaselineWithModel', reuse=True):
-            return_var = tf.get_variable('SimpleGaussianCNNModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'GaussianCNNBaselineWithModel', reuse=True):
+            return_var = tf.compat.v1.get_variable(
+                'SimpleGaussianCNNModel/return_var')
         return_var.load(1.0)
 
         prediction = gcb.predict(obs)
 
         h = pickle.dumps(gcb)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gcb_pickled = pickle.loads(h)
             prediction2 = gcb_pickled.predict(obs)
 

--- a/tests/garage/tf/baselines/test_gaussian_mlp_baseline_with_model.py
+++ b/tests/garage/tf/baselines/test_gaussian_mlp_baseline_with_model.py
@@ -46,8 +46,10 @@ class TestGaussianMLPBaselineWithModel(TfGraphTestCase):
                 env_spec=box_env.spec, name='GaussianMLPBaselineWithModel2')
 
         # Manual change the parameter of GaussianMLPBaselineWithModel
-        with tf.variable_scope('GaussianMLPBaselineWithModel', reuse=True):
-            return_var = tf.get_variable('SimpleGaussianMLPModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'GaussianMLPBaselineWithModel', reuse=True):
+            return_var = tf.compat.v1.get_variable(
+                'SimpleGaussianMLPModel/return_var')
         return_var.load(1.0)
 
         old_param_values = gmb.get_param_values()
@@ -67,7 +69,7 @@ class TestGaussianMLPBaselineWithModel(TfGraphTestCase):
             gmb = GaussianMLPBaselineWithModel(
                 env_spec=box_env.spec, regressor_args=dict())
         params_interal = gmb.get_params_internal()
-        trainable_params = tf.trainable_variables(
+        trainable_params = tf.compat.v1.trainable_variables(
             scope='GaussianMLPBaselineWithModel')
         assert np.array_equal(params_interal, trainable_params)
 
@@ -80,15 +82,17 @@ class TestGaussianMLPBaselineWithModel(TfGraphTestCase):
             gmb = GaussianMLPBaselineWithModel(env_spec=box_env.spec)
         obs = {'observations': [np.full(1, 1), np.full(1, 1)]}
 
-        with tf.variable_scope('GaussianMLPBaselineWithModel', reuse=True):
-            return_var = tf.get_variable('SimpleGaussianMLPModel/return_var')
+        with tf.compat.v1.variable_scope(
+                'GaussianMLPBaselineWithModel', reuse=True):
+            return_var = tf.compat.v1.get_variable(
+                'SimpleGaussianMLPModel/return_var')
         return_var.load(1.0)
 
         prediction = gmb.predict(obs)
 
         h = pickle.dumps(gmb)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gmb_pickled = pickle.loads(h)
             prediction2 = gmb_pickled.predict(obs)
 

--- a/tests/garage/tf/core/test_cnn.py
+++ b/tests/garage/tf/core/test_cnn.py
@@ -19,7 +19,7 @@ class TestCNN(TfGraphTestCase):
                                   self.input_height, 3))
 
         input_shape = self.obs_input.shape[1:]  # height, width, channel
-        self._input_ph = tf.placeholder(
+        self._input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape, name='input')
         self.hidden_nonlinearity = tf.nn.relu
 
@@ -32,7 +32,7 @@ class TestCNN(TfGraphTestCase):
         ((3, 3), (32, 64), (2, 2)),
     ])
     def test_output_shape_same(self, filter_sizes, out_channels, strides):
-        with tf.variable_scope('CNN'):
+        with tf.compat.v1.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
@@ -43,7 +43,7 @@ class TestCNN(TfGraphTestCase):
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         result = self.sess.run(
             self.cnn, feed_dict={self._input_ph: self.obs_input})
@@ -65,7 +65,7 @@ class TestCNN(TfGraphTestCase):
         ((3, 3), (32, 64), (2, 2)),
     ])
     def test_output_shape_valid(self, filter_sizes, out_channels, strides):
-        with tf.variable_scope('CNN'):
+        with tf.compat.v1.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
@@ -76,7 +76,7 @@ class TestCNN(TfGraphTestCase):
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         result = self.sess.run(
             self.cnn, feed_dict={self._input_ph: self.obs_input})
@@ -95,7 +95,7 @@ class TestCNN(TfGraphTestCase):
          ((3, 3), (3, 32), (32, 64), (2, 2))])
     def test_output_with_identity_filter(self, filter_sizes, in_channels,
                                          out_channels, strides):
-        with tf.variable_scope('CNN'):
+        with tf.compat.v1.variable_scope('CNN'):
             self.cnn = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
@@ -106,7 +106,7 @@ class TestCNN(TfGraphTestCase):
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         result = self.sess.run(
             self.cnn, feed_dict={self._input_ph: self.obs_input})
@@ -136,7 +136,7 @@ class TestCNN(TfGraphTestCase):
     def test_output_with_random_filter(self, filter_sizes, in_channels,
                                        out_channels, strides):
         # Build a cnn with random filter weights
-        with tf.variable_scope('CNN'):
+        with tf.compat.v1.variable_scope('CNN'):
             self.cnn2 = cnn(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
@@ -146,19 +146,19 @@ class TestCNN(TfGraphTestCase):
                 padding='VALID',
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         result = self.sess.run(
             self.cnn2, feed_dict={self._input_ph: self.obs_input})
 
         two_layer = len(filter_sizes) == 2
         # get weight values
-        with tf.variable_scope('CNN', reuse=True):
-            h0_w = tf.get_variable('cnn1/h0/weight').eval()
-            h0_b = tf.get_variable('cnn1/h0/bias').eval()
+        with tf.compat.v1.variable_scope('CNN', reuse=True):
+            h0_w = tf.compat.v1.get_variable('cnn1/h0/weight').eval()
+            h0_b = tf.compat.v1.get_variable('cnn1/h0/bias').eval()
             if two_layer:
-                h1_w = tf.get_variable('cnn1/h1/weight').eval()
-                h1_b = tf.get_variable('cnn1/h1/bias').eval()
+                h1_w = tf.compat.v1.get_variable('cnn1/h1/weight').eval()
+                h1_b = tf.compat.v1.get_variable('cnn1/h1/bias').eval()
         filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
         filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
 
@@ -191,7 +191,7 @@ class TestCNN(TfGraphTestCase):
                                      out_channels, strides, pool_shape,
                                      pool_stride):
         # Build a cnn with random filter weights
-        with tf.variable_scope('CNN'):
+        with tf.compat.v1.variable_scope('CNN'):
             self.cnn2 = cnn_with_max_pooling(
                 input_var=self._input_ph,
                 filter_dims=filter_sizes,
@@ -204,19 +204,19 @@ class TestCNN(TfGraphTestCase):
                 hidden_w_init=tf.constant_initializer(1),
                 hidden_nonlinearity=self.hidden_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         result = self.sess.run(
             self.cnn2, feed_dict={self._input_ph: self.obs_input})
 
         two_layer = len(filter_sizes) == 2
         # get weight values
-        with tf.variable_scope('CNN', reuse=True):
-            h0_w = tf.get_variable('cnn1/h0/weight').eval()
-            h0_b = tf.get_variable('cnn1/h0/bias').eval()
+        with tf.compat.v1.variable_scope('CNN', reuse=True):
+            h0_w = tf.compat.v1.get_variable('cnn1/h0/weight').eval()
+            h0_b = tf.compat.v1.get_variable('cnn1/h0/bias').eval()
             if two_layer:
-                h1_w = tf.get_variable('cnn1/h1/weight').eval()
-                h1_b = tf.get_variable('cnn1/h1/bias').eval()
+                h1_w = tf.compat.v1.get_variable('cnn1/h1/weight').eval()
+                h1_b = tf.compat.v1.get_variable('cnn1/h1/bias').eval()
 
         filter_weights = (h0_w, h1_w) if two_layer else (h0_w, )
         filter_bias = (h0_b, h1_b) if two_layer else (h0_b, )
@@ -248,7 +248,7 @@ class TestCNN(TfGraphTestCase):
 
     def test_invalid_padding(self):
         with pytest.raises(ValueError):
-            with tf.variable_scope('CNN'):
+            with tf.compat.v1.variable_scope('CNN'):
                 self.cnn = cnn(
                     input_var=self._input_ph,
                     filter_dims=(3, ),
@@ -259,7 +259,7 @@ class TestCNN(TfGraphTestCase):
 
     def test_invalid_padding_max_pooling(self):
         with pytest.raises(ValueError):
-            with tf.variable_scope('CNN'):
+            with tf.compat.v1.variable_scope('CNN'):
                 self.cnn = cnn_with_max_pooling(
                     input_var=self._input_ph,
                     filter_dims=(3, ),

--- a/tests/garage/tf/core/test_gru.py
+++ b/tests/garage/tf/core/test_gru.py
@@ -13,7 +13,7 @@ class TestGRU(TfGraphTestCase):
         self.batch_size = 2
         self.hidden_dim = 2
 
-        self.step_hidden_var = tf.placeholder(
+        self.step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, self.hidden_dim),
             name='initial_hidden',
             dtype=tf.float32)
@@ -48,15 +48,15 @@ class TestGRU(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='step_input')
         output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('GRU'):
+        with tf.compat.v1.variable_scope('GRU'):
             self.gru = gru(
                 all_input_var=input_var,
                 name='gru',
@@ -66,7 +66,7 @@ class TestGRU(TfGraphTestCase):
                 hidden_state_init=tf.constant_initializer(hidden_init),
                 output_nonlinearity_layer=output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the gru cell
         outputs_t, output_t, h_t, hidden_init = self.gru
@@ -109,15 +109,15 @@ class TestGRU(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='step_input')
         output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('GRU'):
+        with tf.compat.v1.variable_scope('GRU'):
             self.gru = gru(
                 all_input_var=input_var,
                 name='gru',
@@ -127,7 +127,7 @@ class TestGRU(TfGraphTestCase):
                 hidden_state_init=tf.constant_initializer(hidden_init),
                 output_nonlinearity_layer=output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the gru cell
         outputs_t, output_t, h_t, hidden_init = self.gru
@@ -199,15 +199,15 @@ class TestGRU(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='step_input')
         output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('GRU'):
+        with tf.compat.v1.variable_scope('GRU'):
             self.gru = gru(
                 all_input_var=input_var,
                 name='gru',
@@ -217,7 +217,7 @@ class TestGRU(TfGraphTestCase):
                 hidden_state_init_trainable=True,
                 output_nonlinearity_layer=output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the gru cell
         outputs_t, output_t, h_t, hidden_init = self.gru
@@ -229,9 +229,9 @@ class TestGRU(TfGraphTestCase):
                                            step_input_var: obs_input,
                                            self.step_hidden_var: hidden,
                                        })  # noqa: E126
-        with tf.variable_scope('GRU/gru', reuse=True):
-            hidden_init_var = tf.get_variable(name='initial_hidden')
-            assert hidden_init_var in tf.trainable_variables()
+        with tf.compat.v1.variable_scope('GRU/gru', reuse=True):
+            hidden_init_var = tf.compat.v1.get_variable(name='initial_hidden')
+            assert hidden_init_var in tf.compat.v1.trainable_variables()
 
         full_output1 = self.sess.run(
             outputs_t, feed_dict={input_var: obs_inputs})
@@ -266,15 +266,15 @@ class TestGRU(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='step_input')
         output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('GRU'):
+        with tf.compat.v1.variable_scope('GRU'):
             self.gru = gru(
                 all_input_var=input_var,
                 name='gru',
@@ -283,7 +283,7 @@ class TestGRU(TfGraphTestCase):
                 step_hidden_var=self.step_hidden_var,
                 output_nonlinearity_layer=output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the gru cell
         outputs_t, output_t, h_t, hidden_init = self.gru
@@ -347,15 +347,15 @@ class TestGRU(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        input_var = tf.placeholder(
+        input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        step_input_var = tf.placeholder(
+        step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='step_input')
         output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('GRU'):
+        with tf.compat.v1.variable_scope('GRU'):
             self.gru = gru(
                 all_input_var=input_var,
                 name='gru',
@@ -365,14 +365,14 @@ class TestGRU(TfGraphTestCase):
                 hidden_state_init=tf.constant_initializer(hidden_init),
                 output_nonlinearity_layer=output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Create a RNN and compute the entire outputs
         rnn_layer = tf.keras.layers.RNN(
             cell=self.gru_cell, return_sequences=True, return_state=True)
 
         # Set initial state to all 0s
-        hidden_var = tf.get_variable(
+        hidden_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.batch_size, self.hidden_dim),
             initializer=tf.constant_initializer(hidden_init),
@@ -381,7 +381,7 @@ class TestGRU(TfGraphTestCase):
         outputs, hiddens = rnn_layer(input_var, initial_state=[hidden_var])
         outputs = output_nonlinearity(outputs)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         outputs, hiddens = self.sess.run([outputs, hiddens],
                                          feed_dict={input_var: obs_inputs})

--- a/tests/garage/tf/core/test_lstm.py
+++ b/tests/garage/tf/core/test_lstm.py
@@ -13,11 +13,11 @@ class TestLSTM(TfGraphTestCase):
         self.batch_size = 2
         self.hidden_dim = 2
 
-        self._step_hidden_var = tf.placeholder(
+        self._step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, self.hidden_dim),
             name='initial_hidden',
             dtype=tf.float32)
-        self._step_cell_var = tf.placeholder(
+        self._step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, self.hidden_dim),
             name='initial_cell',
             dtype=tf.float32)
@@ -52,15 +52,15 @@ class TestLSTM(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        _input_var = tf.placeholder(
+        _input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        _step_input_var = tf.placeholder(
+        _step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='input')
         _output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('LSTM'):
+        with tf.compat.v1.variable_scope('LSTM'):
             self.lstm = lstm(
                 all_input_var=_input_var,
                 name='lstm',
@@ -72,7 +72,7 @@ class TestLSTM(TfGraphTestCase):
                 cell_state_init=tf.constant_initializer(cell_init),
                 output_nonlinearity_layer=_output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the lstm cell
         outputs_t, output_t, h_t, c_t, hidden_init, cell_init = self.lstm
@@ -119,15 +119,15 @@ class TestLSTM(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        _input_var = tf.placeholder(
+        _input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        _step_input_var = tf.placeholder(
+        _step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='input')
         _output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('LSTM'):
+        with tf.compat.v1.variable_scope('LSTM'):
             self.lstm = lstm(
                 all_input_var=_input_var,
                 name='lstm',
@@ -139,7 +139,7 @@ class TestLSTM(TfGraphTestCase):
                 cell_state_init=tf.constant_initializer(cell_init),
                 output_nonlinearity_layer=_output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the lstm cell
         outputs_t, output_t, h_t, c_t, hidden_init, cell_init = self.lstm
@@ -219,15 +219,15 @@ class TestLSTM(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        _input_var = tf.placeholder(
+        _input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        _step_input_var = tf.placeholder(
+        _step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='input')
         _output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('LSTM'):
+        with tf.compat.v1.variable_scope('LSTM'):
             self.lstm = lstm(
                 all_input_var=_input_var,
                 name='lstm',
@@ -239,7 +239,7 @@ class TestLSTM(TfGraphTestCase):
                 cell_state_init_trainable=True,
                 output_nonlinearity_layer=_output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the lstm cell
         outputs_t, output_t, h_t, c_t, hidden_init, cell_init = self.lstm
@@ -254,11 +254,11 @@ class TestLSTM(TfGraphTestCase):
                 self._step_hidden_var: hidden,
                 self._step_cell_var: cell
             })
-        with tf.variable_scope('LSTM/lstm', reuse=True):
-            hidden_init_var = tf.get_variable(name='initial_hidden')
-            cell_init_var = tf.get_variable(name='initial_cell')
-            assert hidden_init_var in tf.trainable_variables()
-            assert cell_init_var in tf.trainable_variables()
+        with tf.compat.v1.variable_scope('LSTM/lstm', reuse=True):
+            hidden_init_var = tf.compat.v1.get_variable(name='initial_hidden')
+            cell_init_var = tf.compat.v1.get_variable(name='initial_cell')
+            assert hidden_init_var in tf.compat.v1.trainable_variables()
+            assert cell_init_var in tf.compat.v1.trainable_variables()
 
         full_output1 = self.sess.run(
             outputs_t, feed_dict={_input_var: obs_inputs})
@@ -295,15 +295,15 @@ class TestLSTM(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        _input_var = tf.placeholder(
+        _input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        _step_input_var = tf.placeholder(
+        _step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='input')
         _output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('LSTM'):
+        with tf.compat.v1.variable_scope('LSTM'):
             self.lstm = lstm(
                 all_input_var=_input_var,
                 name='lstm',
@@ -313,7 +313,7 @@ class TestLSTM(TfGraphTestCase):
                 step_cell_var=self._step_cell_var,
                 output_nonlinearity_layer=_output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Compute output by doing t step() on the lstm cell
         outputs_t, output_t, h_t, c_t, hidden_init, cell_init = self.lstm
@@ -399,15 +399,15 @@ class TestLSTM(TfGraphTestCase):
         obs_inputs = np.full((self.batch_size, time_step, input_dim), 1.)
         obs_input = np.full((self.batch_size, input_dim), 1.)
 
-        _input_var = tf.placeholder(
+        _input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, input_dim), name='input')
-        _step_input_var = tf.placeholder(
+        _step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, input_dim), name='input')
         _output_nonlinearity = tf.keras.layers.Dense(
             units=output_dim,
             activation=None,
             kernel_initializer=tf.constant_initializer(1))
-        with tf.variable_scope('LSTM'):
+        with tf.compat.v1.variable_scope('LSTM'):
             self.lstm = lstm(
                 all_input_var=_input_var,
                 name='lstm',
@@ -419,20 +419,20 @@ class TestLSTM(TfGraphTestCase):
                 cell_state_init=tf.constant_initializer(cell_init),
                 output_nonlinearity_layer=_output_nonlinearity)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # Create a RNN and compute the entire outputs
         rnn_layer = tf.keras.layers.RNN(
             cell=self.lstm_cell, return_sequences=True, return_state=True)
 
         # Set initial state to all 0s
-        hidden_var = tf.get_variable(
+        hidden_var = tf.compat.v1.get_variable(
             name='initial_hidden',
             shape=(self.batch_size, self.hidden_dim),
             initializer=tf.constant_initializer(hidden_init),
             trainable=False,
             dtype=tf.float32)
-        cell_var = tf.get_variable(
+        cell_var = tf.compat.v1.get_variable(
             name='initial_cell',
             shape=(self.batch_size, self.hidden_dim),
             initializer=tf.constant_initializer(cell_init),
@@ -442,7 +442,7 @@ class TestLSTM(TfGraphTestCase):
             _input_var, initial_state=[hidden_var, cell_var])
         outputs = _output_nonlinearity(outputs)
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         outputs, hiddens, cells = self.sess.run(
             [outputs, hiddens, cells], feed_dict={_input_var: obs_inputs})

--- a/tests/garage/tf/core/test_mlp.py
+++ b/tests/garage/tf/core/test_mlp.py
@@ -12,13 +12,13 @@ class TestMLP(TfGraphTestCase):
         input_shape = self.obs_input.shape[1:]  # 4
         self.hidden_nonlinearity = tf.nn.relu
 
-        self._input = tf.placeholder(
+        self._input = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape, name='input')
 
         self._output_shape = 2
 
         # We build a default mlp
-        with tf.variable_scope('MLP'):
+        with tf.compat.v1.variable_scope('MLP'):
             self.mlp_f = mlp(
                 input_var=self._input,
                 output_dim=self._output_shape,
@@ -26,11 +26,11 @@ class TestMLP(TfGraphTestCase):
                 hidden_nonlinearity=self.hidden_nonlinearity,
                 name='mlp1')
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
     def test_multiple_same_mlp(self):
         # We create another mlp with the same name, trying to reuse it
-        with tf.variable_scope('MLP', reuse=True):
+        with tf.compat.v1.variable_scope('MLP', reuse=True):
             self.mlp_same_copy = mlp(
                 input_var=self._input,
                 output_dim=self._output_shape,
@@ -40,8 +40,8 @@ class TestMLP(TfGraphTestCase):
 
         # We modify the weight of the default mlp and feed
         # The another mlp created should output the same result
-        with tf.variable_scope('MLP', reuse=True):
-            w = tf.get_variable('mlp1/hidden_0/kernel')
+        with tf.compat.v1.variable_scope('MLP', reuse=True):
+            w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
             self.sess.run(w.assign(w + 1))
             mlp_output = self.sess.run(
                 self.mlp_f, feed_dict={self._input: self.obs_input})
@@ -52,7 +52,7 @@ class TestMLP(TfGraphTestCase):
 
     def test_different_mlp(self):
         # We create another mlp with different name
-        with tf.variable_scope('MLP'):
+        with tf.compat.v1.variable_scope('MLP'):
             self.mlp_different_copy = mlp(
                 input_var=self._input,
                 output_dim=self._output_shape,
@@ -61,12 +61,12 @@ class TestMLP(TfGraphTestCase):
                 name='mlp2')
 
         # Initialize the new mlp variables
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # We modify the weight of the default mlp and feed
         # The another mlp created should output different result
-        with tf.variable_scope('MLP', reuse=True):
-            w = tf.get_variable('mlp1/hidden_0/kernel')
+        with tf.compat.v1.variable_scope('MLP', reuse=True):
+            w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
             self.sess.run(w.assign(w + 1))
             mlp_output = self.sess.run(
                 self.mlp_f, feed_dict={self._input: self.obs_input})
@@ -83,13 +83,13 @@ class TestMLP(TfGraphTestCase):
         assert mlp_output.shape[1] == self._output_shape
 
     def test_output_value(self):
-        with tf.variable_scope('MLP', reuse=True):
-            h1_w = tf.get_variable('mlp1/hidden_0/kernel')
-            h1_b = tf.get_variable('mlp1/hidden_0/bias')
-            h2_w = tf.get_variable('mlp1/hidden_1/kernel')
-            h2_b = tf.get_variable('mlp1/hidden_1/bias')
-            out_w = tf.get_variable('mlp1/output/kernel')
-            out_b = tf.get_variable('mlp1/output/bias')
+        with tf.compat.v1.variable_scope('MLP', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
+            h1_b = tf.compat.v1.get_variable('mlp1/hidden_0/bias')
+            h2_w = tf.compat.v1.get_variable('mlp1/hidden_1/kernel')
+            h2_b = tf.compat.v1.get_variable('mlp1/hidden_1/bias')
+            out_w = tf.compat.v1.get_variable('mlp1/output/kernel')
+            out_b = tf.compat.v1.get_variable('mlp1/output/bias')
 
         mlp_output = self.sess.run(
             self.mlp_f, feed_dict={self._input: self.obs_input})
@@ -110,7 +110,7 @@ class TestMLP(TfGraphTestCase):
 
     def test_layer_normalization(self):
         # Create a mlp with layer normalization
-        with tf.variable_scope('MLP'):
+        with tf.compat.v1.variable_scope('MLP'):
             self.mlp_f_w_n = mlp(
                 input_var=self._input,
                 output_dim=self._output_shape,
@@ -120,19 +120,19 @@ class TestMLP(TfGraphTestCase):
                 layer_normalization=True)
 
         # Initialize the new mlp variables
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
-        with tf.variable_scope('MLP', reuse=True):
-            h1_w = tf.get_variable('mlp2/hidden_0/kernel')
-            h1_b = tf.get_variable('mlp2/hidden_0/bias')
-            h2_w = tf.get_variable('mlp2/hidden_1/kernel')
-            h2_b = tf.get_variable('mlp2/hidden_1/bias')
-            out_w = tf.get_variable('mlp2/output/kernel')
-            out_b = tf.get_variable('mlp2/output/bias')
-            beta_1 = tf.get_variable('mlp2/LayerNorm/beta')
-            gamma_1 = tf.get_variable('mlp2/LayerNorm/gamma')
-            beta_2 = tf.get_variable('mlp2/LayerNorm_1/beta')
-            gamma_2 = tf.get_variable('mlp2/LayerNorm_1/gamma')
+        with tf.compat.v1.variable_scope('MLP', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp2/hidden_0/kernel')
+            h1_b = tf.compat.v1.get_variable('mlp2/hidden_0/bias')
+            h2_w = tf.compat.v1.get_variable('mlp2/hidden_1/kernel')
+            h2_b = tf.compat.v1.get_variable('mlp2/hidden_1/bias')
+            out_w = tf.compat.v1.get_variable('mlp2/output/kernel')
+            out_b = tf.compat.v1.get_variable('mlp2/output/bias')
+            beta_1 = tf.compat.v1.get_variable('mlp2/LayerNorm/beta')
+            gamma_1 = tf.compat.v1.get_variable('mlp2/LayerNorm/gamma')
+            beta_2 = tf.compat.v1.get_variable('mlp2/LayerNorm_1/beta')
+            gamma_2 = tf.compat.v1.get_variable('mlp2/LayerNorm_1/gamma')
 
         # First layer
         y = tf.matmul(self._input, h1_w) + h1_b

--- a/tests/garage/tf/core/test_mlp_concat.py
+++ b/tests/garage/tf/core/test_mlp_concat.py
@@ -15,16 +15,16 @@ class TestMLPConcat(TfGraphTestCase):
         input_shape_2 = self.act_input.shape[1:]  # 4
         self.hidden_nonlinearity = tf.nn.relu
 
-        self._obs_input = tf.placeholder(
+        self._obs_input = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape_1, name='input')
 
-        self._act_input = tf.placeholder(
+        self._act_input = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape_2, name='input')
 
         self._output_shape = 2
 
         # We build a default mlp
-        with tf.variable_scope('MLP_Concat'):
+        with tf.compat.v1.variable_scope('MLP_Concat'):
             self.mlp_f = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -34,11 +34,11 @@ class TestMLPConcat(TfGraphTestCase):
                 hidden_nonlinearity=self.hidden_nonlinearity,
                 name='mlp1')
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
     def test_multiple_same_mlp(self):
         # We create another mlp with the same name, trying to reuse it
-        with tf.variable_scope('MLP_Concat', reuse=True):
+        with tf.compat.v1.variable_scope('MLP_Concat', reuse=True):
             self.mlp_same_copy = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -50,8 +50,8 @@ class TestMLPConcat(TfGraphTestCase):
 
         # We modify the weight of the default mlp and feed
         # The another mlp created should output the same result
-        with tf.variable_scope('MLP_Concat', reuse=True):
-            w = tf.get_variable('mlp1/hidden_0/kernel')
+        with tf.compat.v1.variable_scope('MLP_Concat', reuse=True):
+            w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
             self.sess.run(w.assign(w + 1))
             mlp_output = self.sess.run(
                 self.mlp_f,
@@ -70,7 +70,7 @@ class TestMLPConcat(TfGraphTestCase):
 
     def test_different_mlp(self):
         # We create another mlp with different name
-        with tf.variable_scope('MLP_Concat'):
+        with tf.compat.v1.variable_scope('MLP_Concat'):
             self.mlp_different_copy = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -81,12 +81,12 @@ class TestMLPConcat(TfGraphTestCase):
                 name='mlp2')
 
         # Initialize the new mlp variables
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         # We modify the weight of the default mlp and feed
         # The another mlp created should output different result
-        with tf.variable_scope('MLP_Concat', reuse=True):
-            w = tf.get_variable('mlp1/hidden_0/kernel')
+        with tf.compat.v1.variable_scope('MLP_Concat', reuse=True):
+            w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
             self.sess.run(w.assign(w + 1))
             mlp_output = self.sess.run(
                 self.mlp_f,
@@ -114,13 +114,13 @@ class TestMLPConcat(TfGraphTestCase):
         assert mlp_output.shape[1] == self._output_shape
 
     def test_output_value(self):
-        with tf.variable_scope('MLP_Concat', reuse=True):
-            h1_w = tf.get_variable('mlp1/hidden_0/kernel')
-            h1_b = tf.get_variable('mlp1/hidden_0/bias')
-            h2_w = tf.get_variable('mlp1/hidden_1/kernel')
-            h2_b = tf.get_variable('mlp1/hidden_1/bias')
-            out_w = tf.get_variable('mlp1/output/kernel')
-            out_b = tf.get_variable('mlp1/output/bias')
+        with tf.compat.v1.variable_scope('MLP_Concat', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp1/hidden_0/kernel')
+            h1_b = tf.compat.v1.get_variable('mlp1/hidden_0/bias')
+            h2_w = tf.compat.v1.get_variable('mlp1/hidden_1/kernel')
+            h2_b = tf.compat.v1.get_variable('mlp1/hidden_1/bias')
+            out_w = tf.compat.v1.get_variable('mlp1/output/kernel')
+            out_b = tf.compat.v1.get_variable('mlp1/output/bias')
 
         mlp_output = self.sess.run(
             self.mlp_f,
@@ -151,7 +151,7 @@ class TestMLPConcat(TfGraphTestCase):
 
     def test_layer_normalization(self):
         # Create a mlp with layer normalization
-        with tf.variable_scope('MLP_Concat'):
+        with tf.compat.v1.variable_scope('MLP_Concat'):
             self.mlp_f_w_n = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -163,19 +163,19 @@ class TestMLPConcat(TfGraphTestCase):
                 layer_normalization=True)
 
         # Initialize the new mlp variables
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
-        with tf.variable_scope('MLP_Concat', reuse=True):
-            h1_w = tf.get_variable('mlp2/hidden_0/kernel')
-            h1_b = tf.get_variable('mlp2/hidden_0/bias')
-            h2_w = tf.get_variable('mlp2/hidden_1/kernel')
-            h2_b = tf.get_variable('mlp2/hidden_1/bias')
-            out_w = tf.get_variable('mlp2/output/kernel')
-            out_b = tf.get_variable('mlp2/output/bias')
-            beta_1 = tf.get_variable('mlp2/LayerNorm/beta')
-            gamma_1 = tf.get_variable('mlp2/LayerNorm/gamma')
-            beta_2 = tf.get_variable('mlp2/LayerNorm_1/beta')
-            gamma_2 = tf.get_variable('mlp2/LayerNorm_1/gamma')
+        with tf.compat.v1.variable_scope('MLP_Concat', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp2/hidden_0/kernel')
+            h1_b = tf.compat.v1.get_variable('mlp2/hidden_0/bias')
+            h2_w = tf.compat.v1.get_variable('mlp2/hidden_1/kernel')
+            h2_b = tf.compat.v1.get_variable('mlp2/hidden_1/bias')
+            out_w = tf.compat.v1.get_variable('mlp2/output/kernel')
+            out_b = tf.compat.v1.get_variable('mlp2/output/bias')
+            beta_1 = tf.compat.v1.get_variable('mlp2/LayerNorm/beta')
+            gamma_1 = tf.compat.v1.get_variable('mlp2/LayerNorm/gamma')
+            beta_2 = tf.compat.v1.get_variable('mlp2/LayerNorm_1/beta')
+            gamma_2 = tf.compat.v1.get_variable('mlp2/LayerNorm_1/gamma')
 
         # First layer
         y = tf.matmul(tf.concat([self._obs_input, self._act_input], 1),
@@ -212,7 +212,7 @@ class TestMLPConcat(TfGraphTestCase):
 
     @pytest.mark.parametrize('concat_idx', [2, 1, 0, -1, -2])
     def test_concat_layer(self, concat_idx):
-        with tf.variable_scope('mlp_concat_test'):
+        with tf.compat.v1.variable_scope('mlp_concat_test'):
             _ = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -228,10 +228,10 @@ class TestMLPConcat(TfGraphTestCase):
         expected_units[concat_idx] += act_input_size
 
         actual_units = []
-        with tf.variable_scope('mlp_concat_test', reuse=True):
-            h1_w = tf.get_variable('mlp2/hidden_0/kernel')
-            h2_w = tf.get_variable('mlp2/hidden_1/kernel')
-            out_w = tf.get_variable('mlp2/output/kernel')
+        with tf.compat.v1.variable_scope('mlp_concat_test', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp2/hidden_0/kernel')
+            h2_w = tf.compat.v1.get_variable('mlp2/hidden_1/kernel')
+            out_w = tf.compat.v1.get_variable('mlp2/output/kernel')
 
             actual_units.append(h1_w.shape[0].value)
             actual_units.append(h2_w.shape[0].value)
@@ -241,7 +241,7 @@ class TestMLPConcat(TfGraphTestCase):
 
     @pytest.mark.parametrize('concat_idx', [2, 1, 0, -1, -2])
     def test_invalid_concat_args(self, concat_idx):
-        with tf.variable_scope('mlp_concat_test'):
+        with tf.compat.v1.variable_scope('mlp_concat_test'):
             _ = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -256,10 +256,10 @@ class TestMLPConcat(TfGraphTestCase):
         expected_units = [obs_input_size, 64, 32]
 
         actual_units = []
-        with tf.variable_scope('mlp_concat_test', reuse=True):
-            h1_w = tf.get_variable('mlp_no_input2/hidden_0/kernel')
-            h2_w = tf.get_variable('mlp_no_input2/hidden_1/kernel')
-            out_w = tf.get_variable('mlp_no_input2/output/kernel')
+        with tf.compat.v1.variable_scope('mlp_concat_test', reuse=True):
+            h1_w = tf.compat.v1.get_variable('mlp_no_input2/hidden_0/kernel')
+            h2_w = tf.compat.v1.get_variable('mlp_no_input2/hidden_1/kernel')
+            out_w = tf.compat.v1.get_variable('mlp_no_input2/output/kernel')
 
             actual_units.append(h1_w.shape[0].value)
             actual_units.append(h2_w.shape[0].value)
@@ -269,7 +269,7 @@ class TestMLPConcat(TfGraphTestCase):
 
     @pytest.mark.parametrize('concat_idx', [2, 1, 0, -1, -2])
     def test_no_hidden(self, concat_idx):
-        with tf.variable_scope('mlp_concat_test'):
+        with tf.compat.v1.variable_scope('mlp_concat_test'):
             _ = mlp(
                 input_var=self._obs_input,
                 output_dim=self._output_shape,
@@ -287,8 +287,8 @@ class TestMLPConcat(TfGraphTestCase):
         expected_units[0] += act_input_size
 
         actual_units = []
-        with tf.variable_scope('mlp_concat_test', reuse=True):
-            out_w = tf.get_variable('mlp2/output/kernel')
+        with tf.compat.v1.variable_scope('mlp_concat_test', reuse=True):
+            out_w = tf.compat.v1.get_variable('mlp2/output/kernel')
             actual_units.append(out_w.shape[0].value)
 
         assert np.array_equal(expected_units, actual_units)

--- a/tests/garage/tf/core/test_serializable.py
+++ b/tests/garage/tf/core/test_serializable.py
@@ -7,8 +7,8 @@ from garage.tf.core.parameterized import Parameterized, suppress_params_loading
 class Simple(Parameterized, Serializable):
     def __init__(self, name):
         Serializable.quick_init(self, locals())
-        with tf.variable_scope(name):
-            self.w = tf.get_variable('w', [10, 10])
+        with tf.compat.v1.variable_scope(name):
+            self.w = tf.compat.v1.get_variable('w', [10, 10])
 
     def get_params_internal(self, **tags):
         return [self.w]

--- a/tests/garage/tf/misc/test_tensor_utils.py
+++ b/tests/garage/tf/misc/test_tensor_utils.py
@@ -15,9 +15,9 @@ class TestTensorUtil(TfGraphTestCase):
         discount = 1
         gae_lambda = 1
         max_len = 1
-        rewards = tf.placeholder(
+        rewards = tf.compat.v1.placeholder(
             dtype=tf.float32, name='reward', shape=[None, None])
-        baselines = tf.placeholder(
+        baselines = tf.compat.v1.placeholder(
             dtype=tf.float32, name='baseline', shape=[None, None])
         adv = compute_advantages(discount, gae_lambda, max_len, baselines,
                                  rewards)
@@ -36,22 +36,22 @@ class TestTensorUtil(TfGraphTestCase):
         assert np.array_equal(adv, desired_val)
 
     def test_get_target_ops(self):
-        var = tf.get_variable(
+        var = tf.compat.v1.get_variable(
             'var', [1], initializer=tf.constant_initializer(1))
-        target_var = tf.get_variable(
+        target_var = tf.compat.v1.get_variable(
             'target_var', [1], initializer=tf.constant_initializer(2))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
         assert target_var.eval() == 2
         update_ops = get_target_ops([var], [target_var])
         self.sess.run(update_ops)
         assert target_var.eval() == 1
 
     def test_get_target_ops_tau(self):
-        var = tf.get_variable(
+        var = tf.compat.v1.get_variable(
             'var', [1], initializer=tf.constant_initializer(1))
-        target_var = tf.get_variable(
+        target_var = tf.compat.v1.get_variable(
             'target_var', [1], initializer=tf.constant_initializer(2))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
         assert target_var.eval() == 2
         init_ops, update_ops = get_target_ops([var], [target_var], tau=0.2)
         self.sess.run(update_ops)

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -18,7 +18,7 @@ class TestCNNModel(TfGraphTestCase):
         self.obs_input = np.ones((self.batch_size, self.input_width,
                                   self.input_height, 3))
         input_shape = self.obs_input.shape[1:]  # height, width, channel
-        self._input_ph = tf.placeholder(
+        self._input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape, name='input')
 
     # yapf: disable
@@ -138,17 +138,17 @@ class TestCNNModel(TfGraphTestCase):
             hidden_w_init=tf.constant_initializer(1),
             hidden_nonlinearity=None)
         outputs = model.build(self._input_ph)
-        with tf.variable_scope('cnn_model/cnn/h0', reuse=True):
-            bias = tf.get_variable('bias')
+        with tf.compat.v1.variable_scope('cnn_model/cnn/h0', reuse=True):
+            bias = tf.compat.v1.get_variable('bias')
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(
             outputs, feed_dict={self._input_ph: self.obs_input})
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
             input_shape = self.obs_input.shape[1:]  # height, width, channel
-            input_ph = tf.placeholder(
+            input_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, ) + input_shape, name='input')
             outputs = model_pickled.build(input_ph)
             output2 = sess.run(outputs, feed_dict={input_ph: self.obs_input})

--- a/tests/garage/tf/models/test_gaussian_cnn_model.py
+++ b/tests/garage/tf/models/test_gaussian_cnn_model.py
@@ -18,7 +18,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
         self.obs = np.full(
             (self.batch_size, self.input_width, self.input_height, 3), 1)
         input_shape = self.obs.shape[1:]  # height, width, channel
-        self._input_ph = tf.placeholder(
+        self._input_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape, name='input')
 
     @mock.patch('tensorflow.random.normal')
@@ -96,10 +96,10 @@ class TestGaussianCNNModel(TfGraphTestCase):
             output_dim=output_dim,
             std_share_network=True)
         model.build(self._input_ph)
-        with tf.variable_scope(model.name, reuse=True):
-            std_share_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            std_share_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_std_network/output/kernel')
-            std_share_output_bias = tf.get_variable(
+            std_share_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_std_network/output/bias')
         assert std_share_output_weights.shape[1] == output_dim * 2
         assert std_share_output_bias.shape == output_dim * 2
@@ -181,12 +181,12 @@ class TestGaussianCNNModel(TfGraphTestCase):
             std_share_network=False,
             adaptive_std=False)
         model.build(self._input_ph)
-        with tf.variable_scope(model.name, reuse=True):
-            mean_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            mean_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/kernel')
-            mean_output_bias = tf.get_variable(
+            mean_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/bias')
-            log_std_output_weights = tf.get_variable(
+            log_std_output_weights = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/parameter')
         assert mean_output_weights.shape[1] == output_dim
         assert mean_output_bias.shape == output_dim
@@ -289,14 +289,14 @@ class TestGaussianCNNModel(TfGraphTestCase):
             std_output_w_init=tf.constant_initializer(1))
 
         model.build(self._input_ph)
-        with tf.variable_scope(model.name, reuse=True):
-            mean_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            mean_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/kernel')
-            mean_output_bias = tf.get_variable(
+            mean_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/bias')
-            log_std_output_weights = tf.get_variable(
+            log_std_output_weights = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/output/kernel')
-            log_std_output_bias = tf.get_variable(
+            log_std_output_bias = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/output/bias')
 
         assert mean_output_weights.shape[1] == output_dim
@@ -311,7 +311,8 @@ class TestGaussianCNNModel(TfGraphTestCase):
     def test_std_share_network_is_pickleable(self, mock_normal, output_dim,
                                              hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 10, 10, 3))
         model = GaussianCNNModel(
             num_filters=[3, 6],
             filter_dims=[3, 3],
@@ -323,16 +324,18 @@ class TestGaussianCNNModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianCNNModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_std_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_std_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(
+                tf.float32, shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
@@ -346,7 +349,8 @@ class TestGaussianCNNModel(TfGraphTestCase):
     def test_without_std_share_network_is_pickleable(self, mock_normal,
                                                      output_dim, hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 10, 10, 3))
         model = GaussianCNNModel(
             num_filters=[3, 6],
             filter_dims=[3, 3],
@@ -359,16 +363,18 @@ class TestGaussianCNNModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianCNNModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(
+                tf.float32, shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
@@ -382,7 +388,8 @@ class TestGaussianCNNModel(TfGraphTestCase):
     def test_adaptive_std_is_pickleable(self, mock_normal, output_dim,
                                         hidden_sizes, std_hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 10, 10, 3))
         model = GaussianCNNModel(
             num_filters=[3, 6],
             filter_dims=[3, 3],
@@ -406,15 +413,17 @@ class TestGaussianCNNModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianCNNModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         h = pickle.dumps(model)
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 10, 10, 3))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(
+                tf.float32, shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})

--- a/tests/garage/tf/models/test_gaussian_gru_model.py
+++ b/tests/garage/tf/models/test_gaussian_gru_model.py
@@ -22,9 +22,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self.input_var = tf.placeholder(
+        self.input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self.feature_shape), name='input')
-        self.step_input_var = tf.placeholder(
+        self.step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='step_input')
 
     # yapf: disable
@@ -47,7 +47,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -107,7 +107,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -116,9 +116,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
              self.input_var, self.step_input_var, step_hidden_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/kernel' in var.name:
                 std_share_output_weights = var
             if 'output_layer/bias' in var.name:
@@ -150,7 +150,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer,
             init_std=init_std)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -212,7 +212,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -221,9 +221,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
              self.input_var, self.step_input_var, step_hidden_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/kernel' in var.name:
                 std_share_output_weights = var
             if 'output_layer/bias' in var.name:
@@ -254,7 +254,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -263,9 +263,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
              self.input_var, self.step_input_var, step_hidden_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/bias' in var.name:
                 var.load(tf.ones_like(var).eval())
 
@@ -280,18 +280,18 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                 })  # noqa: E126
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, self.feature_shape),
                 name='step_input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_hidden',
                 dtype=tf.float32)
@@ -331,7 +331,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -340,9 +340,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
              self.input_var, self.step_input_var, step_hidden_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/bias' in var.name:
                 var.load(tf.ones_like(var).eval())
 
@@ -357,18 +357,18 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                 })  # noqa: E126
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, self.feature_shape),
                 name='step_input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_hidden',
                 dtype=tf.float32)

--- a/tests/garage/tf/models/test_gaussian_lstm_model.py
+++ b/tests/garage/tf/models/test_gaussian_lstm_model.py
@@ -22,9 +22,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self.input_var = tf.placeholder(
+        self.input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self.feature_shape), name='input')
-        self.step_input_var = tf.placeholder(
+        self.step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='step_input')
 
     # yapf: disable
@@ -47,11 +47,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -120,11 +120,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -134,9 +134,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
                              step_hidden_var, step_cell_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/kernel' in var.name:
                 std_share_output_weights = var
             if 'output_layer/bias' in var.name:
@@ -164,11 +164,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer,
             init_std=init_std)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -239,11 +239,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -253,9 +253,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
                              step_hidden_var, step_cell_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/kernel' in var.name:
                 std_share_output_weights = var
             if 'output_layer/bias' in var.name:
@@ -286,11 +286,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -300,9 +300,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
              step_cell_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/bias' in var.name:
                 var.load(tf.ones_like(var).eval())
 
@@ -320,22 +320,22 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             })
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, self.feature_shape),
                 name='step_input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_hidden',
                 dtype=tf.float32)
-            step_cell_var = tf.placeholder(
+            step_cell_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_cell',
                 dtype=tf.float32)
@@ -376,11 +376,11 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             hidden_w_init=self.default_initializer,
             recurrent_w_init=self.default_initializer,
             output_w_init=self.default_initializer)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -390,9 +390,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
              step_cell_var)
 
         # output layer is a tf.keras.layers.Dense object,
-        # which cannot be access by tf.variable_scope.
-        # A workaround is to access in tf.global_variables()
-        for var in tf.global_variables():
+        # which cannot be access by tf.compat.v1.variable_scope.
+        # A workaround is to access in tf.compat.v1.global_variables()
+        for var in tf.compat.v1.global_variables():
             if 'output_layer/bias' in var.name:
                 var.load(tf.ones_like(var).eval())
 
@@ -410,22 +410,22 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             })
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, self.feature_shape),
                 name='step_input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_hidden',
                 dtype=tf.float32)
-            step_cell_var = tf.placeholder(
+            step_cell_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, hidden_dim),
                 name='initial_cell',
                 dtype=tf.float32)

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -12,7 +12,7 @@ from tests.fixtures import TfGraphTestCase
 class TestGaussianMLPModel(TfGraphTestCase):
     def setup_method(self):
         super().setup_method()
-        self.input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        self.input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         self.obs = np.ones((1, 5))
 
     @mock.patch('tensorflow.random.normal')
@@ -56,10 +56,10 @@ class TestGaussianMLPModel(TfGraphTestCase):
             hidden_sizes=hidden_sizes,
             std_share_network=True)
         model.build(self.input_var)
-        with tf.variable_scope(model.name, reuse=True):
-            std_share_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            std_share_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_std_network/output/kernel')
-            std_share_output_bias = tf.get_variable(
+            std_share_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_std_network/output/bias')
         assert std_share_output_weights.shape[1] == output_dim * 2
         assert std_share_output_bias.shape == output_dim * 2
@@ -106,12 +106,12 @@ class TestGaussianMLPModel(TfGraphTestCase):
             std_share_network=False,
             adaptive_std=False)
         model.build(self.input_var)
-        with tf.variable_scope(model.name, reuse=True):
-            mean_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            mean_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/kernel')
-            mean_output_bias = tf.get_variable(
+            mean_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/bias')
-            log_std_output_weights = tf.get_variable(
+            log_std_output_weights = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/parameter')
         assert mean_output_weights.shape[1] == output_dim
         assert mean_output_bias.shape == output_dim
@@ -168,14 +168,14 @@ class TestGaussianMLPModel(TfGraphTestCase):
             std_share_network=False,
             adaptive_std=True)
         model.build(self.input_var)
-        with tf.variable_scope(model.name, reuse=True):
-            mean_output_weights = tf.get_variable(
+        with tf.compat.v1.variable_scope(model.name, reuse=True):
+            mean_output_weights = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/kernel')
-            mean_output_bias = tf.get_variable(
+            mean_output_bias = tf.compat.v1.get_variable(
                 'dist_params/mean_network/output/bias')
-            log_std_output_weights = tf.get_variable(
+            log_std_output_weights = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/output/kernel')
-            log_std_output_bias = tf.get_variable(
+            log_std_output_bias = tf.compat.v1.get_variable(
                 'dist_params/log_std_network/output/bias')
 
         assert mean_output_weights.shape[1] == output_dim
@@ -190,7 +190,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
     def test_std_share_network_is_pickleable(self, mock_normal, output_dim,
                                              hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = GaussianMLPModel(
             output_dim=output_dim,
             hidden_sizes=hidden_sizes,
@@ -201,16 +201,17 @@ class TestGaussianMLPModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianMLPModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_std_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_std_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
@@ -224,7 +225,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
     def test_without_std_share_network_is_pickleable(self, mock_normal,
                                                      output_dim, hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = GaussianMLPModel(
             output_dim=output_dim,
             hidden_sizes=hidden_sizes,
@@ -236,16 +237,17 @@ class TestGaussianMLPModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianMLPModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
@@ -259,7 +261,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
     def test_adaptive_std_is_pickleable(self, mock_normal, output_dim,
                                         hidden_sizes, std_hidden_sizes):
         mock_normal.return_value = 0.5
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = GaussianMLPModel(
             output_dim=output_dim,
             hidden_sizes=hidden_sizes,
@@ -275,15 +277,16 @@ class TestGaussianMLPModel(TfGraphTestCase):
         outputs = model.build(input_var)
 
         # get output bias
-        with tf.variable_scope('GaussianMLPModel', reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/output/bias')
+        with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/output/bias')
         # assign it to all ones
         bias.load(tf.ones_like(bias).eval())
 
         h = pickle.dumps(model)
         output1 = self.sess.run(outputs[:-1], feed_dict={input_var: self.obs})
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})

--- a/tests/garage/tf/models/test_gru_model.py
+++ b/tests/garage/tf/models/test_gru_model.py
@@ -20,9 +20,9 @@ class TestGRUModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self.input_var = tf.placeholder(
+        self.input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self.feature_shape), name='input')
-        self.step_input_var = tf.placeholder(
+        self.step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='input')
 
     @pytest.mark.parametrize('output_dim, hidden_dim', [(1, 1), (1, 2),
@@ -37,7 +37,7 @@ class TestGRUModel(TfGraphTestCase):
             recurrent_w_init=tf.constant_initializer(1),
             output_w_init=tf.constant_initializer(1))
 
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
@@ -52,13 +52,13 @@ class TestGRUModel(TfGraphTestCase):
 
     def test_is_pickleable(self):
         model = GRUModel(output_dim=1, hidden_dim=1)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, 1), name='step_hidden', dtype=tf.float32)
         model.build(self.input_var, self.step_input_var, step_hidden_var)
 
         # assign bias to all one
-        with tf.variable_scope('GRUModel/gru', reuse=True):
-            init_hidden = tf.get_variable('initial_hidden')
+        with tf.compat.v1.variable_scope('GRUModel/gru', reuse=True):
+            init_hidden = tf.compat.v1.get_variable('initial_hidden')
 
         init_hidden.load(tf.ones_like(init_hidden).eval())
 
@@ -79,17 +79,17 @@ class TestGRUModel(TfGraphTestCase):
             })
         # yapf: enable
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, self.feature_shape), name='input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, 1),
                 name='initial_hidden',
                 dtype=tf.float32)

--- a/tests/garage/tf/models/test_lstm_model.py
+++ b/tests/garage/tf/models/test_lstm_model.py
@@ -20,9 +20,9 @@ class TestLSTMModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self._input_var = tf.placeholder(
+        self._input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self.feature_shape), name='input')
-        self._step_input_var = tf.placeholder(
+        self._step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='input')
 
     @pytest.mark.parametrize('output_dim, hidden_dim', [(1, 1), (1, 2),
@@ -37,11 +37,11 @@ class TestLSTMModel(TfGraphTestCase):
             recurrent_w_init=tf.constant_initializer(1),
             output_w_init=tf.constant_initializer(1))
 
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_hidden',
             dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, hidden_dim),
             name='step_cell',
             dtype=tf.float32)
@@ -56,16 +56,16 @@ class TestLSTMModel(TfGraphTestCase):
 
     def test_is_pickleable(self):
         model = LSTMModel(output_dim=1, hidden_dim=1)
-        step_hidden_var = tf.placeholder(
+        step_hidden_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, 1), name='step_hidden', dtype=tf.float32)
-        step_cell_var = tf.placeholder(
+        step_cell_var = tf.compat.v1.placeholder(
             shape=(self.batch_size, 1), name='step_cell', dtype=tf.float32)
         model.build(self._input_var, self._step_input_var, step_hidden_var,
                     step_cell_var)
 
         # assign bias to all one
-        with tf.variable_scope('LSTMModel/lstm', reuse=True):
-            init_hidden = tf.get_variable('initial_hidden')
+        with tf.compat.v1.variable_scope('LSTMModel/lstm', reuse=True):
+            init_hidden = tf.compat.v1.get_variable('initial_hidden')
 
         init_hidden.load(tf.ones_like(init_hidden).eval())
 
@@ -88,20 +88,20 @@ class TestLSTMModel(TfGraphTestCase):
             })
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.placeholder(
+            input_var = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, None, self.feature_shape),
                 name='input')
-            step_input_var = tf.placeholder(
+            step_input_var = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, self.feature_shape), name='input')
-            step_hidden_var = tf.placeholder(
+            step_hidden_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, 1),
                 name='initial_hidden',
                 dtype=tf.float32)
-            step_cell_var = tf.placeholder(
+            step_cell_var = tf.compat.v1.placeholder(
                 shape=(self.batch_size, 1),
                 name='initial_cell',
                 dtype=tf.float32)

--- a/tests/garage/tf/models/test_mlp_model.py
+++ b/tests/garage/tf/models/test_mlp_model.py
@@ -13,7 +13,7 @@ from tests.fixtures import TfGraphTestCase
 class TestMLPModel(TfGraphTestCase):
     def setup_method(self):
         super().setup_method()
-        self.input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        self.input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         self.obs = np.ones((1, 5))
 
     # yapf: disable
@@ -83,7 +83,7 @@ class TestMLPModel(TfGraphTestCase):
             hidden_w_init=tf.ones_initializer(),
             output_w_init=tf.ones_initializer())
 
-        input_var2 = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var2 = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         obs2 = np.ones((1, 5))
 
         outputs = model.build(self.input_var, input_var2)
@@ -116,16 +116,16 @@ class TestMLPModel(TfGraphTestCase):
         outputs = model.build(self.input_var)
 
         # assign bias to all one
-        with tf.variable_scope('MLPModel/mlp', reuse=True):
-            bias = tf.get_variable('hidden_0/bias')
+        with tf.compat.v1.variable_scope('MLPModel/mlp', reuse=True):
+            bias = tf.compat.v1.get_variable('hidden_0/bias')
 
         bias.load(tf.ones_like(bias).eval())
 
         output1 = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
 
         h = pickle.dumps(model)
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
             outputs = model_pickled.build(input_var)
             output2 = sess.run(outputs, feed_dict={input_var: self.obs})

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -70,7 +70,7 @@ class ComplicatedModel2(Model):
 
 class TestModel(TfGraphTestCase):
     def test_model_creation(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2)
         outputs = model.build(input_var)
         data = np.ones((3, 5))
@@ -81,7 +81,7 @@ class TestModel(TfGraphTestCase):
         assert model.name == type(model).__name__
 
     def test_model_creation_with_custom_name(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2, name='MySimpleModel')
         outputs = model.build(input_var, name='network_2')
         data = np.ones((3, 5))
@@ -92,8 +92,9 @@ class TestModel(TfGraphTestCase):
         assert model.name == 'MySimpleModel'
 
     def test_same_model_with_no_name(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
-        another_input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
+        another_input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2)
         model.build(input_var)
         with pytest.raises(ValueError):
@@ -104,8 +105,9 @@ class TestModel(TfGraphTestCase):
             model2.build(another_input_var)
 
     def test_model_with_different_name(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
-        another_input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
+        another_input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2)
         outputs_1 = model.build(input_var)
         outputs_2 = model.build(another_input_var, name='network_2')
@@ -118,8 +120,9 @@ class TestModel(TfGraphTestCase):
         assert np.array_equal(results_1, results_2)
 
     def test_model_with_different_name_in_different_order(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
-        another_input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
+        another_input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2)
         outputs_1 = model.build(input_var, name='network_1')
         outputs_2 = model.build(another_input_var)
@@ -132,7 +135,7 @@ class TestModel(TfGraphTestCase):
         assert np.array_equal(results_1, results_2)
 
     def test_model_in_model(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = ComplicatedModel(output_dim=2)
         outputs = model.build(input_var)
         data = np.ones((3, 5))
@@ -143,7 +146,7 @@ class TestModel(TfGraphTestCase):
         assert np.array_equal(out, model_out)
 
     def test_model_as_constructor_argument(self):
-        input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         parent_model = SimpleModel(output_dim=4)
         model = ComplicatedModel2(parent_model=parent_model, output_dim=2)
         outputs = model.build(input_var)
@@ -158,13 +161,13 @@ class TestModel(TfGraphTestCase):
         data = np.ones((3, 5))
         model = SimpleModel(output_dim=2)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model.build(input_var)
 
             # assign bias to all one
-            with tf.variable_scope('SimpleModel/state', reuse=True):
-                bias = tf.get_variable('hidden_0/bias')
+            with tf.compat.v1.variable_scope('SimpleModel/state', reuse=True):
+                bias = tf.compat.v1.get_variable('hidden_0/bias')
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
@@ -172,8 +175,8 @@ class TestModel(TfGraphTestCase):
                 feed_dict={model.networks['default'].input: data})
             model_data = pickle.dumps(model)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(model_data)
             outputs = model_pickled.build(input_var)
 
@@ -193,22 +196,22 @@ class TestModel(TfGraphTestCase):
 
         model = ComplicatedModel(output_dim=2)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             outputs = model.build(input_var)
 
             # assign bias to all one
-            with tf.variable_scope(
+            with tf.compat.v1.variable_scope(
                     'ComplicatedModel/SimpleModel/state', reuse=True):
-                bias = tf.get_variable('hidden_0/bias')
+                bias = tf.compat.v1.get_variable('hidden_0/bias')
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})
             model_data = pickle.dumps(model)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(model_data)
             model_pickled.build(input_var)
 
@@ -224,22 +227,22 @@ class TestModel(TfGraphTestCase):
         parent_model = SimpleModel(output_dim=4)
         model = ComplicatedModel2(parent_model=parent_model, output_dim=2)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             outputs = model.build(input_var)
 
             # assign bias to all one
-            with tf.variable_scope(
+            with tf.compat.v1.variable_scope(
                     'ComplicatedModel2/SimpleModel/state', reuse=True):
-                bias = tf.get_variable('hidden_0/bias')
+                bias = tf.compat.v1.get_variable('hidden_0/bias')
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
                 outputs, feed_dict={model.networks['default'].input: data})
             model_data = pickle.dumps(model)
 
-        with tf.Session(graph=tf.Graph()) as sess:
-            input_var = tf.placeholder(tf.float32, shape=(None, 5))
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
+            input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(model_data)
             model_pickled.build(input_var)
 
@@ -252,8 +255,9 @@ class TestModel(TfGraphTestCase):
     def test_simple_model_is_pickleable_with_same_parameters(self):
         model = SimpleModel(output_dim=2)
 
-        with tf.Session(graph=tf.Graph()):
-            state = tf.placeholder(shape=[None, 10, 5], dtype=tf.float32)
+        with tf.compat.v1.Session(graph=tf.Graph()):
+            state = tf.compat.v1.placeholder(
+                shape=[None, 10, 5], dtype=tf.float32)
             model.build(state)
 
             model.parameters = {
@@ -264,9 +268,10 @@ class TestModel(TfGraphTestCase):
             model.parameters = all_one
             h_data = pickle.dumps(model)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             model_pickled = pickle.loads(h_data)
-            state = tf.placeholder(shape=[None, 10, 5], dtype=tf.float32)
+            state = tf.compat.v1.placeholder(
+                shape=[None, 10, 5], dtype=tf.float32)
             model_pickled.build(state)
 
             np.testing.assert_equal(all_one, model_pickled.parameters)
@@ -274,8 +279,9 @@ class TestModel(TfGraphTestCase):
     def test_simple_model_is_pickleable_with_missing_parameters(self):
         model = SimpleModel(output_dim=2)
 
-        with tf.Session(graph=tf.Graph()):
-            state = tf.placeholder(shape=[None, 10, 5], dtype=tf.float32)
+        with tf.compat.v1.Session(graph=tf.Graph()):
+            state = tf.compat.v1.placeholder(
+                shape=[None, 10, 5], dtype=tf.float32)
             model.build(state)
 
             model.parameters = {
@@ -286,9 +292,10 @@ class TestModel(TfGraphTestCase):
             model.parameters = all_one
             h_data = pickle.dumps(model)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             model_pickled = pickle.loads(h_data)
-            state = tf.placeholder(shape=[None, 10, 5], dtype=tf.float32)
+            state = tf.compat.v1.placeholder(
+                shape=[None, 10, 5], dtype=tf.float32)
             # remove one of the parameters
             del model_pickled._default_parameters[
                 'SimpleModel/state/hidden_0/kernel:0']

--- a/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_conv_policy_with_model.py
@@ -157,7 +157,8 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
         expected_prob = np.full(action_dim, 0.5)
 
         obs_dim = env.spec.observation_space.shape
-        state_input = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + obs_dim)
         dist1 = policy.dist_info_sym(state_input, name='policy2')
 
         prob = self.sess.run(dist1['prob'], feed_dict={state_input: [obs]})
@@ -189,16 +190,16 @@ class TestCategoricalConvPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'CategoricalConvPolicy/Sequential/MLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
             policy.model.outputs, feed_dict={policy.model.input: [obs]})
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs,

--- a/tests/garage/tf/policies/test_categorical_gru_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy_with_model.py
@@ -23,7 +23,7 @@ class TestCategoricalGRUPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym(self, obs_dim, action_dim, hidden_dim):
         env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -51,7 +51,7 @@ class TestCategoricalGRUPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_include_action(self, obs_dim, action_dim):
         env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -75,7 +75,7 @@ class TestCategoricalGRUPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_wrong_input(self):
         env = TfEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -185,9 +185,9 @@ class TestCategoricalGRUPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs = env.reset()
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'CategoricalGRUPolicyWithModel/prob_network', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
@@ -197,7 +197,7 @@ class TestCategoricalGRUPolicyWithModel(TfGraphTestCase):
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs[0],

--- a/tests/garage/tf/policies/test_categorical_gru_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy_with_model_transit.py
@@ -58,7 +58,7 @@ class TestCategoricalGRUPolicyWithModelTransit(TfGraphTestCase):
             state_include_action=True,
             name='P2')
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         self.policy3 = CategoricalGRUPolicyWithModel(
             env_spec=env.spec,
@@ -91,9 +91,9 @@ class TestCategoricalGRUPolicyWithModelTransit(TfGraphTestCase):
         self.obs = np.concatenate([self.obs for _ in range(self.time_step)],
                                   axis=0)
 
-        self.obs_ph = tf.placeholder(
+        self.obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
-        self.action_ph = tf.placeholder(
+        self.action_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.action_space.flat_dim))
 
         self.dist1_sym = self.policy1.dist_info_sym(

--- a/tests/garage/tf/policies/test_categorical_lstm_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy_with_model.py
@@ -23,7 +23,7 @@ class TestCategoricalLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym(self, obs_dim, action_dim, hidden_dim):
         env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -51,7 +51,7 @@ class TestCategoricalLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_include_action(self, obs_dim, action_dim):
         env = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -75,7 +75,7 @@ class TestCategoricalLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_wrong_input(self):
         env = TfEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -185,9 +185,9 @@ class TestCategoricalLSTMPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs = env.reset()
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'CategoricalLSTMPolicyWithModel/prob_network', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
@@ -197,7 +197,7 @@ class TestCategoricalLSTMPolicyWithModel(TfGraphTestCase):
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs[0],

--- a/tests/garage/tf/policies/test_categorical_lstm_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy_with_model_transit.py
@@ -58,7 +58,7 @@ class TestCategoricalLSTMPolicyWithModelTransit(TfGraphTestCase):
             state_include_action=True,
             name='P2')
 
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         self.policy3 = CategoricalLSTMPolicyWithModel(
             env_spec=env.spec,
@@ -91,9 +91,9 @@ class TestCategoricalLSTMPolicyWithModelTransit(TfGraphTestCase):
         self.obs = np.concatenate([self.obs for _ in range(self.time_step)],
                                   axis=0)
 
-        self.obs_ph = tf.placeholder(
+        self.obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
-        self.action_ph = tf.placeholder(
+        self.action_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.action_space.flat_dim))
 
         self.dist1_sym = self.policy1.dist_info_sym(

--- a/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy_with_model.py
@@ -84,7 +84,8 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
         expected_prob = np.full(action_dim, 0.5)
 
         obs_dim = env.spec.observation_space.flat_dim
-        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, obs_dim))
         dist1 = policy.dist_info_sym(state_input, name='policy2')
 
         prob = self.sess.run(
@@ -107,8 +108,9 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        with tf.variable_scope('CategoricalMLPPolicy/MLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+        with tf.compat.v1.variable_scope(
+                'CategoricalMLPPolicy/MLPModel', reuse=True):
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
@@ -117,7 +119,7 @@ class TestCategoricalMLPPolicyWithModel(TfGraphTestCase):
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs,

--- a/tests/garage/tf/policies/test_continuous_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_continuous_mlp_policy_with_model.py
@@ -62,7 +62,8 @@ class TestContinuousMLPPolicyWithModel(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
 
         obs_dim = env.spec.observation_space.flat_dim
-        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, obs_dim))
         action_sym = policy.get_action_sym(state_input, name='action_sym')
 
         expected_action = np.full(action_dim, 0.5)
@@ -92,8 +93,9 @@ class TestContinuousMLPPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        with tf.variable_scope('ContinuousMLPPolicy/MLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+        with tf.compat.v1.variable_scope(
+                'ContinuousMLPPolicy/MLPModel', reuse=True):
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
@@ -101,7 +103,7 @@ class TestContinuousMLPPolicyWithModel(TfGraphTestCase):
             feed_dict={policy.model.input: [obs.flatten()]})
 
         p = pickle.dumps(policy)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs,

--- a/tests/garage/tf/policies/test_continuous_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_continuous_mlp_policy_with_model_transit.py
@@ -40,7 +40,7 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
             self.policy4 = ContinuousMLPPolicyWithModel(
                 env_spec=self.box_env, hidden_sizes=(64, 64), name='P4')
 
-            self.sess.run(tf.global_variables_initializer())
+            self.sess.run(tf.compat.v1.global_variables_initializer())
             for a, b in zip(self.policy3.get_params(),
                             self.policy1.get_params()):
                 self.sess.run(a.assign(b))
@@ -74,7 +74,8 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
 
     def test_get_action_sym(self):
         obs_dim = self.box_env.spec.observation_space.flat_dim
-        state_input = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        state_input = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, obs_dim))
 
         action_sym1 = self.policy1.get_action_sym(
             state_input, name='action_sym')

--- a/tests/garage/tf/policies/test_gaussian_gru_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy_with_model.py
@@ -23,7 +23,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym(self, obs_dim, action_dim, hidden_dim):
         env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -55,7 +55,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
                                           hidden_dim):
         env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -80,7 +80,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_wrong_input(self):
         env = TfEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -196,9 +196,9 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs = env.reset()
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianGRUPolicyWithModel/GaussianGRUModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
@@ -208,7 +208,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.networks['default'].mean,

--- a/tests/garage/tf/policies/test_gaussian_gru_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy_with_model_transit.py
@@ -60,7 +60,7 @@ class TestGaussianGRUPolicyWithModelTransit(TfGraphTestCase):
                 state_include_action=True,
                 name='P2')
 
-            self.sess.run(tf.global_variables_initializer())
+            self.sess.run(tf.compat.v1.global_variables_initializer())
 
             self.policy3 = GaussianGRUPolicyWithModel(
                 env_spec=env.spec,
@@ -93,9 +93,9 @@ class TestGaussianGRUPolicyWithModelTransit(TfGraphTestCase):
             self.obs = np.concatenate(
                 [self.obs for _ in range(self.time_step)], axis=0)
 
-            self.obs_ph = tf.placeholder(
+            self.obs_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, None, env.observation_space.flat_dim))
-            self.action_ph = tf.placeholder(
+            self.action_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, None, env.action_space.flat_dim))
 
             self.dist1_sym = self.policy1.dist_info_sym(

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy_with_model.py
@@ -23,7 +23,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym(self, obs_dim, action_dim, hidden_dim):
         env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -55,7 +55,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
                                           hidden_dim):
         env = TfEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -80,7 +80,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
     def test_dist_info_sym_wrong_input(self):
         env = TfEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
 
-        obs_ph = tf.placeholder(
+        obs_ph = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, env.observation_space.flat_dim))
 
         with mock.patch(('garage.tf.policies.'
@@ -196,9 +196,9 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs = env.reset()
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianLSTMPolicyWithModel/GaussianLSTMModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
@@ -208,7 +208,7 @@ class TestGaussianLSTMPolicyWithModel(TfGraphTestCase):
 
         p = pickle.dumps(policy)
 
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.networks['default'].mean,

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy_with_model_transit.py
@@ -60,7 +60,7 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
                 state_include_action=True,
                 name='P2')
 
-            self.sess.run(tf.global_variables_initializer())
+            self.sess.run(tf.compat.v1.global_variables_initializer())
 
             self.policy3 = GaussianLSTMPolicyWithModel(
                 env_spec=env.spec,
@@ -93,9 +93,9 @@ class TestGaussianLSTMPolicyWithModelTransit(TfGraphTestCase):
             self.obs = np.concatenate(
                 [self.obs for _ in range(self.time_step)], axis=0)
 
-            self.obs_ph = tf.placeholder(
+            self.obs_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, None, env.observation_space.flat_dim))
-            self.action_ph = tf.placeholder(
+            self.action_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, None, env.action_space.flat_dim))
 
             self.dist1_sym = self.policy1.dist_info_sym(

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model.py
@@ -69,7 +69,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
 
         obs_dim = env.spec.observation_space.flat_dim
-        obs_ph = tf.placeholder(tf.float32, shape=(None, obs_dim))
+        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, obs_dim))
 
         dist1_sym = policy.dist_info_sym(obs_ph, name='p1_sym')
 
@@ -101,9 +101,9 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
         obs_dim = env.spec.observation_space.flat_dim
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianMLPPolicyWithModel/GaussianMLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         output1 = self.sess.run(
@@ -111,7 +111,7 @@ class TestGaussianMLPPolicyWithModel(TfGraphTestCase):
             feed_dict={policy.model.input: [obs.flatten()]})
 
         p = pickle.dumps(policy)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 policy_pickled.model.outputs[:-1],

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model_transit.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy_with_model_transit.py
@@ -41,20 +41,20 @@ class TestGaussianMLPPolicyWithModelTransit(TfGraphTestCase):
             self.policy4 = GaussianMLPPolicyWithModel(
                 env_spec=self.box_env, init_std=1.2, name='P4')
 
-            self.sess.run(tf.global_variables_initializer())
+            self.sess.run(tf.compat.v1.global_variables_initializer())
 
             for a, b in zip(self.policy3.get_params(),
                             self.policy1.get_params()):
-                self.sess.run(tf.assign(b, a))
+                self.sess.run(tf.compat.v1.assign(b, a))
             for a, b in zip(self.policy4.get_params(),
                             self.policy2.get_params()):
-                self.sess.run(tf.assign(b, a))
+                self.sess.run(tf.compat.v1.assign(b, a))
 
             self.obs = [self.box_env.reset()]
-            self.obs_ph = tf.placeholder(
+            self.obs_ph = tf.compat.v1.placeholder(
                 tf.float32,
                 shape=(None, self.box_env.observation_space.flat_dim))
-            self.action_ph = tf.placeholder(
+            self.action_ph = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, self.box_env.action_space.flat_dim))
 
             self.dist1_sym = self.policy1.dist_info_sym(

--- a/tests/garage/tf/policies/test_policies.py
+++ b/tests/garage/tf/policies/test_policies.py
@@ -25,7 +25,7 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorial_gru_policy(self):
         categorical_gru_policy = CategoricalGRUPolicy(
             env_spec=self.env, hidden_dim=1)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         categorical_gru_policy.reset()
 
@@ -35,7 +35,7 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorical_lstm_policy(self):
         categorical_lstm_policy = CategoricalLSTMPolicy(
             env_spec=self.env, hidden_dim=1)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         categorical_lstm_policy.reset()
 
@@ -45,7 +45,7 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorial_mlp_policy(self):
         categorical_mlp_policy = CategoricalMLPPolicy(
             env_spec=self.env, hidden_sizes=(1, ))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         obs = self.env.observation_space.high
         assert categorical_mlp_policy.get_action(obs)
@@ -63,7 +63,7 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_continuous_mlp_policy(self):
         continuous_mlp_policy = ContinuousMLPPolicy(
             env_spec=self.env, hidden_sizes=(1, ))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         obs = self.env.observation_space.high
         assert continuous_mlp_policy.get_action(obs)
@@ -71,7 +71,7 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_deterministic_mlp_policy(self):
         deterministic_mlp_policy = DeterministicMLPPolicy(
             env_spec=self.env, hidden_sizes=(1, ))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         obs = self.env.observation_space.high
         assert deterministic_mlp_policy.get_action(obs)
@@ -79,7 +79,7 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_gaussian_gru_policy(self):
         gaussian_gru_policy = GaussianGRUPolicy(
             env_spec=self.env, hidden_dim=1)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         gaussian_gru_policy.reset()
 
@@ -89,7 +89,7 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_gaussian_lstm_policy(self):
         gaussian_lstm_policy = GaussianLSTMPolicy(
             env_spec=self.env, hidden_dim=1)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         gaussian_lstm_policy.reset()
 
@@ -99,7 +99,7 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_gaussian_mlp_policy(self):
         gaussian_mlp_policy = GaussianMLPPolicy(
             env_spec=self.env, hidden_sizes=(1, ))
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
 
         obs = self.env.observation_space.high
         assert gaussian_mlp_policy.get_action(obs)

--- a/tests/garage/tf/policies/test_qf_derived_policy.py
+++ b/tests/garage/tf/policies/test_qf_derived_policy.py
@@ -16,7 +16,7 @@ class TestQfDerivedPolicy(TfGraphTestCase):
         self.qf = SimpleQFunction(self.env.spec)
         self.policy = DiscreteQfDerivedPolicy(
             env_spec=self.env.spec, qf=self.qf)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
         self.env.reset()
 
     def test_discrete_qf_derived_policy(self):
@@ -28,15 +28,16 @@ class TestQfDerivedPolicy(TfGraphTestCase):
             assert self.env.action_space.contains(action)
 
     def test_is_pickleable(self):
-        with tf.variable_scope('SimpleQFunction/SimpleMLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+        with tf.compat.v1.variable_scope(
+                'SimpleQFunction/SimpleMLPModel', reuse=True):
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         obs, _, _, _ = self.env.step(1)
         action1 = self.policy.get_action(obs)
 
         p = pickle.dumps(self.policy)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             policy_pickled = pickle.loads(p)
             action2 = policy_pickled.get_action(obs)
             assert action1 == action2

--- a/tests/garage/tf/q_functions/test_continuous_mlp_q_function_transit.py
+++ b/tests/garage/tf/q_functions/test_continuous_mlp_q_function_transit.py
@@ -42,7 +42,7 @@ class TestContinuousMLPQFunctionTransit(TfGraphTestCase):
             self.qf4 = ContinuousMLPQFunctionWithModel(
                 env_spec=self.box_env, hidden_sizes=(64, 64), name='QF4')
 
-            self.sess.run(tf.global_variables_initializer())
+            self.sess.run(tf.compat.v1.global_variables_initializer())
 
             for a, b in zip(self.qf3.get_trainable_vars(),
                             self.qf1.get_trainable_vars()):
@@ -69,11 +69,13 @@ class TestContinuousMLPQFunctionTransit(TfGraphTestCase):
         q_val4 = self.qf4.get_qval([self.obs, self.obs], [self.act, self.act])
 
         assert np.array_equal(q_val1, q_val3)
-        assert np.array_equal(q_val2, q_val4)
+        assert np.allclose(q_val2, q_val4)
 
     def test_get_qval_sym(self):
-        obs_ph = tf.placeholder(tf.float32, shape=(None, ) + self.obs_dim)
-        act_ph = tf.placeholder(tf.float32, shape=(None, ) + self.act_dim)
+        obs_ph = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + self.obs_dim)
+        act_ph = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + self.act_dim)
 
         qval_sym1 = self.qf1.get_qval_sym(obs_ph, act_ph, name='qval_sym')
         qval_sym2 = self.qf2.get_qval_sym(obs_ph, act_ph, name='qval_sym')

--- a/tests/garage/tf/q_functions/test_continuous_mlp_q_function_with_model.py
+++ b/tests/garage/tf/q_functions/test_continuous_mlp_q_function_with_model.py
@@ -106,8 +106,10 @@ class TestContinuousMLPQFunctionWithModel(TfGraphTestCase):
 
         output1 = qf.get_qval([obs], [act])
 
-        input_var1 = tf.placeholder(tf.float32, shape=(None, obs.shape[0]))
-        input_var2 = tf.placeholder(tf.float32, shape=(None, act.shape[0]))
+        input_var1 = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, obs.shape[0]))
+        input_var2 = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, act.shape[0]))
         q_vals = qf.get_qval_sym(input_var1, input_var2, 'another')
         output2 = self.sess.run(
             q_vals, feed_dict={
@@ -138,17 +140,17 @@ class TestContinuousMLPQFunctionWithModel(TfGraphTestCase):
         act = np.full(action_dim, 0.5).flatten()
         obs_ph, act_ph = qf.inputs
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'ContinuousMLPQFunctionWithModel/SimpleMLPMergeModel',
                 reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
         output1 = qf.get_qval([obs], [act])
 
         h_data = pickle.dumps(qf)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             qf_pickled = pickle.loads(h_data)
             obs_ph_pickled, act_ph_pickled = qf_pickled.inputs
             output2 = qf_pickled.get_qval([obs], [act])

--- a/tests/garage/tf/q_functions/test_discrete_cnn_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_cnn_q_function.py
@@ -141,7 +141,8 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
         obs_dim = self.env.observation_space.shape
         action_dim = self.env.action_space.n
 
-        input_var = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
+        input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + obs_dim)
         q_vals = qf.get_qval_sym(input_var, 'another')
         output2 = self.sess.run(q_vals, feed_dict={input_var: [self.obs]})
 
@@ -170,16 +171,16 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
                     num_filters=num_filters,
                     strides=strides,
                     dueling=False)
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'DiscreteCNNQFunction/Sequential/SimpleMLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [self.obs]})
 
         h_data = pickle.dumps(qf)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             qf_pickled = pickle.loads(h_data)
             output2 = sess.run(
                 qf_pickled.q_vals, feed_dict={qf_pickled.input: [self.obs]})

--- a/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_mlp_q_function.py
@@ -91,7 +91,8 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
 
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 
-        input_var = tf.placeholder(tf.float32, shape=(None, ) + obs_dim)
+        input_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + obs_dim)
         q_vals = qf.get_qval_sym(input_var, 'another')
         output2 = self.sess.run(q_vals, feed_dict={input_var: [obs]})
 
@@ -115,16 +116,16 @@ class TestDiscreteMLPQFunction(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'DiscreteMLPQFunction/SimpleMLPModel', reuse=True):
-            return_var = tf.get_variable('return_var')
+            return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
 
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [obs]})
 
         h_data = pickle.dumps(qf)
-        with tf.Session(graph=tf.Graph()) as sess:
+        with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             qf_pickled = pickle.loads(h_data)
             output2 = sess.run(
                 qf_pickled.q_vals, feed_dict={qf_pickled.input: [obs]})

--- a/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_bernoulli_mlp_regressor_with_model.py
@@ -171,8 +171,8 @@ class TestBernoulliMLPRegressorWithModel(TfGraphTestCase):
         bmr = BernoulliMLPRegressorWithModel(
             input_shape=(input_shape[1], ), output_dim=output_dim)
 
-        new_xs_var = tf.placeholder(tf.float32, input_shape)
-        new_ys_var = tf.placeholder(
+        new_xs_var = tf.compat.v1.placeholder(tf.float32, input_shape)
+        new_ys_var = tf.compat.v1.placeholder(
             dtype=tf.float32, name='ys', shape=(None, output_dim))
 
         data = np.full(input_shape, 0.5)
@@ -219,39 +219,39 @@ class TestBernoulliMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable(self):
         bmr = BernoulliMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
                 reuse=True):
-            bias = tf.get_variable('mlp/hidden_0/bias')
+            bias = tf.compat.v1.get_variable('mlp/hidden_0/bias')
         bias.load(tf.ones_like(bias).eval())
         bias1 = bias.eval()
 
         result1 = np.cast['int'](bmr.predict(np.ones((1, 1))))
         h = pickle.dumps(bmr)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             bmr_pickled = pickle.loads(h)
             result2 = np.cast['int'](bmr_pickled.predict(np.ones((1, 1))))
             assert np.array_equal(result1, result2)
 
-            with tf.variable_scope(
+            with tf.compat.v1.variable_scope(
                     'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
                     reuse=True):
-                bias2 = tf.get_variable('mlp/hidden_0/bias').eval()
+                bias2 = tf.compat.v1.get_variable('mlp/hidden_0/bias').eval()
 
             assert np.array_equal(bias1, bias2)
 
     def test_is_pickleable2(self):
         bmr = BernoulliMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'BernoulliMLPRegressorWithModel/NormalizedInputMLPModel',
                 reuse=True):
-            x_mean = tf.get_variable('normalized_vars/x_mean')
+            x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
         x1 = bmr.model.networks['default'].x_mean.eval()
         h = pickle.dumps(bmr)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             bmr_pickled = pickle.loads(h)
             x2 = bmr_pickled.model.networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_categorical_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_categorical_mlp_regressor_with_model.py
@@ -151,7 +151,8 @@ class TestCategoricalMLPRegressorWithModel(TfGraphTestCase):
         cmr = CategoricalMLPRegressorWithModel(
             input_shape=input_shape, output_dim=output_dim)
 
-        new_xs_var = tf.placeholder(tf.float32, shape=(None, ) + input_shape)
+        new_xs_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + input_shape)
 
         data = np.random.random(size=input_shape)
         label = np.random.randint(0, output_dim)
@@ -172,8 +173,9 @@ class TestCategoricalMLPRegressorWithModel(TfGraphTestCase):
         cmr = CategoricalMLPRegressorWithModel(
             input_shape=input_shape, output_dim=output_dim)
 
-        new_xs_var = tf.placeholder(tf.float32, shape=(None, ) + input_shape)
-        new_ys_var = tf.placeholder(
+        new_xs_var = tf.compat.v1.placeholder(
+            tf.float32, shape=(None, ) + input_shape)
+        new_ys_var = tf.compat.v1.placeholder(
             dtype=tf.float32, name='ys', shape=(None, output_dim))
 
         data = np.random.random(size=input_shape)
@@ -221,16 +223,16 @@ class TestCategoricalMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable(self):
         cmr = CategoricalMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'CategoricalMLPRegressorWithModel/NormalizedInputMLPModel',
                 reuse=True):
-            bias = tf.get_variable('mlp/hidden_0/bias')
+            bias = tf.compat.v1.get_variable('mlp/hidden_0/bias')
         bias.load(tf.ones_like(bias).eval())
 
         result1 = cmr.predict(np.ones((1, 1)))
 
         h = pickle.dumps(cmr)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             cmr_pickled = pickle.loads(h)
             result2 = cmr_pickled.predict(np.ones((1, 1)))
             assert np.array_equal(result1, result2)
@@ -238,14 +240,14 @@ class TestCategoricalMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable2(self):
         cmr = CategoricalMLPRegressorWithModel(input_shape=(1, ), output_dim=2)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'CategoricalMLPRegressorWithModel/NormalizedInputMLPModel',
                 reuse=True):
-            x_mean = tf.get_variable('normalized_vars/x_mean')
+            x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
         x1 = cmr.model.networks['default'].x_mean.eval()
         h = pickle.dumps(cmr)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             cmr_pickled = pickle.loads(h)
             x2 = cmr_pickled.model.networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_continuous_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_continuous_mlp_regressor_with_model.py
@@ -77,7 +77,7 @@ class TestContinuousMLPRegressorWithModel(TfGraphTestCase):
             optimizer=LbfgsOptimizer,
             optimizer_args=dict())
 
-        new_input_var = tf.placeholder(
+        new_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape)
 
         data = np.random.random(size=input_shape)
@@ -90,16 +90,16 @@ class TestContinuousMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable(self):
         cmr = ContinuousMLPRegressorWithModel(input_shape=(1, ), output_dim=1)
 
-        with tf.variable_scope(('ContinuousMLPRegressorWithModel/'
-                                'NormalizedInputMLPModel'),
-                               reuse=True):
-            bias = tf.get_variable('mlp/hidden_0/bias')
+        with tf.compat.v1.variable_scope(('ContinuousMLPRegressorWithModel/'
+                                          'NormalizedInputMLPModel'),
+                                         reuse=True):
+            bias = tf.compat.v1.get_variable('mlp/hidden_0/bias')
         bias.load(tf.ones_like(bias).eval())
 
         result1 = cmr.predict(np.ones((1, 1)))
         h = pickle.dumps(cmr)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             cmr_pickled = pickle.loads(h)
             result2 = cmr_pickled.predict(np.ones((1, 1)))
             assert np.array_equal(result1, result2)

--- a/tests/garage/tf/regressors/test_gaussian_cnn_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_gaussian_cnn_regressor_with_model.py
@@ -186,9 +186,9 @@ class TestGaussianCNNRegressorWithModel(TfGraphTestCase):
             adaptive_std=False,
             use_trust_region=False)
 
-        new_input_var = tf.placeholder(
+        new_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape)
-        new_ys_var = tf.placeholder(
+        new_ys_var = tf.compat.v1.placeholder(
             dtype=tf.float32, name='ys', shape=(None, output_dim))
 
         data = np.full(input_shape, 0.5)
@@ -240,16 +240,17 @@ class TestGaussianCNNRegressorWithModel(TfGraphTestCase):
             adaptive_std=False,
             use_trust_region=False)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianCNNRegressorWithModel/GaussianCNNRegressorModel',
                 reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/hidden_0/bias')
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/hidden_0/bias')
         bias.load(tf.ones_like(bias).eval())
 
         result1 = gcr.predict([np.ones(input_shape)])
         h = pickle.dumps(gcr)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gcr_pickled = pickle.loads(h)
             result2 = gcr_pickled.predict([np.ones(input_shape)])
             assert np.array_equal(result1, result2)
@@ -267,14 +268,14 @@ class TestGaussianCNNRegressorWithModel(TfGraphTestCase):
             adaptive_std=False,
             use_trust_region=False)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianCNNRegressorWithModel/GaussianCNNRegressorModel',
                 reuse=True):
-            x_mean = tf.get_variable('normalized_vars/x_mean')
+            x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
         x1 = gcr.model.networks['default'].x_mean.eval()
         h = pickle.dumps(gcr)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gcr_pickled = pickle.loads(h)
             x2 = gcr_pickled.model.networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
@@ -10,7 +10,7 @@ class TestGaussianMlpRegressor(TfGraphTestCase):
     # @pytest.mark.large
     def test_fit_normalized(self):
         gmr = GaussianMLPRegressor(input_shape=(1, ), output_dim=1)
-        self.sess.run(tf.global_variables_initializer())
+        self.sess.run(tf.compat.v1.global_variables_initializer())
         data = np.linspace(-np.pi, np.pi, 1000)
         obs = [{'observations': [[x]], 'returns': [np.sin(x)]} for x in data]
 

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor_with_model.py
@@ -147,9 +147,9 @@ class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
             optimizer=PenaltyLbfgsOptimizer,
             optimizer_args=dict())
 
-        new_input_var = tf.placeholder(
+        new_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, ) + input_shape)
-        new_ys_var = tf.placeholder(
+        new_ys_var = tf.compat.v1.placeholder(
             dtype=tf.float32, name='ys', shape=(None, output_dim))
 
         data = np.random.random(size=input_shape)
@@ -170,16 +170,17 @@ class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable(self):
         gmr = GaussianMLPRegressorWithModel(input_shape=(1, ), output_dim=1)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianMLPRegressorWithModel/GaussianMLPRegressorModel',
                 reuse=True):
-            bias = tf.get_variable('dist_params/mean_network/hidden_0/bias')
+            bias = tf.compat.v1.get_variable(
+                'dist_params/mean_network/hidden_0/bias')
         bias.load(tf.ones_like(bias).eval())
 
         result1 = gmr.predict(np.ones((1, 1)))
         h = pickle.dumps(gmr)
 
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gmr_pickled = pickle.loads(h)
             result2 = gmr_pickled.predict(np.ones((1, 1)))
             assert np.array_equal(result1, result2)
@@ -187,14 +188,14 @@ class TestGaussianMLPRegressorWithModel(TfGraphTestCase):
     def test_is_pickleable2(self):
         gmr = GaussianMLPRegressorWithModel(input_shape=(1, ), output_dim=1)
 
-        with tf.variable_scope(
+        with tf.compat.v1.variable_scope(
                 'GaussianMLPRegressorWithModel/GaussianMLPRegressorModel',
                 reuse=True):
-            x_mean = tf.get_variable('normalized_vars/x_mean')
+            x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
         x1 = gmr.model.networks['default'].x_mean.eval()
         h = pickle.dumps(gmr)
-        with tf.Session(graph=tf.Graph()):
+        with tf.compat.v1.Session(graph=tf.Graph()):
             gmr_pickled = pickle.loads(h)
             x2 = gmr_pickled.model.networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)


### PR DESCRIPTION
This commit updates a lot of deprecated imports to tf.compat.v1 imports, and some other method updates like (tf.log -> tf.math.log) and more. There are still more deprecations, but merging it as-is is still useful since it also brings python 3.7 support.