### PR TITLE
Restrict pyglet version to fix gym

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ required = [
     'polling',
     'protobuf',
     'psutil',
+    # Pyglet 1.4.0 introduces some API change which breaks some
+    # gym environments
+    # See: https://github.com/openai/gym/issues/1588
+    'pyglet<1.4.0,>=1.3.0',
     'pyprind',
     'python-dateutil',
     'scikit-image',


### PR DESCRIPTION
Cron builds on release 2019.02 branch are failing: https://travis-ci.com/rlworkgroup/garage/builds/130811549#L5910

Cherry-picking 5aea794969f9e8d5bb51f1dc5850c6be943dccf0 from master

Pyglet 1.4.0+ breaks gym, especially classic_control envs, due to which some tests are failing on CI. We restrict pyglet in master because of same issue. This commit replicates that.

Ref: https://github.com/openai/gym/issues/1588
