### PR TITLE
Supress ray output

### DIFF
--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -13,7 +13,7 @@ from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
-from garage.tf.policies import GaussianMLPPolicyWithModel
+from garage.tf.policies import GaussianMLPPolicy
 from garage.tf.samplers import RaySamplerTF
 
 seed = 100
@@ -24,8 +24,7 @@ def run_task(snapshot_config, *_):
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('Swimmer-v2'))
 
-        policy = GaussianMLPPolicyWithModel(env_spec=env.spec,
-                                            hidden_sizes=(32, 32))
+        policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(32, 32))
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -47,7 +47,7 @@ class RaySampler(BaseSampler):
         self._max_path_length = self._algo.max_path_length
         self._should_render = should_render
         if not ray.is_initialized():
-            ray.init()
+            ray.init(log_to_driver=False)
         self._num_workers = (num_processors if num_processors else
                              psutil.cpu_count(logical=False))
         self._all_workers = defaultdict(None)


### PR DESCRIPTION
This PR is to suppress all output from sampler workers to the console. This allows us to avoid having the console filled with repeat warnings about tensorflow and mujoco, that are already outputted by the parent process that the training loop is running on. Also we removed GaussianMLPPolicy with model from the codebase, and I updated the ray sampler example to reflect this.