### PR TITLE
Fix CategoricalCNNPolicy examples and benchmark

### DIFF
--- a/examples/tf/ppo_memorize_digits.py
+++ b/examples/tf/ppo_memorize_digits.py
@@ -28,10 +28,10 @@ def run_task(snapshot_config, *_):
 
         baseline = GaussianCNNBaseline(env_spec=env.spec,
                                        regressor_args=dict(
-                                           conv_filters=(32, 64, 64),
-                                           conv_filter_sizes=(5, 3, 2),
-                                           conv_strides=(4, 2, 1),
-                                           conv_pads=('VALID', 'VALID'),
+                                           num_filters=(32, 64, 64),
+                                           filter_dims=(5, 3, 2),
+                                           strides=(4, 2, 1),
+                                           padding='VALID',
                                            hidden_sizes=(256, ),
                                            use_trust_region=True))
 
@@ -40,7 +40,8 @@ def run_task(snapshot_config, *_):
                    baseline=baseline,
                    max_path_length=100,
                    discount=0.99,
-                   max_kl_step=0.01)
+                   max_kl_step=0.01,
+                   flatten_input=False)
 
         runner.setup(algo, env)
         runner.train(n_epochs=1000, batch_size=2048)

--- a/examples/tf/trpo_cubecrash.py
+++ b/examples/tf/trpo_cubecrash.py
@@ -19,7 +19,6 @@ def run_task(snapshot_config, *_):
     """Run task."""
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(normalize(gym.make('CubeCrash-v0')))
-        print('shape= ', env.spec.observation_space.shape)
         policy = CategoricalCNNPolicy(env_spec=env.spec,
                                       conv_filters=(32, 64),
                                       conv_filter_sizes=(8, 4),

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_cnn_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_cnn_policy.py
@@ -24,7 +24,6 @@ params = {
     'conv_filters': (32, 64, 64),
     'conv_filter_sizes': (5, 3, 2),
     'conv_strides': (4, 2, 1),
-    'conv_pads': ('VALID', 'VALID', 'VALID'),
     'conv_pad': 'VALID',
     'hidden_sizes': (256, ),
     'n_epochs': 1000,
@@ -132,7 +131,7 @@ def run_garage(env, seed, log_dir):
             regressor_args=dict(num_filters=params['conv_filters'],
                                 filter_dims=params['conv_filter_sizes'],
                                 strides=params['conv_strides'],
-                                padding=params['conv_pads'],
+                                padding=params['conv_pad'],
                                 hidden_sizes=params['hidden_sizes'],
                                 use_trust_region=params['use_trust_region']))
 
@@ -150,6 +149,7 @@ def run_garage(env, seed, log_dir):
                 max_epochs=10,
                 tf_optimizer_args=dict(learning_rate=1e-3),
             ),
+            flatten_input=False,
         )
 
         # Set up logger since we are not using run_experiment


### PR DESCRIPTION
One of the examples and benchmark script have errors because they are still using old parameter names of GaussianCNNBaseline.