### PR TITLE
Simplify algorithm API

### DIFF
--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -1,3 +1,4 @@
+"""Provides algorithms with access to most of garage's features."""
 import copy
 import time
 import types
@@ -93,8 +94,8 @@ class LocalRunner:
 
         self.has_setup = True
 
-        self._setup_args = types.SimpleNamespace(
-            sampler_cls=sampler_cls, sampler_args=sampler_args)
+        self._setup_args = types.SimpleNamespace(sampler_cls=sampler_cls,
+                                                 sampler_args=sampler_args)
 
     def _start_worker(self):
         """Start Plotter and Sampler workers."""
@@ -110,7 +111,7 @@ class LocalRunner:
         if self.plot:
             self.plotter.close()
 
-    def obtain_samples(self, itr, batch_size):
+    def obtain_samples(self, itr, batch_size=None):
         """Obtain one batch of samples.
 
         Args:
@@ -124,7 +125,8 @@ class LocalRunner:
         """
         if self.train_args.n_epoch_cycles == 1:
             logger.log('Obtaining samples...')
-        return self.sampler.obtain_samples(itr, batch_size)
+        return self.sampler.obtain_samples(
+            itr, (batch_size or self.train_args.batch_size))
 
     def save(self, epoch, paths=None):
         """Save snapshot of current batch.
@@ -174,11 +176,10 @@ class LocalRunner:
         self._setup_args = saved['setup_args']
         self.train_args = saved['train_args']
 
-        self.setup(
-            env=saved['env'],
-            algo=saved['algo'],
-            sampler_cls=self._setup_args.sampler_cls,
-            sampler_args=self._setup_args.sampler_args)
+        self.setup(env=saved['env'],
+                   algo=saved['algo'],
+                   sampler_cls=self._setup_args.sampler_cls,
+                   sampler_args=self._setup_args.sampler_args)
 
         n_epochs = self.train_args.n_epochs
         last_epoch = saved['last_epoch']
@@ -243,25 +244,24 @@ class LocalRunner:
             raise Exception('Use setup() to setup runner before training.')
 
         # Save arguments for restore
-        self.train_args = types.SimpleNamespace(
-            n_epochs=n_epochs,
-            n_epoch_cycles=n_epoch_cycles,
-            batch_size=batch_size,
-            plot=plot,
-            store_paths=store_paths,
-            pause_for_plot=pause_for_plot,
-            start_epoch=0)
+        self.train_args = types.SimpleNamespace(n_epochs=n_epochs,
+                                                n_epoch_cycles=n_epoch_cycles,
+                                                batch_size=batch_size,
+                                                plot=plot,
+                                                store_paths=store_paths,
+                                                pause_for_plot=pause_for_plot,
+                                                start_epoch=0)
 
         self.plot = plot
 
-        return self.algo.train(self, batch_size)
+        return self.algo.train(self)
 
     def step_epochs(self):
-        """Generator for training.
+        """Step through each epoch.
 
-        This function serves as a generator. It is used to separate
-        services such as snapshotting, sampler control from the actual
-        training loop. It is used inside train() in each algorithm.
+        This function returns a magic generator. When iterated through, this
+        generator automatically performs services such as snapshotting and log
+        management. It is used inside train() in each algorithm.
 
         The generator initializes two variables: `self.step_itr` and
         `self.step_path`. To use the generator, these two have to be
@@ -280,8 +280,8 @@ class LocalRunner:
         try:
             self._start_worker()
             self._start_time = time.time()
-            self.step_itr = (
-                self.train_args.start_epoch * self.train_args.n_epoch_cycles)
+            self.step_itr = (self.train_args.start_epoch *
+                             self.train_args.n_epoch_cycles)
             self.step_path = None
 
             for epoch in range(self.train_args.start_epoch,
@@ -331,4 +331,4 @@ class LocalRunner:
         if pause_for_plot is not None:
             self.train_args.pause_for_plot = pause_for_plot
 
-        return self.algo.train(self, batch_size)
+        return self.algo.train(self)

--- a/src/garage/np/algos/base.py
+++ b/src/garage/np/algos/base.py
@@ -13,28 +13,16 @@ class RLAlgorithm(abc.ABC):
     """
 
     @abc.abstractmethod
-    def train_once(self, itr, paths):
-        """Perform one step of policy optimization given one batch of samples.
-
-        Args:
-            itr (int): Iteration number.
-            paths (list[dict]): A list of collected paths.
-
-        """
-        pass
-
-    @abc.abstractmethod
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Obtain samplers and start actual training for each epoch.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
-            The average return in last epoch cycle.
+            The average return in last epoch cycle or None.
 
         """
         pass

--- a/src/garage/np/algos/batch_polopt.py
+++ b/src/garage/np/algos/batch_polopt.py
@@ -42,14 +42,13 @@ class BatchPolopt(RLAlgorithm):
         else:
             self.sampler_cls = BatchSampler
 
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Obtain samplers and start actual training for each epoch.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
             The average return in last epoch cycle.
@@ -59,8 +58,7 @@ class BatchPolopt(RLAlgorithm):
 
         for epoch in runner.step_epochs():
             for cycle in range(self.n_samples):
-                runner.step_path = runner.obtain_samples(
-                    runner.step_itr, batch_size)
+                runner.step_path = runner.obtain_samples(runner.step_itr)
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)
                 runner.step_itr += 1

--- a/src/garage/np/algos/cem.py
+++ b/src/garage/np/algos/cem.py
@@ -69,14 +69,13 @@ class CEM(BatchPolopt):
         return np.random.standard_normal(
             self.n_params) * sample_std + self.cur_mean
 
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Initialize variables and start training.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
             The average return in last epoch cycle.
@@ -95,7 +94,7 @@ class CEM(BatchPolopt):
             'n_samples is too low. Make sure that n_samples * best_frac >= 1')
         self.n_params = len(self.cur_mean)
 
-        return super().train(runner, batch_size)
+        return super().train(runner)
 
     def train_once(self, itr, paths):
         """Perform one step of policy optimization given one batch of samples.

--- a/src/garage/np/algos/cma_es.py
+++ b/src/garage/np/algos/cma_es.py
@@ -44,14 +44,13 @@ class CMAES(BatchPolopt):
     def _sample_params(self):
         return self.es.ask(self.n_samples)
 
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Initialize variables and start training.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
             The average return in last epoch cycle.
@@ -64,7 +63,7 @@ class CMAES(BatchPolopt):
         self.policy.set_param_values(self.cur_params)
         self.all_returns = []
 
-        return super().train(runner, batch_size)
+        return super().train(runner)
 
     def train_once(self, itr, paths):
         """Perform one step of policy optimization given one batch of samples.

--- a/src/garage/np/algos/off_policy_rl_algorithm.py
+++ b/src/garage/np/algos/off_policy_rl_algorithm.py
@@ -70,14 +70,13 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
 
         self.init_opt()
 
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Obtain samplers and start actual training for each epoch.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
             The average return in last epoch cycle.
@@ -87,8 +86,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
 
         for epoch in runner.step_epochs():
             for cycle in range(self.n_epoch_cycles):
-                runner.step_path = runner.obtain_samples(
-                    runner.step_itr, batch_size)
+                runner.step_path = runner.obtain_samples(runner.step_itr)
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)
                 runner.step_itr += 1
@@ -139,4 +137,14 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
 
     def optimize_policy(self, itr, samples_data):
         """Optimize policy network."""
+        raise NotImplementedError
+
+    def train_once(self, itr, paths):
+        """Perform one step of policy optimization given one batch of samples.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        """
         raise NotImplementedError

--- a/src/garage/tf/algos/batch_polopt.py
+++ b/src/garage/tf/algos/batch_polopt.py
@@ -70,14 +70,13 @@ class BatchPolopt(RLAlgorithm):
 
         self.init_opt()
 
-    def train(self, runner, batch_size):
+    def train(self, runner):
         """Obtain samplers and start actual training for each epoch.
 
         Args:
             runner (LocalRunner): LocalRunner is passed to give algorithm
                 the access to runner.step_epochs(), which provides services
                 such as snapshotting and sampler control.
-            batch_size (int): Batch size used to obtain samplers.
 
         Returns:
             The average return in last epoch cycle.
@@ -86,8 +85,7 @@ class BatchPolopt(RLAlgorithm):
         last_return = None
 
         for epoch in runner.step_epochs():
-            runner.step_path = runner.obtain_samples(runner.step_itr,
-                                                     batch_size)
+            runner.step_path = runner.obtain_samples(runner.step_itr)
             last_return = self.train_once(runner.step_itr, runner.step_path)
             runner.step_itr += 1
 

--- a/tests/fixtures/algos/dummy_algo.py
+++ b/tests/fixtures/algos/dummy_algo.py
@@ -5,15 +5,11 @@ class DummyAlgo(BatchPolopt):
     """Dummy algo for test."""
 
     def __init__(self, policy, baseline):
-        super().__init__(
-            policy=policy,
-            baseline=baseline,
-            discount=0.1,
-            max_path_length=1,
-            n_samples=10)
+        super().__init__(policy=policy,
+                         baseline=baseline,
+                         discount=0.1,
+                         max_path_length=1,
+                         n_samples=10)
 
-    def train(self, runner, batch_size):
-        pass
-
-    def train_once(self, itr, paths):
+    def train(self, runner):
         pass

--- a/tests/fixtures/tf/algos/dummy_off_policy_algo.py
+++ b/tests/fixtures/tf/algos/dummy_off_policy_algo.py
@@ -2,11 +2,9 @@ from garage.np.algos import OffPolicyRLAlgorithm
 
 
 class DummyOffPolicyAlgo(OffPolicyRLAlgorithm):
+
     def init_opt(self):
         pass
 
-    def train_once(self, itr, paths):
-        pass
-
-    def train(self, runner, batch_size):
+    def train(self, runner):
         pass


### PR DESCRIPTION
Specifically, remove the `batch_size` parameter from `train()`, make the
return value of `train` optional, and remove the `train_once()` method.