### PR TITLE
Configure TravisCI to build master on commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,9 @@ deploy:
 git:
   depth: false
 
+branches:
+  only:
+  - master
+
 notifications:
   email: false


### PR DESCRIPTION
We disable branch builds in TravisCI to conserve build resources,
since PR builds execute when their associated branches get new commits
anyway.

One notable exception to this configuration should be master: in
principle the PR build should have verified the commit was safe, but
some problems only show up when the commit his master (e.g. some
documentation generation issues).