### PR TITLE
Set environment seed

### DIFF
--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -13,6 +13,7 @@ import pickle
 
 import numpy as np
 
+from garage.experiment import deterministic
 from garage.misc import tensor_utils
 from garage.misc.overrides import overrides
 from garage.sampler.batch_sampler import BatchSampler
@@ -47,6 +48,11 @@ class OffPolicyVectorizedSampler(BatchSampler):
         """Initialize the sampler."""
         n_envs = self.n_envs
         envs = [pickle.loads(pickle.dumps(self.env)) for _ in range(n_envs)]
+
+        # Deterministically set environment seeds based on the global seed.
+        for (i, e) in enumerate(envs):
+            e.seed(deterministic.get_seed() + i)
+
         self.vec_env = VecEnvExecutor(
             envs=envs, max_path_length=self.algo.max_path_length)
         self.env_spec = self.env.spec

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -5,6 +5,7 @@ import pickle
 from dowel import logger, tabular
 import numpy as np
 
+from garage.experiment import deterministic
 from garage.misc import tensor_utils
 from garage.misc.overrides import overrides
 from garage.misc.prog_bar_counter import ProgBarCounter
@@ -28,6 +29,11 @@ class OnPolicyVectorizedSampler(BatchSampler):
         """Start workers."""
         n_envs = self.n_envs
         envs = [pickle.loads(pickle.dumps(self.env)) for _ in range(n_envs)]
+
+        # Deterministically set environment seeds based on the global seed.
+        for (i, e) in enumerate(envs):
+            e.seed(deterministic.get_seed() + i)
+
         self.vec_env = VecEnvExecutor(
             envs=envs, max_path_length=self.algo.max_path_length)
         self.env_spec = self.env.spec


### PR DESCRIPTION
Currently, all environments run with random seeds. They should be set in a deterministic fashion to obtain reproducible results during benchmarking. This PR should be merged before running any benchmarks. This change has been made only on [On/Off]PolicyVectorizedSamplers since they are the main samplers used while benchmarking.