### PR TITLE
Fix CI for branch builds; Update flake8-docstrings

### DIFF
--- a/scripts/travisci/check_precommit.sh
+++ b/scripts/travisci/check_precommit.sh
@@ -24,7 +24,8 @@ if [[ "${TRAVIS_PULL_REQUEST}" != "false" && "${TRAVIS}" == "true" ]]; then
 else
   git remote set-branches --add origin master
   git fetch
-  pre-commit run --source origin/master --origin ${TRAVIS_BRANCH}
+  merge_base=$(git merge-base origin/master ${TRAVIS_BRANCH})
+  pre-commit run --source ${merge_base} --origin ${TRAVIS_BRANCH}
   status="$((${status} | ${?}))"
 
   # Check commit messages
@@ -41,7 +42,7 @@ else
       cat "${commit_msg}"
     fi
 
-  done < <(git rev-list origin/master..."${TRAVIS_BRANCH}")
+  done < <(git rev-list ^origin/master "${TRAVIS_BRANCH}")
 fi
 
 exit "${status}"

--- a/setup.py
+++ b/setup.py
@@ -60,15 +60,13 @@ extras['dev'] = [
     # Please keep alphabetized
     'baselines @ https://api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3',  # noqa: E501
     'flake8',
-    'flake8-docstrings==1.3.0',
+    'flake8-docstrings==1.4.0',
     'flake8-import-order',
     'gtimer',
     'pandas',
     'pep8-naming==0.7.0',
     'pre-commit',
-    # pydocstyle 4.0.0 breaks flake8-docstrings 1.3.0
-    # See https://gitlab.com/pycqa/flake8-docstrings/issues/36
-    'pydocstyle<4.0.0',
+    'pydocstyle<4.1,>=4.0',
     'pylint==1.9.2',
     'pytest>=3.6',  # Required for pytest-cov on Python 3.6
     'pytest-cov',


### PR DESCRIPTION
Currently check_precommit.sh fails for release branches because it checks all commits that are different between master and branch.

However, not all commits in master follow the commit message guidelines since those messages are made through github squash and merge interface. Also, there's no point to checking commits that are already in master.

Unlike suggested in https://github.com/rlworkgroup/garage/issues/812, this PR still assumes that branches (hence CI jobs) are based off master, but I think it's a valid assumption for out workflow.

This commit modifies check_precommit.sh to pick only commits in the branch that are not in master, by taking the commits in branch that were made after the last common (merge-base) commit of master and branch.

Test run in a branch cut from release-2019.02:
5d4ce23
https://travis-ci.com/rlworkgroup/garage/builds/128575672

This PR also updates flake8-docstrings to current functioning version 1.4.0 (1.3.0 breaks current active release branches too), and updates and restricts pydocstyle to 4.0.x

