### PR TITLE
Fix indirect mujoco requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ required = [
     'cloudpickle',
     'cma==1.1.06',
     'dowel==0.0.2',
-    'gym[all]==0.12.4',
+    'gym[box2d,atari]==0.12.4',
     'joblib<0.13,>=0.12',
     'matplotlib',
     'numpy==1.14.5',
@@ -47,6 +47,7 @@ extras = {}
 
 extras['mujoco'] = [
     'mujoco-py<2.1,>=2.0',
+    'gym[all]==0.12.4',
 ]
 
 extras['dm_control'] = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ required = [
     'cloudpickle',
     'cma==1.1.06',
     'dowel==0.0.2',
-    'gym[box2d,atari]==0.12.4',
+    'gym[atari,box2d,classic_control]==0.12.4',
     'joblib<0.13,>=0.12',
     'matplotlib',
     'numpy==1.14.5',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ except ImportError:
         'https://github.com/rlworkgroup/garage/issues/800 for more info.')
 
 TF_VERSION = '<1.15,>=1.14.0'
+GYM_VERSION = '==0.12.4'
 
 # Required dependencies
 required = [
@@ -22,7 +23,7 @@ required = [
     'cloudpickle',
     'cma==1.1.06',
     'dowel==0.0.2',
-    'gym[atari,box2d,classic_control]==0.12.4',
+    'gym[atari,box2d,classic_control]' + GYM_VERSION,
     'joblib<0.13,>=0.12',
     'matplotlib',
     'numpy==1.14.5',
@@ -47,7 +48,7 @@ extras = {}
 
 extras['mujoco'] = [
     'mujoco-py<2.1,>=2.0',
-    'gym[all]==0.12.4',
+    'gym[all]' + GYM_VERSION,
 ]
 
 extras['dm_control'] = [

--- a/src/garage/envs/base.py
+++ b/src/garage/envs/base.py
@@ -86,7 +86,12 @@ class GarageEnv(gym.Wrapper, Serializable):
                    for package in KNOWN_GYM_NOT_CLOSE_MJ_VIEWER):
                 # This import is not in the header to avoid a MuJoCo dependency
                 # with non-MuJoCo environments that use this base class.
-                from mujoco_py.mjviewer import MjViewer
+                try:
+                    from mujoco_py.mjviewer import MjViewer
+                except ImportError:
+                    # If we can't import mujoco_py, we must not have an
+                    # instance of a class that we know how to close here.
+                    return
                 if (hasattr(self.env, 'viewer')
                         and isinstance(self.env.viewer, MjViewer)):
                     glfw.destroy_window(self.env.viewer.window)


### PR DESCRIPTION
This change *actually* makes it possible to `pip install garage`
(assuming numpy==1.14.5 is already installed) without mujoco installed.