### PR TITLE
Make dm_control an extra dependency

### DIFF
--- a/examples/step_dm_control_env.py
+++ b/examples/step_dm_control_env.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-"""Example of how to load, step, and visualize an environment."""
-import gym
+"""Example of how to load, step, and visualize an environment.
+
+This example requires that garage[dm_control] be installed.
+"""
+from garage.envs.dm_control import DmControlEnv
 
 # Construct the environment
-env = gym.make('MountainCar-v0')
+env = DmControlEnv.from_suite('walker', 'run')
 
 # Reset the environment and launch the viewer
 env.reset()

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,6 @@ required = [
     'click',
     'cloudpickle',
     'cma==1.1.06',
-    # dm_control throws an error during install about not being able to
-    # find a build dependency (absl-py). Later pip executes the `install`
-    # command again and the install succeeds because absl-py has been
-    # installed. This is stupid, but harmless.
-    'dm_control @ https://api.github.com/repos/deepmind/dm_control/tarball/7a36377879c57777e5d5b4da5aae2cd2a29b607a',  # noqa: E501
     'dowel==0.0.2',
     'gym[all]==0.12.4',
     'joblib<0.13,>=0.12',
@@ -48,6 +43,15 @@ required = [
 
 # Dependencies for optional features
 extras = {}
+
+extras['dm_control'] = [
+    # dm_control throws an error during install about not being able to
+    # find a build dependency (absl-py). Later pip executes the `install`
+    # command again and the install succeeds because absl-py has been
+    # installed. This is stupid, but harmless.
+    'dm_control @ https://api.github.com/repos/deepmind/dm_control/tarball/7a36377879c57777e5d5b4da5aae2cd2a29b607a',  # noqa: E501
+]
+
 extras['all'] = list(set(sum(extras.values(), [])))
 
 # Intel dependencies not included in all

--- a/src/garage/envs/dm_control/__init__.py
+++ b/src/garage/envs/dm_control/__init__.py
@@ -3,6 +3,12 @@ Wrappers for the DeepMind Control Suite.
 
 See https://github.com/deepmind/dm_control
 """
+try:
+    import dm_control  # noqa: F401
+except ImportError:
+    raise ImportError("To use garage's dm_control wrappers, please install "
+                      'garage[dm_control].')
+
 from garage.envs.dm_control.dm_control_viewer import DmControlViewer
 from garage.envs.dm_control.dm_control_env import DmControlEnv  # noqa: I100
 


### PR DESCRIPTION
Because dm_control needs to be installed from vcs or tarball, garage
cannot be directly installed in pipenv (see [this
issue](https://github.com/pypa/pipenv/issues/3396)).

I've copied the example that used our dm_control wrapper, modified
the original example to use gym, and modified the copy to clarify the
extra dependency.

I've also modified the `garage.env.dm_control` module to report a
helpful error message if dm_control isn't found.

`pip install garage[all]` will still install dm_control.