### PR TITLE
Whitelist release branches and tags for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ git:
 branches:
   only:
   - master
+  - release-*
+  - /^v\d+\.\d+(\.\d+)?(-\S*)?$/  # regex for release tags
 
 notifications:
   email: false


### PR DESCRIPTION
Whitelists release branches and tags in .travis.yml, so Travis will
build then when new commits are added.