### PR TITLE
Benchmark continuous mlp regressor/baseline

### DIFF
--- a/src/garage/tf/regressors/continuous_mlp_regressor.py
+++ b/src/garage/tf/regressors/continuous_mlp_regressor.py
@@ -56,21 +56,21 @@ class ContinuousMLPRegressor(LayersPowered, Serializable, Parameterized):
 
             self._network_name = 'network'
             if network is None:
-                network = MLP(
-                    input_shape=input_shape,
-                    output_dim=output_dim,
-                    hidden_sizes=hidden_sizes,
-                    hidden_nonlinearity=hidden_nonlinearity,
-                    output_nonlinearity=output_nonlinearity,
-                    name=self._network_name)
+                network = MLP(input_shape=input_shape,
+                              output_dim=output_dim,
+                              hidden_sizes=hidden_sizes,
+                              hidden_nonlinearity=hidden_nonlinearity,
+                              output_nonlinearity=output_nonlinearity,
+                              name=self._network_name)
 
             l_out = network.output_layer
 
             LayersPowered.__init__(self, [l_out])
 
             xs_var = network.input_layer.input_var
-            ys_var = tf.compat.v1.placeholder(
-                dtype=tf.float32, shape=[None, output_dim], name='ys')
+            ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
+                                              shape=[None, output_dim],
+                                              name='ys')
 
             x_mean_var = tf.compat.v1.get_variable(
                 name='x_mean',
@@ -87,7 +87,7 @@ class ContinuousMLPRegressor(LayersPowered, Serializable, Parameterized):
                 fit_ys_var = L.get_output(
                     l_out, {network.input_layer: normalized_xs_var})
 
-            loss = -tf.reduce_mean(tf.square(fit_ys_var - ys_var))
+            loss = tf.reduce_mean(tf.square(fit_ys_var - ys_var))
 
             self.f_predict = tensor_utils.compile_function([xs_var],
                                                            fit_ys_var)

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -90,31 +90,29 @@ class TestBenchmarkPPO:
 
             env.close()
 
-            Rh.plot(
-                b_csvs=garage_models_csvs,
-                g_csvs=garage_csvs,
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='Iteration',
-                b_y='AverageReturn',
-                trials=task['trials'],
-                seeds=seeds,
-                plt_file=plt_file,
-                env_id=env_id,
-                x_label='Iteration',
-                y_label='AverageReturn')
+            Rh.plot(b_csvs=garage_models_csvs,
+                    g_csvs=garage_csvs,
+                    g_x='Iteration',
+                    g_y='AverageReturn',
+                    b_x='Iteration',
+                    b_y='AverageReturn',
+                    trials=task['trials'],
+                    seeds=seeds,
+                    plt_file=plt_file,
+                    env_id=env_id,
+                    x_label='Iteration',
+                    y_label='AverageReturn')
 
-            result_json[env_id] = Rh.create_json(
-                b_csvs=garage_models_csvs,
-                g_csvs=garage_csvs,
-                seeds=seeds,
-                trails=task['trials'],
-                g_x='Iteration',
-                g_y='AverageReturn',
-                b_x='Iteration',
-                b_y='AverageReturn',
-                factor_g=2048,
-                factor_b=2048)
+            result_json[env_id] = Rh.create_json(b_csvs=garage_models_csvs,
+                                                 g_csvs=garage_csvs,
+                                                 seeds=seeds,
+                                                 trails=task['trials'],
+                                                 g_x='Iteration',
+                                                 g_y='AverageReturn',
+                                                 b_x='Iteration',
+                                                 b_y='AverageReturn',
+                                                 factor_g=2048,
+                                                 factor_b=2048)
 
         Rh.write_file(result_json, 'PPO')
 
@@ -131,10 +129,9 @@ def run_garage(env, seed, log_dir):
     :return:
     '''
     deterministic.set_seed(seed)
-    config = tf.ConfigProto(
-        allow_soft_placement=True,
-        intra_op_parallelism_threads=12,
-        inter_op_parallelism_threads=12)
+    config = tf.ConfigProto(allow_soft_placement=True,
+                            intra_op_parallelism_threads=12,
+                            inter_op_parallelism_threads=12)
     sess = tf.Session(config=config)
     with LocalTFRunner(snapshot_config, sess=sess, max_cpus=12) as runner:
         env = TfEnv(normalize(env))
@@ -183,7 +180,7 @@ def run_garage(env, seed, log_dir):
         dowel_logger.add_output(dowel.TensorBoardOutput(log_dir))
 
         runner.setup(algo, env, sampler_args=dict(n_envs=12))
-        runner.train(n_epochs=3, batch_size=2048)
+        runner.train(n_epochs=488, batch_size=2048)
         dowel_logger.remove_all()
 
         return tabular_log_file
@@ -201,10 +198,9 @@ def run_garage_with_models(env, seed, log_dir):
     :return:
     '''
     deterministic.set_seed(seed)
-    config = tf.ConfigProto(
-        allow_soft_placement=True,
-        intra_op_parallelism_threads=12,
-        inter_op_parallelism_threads=12)
+    config = tf.ConfigProto(allow_soft_placement=True,
+                            intra_op_parallelism_threads=12,
+                            inter_op_parallelism_threads=12)
     sess = tf.Session(config=config)
     with LocalTFRunner(snapshot_config, sess=sess, max_cpus=12) as runner:
         env = TfEnv(normalize(env))
@@ -231,21 +227,20 @@ def run_garage_with_models(env, seed, log_dir):
             ),
             name='GaussianMLPBaselineBenchmark')
 
-        algo = PPO(
-            env_spec=env.spec,
-            policy=policy,
-            baseline=baseline,
-            max_path_length=100,
-            discount=0.99,
-            gae_lambda=0.95,
-            lr_clip_range=0.2,
-            policy_ent_coeff=0.0,
-            optimizer_args=dict(
-                batch_size=32,
-                max_epochs=10,
-                tf_optimizer_args=dict(learning_rate=1e-3),
-            ),
-            name='PPOBenchmark')
+        algo = PPO(env_spec=env.spec,
+                   policy=policy,
+                   baseline=baseline,
+                   max_path_length=100,
+                   discount=0.99,
+                   gae_lambda=0.95,
+                   lr_clip_range=0.2,
+                   policy_ent_coeff=0.0,
+                   optimizer_args=dict(
+                       batch_size=32,
+                       max_epochs=10,
+                       tf_optimizer_args=dict(learning_rate=1e-3),
+                   ),
+                   name='PPOBenchmark')
 
         # Set up logger since we are not using run_experiment
         tabular_log_file = osp.join(log_dir, 'progress.csv')
@@ -254,7 +249,7 @@ def run_garage_with_models(env, seed, log_dir):
         dowel_logger.add_output(dowel.TensorBoardOutput(log_dir))
 
         runner.setup(algo, env, sampler_args=dict(n_envs=12))
-        runner.train(n_epochs=3, batch_size=2048)
+        runner.train(n_epochs=488, batch_size=2048)
         dowel_logger.remove_all()
 
         return tabular_log_file

--- a/tests/benchmarks/test_benchmark_ppo.py
+++ b/tests/benchmarks/test_benchmark_ppo.py
@@ -83,6 +83,7 @@ class TestBenchmarkPPO:
                     # Run garage algorithms
                     env.reset()
                     garage_csv = run_garage(env, seed, garage_dir)
+                    env.reset()
                     garage_models_csv = run_garage_with_models(
                         env, seed, garage_models_dir)
                 garage_csvs.append(garage_csv)

--- a/tests/benchmarks/test_benchmark_ppo_continous_mlp_baseline.py
+++ b/tests/benchmarks/test_benchmark_ppo_continous_mlp_baseline.py
@@ -1,0 +1,273 @@
+'''
+This script creates a regression test over garage-DDPG and baselines-DDPG.
+It get Mujoco1M benchmarks from baselines benchmark, and test each task in
+its trial times on garage model and baselines model. For each task, there will
+be `trial` times with different random seeds. For each trial, there will be two
+log directories corresponding to baselines and garage. And there will be a plot
+plotting the average return curve from baselines and garage.
+'''
+import datetime
+import os
+import os.path as osp
+import random
+
+from baselines.bench import benchmarks
+import dowel
+from dowel import logger as dowel_logger
+import gym
+import pytest
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.experiment import deterministic
+from garage.tf.algos import PPO
+from garage.tf.baselines import (ContinuousMLPBaseline,
+                                 ContinuousMLPBaselineWithModel)
+from garage.tf.envs import TfEnv
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.optimizers import FirstOrderOptimizer
+from garage.tf.policies import GaussianLSTMPolicy
+from tests.fixtures import snapshot_config
+import tests.helpers as Rh
+# from tests.wrappers import AutoStopEnv
+
+# Hyperparams for baselines and garage
+
+policy_params = {
+    'policy_lr': 1e-3,
+    'policy_hidden_sizes': 32,
+    'hidden_nonlinearity': tf.nn.tanh
+}
+
+baseline_params = {
+    'regressor_args':
+    dict(hidden_sizes=(64, 64),
+         use_trust_region=False,
+         optimizer=FirstOrderOptimizer,
+         optimizer_args=dict(
+             batch_size=32,
+             max_epochs=10,
+             tf_optimizer_args=dict(learning_rate=1e-3),
+         ))  # noqa
+}
+
+baseline_with_model_params = {}
+
+algo_params = {
+    'n_envs':
+    12,
+    'n_epochs':
+    488,
+    'n_rollout_steps':
+    2048,
+    'discount':
+    0.99,
+    'max_path_length':
+    100,
+    'gae_lambda':
+    0.95,
+    'lr_clip_range':
+    0.2,
+    'policy_ent_coeff':
+    0.0,
+    'optimizer_args':
+    dict(
+        batch_size=32,
+        max_epochs=10,
+        tf_optimizer_args=dict(learning_rate=policy_params['policy_lr']),
+    )
+}
+
+# number of processing elements to use for tensorflow
+num_proc = 4 * 2
+# number of trials to run per environment
+num_trials = 3
+
+
+class TestBenchmarkPPOContinuousMLPBaseline:
+    '''Compare benchmarks between garage and baselines.'''
+
+    @pytest.mark.huge
+    def test_benchmark_ppo_continuous_mlp_baseline(self):
+        '''
+        Compare benchmarks between CMB with and without Model.
+        '''
+        mujoco1m = benchmarks.get_benchmark('Mujoco1M')
+
+        timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
+        benchmark_dir = osp.join(os.getcwd(), 'data', 'local', 'benchmarks',
+                                 'ppo_cmb', timestamp)
+        result_json = {}
+        for task in mujoco1m['tasks']:
+            env_id = task['env_id']
+            env = gym.make(env_id)
+
+            seeds = random.sample(range(100), num_trials)
+
+            task_dir = osp.join(benchmark_dir, env_id)
+            plt_file = osp.join(benchmark_dir,
+                                '{}_benchmark.png'.format(env_id))
+            cmb_csvs = []
+            cmb_with_model_csvs = []
+
+            for trial in range(num_trials):
+                seed = seeds[trial]
+
+                trial_dir = task_dir + '/trial_%d_seed_%d' % (trial + 1, seed)
+                cmb_dir = trial_dir + '/continuous_mlp_baseline'
+                cmb_with_models_dir = (trial_dir +
+                                       '/continuous_mlp_baseline_with_model')
+
+                with tf.Graph().as_default():
+                    env.reset()
+                    cmb_csv = ppo_cmb(env, seed, cmb_dir)
+                with tf.Graph().as_default():
+                    env.reset()
+                    cmb_with_model_csv = ppo_cmb_w_model(
+                        env, seed, cmb_with_models_dir)
+                cmb_csvs.append(cmb_csv)
+                cmb_with_model_csvs.append(cmb_with_model_csv)
+
+            env.close()
+
+            Rh.plot(b_csvs=cmb_with_model_csvs,
+                    g_csvs=cmb_csvs,
+                    g_x='Epoch',
+                    g_y='AverageReturn',
+                    b_x='Epoch',
+                    b_y='AverageReturn',
+                    trials=num_trials,
+                    seeds=seeds,
+                    plt_file=plt_file,
+                    env_id=env_id,
+                    x_label='Iteration',
+                    y_label='AverageReturn')
+
+            result_json[env_id] = Rh.create_json(b_csvs=cmb_with_model_csvs,
+                                                 g_csvs=cmb_csvs,
+                                                 seeds=seeds,
+                                                 trails=num_trials,
+                                                 g_x='Epoch',
+                                                 g_y='AverageReturn',
+                                                 b_x='Epoch',
+                                                 b_y='AverageReturn',
+                                                 factor_g=2048,
+                                                 factor_b=2048)
+
+        Rh.write_file(result_json, 'PPO_CMB')
+
+
+def ppo_cmb(env, seed, log_dir):
+    '''
+    Create test continuous mlp baseline withOUT model on ppo
+
+    args:
+        env - Environment of the task.
+        seed - Random seed for the trial.
+        log_dir - Log dir path.
+    returns:
+        tabular_log_file - training results in csv format
+    '''
+    deterministic.set_seed(seed)
+    config = tf.ConfigProto(allow_soft_placement=True,
+                            intra_op_parallelism_threads=num_proc,
+                            inter_op_parallelism_threads=num_proc)
+    sess = tf.Session(config=config)
+    with LocalTFRunner(snapshot_config, sess=sess,
+                       max_cpus=num_proc) as runner:
+        env = TfEnv(normalize(env))
+
+        policy = GaussianLSTMPolicy(
+            env_spec=env.spec,
+            hidden_dim=policy_params['policy_hidden_sizes'],
+            hidden_nonlinearity=policy_params['hidden_nonlinearity'],
+        )
+
+        baseline = ContinuousMLPBaseline(
+            env_spec=env.spec,
+            regressor_args=baseline_params['regressor_args'],
+        )
+
+        algo = PPO(env_spec=env.spec,
+                   policy=policy,
+                   baseline=baseline,
+                   max_path_length=algo_params['max_path_length'],
+                   discount=algo_params['discount'],
+                   gae_lambda=algo_params['gae_lambda'],
+                   lr_clip_range=algo_params['lr_clip_range'],
+                   policy_ent_coeff=algo_params['policy_ent_coeff'],
+                   optimizer_args=algo_params['optimizer_args'])
+
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, 'progress.csv')
+        dowel_logger.add_output(dowel.StdOutput())
+        dowel_logger.add_output(dowel.CsvOutput(tabular_log_file))
+        dowel_logger.add_output(dowel.TensorBoardOutput(log_dir))
+
+        runner.setup(algo,
+                     env,
+                     sampler_args=dict(n_envs=algo_params['n_envs']))
+        runner.train(n_epochs=algo_params['n_epochs'],
+                     batch_size=algo_params['n_rollout_steps'])
+
+        dowel_logger.remove_all()
+
+        return tabular_log_file
+
+
+def ppo_cmb_w_model(env, seed, log_dir):
+    '''
+    Create test continuous mlp baseline with model on ppo
+
+    args:
+        env - Environment of the task.
+        seed - Random seed for the trial.
+        log_dir - Log dir path.
+    returns:
+        tabular_log_file - training results in csv format
+    '''
+    deterministic.set_seed(seed)
+    config = tf.ConfigProto(allow_soft_placement=True,
+                            intra_op_parallelism_threads=num_proc,
+                            inter_op_parallelism_threads=num_proc)
+    sess = tf.Session(config=config)
+    with LocalTFRunner(snapshot_config, sess=sess,
+                       max_cpus=num_proc) as runner:
+        env = TfEnv(normalize(env))
+
+        policy = GaussianLSTMPolicy(
+            env_spec=env.spec,
+            hidden_dim=policy_params['policy_hidden_sizes'],
+            hidden_nonlinearity=policy_params['hidden_nonlinearity'],
+        )
+
+        baseline = ContinuousMLPBaselineWithModel(
+            env_spec=env.spec,
+            regressor_args=baseline_with_model_params['regressor_args'],
+        )
+
+        algo = PPO(env_spec=env.spec,
+                   policy=policy,
+                   baseline=baseline,
+                   max_path_length=algo_params['max_path_length'],
+                   discount=algo_params['discount'],
+                   gae_lambda=algo_params['gae_lambda'],
+                   lr_clip_range=algo_params['lr_clip_range'],
+                   policy_ent_coeff=algo_params['policy_ent_coeff'],
+                   optimizer_args=algo_params['optimizer_args'])
+
+        # Set up logger since we are not using run_experiment
+        tabular_log_file = osp.join(log_dir, 'progress.csv')
+        dowel_logger.add_output(dowel.StdOutput())
+        dowel_logger.add_output(dowel.CsvOutput(tabular_log_file))
+        dowel_logger.add_output(dowel.TensorBoardOutput(log_dir))
+
+        runner.setup(algo,
+                     env,
+                     sampler_args=dict(n_envs=algo_params['n_envs']))
+        runner.train(n_epochs=algo_params['n_epochs'],
+                     batch_size=algo_params['n_rollout_steps'])
+
+        dowel_logger.remove_all()
+
+        return tabular_log_file

--- a/tests/benchmarks/test_benchmark_ppo_continous_mlp_baseline.py
+++ b/tests/benchmarks/test_benchmark_ppo_continous_mlp_baseline.py
@@ -25,10 +25,8 @@ from garage.tf.baselines import (ContinuousMLPBaseline,
                                  ContinuousMLPBaselineWithModel)
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
-from garage.tf.optimizers import FirstOrderOptimizer
 from garage.tf.policies import GaussianLSTMPolicy
 from tests.fixtures import snapshot_config
-import tests.helpers as Rh
 # from tests.wrappers import AutoStopEnv
 
 # Hyperparams for baselines and garage
@@ -52,15 +50,11 @@ policy_params = {
 # }
 
 baseline_params = {
-    'regressor_args':
-    dict(hidden_sizes=(64, 64))
-        #  use_trust_region=False,)
+    'regressor_args': dict(hidden_sizes=(64, 64))
+    #  use_trust_region=False,)
 }
 
-baseline_with_model_params = {
-    'regressor_args':
-    dict(hidden_sizes=(64, 64))
-}
+baseline_with_model_params = {'regressor_args': dict(hidden_sizes=(64, 64))}
 
 algo_params = {
     'n_envs':
@@ -110,7 +104,6 @@ class TestBenchmarkPPOContinuousMLPBaseline:
         timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
         benchmark_dir = osp.join(os.getcwd(), 'data', 'local', 'benchmarks',
                                  'ppo_cmb', timestamp)
-        result_json = {}
         for task in mujoco1m['tasks']:
             env_id = task['env_id']
             env = gym.make(env_id)
@@ -118,8 +111,6 @@ class TestBenchmarkPPOContinuousMLPBaseline:
             seeds = random.sample(range(100), num_trials)
 
             task_dir = osp.join(benchmark_dir, env_id)
-            plt_file = osp.join(benchmark_dir,
-                                '{}_benchmark_{}.png'.format(env_id))
             cmb_csvs = []
             cmb_with_model_csvs = []
 
@@ -142,32 +133,6 @@ class TestBenchmarkPPOContinuousMLPBaseline:
                 cmb_with_model_csvs.append(cmb_with_model_csv)
 
             env.close()
-
-        #     Rh.plot(b_csvs=cmb_with_model_csvs,
-        #             g_csvs=cmb_csvs,
-        #             g_x='Epoch',
-        #             g_y='AverageReturn',
-        #             b_x='Epoch',
-        #             b_y='AverageReturn',
-        #             trials=num_trials,
-        #             seeds=seeds,
-        #             plt_file=plt_file,
-        #             env_id=env_id,
-        #             x_label='Iteration',
-        #             y_label='AverageReturn')
-
-        #     result_json[env_id] = Rh.create_json(b_csvs=cmb_with_model_csvs,
-        #                                          g_csvs=cmb_csvs,
-        #                                          seeds=seeds,
-        #                                          trails=num_trials,
-        #                                          g_x='Epoch',
-        #                                          g_y='AverageReturn',
-        #                                          b_x='Epoch',
-        #                                          b_y='AverageReturn',
-        #                                          factor_g=2048,
-        #                                          factor_b=2048)
-
-        # Rh.write_file(result_json, 'PPO_CMB')
 
 
 def ppo_cmb(env, seed, log_dir):

--- a/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model_transit.py
+++ b/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model_transit.py
@@ -1,0 +1,125 @@
+"""
+Unit test for ContinuousMLPBaselineWithModel.
+
+This test consists of two ContinuousMLPBaseline's: B1 and B2, and
+two ContinuousMLPBaselineWithModel: B3 and B4.
+
+This test ensures the outputs from all the baselines are the same,
+for the transition from using ContinuousMLPBaseline to
+ContinuousMLPBaselineWithModel.
+
+"""
+from unittest import mock
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from garage.tf.envs import TfEnv
+from garage.tf.baselines import ContinuousMLPBaseline
+from garage.tf.baselines import ContinuousMLPBaselineWithModel
+from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
+    def setup_method(self):
+        with mock.patch('tensorflow.random.normal') as mock_rand:
+            mock_rand.return_value = 0.5
+            super().setup_method()
+            self.box_env = TfEnv(DummyBoxEnv())
+            self.baseline1 = ContinuousMLPBaseline(
+                                    self.box_env.spec,
+                                    regressor_args=dict(hidden_sizes=(32, 32)),
+                                    name="CMB_1")
+            self.baseline2 = ContinuousMLPBaseline(
+                                    self.box_env.spec,
+                                    regressor_args=dict(hidden_sizes=(64, 64)),
+                                    name="CMB_2")
+            self.baseline3 = ContinuousMLPBaselineWithModel(
+                                    self.box_env.spec,
+                                    regressor_args=dict(hidden_sizes=(32, 32)),
+                                    name="CMB_WM_1")
+            self.baseline4 = ContinuousMLPBaselineWithModel(
+                                    self.box_env.spec,
+                                    regressor_args=dict(hidden_sizes=(64, 64)),
+                                    name="CMB_WM_2")
+
+            self.sess.run(tf.compat.v1.global_variables_initializer())
+            for a, b in zip(self.baseline1.get_params_internal(),
+                            self.baseline3.get_params_internal()):
+                self.sess.run(a.assign(b))
+
+            for a, b in zip(self.baseline4.get_params_internal(),
+                            self.baseline2.get_params_internal()):
+                self.sess.run(a.assign(b))
+            assert(np.array_equal(self.baseline4.get_param_values(), self.baseline2.get_param_values()))
+            assert(np.array_equal(self.baseline1.get_param_values(), self.baseline3.get_param_values()))
+
+    def test_transition(self):
+        """ Test to see that CMLPBase with and without model have the same outputs.
+        Fit to the same mock observations.
+        Check that there is same output.
+        """
+        obs_dim = self.box_env.observation_space.shape
+        # with mock.patch('numpy.random.normal') as mock_rand:
+        #     mock_rand.return_value = 0.5
+        paths = [{'observations': [np.full(shape=obs_dim, fill_value=1)],
+                    'returns': [1]}, 
+                    {'observations': [np.full(shape=obs_dim, fill_value=2)],
+                    'returns': [2]}
+                ]
+        
+        obs = {'observations': [np.full(obs_dim, 1), np.full(obs_dim, 2)]}
+        prediction1 = self.baseline1.predict(obs)
+        prediction2 = self.baseline2.predict(obs)
+        prediction3 = self.baseline3.predict(obs)
+        prediction4 = self.baseline4.predict(obs)
+
+        # check before fitting that predictions are the same
+        # between model vs not model
+
+        # assert np.allclose(prediction1, prediction3, rtol=1e-6)
+        # assert np.allclose(prediction2, prediction4, rtol=1e-6)
+        import ipdb; ipdb.set_trace()
+
+        self.baseline1.fit(paths)
+        self.baseline2.fit(paths)
+        self.baseline3.fit(paths)
+        self.baseline4.fit(paths)
+
+        obs = {'observations': [np.full(obs_dim, 1), np.full(obs_dim, 2)]}
+        prediction1 = self.baseline1.predict(obs)
+        prediction2 = self.baseline2.predict(obs)
+        prediction3 = self.baseline3.predict(obs)
+        prediction4 = self.baseline4.predict(obs)
+
+        assert np.array_equal(prediction1, prediction3)
+        assert np.array_equal(prediction2, prediction4)
+
+
+    # def test_get_action_sym(self):
+    #     obs_dim = self.box_env.spec.observation_space.flat_dim
+    #     state_input = tf.compat.v1.placeholder(
+    #         tf.float32, shape=(None, obs_dim))
+
+    #     action_sym1 = self.policy1.get_action_sym(
+    #         state_input, name='action_sym')
+    #     action_sym2 = self.policy2.get_action_sym(
+    #         state_input, name='action_sym')
+    #     action_sym3 = self.policy3.get_action_sym(
+    #         state_input, name='action_sym')
+    #     action_sym4 = self.policy4.get_action_sym(
+    #         state_input, name='action_sym')
+
+    #     action1 = self.sess.run(
+    #         action_sym1, feed_dict={state_input: [self.obs]})
+    #     action2 = self.sess.run(
+    #         action_sym2, feed_dict={state_input: [self.obs]})
+    #     action3 = self.sess.run(
+    #         action_sym3, feed_dict={state_input: [self.obs]})
+    #     action4 = self.sess.run(
+    #         action_sym4, feed_dict={state_input: [self.obs]})
+
+    #     assert np.array_equal(action1, action3 * self.action_bound)
+    #     assert np.array_equal(action2, action4 * self.action_bound)

--- a/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model_transit.py
+++ b/tests/garage/tf/baselines/test_continuous_mlp_baseline_with_model_transit.py
@@ -12,38 +12,38 @@ ContinuousMLPBaselineWithModel.
 from unittest import mock
 
 import numpy as np
-import pytest
 import tensorflow as tf
 
-from garage.tf.envs import TfEnv
 from garage.tf.baselines import ContinuousMLPBaseline
 from garage.tf.baselines import ContinuousMLPBaselineWithModel
+from garage.tf.envs import TfEnv
 from tests.fixtures import TfGraphTestCase
 from tests.fixtures.envs.dummy import DummyBoxEnv
 
 
 class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
+
     def setup_method(self):
         with mock.patch('tensorflow.random.normal') as mock_rand:
             mock_rand.return_value = 0.5
             super().setup_method()
             self.box_env = TfEnv(DummyBoxEnv())
             self.baseline1 = ContinuousMLPBaseline(
-                                    self.box_env.spec,
-                                    regressor_args=dict(hidden_sizes=(32, 32)),
-                                    name="CMB_1")
+                self.box_env.spec,
+                regressor_args=dict(hidden_sizes=(32, 32)),
+                name='CMB_1')
             self.baseline2 = ContinuousMLPBaseline(
-                                    self.box_env.spec,
-                                    regressor_args=dict(hidden_sizes=(64, 64)),
-                                    name="CMB_2")
+                self.box_env.spec,
+                regressor_args=dict(hidden_sizes=(64, 64)),
+                name='CMB_2')
             self.baseline3 = ContinuousMLPBaselineWithModel(
-                                    self.box_env.spec,
-                                    regressor_args=dict(hidden_sizes=(32, 32)),
-                                    name="CMB_WM_1")
+                self.box_env.spec,
+                regressor_args=dict(hidden_sizes=(32, 32)),
+                name='CMB_WM_1')
             self.baseline4 = ContinuousMLPBaselineWithModel(
-                                    self.box_env.spec,
-                                    regressor_args=dict(hidden_sizes=(64, 64)),
-                                    name="CMB_WM_2")
+                self.box_env.spec,
+                regressor_args=dict(hidden_sizes=(64, 64)),
+                name='CMB_WM_2')
 
             self.sess.run(tf.compat.v1.global_variables_initializer())
             for a, b in zip(self.baseline1.get_params_internal(),
@@ -53,8 +53,10 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
             for a, b in zip(self.baseline4.get_params_internal(),
                             self.baseline2.get_params_internal()):
                 self.sess.run(a.assign(b))
-            assert(np.array_equal(self.baseline4.get_param_values(), self.baseline2.get_param_values()))
-            assert(np.array_equal(self.baseline1.get_param_values(), self.baseline3.get_param_values()))
+            assert (np.array_equal(self.baseline4.get_param_values(),
+                                   self.baseline2.get_param_values()))
+            assert (np.array_equal(self.baseline1.get_param_values(),
+                                   self.baseline3.get_param_values()))
 
     def test_transition(self):
         """ Test to see that CMLPBase with and without model have the same outputs.
@@ -64,12 +66,14 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
         obs_dim = self.box_env.observation_space.shape
         # with mock.patch('numpy.random.normal') as mock_rand:
         #     mock_rand.return_value = 0.5
-        paths = [{'observations': [np.full(shape=obs_dim, fill_value=1)],
-                    'returns': [1]}, 
-                    {'observations': [np.full(shape=obs_dim, fill_value=2)],
-                    'returns': [2]}
-                ]
-        
+        paths = [{
+            'observations': [np.full(shape=obs_dim, fill_value=1)],
+            'returns': [1]
+        }, {
+            'observations': [np.full(shape=obs_dim, fill_value=2)],
+            'returns': [2]
+        }]
+
         obs = {'observations': [np.full(obs_dim, 1), np.full(obs_dim, 2)]}
         prediction1 = self.baseline1.predict(obs)
         prediction2 = self.baseline2.predict(obs)
@@ -81,7 +85,6 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
 
         # assert np.allclose(prediction1, prediction3, rtol=1e-6)
         # assert np.allclose(prediction2, prediction4, rtol=1e-6)
-        import ipdb; ipdb.set_trace()
 
         self.baseline1.fit(paths)
         self.baseline2.fit(paths)
@@ -96,7 +99,6 @@ class TestContinuousMLPPolicyWithModelTransit(TfGraphTestCase):
 
         assert np.array_equal(prediction1, prediction3)
         assert np.array_equal(prediction2, prediction4)
-
 
     # def test_get_action_sym(self):
     #     obs_dim = self.box_env.spec.observation_space.flat_dim


### PR DESCRIPTION
This PR is to fully integrate the continuous mlp baseline/regressor with the model primitive. 

Included are
- A transition test
- A fix for the formerly not working continuous mlp regressor without baseline, which previously was maximizing the difference between the expected return and actual return, NOT minimizing it.
- A benchmark test that shows that the average returns are almost the same, if not better with the model primitive.

closes #883 

