### PR TITLE
Add curl to 18.04 Dockerfile so codecov works

### DIFF
--- a/docker/Dockerfile.base.18.04
+++ b/docker/Dockerfile.base.18.04
@@ -19,6 +19,7 @@ RUN \
     wget \
     unzip \
     git \
+    curl \
     # For building glfw
     cmake \
     xorg-dev \


### PR DESCRIPTION
Code coverage seems to be failing because curl isn't installed in the docker image where we are running the ci tests. This change install curl in those images.