### PR TITLE
Set VectorizedSamplers default n_envs

### DIFF
--- a/examples/resume_training.py
+++ b/examples/resume_training.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""
-This is an example to resume training programmatically.
-"""
+"""This is an example to resume training programmatically."""
 from garage.experiment import run_experiment
 from garage.tf.experiment import LocalTFRunner
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         runner.restore(from_dir='dir/', from_epoch=2)
         runner.resume()

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -23,39 +23,38 @@ from garage.tf.q_functions import ContinuousMLPQFunction
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('InvertedDoublePendulum-v2'))
 
         action_noise = OUStrategy(env.spec, sigma=0.2)
 
-        policy = ContinuousMLPPolicyWithModel(
-            env_spec=env.spec,
-            hidden_sizes=[64, 64],
-            hidden_nonlinearity=tf.nn.relu,
-            output_nonlinearity=tf.nn.tanh)
+        policy = ContinuousMLPPolicyWithModel(env_spec=env.spec,
+                                              hidden_sizes=[64, 64],
+                                              hidden_nonlinearity=tf.nn.relu,
+                                              output_nonlinearity=tf.nn.tanh)
 
-        qf = ContinuousMLPQFunction(
-            env_spec=env.spec,
-            hidden_sizes=[64, 64],
-            hidden_nonlinearity=tf.nn.relu)
+        qf = ContinuousMLPQFunction(env_spec=env.spec,
+                                    hidden_sizes=[64, 64],
+                                    hidden_nonlinearity=tf.nn.relu)
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec, size_in_transitions=int(1e6), time_horizon=100)
+        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                           size_in_transitions=int(1e6),
+                                           time_horizon=100)
 
-        ddpg = DDPG(
-            env_spec=env.spec,
-            policy=policy,
-            policy_lr=1e-4,
-            qf_lr=1e-3,
-            qf=qf,
-            replay_buffer=replay_buffer,
-            target_update_tau=1e-2,
-            n_train_steps=50,
-            discount=0.9,
-            min_buffer_size=int(1e4),
-            exploration_strategy=action_noise,
-            policy_optimizer=tf.train.AdamOptimizer,
-            qf_optimizer=tf.train.AdamOptimizer)
+        ddpg = DDPG(env_spec=env.spec,
+                    policy=policy,
+                    policy_lr=1e-4,
+                    qf_lr=1e-3,
+                    qf=qf,
+                    replay_buffer=replay_buffer,
+                    target_update_tau=1e-2,
+                    n_train_steps=50,
+                    discount=0.9,
+                    min_buffer_size=int(1e4),
+                    exploration_strategy=action_noise,
+                    policy_optimizer=tf.train.AdamOptimizer,
+                    qf_optimizer=tf.train.AdamOptimizer)
 
         runner.setup(algo=ddpg, env=env)
 

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -24,8 +24,9 @@ def run_task(snapshot_config, *_):
         sampler_batch_size = 500
         num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
         env = TfEnv(gym.make('CartPole-v0'))
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec, size_in_transitions=int(1e4), time_horizon=1)
+        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                           size_in_transitions=int(1e4),
+                                           time_horizon=1)
         qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
         policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
         epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -34,26 +35,24 @@ def run_task(snapshot_config, *_):
             max_epsilon=1.0,
             min_epsilon=0.02,
             decay_ratio=0.1)
-        algo = DQN(
-            env_spec=env.spec,
-            policy=policy,
-            qf=qf,
-            exploration_strategy=epilson_greedy_strategy,
-            replay_buffer=replay_buffer,
-            qf_lr=1e-4,
-            discount=1.0,
-            min_buffer_size=int(1e3),
-            double_q=True,
-            n_train_steps=500,
-            n_epoch_cycles=n_epoch_cycles,
-            target_network_update_freq=1,
-            buffer_batch_size=32)
+        algo = DQN(env_spec=env.spec,
+                   policy=policy,
+                   qf=qf,
+                   exploration_strategy=epilson_greedy_strategy,
+                   replay_buffer=replay_buffer,
+                   qf_lr=1e-4,
+                   discount=1.0,
+                   min_buffer_size=int(1e3),
+                   double_q=True,
+                   n_train_steps=500,
+                   n_epoch_cycles=n_epoch_cycles,
+                   target_network_update_freq=1,
+                   buffer_batch_size=32)
 
         runner.setup(algo, env)
-        runner.train(
-            n_epochs=n_epochs,
-            n_epoch_cycles=n_epoch_cycles,
-            batch_size=sampler_batch_size)
+        runner.train(n_epochs=n_epochs,
+                     n_epoch_cycles=n_epoch_cycles,
+                     batch_size=sampler_batch_size)
 
 
 run_experiment(run_task, snapshot_mode='last', seed=1)

--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -45,15 +45,15 @@ def run_task(snapshot_config, *_):
 
         env = TfEnv(env)
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec, size_in_transitions=int(5e4), time_horizon=1)
+        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                           size_in_transitions=int(5e4),
+                                           time_horizon=1)
 
-        qf = DiscreteCNNQFunction(
-            env_spec=env.spec,
-            filter_dims=(8, 4, 3),
-            num_filters=(32, 64, 64),
-            strides=(4, 2, 1),
-            dueling=False)
+        qf = DiscreteCNNQFunction(env_spec=env.spec,
+                                  filter_dims=(8, 4, 3),
+                                  num_filters=(32, 64, 64),
+                                  strides=(4, 2, 1),
+                                  dueling=False)
 
         policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
         epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -63,26 +63,24 @@ def run_task(snapshot_config, *_):
             min_epsilon=0.02,
             decay_ratio=0.1)
 
-        algo = DQN(
-            env_spec=env.spec,
-            policy=policy,
-            qf=qf,
-            exploration_strategy=epilson_greedy_strategy,
-            replay_buffer=replay_buffer,
-            qf_lr=1e-4,
-            discount=0.99,
-            min_buffer_size=int(1e4),
-            double_q=False,
-            n_train_steps=500,
-            n_epoch_cycles=n_epoch_cycles,
-            target_network_update_freq=2,
-            buffer_batch_size=32)
+        algo = DQN(env_spec=env.spec,
+                   policy=policy,
+                   qf=qf,
+                   exploration_strategy=epilson_greedy_strategy,
+                   replay_buffer=replay_buffer,
+                   qf_lr=1e-4,
+                   discount=0.99,
+                   min_buffer_size=int(1e4),
+                   double_q=False,
+                   n_train_steps=500,
+                   n_epoch_cycles=n_epoch_cycles,
+                   target_network_update_freq=2,
+                   buffer_batch_size=32)
 
         runner.setup(algo, env)
-        runner.train(
-            n_epochs=n_epochs,
-            n_epoch_cycles=n_epoch_cycles,
-            batch_size=sampler_batch_size)
+        runner.train(n_epochs=n_epochs,
+                     n_epoch_cycles=n_epoch_cycles,
+                     batch_size=sampler_batch_size)
 
 
 run_experiment(

--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -17,20 +17,21 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = ERWR(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99)
+        algo = ERWR(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99)
 
         runner.setup(algo=algo, env=env)
 

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -22,6 +22,7 @@ from garage.tf.q_functions import ContinuousMLPQFunction
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('FetchReach-v1'))
 
@@ -44,12 +45,11 @@ def run_task(snapshot_config, *_):
             input_include_goal=True,
         )
 
-        replay_buffer = HerReplayBuffer(
-            env_spec=env.spec,
-            size_in_transitions=int(1e6),
-            time_horizon=100,
-            replay_k=0.4,
-            reward_fun=env.compute_reward)
+        replay_buffer = HerReplayBuffer(env_spec=env.spec,
+                                        size_in_transitions=int(1e6),
+                                        time_horizon=100,
+                                        replay_k=0.4,
+                                        reward_fun=env.compute_reward)
 
         ddpg = DDPG(
             env_spec=env.spec,

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """
 This is an example to train a task with PPO algorithm.
+
 Here it creates InvertedDoublePendulum using gym. And uses a PPO with 1M
 steps.
+
 Results:
     AverageDiscountedReturn: 500
     RiseTime: itr 40
+
 """
 import gym
 import tensorflow as tf
@@ -20,6 +23,7 @@ from garage.tf.policies import GaussianMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
 

--- a/examples/tf/reps_gym_cartpole.py
+++ b/examples/tf/reps_gym_cartpole.py
@@ -7,6 +7,7 @@ Here it runs gym CartPole env with 100 iterations.
 Results:
     AverageReturn: 100 +/- 40
     RiseTime: itr 10 +/- 5
+
 """
 
 import gym
@@ -20,6 +21,7 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('CartPole-v0'))
 
@@ -27,12 +29,11 @@ def run_task(snapshot_config, *_):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = REPS(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99)
+        algo = REPS(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99)
 
         runner.setup(algo, env)
         runner.train(n_epochs=100, batch_size=4000, plot=False)

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -17,21 +17,22 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99,
-            max_kl_step=0.01)
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01)
 
         runner.setup(algo, env)
         runner.train(n_epochs=100, batch_size=4000)

--- a/examples/tf/trpo_cartpole_batch_sampler.py
+++ b/examples/tf/trpo_cartpole_batch_sampler.py
@@ -22,28 +22,28 @@ n_envs = batch_size // max_path_length
 
 
 def run_task(snapshot_config, *_):
-    with LocalTFRunner(
-            snapshot_config=snapshot_config, max_cpus=n_envs) as runner:
+    """Run task."""
+    with LocalTFRunner(snapshot_config=snapshot_config,
+                       max_cpus=n_envs) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=max_path_length,
-            discount=0.99,
-            max_kl_step=0.01)
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=max_path_length,
+                    discount=0.99,
+                    max_kl_step=0.01)
 
-        runner.setup(
-            algo=algo,
-            env=env,
-            sampler_cls=BatchSampler,
-            sampler_args={'n_envs': n_envs})
+        runner.setup(algo=algo,
+                     env=env,
+                     sampler_cls=BatchSampler,
+                     sampler_args={'n_envs': n_envs})
 
         runner.train(n_epochs=100, batch_size=4000, plot=False)
 

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """
-This is an example to train a task with TRPO algorithm. It uses an LSTM-based
-recurrent policy. To use a GRU-based recurrent policy, swap the commented
-lines.
+This is an example to train a task with TRPO algorithm.
 
-Here it runs CartPole-v1 environment with 100 iterations.
+It uses an LSTM-based recurrent policy. To use a GRU-based recurrent
+policy, swap the commented lines. Here it runs CartPole-v1 environment
+with 100 iterations.
 
 Results:
     AverageReturn: 100
     RiseTime: itr 13
+
 """
 from garage.experiment import run_experiment
 from garage.np.baselines import LinearFeatureBaseline
@@ -22,6 +23,7 @@ from garage.tf.policies import CategoricalLSTMPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
@@ -34,16 +36,15 @@ def run_task(snapshot_config, *_):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99,
-            max_kl_step=0.01,
-            optimizer=ConjugateGradientOptimizer,
-            optimizer_args=dict(
-                hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01,
+                    optimizer=ConjugateGradientOptimizer,
+                    optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                        base_eps=1e-5)))
 
         runner.setup(algo, env)
         runner.train(n_epochs=100, batch_size=4000)

--- a/examples/tf/trpo_cartpole_recurrent_with_model.py
+++ b/examples/tf/trpo_cartpole_recurrent_with_model.py
@@ -25,21 +25,20 @@ def run_task(snapshot_config, *_):
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalLSTMPolicyWithModel(
-            name='policy', env_spec=env.spec)
+        policy = CategoricalLSTMPolicyWithModel(name='policy',
+                                                env_spec=env.spec)
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99,
-            max_kl_step=0.01,
-            optimizer=ConjugateGradientOptimizer,
-            optimizer_args=dict(
-                hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01,
+                    optimizer=ConjugateGradientOptimizer,
+                    optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                        base_eps=1e-5)))
 
         runner.setup(algo, env)
         runner.train(n_epochs=100, batch_size=4000)

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+"""An example to train a task with TRPO algorithm."""
 import gym
 
 from garage.experiment import run_experiment
@@ -11,11 +11,13 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('CartPole-v0'))
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 

--- a/examples/tf/trpo_swimmer.py
+++ b/examples/tf/trpo_swimmer.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""An example to train a task with TRPO algorithm."""
 import gym
 
 from garage.experiment import run_experiment
@@ -10,6 +11,7 @@ from garage.tf.policies import GaussianMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('Swimmer-v2'))
 
@@ -17,13 +19,12 @@ def run_task(snapshot_config, *_):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=500,
-            discount=0.99,
-            max_kl_step=0.01)
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=500,
+                    discount=0.99,
+                    max_kl_step=0.01)
 
         runner.setup(algo, env)
         runner.train(n_epochs=40, batch_size=4000)

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -20,24 +20,26 @@ seed = 100
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('Swimmer-v2'))
 
-        policy = GaussianMLPPolicyWithModel(
-            env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = GaussianMLPPolicyWithModel(env_spec=env.spec,
+                                            hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=500,
-            discount=0.99,
-            max_kl_step=0.01)
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=500,
+                    discount=0.99,
+                    max_kl_step=0.01)
 
-        runner.setup(
-            algo, env, sampler_cls=RaySamplerTF, sampler_args={'seed': seed})
+        runner.setup(algo,
+                     env,
+                     sampler_cls=RaySamplerTF,
+                     sampler_args={'seed': seed})
         runner.train(n_epochs=40, batch_size=4000)
 
 

--- a/examples/tf/trpois_inverted_pendulum.py
+++ b/examples/tf/trpois_inverted_pendulum.py
@@ -24,16 +24,17 @@ def run_task(snapshot_config, *_):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        algo = TRPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99,
-            max_kl_step=0.01)
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01)
 
-        runner.setup(
-            algo, env, sampler_cls=ISSampler, sampler_args=dict(n_backtrack=1))
+        runner.setup(algo,
+                     env,
+                     sampler_cls=ISSampler,
+                     sampler_args=dict(n_backtrack=1))
         runner.train(n_epochs=200, batch_size=4000)
 
 

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -17,11 +17,13 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
+    """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 

--- a/examples/tf/vpgis_inverted_pendulum.py
+++ b/examples/tf/vpgis_inverted_pendulum.py
@@ -33,8 +33,10 @@ def run_task(snapshot_config, *_):
             max_kl_step=0.01,
         )
 
-        runner.setup(
-            algo, env, sampler_cls=ISSampler, sampler_args=dict(n_backtrack=1))
+        runner.setup(algo,
+                     env,
+                     sampler_cls=ISSampler,
+                     sampler_args=dict(n_backtrack=1))
         runner.train(n_epochs=40, batch_size=4000)
 
 

--- a/scripts/garage
+++ b/scripts/garage
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Script for resuming training from command line."""
 import click
 
 from garage.experiment import run_experiment
@@ -6,7 +7,7 @@ from garage.tf.experiment import LocalTFRunner
 
 
 @click.group()
-def cli():
+def cli():  # noqa: D103
     pass
 
 
@@ -23,6 +24,7 @@ def cli():
     help='Path to save the log snapshot. If not specified, will be the same '
     'as from_dir.')
 def resume(from_dir, from_epoch, log_dir):
+    """Resume from command line."""
     if log_dir is None:
         log_dir = from_dir
 
@@ -31,11 +33,10 @@ def resume(from_dir, from_epoch, log_dir):
             runner.restore(from_dir=_from_dir, from_epoch=_from_epoch)
             runner.resume()
 
-    run_experiment(
-        run_task,
-        log_dir=log_dir,
-        resume_from_dir=from_dir,
-        resume_from_epoch=from_epoch)
+    run_experiment(run_task,
+                   log_dir=log_dir,
+                   resume_from_dir=from_dir,
+                   resume_from_epoch=from_epoch)
 
 
 if __name__ == '__main__':

--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -18,6 +18,7 @@ from garage.core import Serializable
 
 
 class AttrDict(dict):
+
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
@@ -28,6 +29,7 @@ def flatten(l):
 
 
 class BinaryOp(Serializable):
+
     def __init__(self):
         Serializable.quick_init(self, locals())
 
@@ -40,6 +42,7 @@ class BinaryOp(Serializable):
 
 
 class VariantDict(AttrDict):
+
     def __init__(self, d, hidden_keys):
         super(VariantDict, self).__init__(d)
         self._hidden_keys = hidden_keys
@@ -160,6 +163,7 @@ class VariantGenerator:
 
 
 def variant(*args, **kwargs):
+
     def _variant(fn):
         fn.__is_variant = True
         fn.__variant_config = kwargs
@@ -257,14 +261,13 @@ def run_experiment(method_call=None,
 
     if batch_tasks is None:
         batch_tasks = [
-            dict(
-                kwargs,
-                pre_commands=pre_commands,
-                method_call=method_call,
-                exp_name=exp_name,
-                log_dir=log_dir,
-                env=env,
-                variant=variant)
+            dict(kwargs,
+                 pre_commands=pre_commands,
+                 method_call=method_call,
+                 exp_name=exp_name,
+                 log_dir=log_dir,
+                 env=env,
+                 variant=variant)
         ]
 
     global exp_count
@@ -306,8 +309,9 @@ def run_experiment(method_call=None,
 
     for task in batch_tasks:
         env = task.pop('env', None)
-        command = to_local_command(
-            task, python_command=python_command, script=script)
+        command = to_local_command(task,
+                                   python_command=python_command,
+                                   script=script)
         print(command)
         if dry:
             return

--- a/src/garage/experiment/experiment_wrapper.py
+++ b/src/garage/experiment/experiment_wrapper.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Run an experiment triggered by `run_experiment()` in `experiment.py`."""
 import argparse
 import ast
 import base64
@@ -27,10 +28,12 @@ import garage.tf.plotter
 
 
 def is_iterable(obj):
+    """Return if instance is iterable."""
     return isinstance(obj, str) or getattr(obj, '__iter__', False)
 
 
 def run_experiment(argv):
+    """Run experiment."""
     now = datetime.datetime.now(dateutil.tz.tzlocal())
 
     # avoid name clashes when running distributed jobs
@@ -45,85 +48,76 @@ def run_experiment(argv):
         default=1,
         help=('Number of parallel workers to perform rollouts. '
               "0 => don't start any workers"))
-    parser.add_argument(
-        '--exp_name',
-        type=str,
-        default=default_exp_name,
-        help='Name of the experiment.')
-    parser.add_argument(
-        '--log_dir',
-        type=str,
-        default=None,
-        help='Path to save the log and iteration snapshot.')
-    parser.add_argument(
-        '--snapshot_mode',
-        type=str,
-        default='last',
-        help='Mode to save the snapshot. Can be either "all" '
-        '(all iterations will be saved), "last" (only '
-        'the last iteration will be saved), "gap" (every'
-        '`snapshot_gap` iterations are saved), or "none" '
-        '(do not save snapshots)')
-    parser.add_argument(
-        '--snapshot_gap',
-        type=int,
-        default=1,
-        help='Gap between snapshot iterations.')
+    parser.add_argument('--exp_name',
+                        type=str,
+                        default=default_exp_name,
+                        help='Name of the experiment.')
+    parser.add_argument('--log_dir',
+                        type=str,
+                        default=None,
+                        help='Path to save the log and iteration snapshot.')
+    parser.add_argument('--snapshot_mode',
+                        type=str,
+                        default='last',
+                        help='Mode to save the snapshot. Can be either "all" '
+                        '(all iterations will be saved), "last" (only '
+                        'the last iteration will be saved), "gap" (every'
+                        '`snapshot_gap` iterations are saved), or "none" '
+                        '(do not save snapshots)')
+    parser.add_argument('--snapshot_gap',
+                        type=int,
+                        default=1,
+                        help='Gap between snapshot iterations.')
     parser.add_argument(
         '--resume_from_dir',
         type=str,
         default=None,
         help='Directory of the pickle file to resume experiment from.')
-    parser.add_argument(
-        '--resume_from_epoch',
-        type=str,
-        default=None,
-        help='Index of iteration to restore from. '
-        'Can be "first", "last" or a number. '
-        'Not applicable when snapshot_mode="last"')
-    parser.add_argument(
-        '--tabular_log_file',
-        type=str,
-        default='progress.csv',
-        help='Name of the tabular log file (in csv).')
-    parser.add_argument(
-        '--text_log_file',
-        type=str,
-        default='debug.log',
-        help='Name of the text log file (in pure text).')
-    parser.add_argument(
-        '--tensorboard_step_key',
-        type=str,
-        default=None,
-        help='Name of the step key in tensorboard_summary.')
-    parser.add_argument(
-        '--params_log_file',
-        type=str,
-        default='params.json',
-        help='Name of the parameter log file (in json).')
-    parser.add_argument(
-        '--variant_log_file',
-        type=str,
-        default='variant.json',
-        help='Name of the variant log file (in json).')
-    parser.add_argument(
-        '--plot',
-        type=ast.literal_eval,
-        default=False,
-        help='Whether to plot the iteration results')
+    parser.add_argument('--resume_from_epoch',
+                        type=str,
+                        default=None,
+                        help='Index of iteration to restore from. '
+                        'Can be "first", "last" or a number. '
+                        'Not applicable when snapshot_mode="last"')
+    parser.add_argument('--tabular_log_file',
+                        type=str,
+                        default='progress.csv',
+                        help='Name of the tabular log file (in csv).')
+    parser.add_argument('--text_log_file',
+                        type=str,
+                        default='debug.log',
+                        help='Name of the text log file (in pure text).')
+    parser.add_argument('--tensorboard_step_key',
+                        type=str,
+                        default=None,
+                        help='Name of the step key in tensorboard_summary.')
+    parser.add_argument('--params_log_file',
+                        type=str,
+                        default='params.json',
+                        help='Name of the parameter log file (in json).')
+    parser.add_argument('--variant_log_file',
+                        type=str,
+                        default='variant.json',
+                        help='Name of the variant log file (in json).')
+    parser.add_argument('--plot',
+                        type=ast.literal_eval,
+                        default=False,
+                        help='Whether to plot the iteration results')
     parser.add_argument(
         '--log_tabular_only',
         type=ast.literal_eval,
         default=False,
         help='Print only the tabular log information (in a horizontal format)')
-    parser.add_argument(
-        '--seed', type=int, default=None, help='Random seed for numpy')
-    parser.add_argument(
-        '--args_data', type=str, help='Pickled data for objects')
-    parser.add_argument(
-        '--variant_data',
-        type=str,
-        help='Pickled data for variant configuration')
+    parser.add_argument('--seed',
+                        type=int,
+                        default=None,
+                        help='Random seed for numpy')
+    parser.add_argument('--args_data',
+                        type=str,
+                        help='Pickled data for objects')
+    parser.add_argument('--variant_data',
+                        type=str,
+                        help='Pickled data for variant configuration')
 
     args = parser.parse_args(argv[1:])
 
@@ -153,8 +147,8 @@ def run_experiment(argv):
         garage.tf.plotter.Plotter.disable()
 
     if args.log_dir is None:
-        log_dir = os.path.join(
-            os.path.join(os.getcwd(), 'data'), args.exp_name)
+        log_dir = os.path.join(os.path.join(os.getcwd(), 'data'),
+                               args.exp_name)
     else:
         log_dir = args.log_dir
 
@@ -178,10 +172,9 @@ def run_experiment(argv):
 
     logger.push_prefix('[%s] ' % args.exp_name)
 
-    snapshot_config = SnapshotConfig(
-        snapshot_dir=log_dir,
-        snapshot_mode=args.snapshot_mode,
-        snapshot_gap=args.snapshot_gap)
+    snapshot_config = SnapshotConfig(snapshot_dir=log_dir,
+                                     snapshot_mode=args.snapshot_mode,
+                                     snapshot_gap=args.snapshot_gap)
 
     method_call = cloudpickle.loads(base64.b64decode(args.args_data))
     try:
@@ -200,6 +193,7 @@ def run_experiment(argv):
 
 
 def child_proc_shutdown(children):
+    """Shut down children processes."""
     run_exp_proc = psutil.Process()
     alive = run_exp_proc.children(recursive=True)
     for proc in alive:

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -1,5 +1,4 @@
 """BatchSampler which uses VecEnvExecutor to run multiple environments."""
-
 import itertools
 import pickle
 
@@ -10,6 +9,7 @@ from garage.misc import tensor_utils
 from garage.misc.overrides import overrides
 from garage.misc.prog_bar_counter import ProgBarCounter
 from garage.sampler.batch_sampler import BatchSampler
+from garage.sampler.stateful_pool import singleton_pool
 from garage.sampler.utils import truncate_paths
 from garage.sampler.vec_env_executor import VecEnvExecutor
 
@@ -17,7 +17,9 @@ from garage.sampler.vec_env_executor import VecEnvExecutor
 class OnPolicyVectorizedSampler(BatchSampler):
     """BatchSampler which uses VecEnvExecutor to run multiple environments."""
 
-    def __init__(self, algo, env, n_envs=1):
+    def __init__(self, algo, env, n_envs=None):
+        if n_envs is None:
+            n_envs = singleton_pool.n_parallel * 4
         super().__init__(algo, env)
         self.n_envs = n_envs
 

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -95,8 +95,9 @@ class RaySampler(BaseSampler):
             # are done updating, and start collecting trajectories on
             # those workers.
             if updating_workers:
-                updated, updating_workers = ray.wait(
-                    updating_workers, num_returns=1, timeout=0.1)
+                updated, updating_workers = ray.wait(updating_workers,
+                                                     num_returns=1,
+                                                     timeout=0.1)
                 upd = [ray.get(up) for up in updated]
                 self._idle_worker_ids.extend(upd)
 
@@ -111,8 +112,9 @@ class RaySampler(BaseSampler):
             # check which workers are done/not done collecting a sample
             # if any are done, send them to process the collected trajectory
             # if they are not, keep checking if they are done
-            ready, not_ready = ray.wait(
-                self._active_workers, num_returns=1, timeout=0.001)
+            ready, not_ready = ray.wait(self._active_workers,
+                                        num_returns=1,
+                                        timeout=0.001)
             self._active_workers = not_ready
             for result in ready:
                 trajectory, num_returned_samples = self._process_trajectory(

--- a/src/garage/tf/samplers/ray_sampler.py
+++ b/src/garage/tf/samplers/ray_sampler.py
@@ -24,13 +24,12 @@ class RaySamplerTF(RaySampler):
                  seed,
                  should_render=False,
                  num_processors=None):
-        super().__init__(
-            algo,
-            env,
-            seed,
-            should_render=False,
-            num_processors=None,
-            sampler_worker_cls=SamplerWorkerTF)
+        super().__init__(algo,
+                         env,
+                         seed,
+                         should_render=False,
+                         num_processors=None,
+                         sampler_worker_cls=SamplerWorkerTF)
 
     def shutdown_worker(self, local=False):
         """Shuts down the worker."""
@@ -64,13 +63,12 @@ class SamplerWorkerTF(SamplerWorker):
             # order to execute the policy.
             self.sess = tf.Session()
             self.sess.__enter__()
-        super().__init__(
-            worker_id,
-            env_pkl,
-            agent_pkl,
-            seed,
-            max_path_length,
-            should_render=should_render)
+        super().__init__(worker_id,
+                         env_pkl,
+                         agent_pkl,
+                         seed,
+                         max_path_length,
+                         should_render=should_render)
 
     def shutdown(self):
         """Perform shutdown processes for TF."""

--- a/tests/benchmarks/test_benchmark_ddpg.py
+++ b/tests/benchmarks/test_benchmark_ddpg.py
@@ -109,19 +109,18 @@ class TestBenchmarkDDPG:
 
             env.close()
 
-            Rh.plot(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                g_x='Epoch',
-                g_y='AverageReturn',
-                b_x='total/epochs',
-                b_y='rollout/return',
-                trials=task['trials'],
-                seeds=seeds,
-                plt_file=plt_file,
-                env_id=env_id,
-                x_label='Epoch',
-                y_label='AverageReturn')
+            Rh.plot(b_csvs=baselines_csvs,
+                    g_csvs=garage_csvs,
+                    g_x='Epoch',
+                    g_y='AverageReturn',
+                    b_x='total/epochs',
+                    b_y='rollout/return',
+                    trials=task['trials'],
+                    seeds=seeds,
+                    plt_file=plt_file,
+                    env_id=env_id,
+                    x_label='Epoch',
+                    y_label='AverageReturn')
 
             result_json[env_id] = Rh.create_json(
                 b_csvs=baselines_csvs,
@@ -160,30 +159,28 @@ def run_garage(env, seed, log_dir):
             hidden_nonlinearity=tf.nn.relu,
             output_nonlinearity=tf.nn.tanh)
 
-        qf = ContinuousMLPQFunction(
-            env_spec=env.spec,
-            hidden_sizes=params['qf_hidden_sizes'],
-            hidden_nonlinearity=tf.nn.relu)
+        qf = ContinuousMLPQFunction(env_spec=env.spec,
+                                    hidden_sizes=params['qf_hidden_sizes'],
+                                    hidden_nonlinearity=tf.nn.relu)
 
         replay_buffer = SimpleReplayBuffer(
             env_spec=env.spec,
             size_in_transitions=params['replay_buffer_size'],
             time_horizon=params['n_rollout_steps'])
 
-        ddpg = DDPG(
-            env_spec=env.spec,
-            policy=policy,
-            qf=qf,
-            replay_buffer=replay_buffer,
-            policy_lr=params['policy_lr'],
-            qf_lr=params['qf_lr'],
-            target_update_tau=params['tau'],
-            n_train_steps=params['n_train_steps'],
-            discount=params['discount'],
-            min_buffer_size=int(1e4),
-            exploration_strategy=action_noise,
-            policy_optimizer=tf.train.AdamOptimizer,
-            qf_optimizer=tf.train.AdamOptimizer)
+        ddpg = DDPG(env_spec=env.spec,
+                    policy=policy,
+                    qf=qf,
+                    replay_buffer=replay_buffer,
+                    policy_lr=params['policy_lr'],
+                    qf_lr=params['qf_lr'],
+                    target_update_tau=params['tau'],
+                    n_train_steps=params['n_train_steps'],
+                    discount=params['discount'],
+                    min_buffer_size=int(1e4),
+                    exploration_strategy=action_noise,
+                    policy_optimizer=tf.train.AdamOptimizer,
+                    qf_optimizer=tf.train.AdamOptimizer)
 
         # Set up logger since we are not using run_experiment
         tabular_log_file = osp.join(log_dir, 'progress.csv')
@@ -193,10 +190,9 @@ def run_garage(env, seed, log_dir):
         dowel_logger.add_output(dowel.TensorBoardOutput(tensorboard_log_dir))
 
         runner.setup(ddpg, env)
-        runner.train(
-            n_epochs=params['n_epochs'],
-            n_epoch_cycles=params['n_epoch_cycles'],
-            batch_size=params['n_rollout_steps'])
+        runner.train(n_epochs=params['n_epochs'],
+                     n_epoch_cycles=params['n_epoch_cycles'],
+                     batch_size=params['n_rollout_steps'])
 
         dowel_logger.remove_all()
 
@@ -226,40 +222,38 @@ def run_baselines(env, seed, log_dir):
     nb_actions = env.action_space.shape[-1]
     layer_norm = False
 
-    action_noise = OrnsteinUhlenbeckActionNoise(
-        mu=np.zeros(nb_actions),
-        sigma=float(params['sigma']) * np.ones(nb_actions))
-    memory = Memory(
-        limit=params['replay_buffer_size'],
-        action_shape=env.action_space.shape,
-        observation_shape=env.observation_space.shape)
+    action_noise = OrnsteinUhlenbeckActionNoise(mu=np.zeros(nb_actions),
+                                                sigma=float(params['sigma']) *
+                                                np.ones(nb_actions))
+    memory = Memory(limit=params['replay_buffer_size'],
+                    action_shape=env.action_space.shape,
+                    observation_shape=env.observation_space.shape)
     critic = Critic(layer_norm=layer_norm)
     actor = Actor(nb_actions, layer_norm=layer_norm)
 
-    training.train(
-        env=env,
-        eval_env=None,
-        param_noise=None,
-        action_noise=action_noise,
-        actor=actor,
-        critic=critic,
-        memory=memory,
-        nb_epochs=params['n_epochs'],
-        nb_epoch_cycles=params['n_epoch_cycles'],
-        render_eval=False,
-        reward_scale=1.,
-        render=False,
-        normalize_returns=False,
-        normalize_observations=False,
-        critic_l2_reg=0,
-        actor_lr=params['policy_lr'],
-        critic_lr=params['qf_lr'],
-        popart=False,
-        gamma=params['discount'],
-        clip_norm=None,
-        nb_train_steps=params['n_train_steps'],
-        nb_rollout_steps=params['n_rollout_steps'],
-        nb_eval_steps=100,
-        batch_size=64)
+    training.train(env=env,
+                   eval_env=None,
+                   param_noise=None,
+                   action_noise=action_noise,
+                   actor=actor,
+                   critic=critic,
+                   memory=memory,
+                   nb_epochs=params['n_epochs'],
+                   nb_epoch_cycles=params['n_epoch_cycles'],
+                   render_eval=False,
+                   reward_scale=1.,
+                   render=False,
+                   normalize_returns=False,
+                   normalize_observations=False,
+                   critic_l2_reg=0,
+                   actor_lr=params['policy_lr'],
+                   critic_lr=params['qf_lr'],
+                   popart=False,
+                   gamma=params['discount'],
+                   clip_norm=None,
+                   nb_train_steps=params['n_train_steps'],
+                   nb_rollout_steps=params['n_rollout_steps'],
+                   nb_eval_steps=100,
+                   batch_size=64)
 
     return osp.join(log_dir, 'progress.csv')

--- a/tests/benchmarks/test_benchmark_her.py
+++ b/tests/benchmarks/test_benchmark_her.py
@@ -90,17 +90,16 @@ class TestBenchmarkHER:
 
             env.close()
 
-            plot(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                g_x='Epoch',
-                g_y='AverageSuccessRate',
-                b_x='epoch',
-                b_y='train/success_rate',
-                trials=task['trials'],
-                seeds=seeds,
-                plt_file=plt_file,
-                env_id=env_id)
+            plot(b_csvs=baselines_csvs,
+                 g_csvs=garage_csvs,
+                 g_x='Epoch',
+                 g_y='AverageSuccessRate',
+                 b_x='epoch',
+                 b_y='train/success_rate',
+                 trials=task['trials'],
+                 seeds=seeds,
+                 plt_file=plt_file,
+                 env_id=env_id)
 
 
 def run_garage(env, seed, log_dir):
@@ -169,10 +168,9 @@ def run_garage(env, seed, log_dir):
         logger.add_output(dowel.TensorBoardOutput(log_dir))
 
         runner.setup(algo, env)
-        runner.train(
-            n_epochs=params['n_epochs'],
-            n_epoch_cycles=params['n_epoch_cycles'],
-            batch_size=params['n_rollout_steps'])
+        runner.train(n_epochs=params['n_epochs'],
+                     n_epoch_cycles=params['n_epoch_cycles'],
+                     batch_size=params['n_rollout_steps'])
 
         logger.remove_all()
 
@@ -229,14 +227,12 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id):
         df_g = pd.read_csv(g_csvs[trial])
         df_b = pd.read_csv(b_csvs[trial])
 
-        plt.plot(
-            df_g[g_x],
-            df_g[g_y],
-            label='garage_trial{}_seed{}'.format(trial + 1, seed))
-        plt.plot(
-            df_b[b_x],
-            df_b[b_y],
-            label='baselines_trial{}_seed{}'.format(trial + 1, seed))
+        plt.plot(df_g[g_x],
+                 df_g[g_y],
+                 label='garage_trial{}_seed{}'.format(trial + 1, seed))
+        plt.plot(df_b[b_x],
+                 df_b[b_y],
+                 label='baselines_trial{}_seed{}'.format(trial + 1, seed))
 
     plt.legend()
     plt.xlabel('Iteration')

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -87,31 +87,29 @@ class TestBenchmarkPPO:
 
             env.close()
 
-            Rh.plot(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='nupdates',
-                b_y='eprewmean',
-                trials=task['trials'],
-                seeds=seeds,
-                plt_file=plt_file,
-                env_id=env_id,
-                x_label='Iteration',
-                y_label='AverageReturn')
+            Rh.plot(b_csvs=baselines_csvs,
+                    g_csvs=garage_csvs,
+                    g_x='Iteration',
+                    g_y='AverageReturn',
+                    b_x='nupdates',
+                    b_y='eprewmean',
+                    trials=task['trials'],
+                    seeds=seeds,
+                    plt_file=plt_file,
+                    env_id=env_id,
+                    x_label='Iteration',
+                    y_label='AverageReturn')
 
-            result_json[env_id] = Rh.create_json(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                seeds=seeds,
-                trails=task['trials'],
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='nupdates',
-                b_y='eprewmean',
-                factor_g=2048,
-                factor_b=2048)
+            result_json[env_id] = Rh.create_json(b_csvs=baselines_csvs,
+                                                 g_csvs=garage_csvs,
+                                                 seeds=seeds,
+                                                 trails=task['trials'],
+                                                 g_x='Iteration',
+                                                 g_y='AverageReturn',
+                                                 b_x='nupdates',
+                                                 b_y='eprewmean',
+                                                 factor_g=2048,
+                                                 factor_b=2048)
 
         Rh.write_file(result_json, 'PPO')
 
@@ -195,10 +193,9 @@ def run_baselines(env, seed, log_dir):
     :return
     '''
     ncpu = max(multiprocessing.cpu_count() // 2, 1)
-    config = tf.ConfigProto(
-        allow_soft_placement=True,
-        intra_op_parallelism_threads=ncpu,
-        inter_op_parallelism_threads=ncpu)
+    config = tf.ConfigProto(allow_soft_placement=True,
+                            intra_op_parallelism_threads=ncpu,
+                            inter_op_parallelism_threads=ncpu)
     tf.compat.v1.Session(config=config).__enter__()
 
     # Set up logger for baselines
@@ -207,8 +204,9 @@ def run_baselines(env, seed, log_dir):
         0, seed, baselines_logger.get_dir()))
 
     def make_env():
-        monitor = bench.Monitor(
-            env, baselines_logger.get_dir(), allow_early_resets=True)
+        monitor = bench.Monitor(env,
+                                baselines_logger.get_dir(),
+                                allow_early_resets=True)
         return monitor
 
     env = DummyVecEnv([make_env])
@@ -216,20 +214,19 @@ def run_baselines(env, seed, log_dir):
 
     set_global_seeds(seed)
     policy = MlpPolicy
-    ppo2.learn(
-        policy=policy,
-        env=env,
-        nsteps=2048,
-        nminibatches=32,
-        lam=0.95,
-        gamma=0.99,
-        noptepochs=10,
-        log_interval=1,
-        ent_coef=0.0,
-        lr=1e-3,
-        vf_coef=0.5,
-        max_grad_norm=None,
-        cliprange=0.2,
-        total_timesteps=int(1e6))
+    ppo2.learn(policy=policy,
+               env=env,
+               nsteps=2048,
+               nminibatches=32,
+               lam=0.95,
+               gamma=0.99,
+               noptepochs=10,
+               log_interval=1,
+               ent_coef=0.0,
+               lr=1e-3,
+               vf_coef=0.5,
+               max_grad_norm=None,
+               cliprange=0.2,
+               total_timesteps=int(1e6))
 
     return osp.join(log_dir, 'progress.csv')

--- a/tests/benchmarks/test_benchmark_trpo.py
+++ b/tests/benchmarks/test_benchmark_trpo.py
@@ -81,31 +81,29 @@ class TestBenchmarkPPO:
                 garage_csvs.append(garage_csv)
                 baselines_csvs.append(baselines_csv)
 
-            Rh.plot(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='EpThisIter',
-                b_y='EpRewMean',
-                trials=task['trials'],
-                seeds=seeds,
-                plt_file=plt_file,
-                env_id=env_id,
-                x_label='Iteration',
-                y_label='AverageReturn')
+            Rh.plot(b_csvs=baselines_csvs,
+                    g_csvs=garage_csvs,
+                    g_x='Iteration',
+                    g_y='AverageReturn',
+                    b_x='EpThisIter',
+                    b_y='EpRewMean',
+                    trials=task['trials'],
+                    seeds=seeds,
+                    plt_file=plt_file,
+                    env_id=env_id,
+                    x_label='Iteration',
+                    y_label='AverageReturn')
 
-            result_json[env_id] = Rh.create_json(
-                b_csvs=baselines_csvs,
-                g_csvs=garage_csvs,
-                seeds=seeds,
-                trails=task['trials'],
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='TimestepsSoFar',
-                b_y='EpRewMean',
-                factor_g=1024,
-                factor_b=1)
+            result_json[env_id] = Rh.create_json(b_csvs=baselines_csvs,
+                                                 g_csvs=garage_csvs,
+                                                 seeds=seeds,
+                                                 trails=task['trials'],
+                                                 g_x='Iteration',
+                                                 g_y='AverageReturn',
+                                                 b_x='TimestepsSoFar',
+                                                 b_y='EpRewMean',
+                                                 factor_g=1024,
+                                                 factor_b=1)
             env.close()
 
         Rh.write_file(result_json, 'TRPO')
@@ -182,25 +180,23 @@ def run_baselines(env, seed, log_dir):
         baselines_logger.configure(log_dir)
 
         def policy_fn(name, ob_space, ac_space):
-            return MlpPolicy(
-                name=name,
-                ob_space=ob_space,
-                ac_space=ac_space,
-                hid_size=32,
-                num_hid_layers=2)
+            return MlpPolicy(name=name,
+                             ob_space=ob_space,
+                             ac_space=ac_space,
+                             hid_size=32,
+                             num_hid_layers=2)
 
-        trpo_mpi.learn(
-            env,
-            policy_fn,
-            timesteps_per_batch=1024,
-            max_kl=0.01,
-            cg_iters=10,
-            cg_damping=0.1,
-            max_timesteps=int(1e6),
-            gamma=0.99,
-            lam=0.98,
-            vf_iters=5,
-            vf_stepsize=1e-3)
+        trpo_mpi.learn(env,
+                       policy_fn,
+                       timesteps_per_batch=1024,
+                       max_kl=0.01,
+                       cg_iters=10,
+                       cg_damping=0.1,
+                       max_timesteps=int(1e6),
+                       gamma=0.99,
+                       lam=0.98,
+                       vf_iters=5,
+                       vf_stepsize=1e-3)
         env.close()
 
     return osp.join(log_dir, 'progress.csv')

--- a/tests/fixtures/experiment/fixture_experiment.py
+++ b/tests/fixtures/experiment/fixture_experiment.py
@@ -9,8 +9,9 @@ def fixture_exp(snapshot_config, sess):
     with LocalTFRunner(snapshot_config=snapshot_config, sess=sess) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(8, 8))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(8, 8))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 

--- a/tests/garage/envs/dm_control/test_dm_control_tf_policy.py
+++ b/tests/garage/envs/dm_control/test_dm_control_tf_policy.py
@@ -10,6 +10,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestDmControlTfPolicy(TfGraphTestCase):
+
     def test_dm_control_tf_policy(self):
         task = ALL_TASKS[0]
 

--- a/tests/garage/experiment/test_resume.py
+++ b/tests/garage/experiment/test_resume.py
@@ -9,13 +9,13 @@ from tests.fixtures.experiment import fixture_exp
 
 
 class TestResume(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.snapshot_config = SnapshotConfig(
-            snapshot_dir=self.temp_dir.name,
-            snapshot_mode='last',
-            snapshot_gap=1)
+        self.snapshot_config = SnapshotConfig(snapshot_dir=self.temp_dir.name,
+                                              snapshot_mode='last',
+                                              snapshot_gap=1)
         self.policy_params = fixture_exp(self.snapshot_config, self.sess)
         for c in self.graph.collections:
             self.graph.clear_collection(c)
@@ -38,11 +38,10 @@ class TestResume(TfGraphTestCase):
             batch_size = runner.train_args.batch_size
             n_epoch_cycles = runner.train_args.n_epoch_cycles
 
-            runner.resume(
-                n_epochs=10,
-                plot=False,
-                store_paths=True,
-                pause_for_plot=False)
+            runner.resume(n_epochs=10,
+                          plot=False,
+                          store_paths=True,
+                          pause_for_plot=False)
 
             assert runner.train_args.n_epochs == 10
             assert runner.train_args.batch_size == batch_size

--- a/tests/garage/np/policies/test_scripted_policy.py
+++ b/tests/garage/np/policies/test_scripted_policy.py
@@ -2,6 +2,7 @@ from garage.np.policies import ScriptedPolicy
 
 
 class TestScriptedPolicy:
+
     def setup_method(self):
         self.sp = ScriptedPolicy(scripted_actions=[1], agent_env_infos={0: 1})
 

--- a/tests/garage/sampler/test_is_sampler.py
+++ b/tests/garage/sampler/test_is_sampler.py
@@ -13,25 +13,24 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestISSampler(TfGraphTestCase):
+
     def test_is_sampler(self):
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(normalize(gym.make('InvertedPendulum-v2')))
-            policy = GaussianMLPPolicy(
-                env_spec=env.spec, hidden_sizes=(32, 32))
+            policy = GaussianMLPPolicy(env_spec=env.spec,
+                                       hidden_sizes=(32, 32))
             baseline = LinearFeatureBaseline(env_spec=env.spec)
-            algo = TRPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                max_kl_step=0.01)
+            algo = TRPO(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        max_kl_step=0.01)
 
-            runner.setup(
-                algo,
-                env,
-                sampler_cls=ISSampler,
-                sampler_args=dict(n_backtrack=1, init_is=1))
+            runner.setup(algo,
+                         env,
+                         sampler_cls=ISSampler,
+                         sampler_args=dict(n_backtrack=1, init_is=1))
             runner._start_worker()
 
             paths = runner.sampler.obtain_samples(1)

--- a/tests/garage/sampler/test_on_policy_vectorized_sampler.py
+++ b/tests/garage/sampler/test_on_policy_vectorized_sampler.py
@@ -1,24 +1,23 @@
-"""
-This script creates a test that fails when garage.tf.algos.REPS performance is
-too low.
-"""
 import gym
 import pytest
 
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import OnPolicyVectorizedSampler
 from garage.tf.algos import REPS
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 from tests.fixtures import TfGraphTestCase
 
+configs = [(1, None, 4), (3, None, 12), (2, 3, 3)]
 
-class TestREPS(TfGraphTestCase):
 
-    @pytest.mark.large
-    def test_reps_cartpole(self):
-        """Test REPS with gym Cartpole environment."""
-        with LocalTFRunner(sess=self.sess) as runner:
+class TestOnPolicyVectorizedSampler(TfGraphTestCase):
+
+    @pytest.mark.parametrize('cpus, n_envs, expected_n_envs', [*configs])
+    def test_on_policy_vectorized_sampler_n_envs(self, cpus, n_envs,
+                                                 expected_n_envs):
+        with LocalTFRunner(sess=self.sess, max_cpus=cpus) as runner:
             env = TfEnv(gym.make('CartPole-v0'))
 
             policy = CategoricalMLPPolicy(env_spec=env.spec,
@@ -32,9 +31,9 @@ class TestREPS(TfGraphTestCase):
                         max_path_length=100,
                         discount=0.99)
 
-            runner.setup(algo, env)
+            runner.setup(algo, env, sampler_args=dict(n_envs=n_envs))
 
-            last_avg_ret = runner.train(n_epochs=10, batch_size=4000)
-            assert last_avg_ret > 5
+            assert isinstance(runner.sampler, OnPolicyVectorizedSampler)
+            assert runner.sampler.n_envs == expected_n_envs
 
             env.close()

--- a/tests/garage/sampler/test_sampler.py
+++ b/tests/garage/sampler/test_sampler.py
@@ -13,6 +13,7 @@ from tests.fixtures.logger import NullOutput
 
 
 class TestSampler:
+
     def setup_method(self):
         logger.add_output(NullOutput())
 
@@ -58,23 +59,22 @@ class TestSampler:
         with LocalTFRunner(max_cpus=max_cpus) as runner:
             env = TfEnv(env_name='CartPole-v1')
 
-            policy = CategoricalMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(32, 32))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = VPG(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=1,
-                discount=0.99)
+            algo = VPG(env_spec=env.spec,
+                       policy=policy,
+                       baseline=baseline,
+                       max_path_length=1,
+                       discount=0.99)
 
-            runner.setup(
-                algo,
-                env,
-                sampler_cls=BatchSampler,
-                sampler_args={'n_envs': max_cpus})
+            runner.setup(algo,
+                         env,
+                         sampler_cls=BatchSampler,
+                         sampler_args={'n_envs': max_cpus})
 
             try:
                 runner.initialize_tf_vars()
@@ -84,8 +84,9 @@ class TestSampler:
 
             runner._start_worker()
 
-            paths = runner.sampler.obtain_samples(
-                0, batch_size=8, whole_paths=True)
+            paths = runner.sampler.obtain_samples(0,
+                                                  batch_size=8,
+                                                  whole_paths=True)
             assert len(paths) >= max_cpus, (
                 'BatchSampler should sample more than max_cpus={} '
                 'trajectories'.format(max_cpus))

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -18,6 +18,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestDDPG(TfGraphTestCase):
+
     @pytest.mark.large
     def test_ddpg_double_pendulum(self):
         """Test DDPG with Pendulum environment."""
@@ -29,14 +30,12 @@ class TestDDPG(TfGraphTestCase):
                 hidden_sizes=[64, 64],
                 hidden_nonlinearity=tf.nn.relu,
                 output_nonlinearity=tf.nn.tanh)
-            qf = ContinuousMLPQFunction(
-                env_spec=env.spec,
-                hidden_sizes=[64, 64],
-                hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e6),
-                time_horizon=100)
+            qf = ContinuousMLPQFunction(env_spec=env.spec,
+                                        hidden_sizes=[64, 64],
+                                        hidden_nonlinearity=tf.nn.relu)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e6),
+                                               time_horizon=100)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -51,8 +50,9 @@ class TestDDPG(TfGraphTestCase):
                 exploration_strategy=action_noise,
             )
             runner.setup(algo, env)
-            last_avg_ret = runner.train(
-                n_epochs=10, n_epoch_cycles=20, batch_size=100)
+            last_avg_ret = runner.train(n_epochs=10,
+                                        n_epoch_cycles=20,
+                                        batch_size=100)
             assert last_avg_ret > 60
 
             env.close()
@@ -72,14 +72,12 @@ class TestDDPG(TfGraphTestCase):
                 hidden_sizes=[64, 64],
                 hidden_nonlinearity=tf.nn.relu,
                 output_nonlinearity=tf.nn.tanh)
-            qf = ContinuousMLPQFunction(
-                env_spec=env.spec,
-                hidden_sizes=[64, 64],
-                hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e6),
-                time_horizon=100)
+            qf = ContinuousMLPQFunction(env_spec=env.spec,
+                                        hidden_sizes=[64, 64],
+                                        hidden_nonlinearity=tf.nn.relu)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e6),
+                                               time_horizon=100)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -94,8 +92,9 @@ class TestDDPG(TfGraphTestCase):
                 exploration_strategy=action_noise,
             )
             runner.setup(algo, env)
-            last_avg_ret = runner.train(
-                n_epochs=10, n_epoch_cycles=20, batch_size=100)
+            last_avg_ret = runner.train(n_epochs=10,
+                                        n_epoch_cycles=20,
+                                        batch_size=100)
             assert last_avg_ret > 10
 
             env.close()

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -20,6 +20,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestDQN(TfGraphTestCase):
+
     @pytest.mark.large
     def test_dqn_cartpole(self):
         """Test DQN with CartPole environment."""
@@ -29,10 +30,9 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e4),
-                time_horizon=1)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e4),
+                                               time_horizon=1)
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -41,26 +41,24 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            algo = DQN(
-                env_spec=env.spec,
-                policy=policy,
-                qf=qf,
-                exploration_strategy=epilson_greedy_strategy,
-                replay_buffer=replay_buffer,
-                qf_lr=1e-4,
-                discount=1.0,
-                min_buffer_size=int(1e3),
-                double_q=False,
-                n_train_steps=500,
-                n_epoch_cycles=n_epoch_cycles,
-                target_network_update_freq=1,
-                buffer_batch_size=32)
+            algo = DQN(env_spec=env.spec,
+                       policy=policy,
+                       qf=qf,
+                       exploration_strategy=epilson_greedy_strategy,
+                       replay_buffer=replay_buffer,
+                       qf_lr=1e-4,
+                       discount=1.0,
+                       min_buffer_size=int(1e3),
+                       double_q=False,
+                       n_train_steps=500,
+                       n_epoch_cycles=n_epoch_cycles,
+                       target_network_update_freq=1,
+                       buffer_batch_size=32)
 
             runner.setup(algo, env)
-            last_avg_ret = runner.train(
-                n_epochs=n_epochs,
-                n_epoch_cycles=n_epoch_cycles,
-                batch_size=sampler_batch_size)
+            last_avg_ret = runner.train(n_epochs=n_epochs,
+                                        n_epoch_cycles=n_epoch_cycles,
+                                        batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
             env.close()
@@ -74,10 +72,9 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e4),
-                time_horizon=1)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e4),
+                                               time_horizon=1)
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -86,26 +83,24 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            algo = DQN(
-                env_spec=env.spec,
-                policy=policy,
-                qf=qf,
-                exploration_strategy=epilson_greedy_strategy,
-                replay_buffer=replay_buffer,
-                qf_lr=1e-4,
-                discount=1.0,
-                min_buffer_size=int(1e3),
-                double_q=True,
-                n_train_steps=500,
-                n_epoch_cycles=n_epoch_cycles,
-                target_network_update_freq=1,
-                buffer_batch_size=32)
+            algo = DQN(env_spec=env.spec,
+                       policy=policy,
+                       qf=qf,
+                       exploration_strategy=epilson_greedy_strategy,
+                       replay_buffer=replay_buffer,
+                       qf_lr=1e-4,
+                       discount=1.0,
+                       min_buffer_size=int(1e3),
+                       double_q=True,
+                       n_train_steps=500,
+                       n_epoch_cycles=n_epoch_cycles,
+                       target_network_update_freq=1,
+                       buffer_batch_size=32)
 
             runner.setup(algo, env)
-            last_avg_ret = runner.train(
-                n_epochs=n_epochs,
-                n_epoch_cycles=n_epoch_cycles,
-                batch_size=sampler_batch_size)
+            last_avg_ret = runner.train(n_epochs=n_epochs,
+                                        n_epoch_cycles=n_epoch_cycles,
+                                        batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
             env.close()
@@ -119,10 +114,9 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e4),
-                time_horizon=1)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e4),
+                                               time_horizon=1)
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -131,27 +125,25 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            algo = DQN(
-                env_spec=env.spec,
-                policy=policy,
-                qf=qf,
-                exploration_strategy=epilson_greedy_strategy,
-                replay_buffer=replay_buffer,
-                qf_lr=1e-4,
-                discount=1.0,
-                min_buffer_size=int(1e3),
-                double_q=False,
-                n_train_steps=500,
-                grad_norm_clipping=5.0,
-                n_epoch_cycles=n_epoch_cycles,
-                target_network_update_freq=1,
-                buffer_batch_size=32)
+            algo = DQN(env_spec=env.spec,
+                       policy=policy,
+                       qf=qf,
+                       exploration_strategy=epilson_greedy_strategy,
+                       replay_buffer=replay_buffer,
+                       qf_lr=1e-4,
+                       discount=1.0,
+                       min_buffer_size=int(1e3),
+                       double_q=False,
+                       n_train_steps=500,
+                       grad_norm_clipping=5.0,
+                       n_epoch_cycles=n_epoch_cycles,
+                       target_network_update_freq=1,
+                       buffer_batch_size=32)
 
             runner.setup(algo, env)
-            last_avg_ret = runner.train(
-                n_epochs=n_epochs,
-                n_epoch_cycles=n_epoch_cycles,
-                batch_size=sampler_batch_size)
+            last_avg_ret = runner.train(n_epochs=n_epochs,
+                                        n_epoch_cycles=n_epoch_cycles,
+                                        batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
             env.close()
@@ -164,10 +156,9 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(
-                env_spec=env.spec,
-                size_in_transitions=int(1e4),
-                time_horizon=1)
+            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
+                                               size_in_transitions=int(1e4),
+                                               time_horizon=1)
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_strategy = EpsilonGreedyStrategy(
@@ -176,21 +167,20 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            algo = DQN(
-                env_spec=env.spec,
-                policy=policy,
-                qf=qf,
-                exploration_strategy=epilson_greedy_strategy,
-                replay_buffer=replay_buffer,
-                qf_lr=1e-4,
-                discount=1.0,
-                min_buffer_size=int(1e3),
-                double_q=False,
-                n_train_steps=500,
-                grad_norm_clipping=5.0,
-                n_epoch_cycles=n_epoch_cycles,
-                target_network_update_freq=1,
-                buffer_batch_size=32)
+            algo = DQN(env_spec=env.spec,
+                       policy=policy,
+                       qf=qf,
+                       exploration_strategy=epilson_greedy_strategy,
+                       replay_buffer=replay_buffer,
+                       qf_lr=1e-4,
+                       discount=1.0,
+                       min_buffer_size=int(1e3),
+                       double_q=False,
+                       n_train_steps=500,
+                       grad_norm_clipping=5.0,
+                       n_epoch_cycles=n_epoch_cycles,
+                       target_network_update_freq=1,
+                       buffer_batch_size=32)
             runner.setup(algo, env)
             with tf.compat.v1.variable_scope(
                     'DiscreteMLPQFunction/MLPModel/mlp/hidden_0', reuse=True):

--- a/tests/garage/tf/algos/test_erwr.py
+++ b/tests/garage/tf/algos/test_erwr.py
@@ -9,23 +9,24 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestERWR(TfGraphTestCase):
+
     @pytest.mark.large
     def test_erwr_cartpole(self):
         """Test ERWR with Cartpole-v1 environment."""
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(env_name='CartPole-v1')
 
-            policy = CategoricalMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(32, 32))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = ERWR(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99)
+            algo = ERWR(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_path_length=100,
+                        discount=0.99)
 
             runner.setup(algo, env)
 

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -16,6 +16,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestNPO(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
@@ -34,14 +35,13 @@ class TestNPO(TfGraphTestCase):
     def test_npo_pendulum(self):
         """Test NPO with Pendulum environment."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = NPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                policy_ent_coeff=0.0)
+            algo = NPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       gae_lambda=0.98,
+                       policy_ent_coeff=0.0)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 20

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -15,6 +15,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestPPO(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
@@ -35,14 +36,13 @@ class TestPPO(TfGraphTestCase):
     def test_ppo_pendulum(self):
         """Test PPO with Pendulum environment."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = PPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10))
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10))
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
@@ -70,18 +70,17 @@ class TestPPO(TfGraphTestCase):
     def test_ppo_with_maximum_entropy(self):
         """Test PPO with maxium entropy method."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = PPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
-                stop_entropy_gradient=True,
-                entropy_method='max',
-                policy_ent_coeff=0.02,
-                center_adv=False)
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10),
+                       stop_entropy_gradient=True,
+                       entropy_method='max',
+                       policy_ent_coeff=0.02,
+                       center_adv=False)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
@@ -94,19 +93,18 @@ class TestPPO(TfGraphTestCase):
         entropy method.
         """
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = PPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
-                stop_entropy_gradient=True,
-                use_neg_logli_entropy=True,
-                entropy_method='max',
-                policy_ent_coeff=0.02,
-                center_adv=False)
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10),
+                       stop_entropy_gradient=True,
+                       use_neg_logli_entropy=True,
+                       entropy_method='max',
+                       policy_ent_coeff=0.02,
+                       center_adv=False)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
@@ -119,19 +117,18 @@ class TestPPO(TfGraphTestCase):
         regularized entropy method.
         """
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = PPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
-                stop_entropy_gradient=True,
-                use_neg_logli_entropy=True,
-                entropy_method='regularized',
-                policy_ent_coeff=0.0,
-                center_adv=True)
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10),
+                       stop_entropy_gradient=True,
+                       use_neg_logli_entropy=True,
+                       entropy_method='regularized',
+                       policy_ent_coeff=0.0,
+                       center_adv=True)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
@@ -141,18 +138,17 @@ class TestPPO(TfGraphTestCase):
     def test_ppo_with_regularized_entropy(self):
         """Test PPO with regularized entropy method."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = PPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                lr_clip_range=0.01,
-                optimizer_args=dict(batch_size=32, max_epochs=10),
-                stop_entropy_gradient=False,
-                entropy_method='regularized',
-                policy_ent_coeff=0.02,
-                center_adv=True)
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10),
+                       stop_entropy_gradient=False,
+                       entropy_method='regularized',
+                       policy_ent_coeff=0.02,
+                       center_adv=True)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40

--- a/tests/garage/tf/algos/test_ppo_with_model.py
+++ b/tests/garage/tf/algos/test_ppo_with_model.py
@@ -18,6 +18,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestPPOWithModel(TfGraphTestCase):
+
     @pytest.mark.large
     def test_ppo_pendulum_with_model(self):
         """Test PPO with model, with Pendulum environment."""

--- a/tests/garage/tf/algos/test_ppo_with_model_baseline.py
+++ b/tests/garage/tf/algos/test_ppo_with_model_baseline.py
@@ -16,6 +16,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestPPO(TfGraphTestCase):
+
     @pytest.mark.huge
     def test_ppo_pendulum_continuous_baseline(self):
         """Test PPO with Pendulum environment."""

--- a/tests/garage/tf/algos/test_ppo_with_models.py
+++ b/tests/garage/tf/algos/test_ppo_with_models.py
@@ -18,6 +18,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestPPOWithModel(TfGraphTestCase):
+
     @pytest.mark.large
     def test_ppo_pendulum_with_model(self):
         """Test PPO with model, with Pendulum environment."""

--- a/tests/garage/tf/algos/test_tnpg.py
+++ b/tests/garage/tf/algos/test_tnpg.py
@@ -11,24 +11,25 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestTNPG(TfGraphTestCase):
+
     @pytest.mark.large
     def test_tnpg_inverted_pendulum(self):
         """Test TNPG with InvertedPendulum-v2 environment."""
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(normalize(gym.make('InvertedPendulum-v2')))
 
-            policy = GaussianMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+            policy = GaussianMLPPolicy(name='policy',
+                                       env_spec=env.spec,
+                                       hidden_sizes=(32, 32))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = TNPG(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                optimizer_args=dict(reg_coeff=5e-1))
+            algo = TNPG(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        optimizer_args=dict(reg_coeff=5e-1))
 
             runner.setup(algo, env)
 

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -16,6 +16,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestTRPO(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.env = TfEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
@@ -34,14 +35,13 @@ class TestTRPO(TfGraphTestCase):
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = TRPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                policy_ent_coeff=0.0)
+            algo = TRPO(env_spec=self.env.spec,
+                        policy=self.policy,
+                        baseline=self.baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        gae_lambda=0.98,
+                        policy_ent_coeff=0.0)
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 50
@@ -64,15 +64,14 @@ class TestTRPO(TfGraphTestCase):
     def test_trpo_soft_kl_constraint(self):
         """Test TRPO with unkown KL constraints."""
         with LocalTFRunner(sess=self.sess) as runner:
-            algo = TRPO(
-                env_spec=self.env.spec,
-                policy=self.policy,
-                baseline=self.baseline,
-                max_path_length=100,
-                discount=0.99,
-                gae_lambda=0.98,
-                policy_ent_coeff=0.0,
-                kl_constraint='soft')
+            algo = TRPO(env_spec=self.env.spec,
+                        policy=self.policy,
+                        baseline=self.baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        gae_lambda=0.98,
+                        policy_ent_coeff=0.0,
+                        kl_constraint='soft')
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 50

--- a/tests/garage/tf/algos/test_trpo_with_model.py
+++ b/tests/garage/tf/algos/test_trpo_with_model.py
@@ -18,25 +18,25 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestTRPO(TfGraphTestCase):
+
     @pytest.mark.large
     def test_trpo_lstm_cartpole(self):
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(normalize(gym.make('CartPole-v1')))
 
-            policy = CategoricalLSTMPolicyWithModel(
-                name='policy', env_spec=env.spec)
+            policy = CategoricalLSTMPolicyWithModel(name='policy',
+                                                    env_spec=env.spec)
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = TRPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                max_kl_step=0.01,
-                optimizer_args=dict(
-                    hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+            algo = TRPO(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        max_kl_step=0.01,
+                        optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                            base_eps=1e-5)))
 
             snapshotter.snapshot_dir = './'
             runner.setup(algo, env)
@@ -50,20 +50,19 @@ class TestTRPO(TfGraphTestCase):
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(normalize(gym.make('CartPole-v1')))
 
-            policy = CategoricalGRUPolicyWithModel(
-                name='policy', env_spec=env.spec)
+            policy = CategoricalGRUPolicyWithModel(name='policy',
+                                                   env_spec=env.spec)
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = TRPO(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                max_kl_step=0.01,
-                optimizer_args=dict(
-                    hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)))
+            algo = TRPO(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_path_length=100,
+                        discount=0.99,
+                        max_kl_step=0.01,
+                        optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                            base_eps=1e-5)))
 
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)

--- a/tests/garage/tf/algos/test_vpg.py
+++ b/tests/garage/tf/algos/test_vpg.py
@@ -9,25 +9,26 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestVPG(TfGraphTestCase):
+
     @pytest.mark.large
     def test_vpg_cartpole(self):
         """Test VPG with CartPole-v1 environment."""
         with LocalTFRunner(sess=self.sess) as runner:
             env = TfEnv(env_name='CartPole-v1')
 
-            policy = CategoricalMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(32, 32))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = VPG(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                optimizer_args=dict(
-                    tf_optimizer_args=dict(learning_rate=0.01, )))
+            algo = VPG(env_spec=env.spec,
+                       policy=policy,
+                       baseline=baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       optimizer_args=dict(
+                           tf_optimizer_args=dict(learning_rate=0.01, )))
 
             runner.setup(algo, env)
 

--- a/tests/garage/tf/experiment/test_local_tf_runner.py
+++ b/tests/garage/tf/experiment/test_local_tf_runner.py
@@ -12,6 +12,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestLocalRunner(TfGraphTestCase):
+
     def test_session(self):
         with LocalTFRunner():
             assert tf.compat.v1.get_default_session() is not None, (
@@ -32,19 +33,19 @@ class TestLocalRunner(TfGraphTestCase):
         with LocalTFRunner() as runner:
             env = TfEnv(env_name='CartPole-v1')
 
-            policy = CategoricalMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(8, 8))
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(8, 8))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = VPG(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                optimizer_args=dict(
-                    tf_optimizer_args=dict(learning_rate=0.01, )))
+            algo = VPG(env_spec=env.spec,
+                       policy=policy,
+                       baseline=baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       optimizer_args=dict(
+                           tf_optimizer_args=dict(learning_rate=0.01, )))
 
             runner.setup(algo, env)
             runner.train(n_epochs=1, batch_size=100)
@@ -60,19 +61,19 @@ class TestLocalRunner(TfGraphTestCase):
         with LocalTFRunner() as runner:
             env = TfEnv(env_name='CartPole-v1')
 
-            policy = CategoricalMLPPolicy(
-                name='policy', env_spec=env.spec, hidden_sizes=(8, 8))
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(8, 8))
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            algo = VPG(
-                env_spec=env.spec,
-                policy=policy,
-                baseline=baseline,
-                max_path_length=100,
-                discount=0.99,
-                optimizer_args=dict(
-                    tf_optimizer_args=dict(learning_rate=0.01, )))
+            algo = VPG(env_spec=env.spec,
+                       policy=policy,
+                       baseline=baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       optimizer_args=dict(
+                           tf_optimizer_args=dict(learning_rate=0.01, )))
 
             runner.setup(algo, env)
             runner.train(n_epochs=1, batch_size=100, plot=True)

--- a/tests/garage/tf/policies/test_categorical_policies.py
+++ b/tests/garage/tf/policies/test_categorical_policies.py
@@ -21,6 +21,7 @@ policies = [CategoricalGRUPolicy, CategoricalLSTMPolicy, CategoricalMLPPolicy]
 
 
 class TestCategoricalPolicies(TfGraphTestCase):
+
     @pytest.mark.parametrize('policy_cls', [*policies])
     def test_categorical_policies(self, policy_cls):
         with LocalTFRunner(sess=self.sess) as runner:
@@ -38,8 +39,8 @@ class TestCategoricalPolicies(TfGraphTestCase):
                 discount=0.99,
                 max_kl_step=0.01,
                 optimizer=ConjugateGradientOptimizer,
-                optimizer_args=dict(
-                    hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)),
+                optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                    base_eps=1e-5)),
             )
 
             runner.setup(algo, env)

--- a/tests/garage/tf/policies/test_gaussian_policies.py
+++ b/tests/garage/tf/policies/test_gaussian_policies.py
@@ -17,6 +17,7 @@ policies = [GaussianGRUPolicy, GaussianLSTMPolicy, GaussianMLPPolicy]
 
 
 class TestGaussianPolicies(TfGraphTestCase):
+
     @pytest.mark.parametrize('policy_cls', policies)
     def test_gaussian_policies(self, policy_cls):
         with LocalTFRunner(sess=self.sess) as runner:
@@ -34,8 +35,8 @@ class TestGaussianPolicies(TfGraphTestCase):
                 discount=0.99,
                 max_kl_step=0.01,
                 optimizer=ConjugateGradientOptimizer,
-                optimizer_args=dict(
-                    hvp_approach=FiniteDifferenceHvp(base_eps=1e-5)),
+                optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                    base_eps=1e-5)),
             )
 
             runner.setup(algo, env)

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -44,14 +44,17 @@ class TestRaySamplerTF():
         self.env = TfEnv(GridWorldEnv(desc='4x4'))
         self.policy = ScriptedPolicy(
             scripted_actions=[2, 2, 1, 0, 3, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1])
-        self.algo = Mock(
-            env_spec=self.env.spec, policy=self.policy, max_path_length=16)
+        self.algo = Mock(env_spec=self.env.spec,
+                         policy=self.policy,
+                         max_path_length=16)
 
     def teardown_method(self):
         self.env.close()
 
     def test_ray_batch_sampler(self):
-        sampler1 = RaySamplerTF(
-            self.algo, self.env, seed=100, num_processors=1)
+        sampler1 = RaySamplerTF(self.algo,
+                                self.env,
+                                seed=100,
+                                num_processors=1)
         sampler1.start_worker()
         sampler1.shutdown_worker(local=True)

--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -13,8 +13,9 @@ def _run_task(snapshot_config, *_):
     with LocalRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
-        policy = CategoricalMLPPolicy(
-            name='policy', env_spec=env.spec, hidden_sizes=(32, 32))
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 


### PR DESCRIPTION
Address #790.
When cpu is 1, tested 3 times for `n_envs` in [1...8] using:
```
with LocalRunner(sess=self.sess) as runner:
    env = TfEnv(gym.make('CartPole-v0'))

    policy = CategoricalMLPPolicy(
        env_spec=env.spec, hidden_sizes=[32, 32])

    baseline = LinearFeatureBaseline(env_spec=env.spec)

    algo = REPS(
        env_spec=env.spec,
        policy=policy,
        baseline=baseline,
        max_path_length=100,
        discount=0.99)

    runner.setup(algo, env)

    last_avg_ret = runner.train(n_epochs=30, batch_size=4000)
    assert last_avg_ret > 5
```
<img width="547" alt="Screen Shot 2019-07-29 at 12 02 21" src="https://user-images.githubusercontent.com/18158257/62074960-bf3d9280-b1f8-11e9-99a3-f3e7d029db6c.png">

Set default `n_envs` to 4 * `max_cpus`.

