### PR TITLE
Support non-linearity function and module for PyTorch Module

### DIFF
--- a/src/garage/torch/modules/mlp_module.py
+++ b/src/garage/torch/modules/mlp_module.py
@@ -1,17 +1,16 @@
-"""
-MLP Module.
+"""MLP Module."""
 
-A Pytorch module composed only of a multi-layer perceptron (MLP), which maps
-real-valued inputs to real-valued outputs.
-"""
+from torch import nn
+from torch.nn import functional as F
 
-from torch import nn as nn
-from torch.nn import functional as F  # NOQA
+from garage.torch.modules.multi_headed_mlp_module import MultiHeadedMLPModule
 
 
-class MLPModule(nn.Module):
-    """
-    MLP Model.
+class MLPModule(MultiHeadedMLPModule):
+    """MLP Model.
+
+    A Pytorch module composed only of a multi-layer perceptron (MLP), which
+    maps real-valued inputs to real-valued outputs.
 
     Args:
         input_dim (int) : Dimension of the network input.
@@ -19,18 +18,18 @@ class MLPModule(nn.Module):
         hidden_sizes (list[int]): Output dimension of dense layer(s).
             For example, (32, 32) means this MLP consists of two
             hidden layers, each with 32 hidden units.
-        hidden_nonlinearity (callable): Activation function for intermediate
-            dense layer(s). It should return a torch.Tensor. Set it to
-            None to maintain a linear activation.
+        hidden_nonlinearity (callable or torch.nn.Module): Activation function
+            for intermediate dense layer(s). It should return a torch.Tensor.
+            Set it to None to maintain a linear activation.
         hidden_w_init (callable): Initializer function for the weight
             of intermediate dense layer(s). The function should return a
             torch.Tensor.
         hidden_b_init (callable): Initializer function for the bias
             of intermediate dense layer(s). The function should return a
             torch.Tensor.
-        output_nonlinearity (callable): Activation function for output dense
-            layer. It should return a torch.Tensor. Set it to None to
-            maintain a linear activation.
+        output_nonlinearity (callable or torch.nn.Module): Activation function
+            for output dense layer. It should return a torch.Tensor.
+            Set it to None to maintain a linear activation.
         output_w_init (callable): Initializer function for the weight
             of output dense layer(s). The function should return a
             torch.Tensor.
@@ -39,8 +38,6 @@ class MLPModule(nn.Module):
             torch.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
 
-    Return:
-        The output torch.Tensor of the MLP
     """
 
     def __init__(self,
@@ -54,41 +51,21 @@ class MLPModule(nn.Module):
                  output_w_init=nn.init.xavier_normal_,
                  output_b_init=nn.init.zeros_,
                  layer_normalization=False):
-        super().__init__()
+        super().__init__(1, input_dim, output_dim, hidden_sizes,
+                         hidden_nonlinearity, hidden_w_init, hidden_b_init,
+                         output_nonlinearity, output_w_init, output_b_init,
+                         layer_normalization)
 
-        self._input_dim = input_dim
-        self._output_dim = output_dim
-        self._hidden_nonlinearity = hidden_nonlinearity
-        self._output_nonlinearity = output_nonlinearity
-        self._layer_normalization = layer_normalization
-        self._layers = nn.ModuleList()
+    # pylint: disable=arguments-differ
+    def forward(self, input_value):
+        """Forward method.
 
-        prev_size = input_dim
+        Args:
+            input_value (torch.Tensor): Input values with (N, *, input_dim)
+                shape.
 
-        for size in hidden_sizes:
-            layer = nn.Linear(prev_size, size)
-            hidden_w_init(layer.weight)
-            hidden_b_init(layer.bias)
-            self._layers.append(layer)
-            prev_size = size
+        Returns:
+            torch.Tensor: Output value
 
-        layer = nn.Linear(prev_size, output_dim)
-        output_w_init(layer.weight)
-        output_b_init(layer.bias)
-        self._layers.append(layer)
-
-    def forward(self, input_val):
-        """Forward method."""
-        x = input_val
-        for layer in self._layers[:-1]:
-            x = layer(x)
-            if self._hidden_nonlinearity is not None:
-                x = self._hidden_nonlinearity(x)
-            if self._layer_normalization:
-                x = nn.LayerNorm(x.shape[1])(x)
-
-        x = self._layers[-1](x)
-        if self._output_nonlinearity is not None:
-            x = self._output_nonlinearity(x)
-
-        return x
+        """
+        return super().forward(input_value)[0]

--- a/tests/garage/torch/modules/test_mlp_module.py
+++ b/tests/garage/torch/modules/test_mlp_module.py
@@ -1,3 +1,5 @@
+"""Test MLPModule."""
+
 import pickle
 
 import numpy as np
@@ -9,6 +11,7 @@ from garage.torch.modules import MLPModule
 
 
 class TestMLPModel:
+    """Test MLPModule."""
     # yapf: disable
     @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', [
         (5, 1, (1, )),
@@ -19,21 +22,42 @@ class TestMLPModel:
     ])
     # yapf: enable
     def test_output_values(self, input_dim, output_dim, hidden_sizes):
-        input_val = torch.ones([1, 5], dtype=torch.float32)
-        module = MLPModule(
+        """Test output values from MLPModule.
+
+        Args:
+            input_dim (int): Input dimension.
+            output_dim (int): Ouput dimension.
+            hidden_sizes (list[int]): Size of hidden layers.
+
+        """
+        input_val = torch.ones([1, input_dim], dtype=torch.float32)
+        module_with_nonlinear_function_and_module = MLPModule(
             input_dim=input_dim,
             output_dim=output_dim,
-            hidden_nonlinearity=None,
+            hidden_nonlinearity=torch.relu,
             hidden_sizes=hidden_sizes,
             hidden_w_init=nn.init.ones_,
-            output_w_init=nn.init.ones_)
-        output = module(input_val)
+            output_w_init=nn.init.ones_,
+            output_nonlinearity=torch.nn.ReLU)
+
+        module_with_nonlinear_module_instance_and_function = MLPModule(
+            input_dim=input_dim,
+            output_dim=output_dim,
+            hidden_nonlinearity=torch.nn.ReLU(),
+            hidden_sizes=hidden_sizes,
+            hidden_w_init=nn.init.ones_,
+            output_w_init=nn.init.ones_,
+            output_nonlinearity=torch.relu)
+
+        output1 = module_with_nonlinear_function_and_module(input_val)
+        output2 = module_with_nonlinear_module_instance_and_function(input_val)
 
         expected_output = torch.full([1, output_dim],
                                      fill_value=5 * np.prod(hidden_sizes),
                                      dtype=torch.float32)
 
-        assert torch.all(torch.eq(output, expected_output))
+        assert torch.all(torch.eq(expected_output, output1))
+        assert torch.all(torch.eq(expected_output, output2))
 
     # yapf: disable
     @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', [
@@ -45,14 +69,23 @@ class TestMLPModel:
     ])
     # yapf: enable
     def test_is_pickleable(self, input_dim, output_dim, hidden_sizes):
-        input_val = torch.ones([1, 5], dtype=torch.float32)
-        module = MLPModule(
-            input_dim=input_dim,
-            output_dim=output_dim,
-            hidden_nonlinearity=None,
-            hidden_sizes=hidden_sizes,
-            hidden_w_init=nn.init.ones_,
-            output_w_init=nn.init.ones_)
+        """Check MLPModule is pickeable.
+
+        Args:
+            input_dim (int): Input dimension.
+            output_dim (int): Ouput dimension.
+            hidden_sizes (list[int]): Size of hidden layers.
+
+        """
+        input_val = torch.ones([1, input_dim], dtype=torch.float32)
+        module = MLPModule(input_dim=input_dim,
+                           output_dim=output_dim,
+                           hidden_nonlinearity=torch.relu,
+                           hidden_sizes=hidden_sizes,
+                           hidden_w_init=nn.init.ones_,
+                           output_w_init=nn.init.ones_,
+                           output_nonlinearity=torch.nn.ReLU)
+
         output1 = module(input_val)
 
         h = pickle.dumps(module)
@@ -60,3 +93,49 @@ class TestMLPModel:
         output2 = model_pickled(input_val)
 
         assert np.array_equal(torch.all(torch.eq(output1, output2)), True)
+
+    # yapf: disable
+    @pytest.mark.parametrize('hidden_nonlinear, output_nonlinear', [
+        (torch.nn.ReLU, 'test'),
+        ('test', torch.relu),
+        (object(), torch.tanh),
+        (torch.tanh, object())
+    ])
+    # yapf: enable
+    def test_no_head_invalid_settings(self, hidden_nonlinear,
+                                      output_nonlinear):
+        """Check MLPModule throws exception with invalid non-linear functions.
+
+        Args:
+            hidden_nonlinear (callable or torch.nn.Module): Non-linear
+                functions for hidden layers.
+            output_nonlinear (callable or torch.nn.Module): Non-linear
+                functions for output layer.
+
+        """
+        expected_msg = 'Non linear function .* is not supported'
+        with pytest.raises(ValueError, match=expected_msg):
+            MLPModule(input_dim=3,
+                      output_dim=5,
+                      hidden_sizes=(2, 3),
+                      hidden_nonlinearity=hidden_nonlinear,
+                      output_nonlinearity=output_nonlinear)
+
+    def test_mlp_with_learnable_non_linear_function(self):
+        """Test MLPModule with learnable non-linear functions."""
+        input_dim, output_dim, hidden_sizes = 1, 1, (3, 2)
+
+        input_val = -torch.ones([1, input_dim], dtype=torch.float32)
+        module = MLPModule(input_dim=input_dim,
+                           output_dim=output_dim,
+                           hidden_nonlinearity=torch.nn.PReLU(init=10.),
+                           hidden_sizes=hidden_sizes,
+                           hidden_w_init=nn.init.ones_,
+                           output_w_init=nn.init.ones_,
+                           output_nonlinearity=torch.nn.PReLU(init=1.))
+
+        output = module(input_val)
+        output.sum().backward()
+
+        for tt in module.parameters():
+            assert torch.all(torch.ne(tt.grad, 0))


### PR DESCRIPTION
Throw an error because of using non-linear functions in `torch.nn`.
Change into using non-linear funcitons in `torch.nn.functional` or `torch`

Previously, MultiHeadedMLPModule assumes that we are using non-linear function in torch.nn.
So we make a computational graph inside of \_\_init\_\_ and pass the type of the non-linear function to ModuleList. (`layer.add_module('non_linearity', hidden_nonlinearity)`)

However, for consistency with other modules, I changed the way we use the non-linear functions. 
(Similar with `MLPModule`, ) make linear layers only in \_\_init\_\_ and call the non-linear functions in the forward function. (`x = self._hidden_nonlinearity(x)`)

So now, we need to pass non-linear functions in the torch.nn.functional (ex. `torch.tanh` or `torch.nn.functional.relu`) instead of in the torch.nn (ex `torch.nn.Tanh`, `torch.nn.ReLU`)