### PR TITLE
Make the PyTorch DDPG test more lenient

### DIFF
--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -55,7 +55,7 @@ class TestDDPG:
         last_avg_ret = runner.train(n_epochs=10,
                                     n_epoch_cycles=20,
                                     batch_size=100)
-        assert last_avg_ret > 60
+        assert last_avg_ret > 50
 
         env.close()
 


### PR DESCRIPTION
It's consistently above 50, but often below 60, so it kept causing PRs
to fail testing.