### PR TITLE
Use akro v0.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # Required dependencies
 required = [
     # Please keep alphabetized
-    'akro==0.0.5',
+    'akro==0.0.6',
     'cached_property',
     'click',
     'cloudpickle',


### PR DESCRIPTION
akro v0.0.6 relaxes the gym version requirement, so it's easier to solve the dependency graph.