### PR TITLE
Don't overwrite mjkey.txt if it exists

### DIFF
--- a/scripts/setup_colab.sh
+++ b/scripts/setup_colab.sh
@@ -198,7 +198,9 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
 fi
 
 # We need a MuJoCo key to import mujoco_py
-cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+if [[ ! -f "${HOME}/.mujoco/mjkey.txt" ]]; then
+  cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+fi
 {
   # Prevent pip from complaining about available upgrades
   pip install --upgrade pip

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -183,7 +183,9 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
 fi
 
 # We need a MuJoCo key to import mujoco_py
-cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+if [[ ! -f "${HOME}/.mujoco/mjkey.txt" ]]; then
+  cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+fi
 
 if [[ "${_arg_modify_bashrc}" != on ]]; then
   echo -e "\nRemember to execute the following commands before running garage:"

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -217,7 +217,9 @@ if [[ "${_arg_modify_bashrc}" = on ]]; then
 fi
 
 # We need a MuJoCo key to import mujoco_py
-cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+if [[ ! -f "${HOME}/.mujoco/mjkey.txt" ]]; then
+  cp "${_arg_mjkey}" "${HOME}/.mujoco/mjkey.txt"
+fi
 
 # Add garage to python modules
 if [[ "${_arg_modify_bashrc}" != on ]]; then


### PR DESCRIPTION
This is primarily useful for re-running the setup script, since it requires mjkey be specified, and fails if you give the mjkey which is already installed.