### PR TITLE
Remove flattening observation in samplers

### DIFF
--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -100,9 +100,9 @@ class OnPolicyVectorizedSampler(BatchSampler):
                 running_paths[idx]['env_infos'].append(env_info)
                 running_paths[idx]['agent_infos'].append(agent_info)
                 if done:
+                    obs = np.asarray(running_paths[idx]['observations'])
                     paths.append(
-                        dict(observations=self.env_spec.observation_space.
-                             flatten_n(running_paths[idx]['observations']),
+                        dict(observations=obs,
                              actions=self.env_spec.action_space.flatten_n(
                                  running_paths[idx]['actions']),
                              rewards=tensor_utils.stack_tensor_list(

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -101,10 +101,10 @@ class OnPolicyVectorizedSampler(BatchSampler):
                 running_paths[idx]['agent_infos'].append(agent_info)
                 if done:
                     obs = np.asarray(running_paths[idx]['observations'])
+                    actions = np.asarray(running_paths[idx]['actions'])
                     paths.append(
                         dict(observations=obs,
-                             actions=self.env_spec.action_space.flatten_n(
-                                 running_paths[idx]['actions']),
+                             actions=actions,
                              rewards=tensor_utils.stack_tensor_list(
                                  running_paths[idx]['rewards']),
                              env_infos=tensor_utils.stack_tensor_dict_list(

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -142,8 +142,7 @@ class RaySampler(BaseSampler):
         self._active_worker_ids.remove(ready_worker_id)
         self._idle_worker_ids.append(ready_worker_id)
         trajectory = dict(
-            observations=self._algo.env_spec.observation_space.flatten_n(
-                trajectory[1]),
+            observations=np.asarray(trajectory[1]),
             actions=self._algo.env_spec.action_space.flatten_n(trajectory[2]),
             rewards=tensor_utils.stack_tensor_list(trajectory[3]),
             agent_infos=trajectory[4],

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -141,12 +141,12 @@ class RaySampler(BaseSampler):
         ready_worker_id = trajectory[0]
         self._active_worker_ids.remove(ready_worker_id)
         self._idle_worker_ids.append(ready_worker_id)
-        trajectory = dict(
-            observations=np.asarray(trajectory[1]),
-            actions=self._algo.env_spec.action_space.flatten_n(trajectory[2]),
-            rewards=tensor_utils.stack_tensor_list(trajectory[3]),
-            agent_infos=trajectory[4],
-            env_infos=trajectory[5])
+        trajectory = dict(observations=np.asarray(trajectory[1]),
+                          actions=np.asarray(trajectory[2]),
+                          rewards=tensor_utils.stack_tensor_list(
+                              trajectory[3]),
+                          agent_infos=trajectory[4],
+                          env_infos=trajectory[5])
         num_returned_samples = len(trajectory['observations'])
         return trajectory, num_returned_samples
 

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -1,3 +1,4 @@
+"""Proximal Policy Optimization."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import FirstOrderOptimizer
 
@@ -72,30 +73,31 @@ class PPO(NPO):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
                  name='PPO'):
         if optimizer is None:
             optimizer = FirstOrderOptimizer
             if optimizer_args is None:
                 optimizer_args = dict()
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss=pg_loss,
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         name=name)

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -49,6 +49,9 @@ class PPO(NPO):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
         name (str): The name of the algorithm.
     """
 

--- a/tests/fixtures/envs/wrappers/__init__.py
+++ b/tests/fixtures/envs/wrappers/__init__.py
@@ -1,0 +1,3 @@
+from tests.fixtures.envs.wrappers.reshape_observation import ReshapeObservation
+
+__all__ = ['ReshapeObservation']

--- a/tests/fixtures/envs/wrappers/reshape_observation.py
+++ b/tests/fixtures/envs/wrappers/reshape_observation.py
@@ -1,0 +1,46 @@
+"""Reshaping Observation for gym.Env."""
+import gym
+import numpy as np
+
+
+class ReshapeObservation(gym.Wrapper):
+    """
+    Reshaping Observation wrapper for gym.Env.
+
+    This wrapper convert the observations into the given shape.
+
+    Args:
+        env (gym.Env): The environment to be wrapped.
+        shape (list[int]): Target shape to be applied on the observations.
+    """
+
+    def __init__(self, env, shape):
+        super().__init__(env)
+        print(env.observation_space.shape)
+        assert np.prod(shape) == np.prod(env.observation_space.shape)
+        _low = env.observation_space.low.flatten()[0]
+        _high = env.observation_space.high.flatten()[0]
+        self._observation_space = gym.spaces.Box(
+            _low, _high, shape=shape, dtype=env.observation_space.dtype)
+        self._shape = shape
+
+    @property
+    def observation_space(self):
+        """gym.Env observation space."""
+        return self._observation_space
+
+    @observation_space.setter
+    def observation_space(self, observation_space):
+        self._observation_space = observation_space
+
+    def _observation(self, obs):
+        return obs.reshape(self._shape)
+
+    def reset(self):
+        """gym.Env reset function."""
+        return self._observation(self.env.reset())
+
+    def step(self, action):
+        """gym.Env step function."""
+        obs, reward, done, info = self.env.step(action)
+        return self._observation(obs), reward, done, info

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -56,18 +56,12 @@ class TestSampler:
         trajs1 = sampler1.obtain_samples(0, 16)
         trajs2 = sampler2.obtain_samples(0, 1)
         assert (trajs1[0]['observations'].shape == np.array(
-            trajs2[0]['observations']).shape == (6, 16))
+            trajs2[0]['observations']).shape == (6, ))
         traj2_action_shape = np.array(trajs2[0]['actions']).shape
         assert (trajs1[0]['actions'].shape == traj2_action_shape == (6, 4))
         assert (sum(trajs1[0]['rewards']) == sum(trajs2[0]['rewards']) == 1)
 
-        true_obs = np.array(
-            [[1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-             [0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-             [0., 0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-             [0., 0., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0., 0., 0., 0., 0.],
-             [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 0., 0., 0., 0., 0.],
-             [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 0.]])
+        true_obs = np.array([0, 1, 2, 6, 10, 14])
         true_actions = np.array([[0., 0., 1., 0.], [0., 0., 1., 0.],
                                  [0., 1., 0., 0.], [0., 1., 0., 0.],
                                  [0., 1., 0., 0.], [0., 0., 1., 0.]])

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -58,13 +58,11 @@ class TestSampler:
         assert (trajs1[0]['observations'].shape == np.array(
             trajs2[0]['observations']).shape == (6, ))
         traj2_action_shape = np.array(trajs2[0]['actions']).shape
-        assert (trajs1[0]['actions'].shape == traj2_action_shape == (6, 4))
+        assert (trajs1[0]['actions'].shape == traj2_action_shape == (6, ))
         assert (sum(trajs1[0]['rewards']) == sum(trajs2[0]['rewards']) == 1)
 
         true_obs = np.array([0, 1, 2, 6, 10, 14])
-        true_actions = np.array([[0., 0., 1., 0.], [0., 0., 1., 0.],
-                                 [0., 1., 0., 0.], [0., 1., 0., 0.],
-                                 [0., 1., 0., 0.], [0., 0., 1., 0.]])
+        true_actions = np.array([2, 2, 1, 1, 1, 2])
         true_rewards = np.array([0, 0, 0, 0, 0, 1])
         for trajectory in trajs1:
             assert (np.array_equal(trajectory['observations'], true_obs))


### PR DESCRIPTION
Flattening of observations should be decoupled to the consumer, e.g. algorithms. The assumption that the observations should be flattened is not valid in some use cases, e.g. when observations are images.