### PR TITLE
OnPolicyVectorizedSampler should always flatten actions

### DIFF
--- a/examples/tf/trpo_cubecrash.py
+++ b/examples/tf/trpo_cubecrash.py
@@ -41,7 +41,8 @@ def run_task(snapshot_config, *_):
                     baseline=baseline,
                     max_path_length=100,
                     discount=0.99,
-                    max_kl_step=0.01)
+                    max_kl_step=0.01,
+                    flatten_input=False)
 
         runner.setup(algo, env)
         runner.train(n_epochs=100, batch_size=4000)

--- a/src/garage/tf/algos/batch_polopt.py
+++ b/src/garage/tf/algos/batch_polopt.py
@@ -154,6 +154,17 @@ class BatchPolopt(RLAlgorithm):
                     env_infos=path['env_infos'],
                     agent_infos=path['agent_infos']) for path in paths
             ]
+        else:
+            paths = [
+                dict(
+                    observations=path['observations'],
+                    actions=(
+                        self.env_spec.action_space.flatten_n(  # noqa: E126
+                            path['actions'])),
+                    rewards=path['rewards'],
+                    env_infos=path['env_infos'],
+                    agent_infos=path['agent_infos']) for path in paths
+            ]
 
         if hasattr(self.baseline, 'predict_n'):
             all_path_baselines = self.baseline.predict_n(paths)

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -205,15 +205,11 @@ class NPO(BatchPolopt):
                     tf.float32,
                     shape=[None, None, observation_space.flat_dim],
                     name='obs')
-                action_var = tf.compat.v1.placeholder(
-                    tf.float32,
-                    shape=[None, None, action_space.flat_dim],
-                    name='action')
             else:
                 obs_var = observation_space.to_tf_placeholder(name='obs',
                                                               batch_dims=2)
-                action_var = action_space.to_tf_placeholder(name='action',
-                                                            batch_dims=2)
+            action_var = action_space.to_tf_placeholder(name='action',
+                                                        batch_dims=2)
             reward_var = tensor_utils.new_tensor(name='reward',
                                                  ndim=2,
                                                  dtype=tf.float32)

--- a/src/garage/tf/algos/trpo.py
+++ b/src/garage/tf/algos/trpo.py
@@ -1,3 +1,4 @@
+"""Trust Region Policy Optimization."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import ConjugateGradientOptimizer
 from garage.tf.optimizers import PenaltyLbfgsOptimizer
@@ -74,6 +75,7 @@ class TRPO(NPO):
                  stop_entropy_gradient=False,
                  kl_constraint='hard',
                  entropy_method='no_entropy',
+                 flatten_input=True,
                  name='TRPO'):
         if not optimizer:
             if kl_constraint == 'hard':
@@ -86,25 +88,25 @@ class TRPO(NPO):
         if optimizer_args is None:
             optimizer_args = dict()
 
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss=pg_loss,
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         name=name)


### PR DESCRIPTION
This is a bug introduced by PR #930. Regardless of observation type, sampler should always flatten the action inputs
Also add a missing constructor arguments to `TRPO`.