### PR TITLE
Add multi env wrapper

### DIFF
--- a/examples/tf/multi_env_ppo.py
+++ b/examples/tf/multi_env_ppo.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""This is an example to train multiple tasks with PPO algorithm."""
+import gym
+import tensorflow as tf
+
+from garage.envs import normalize
+from garage.envs.multi_env_wrapper import MultiEnvWrapper
+from garage.experiment import run_experiment
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import PPO
+from garage.tf.envs import TfEnv
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.policies import CategoricalMLPPolicy
+
+
+def run_task(snapshot_config, *_):
+    """Run task.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+
+        _ (object): Ignored by this function.
+
+    """
+    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+        env1 = TfEnv(normalize(gym.make('Adventure-ram-v4')))
+        env2 = TfEnv(normalize(gym.make('Alien-ram-v4')))
+        env = MultiEnvWrapper([env1, env2])
+
+        policy = CategoricalMLPPolicy(
+            env_spec=env.spec,
+            hidden_nonlinearity=tf.nn.tanh,
+        )
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = PPO(env_spec=env.spec,
+                   policy=policy,
+                   baseline=baseline,
+                   max_path_length=100,
+                   discount=0.99,
+                   gae_lambda=0.95,
+                   lr_clip_range=0.2,
+                   policy_ent_coeff=0.0,
+                   optimizer_args=dict(
+                       batch_size=32,
+                       max_epochs=10,
+                       tf_optimizer_args=dict(learning_rate=1e-3),
+                   ))
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=120, batch_size=2048, plot=False)
+
+
+run_experiment(run_task, snapshot_mode='last', seed=1)

--- a/src/garage/envs/__init__.py
+++ b/src/garage/envs/__init__.py
@@ -1,3 +1,5 @@
+"""Garage wrappers for gym environments."""
+
 from garage.envs.base import GarageEnv
 from garage.envs.base import Step
 from garage.envs.env_spec import EnvSpec

--- a/src/garage/envs/multi_env_wrapper.py
+++ b/src/garage/envs/multi_env_wrapper.py
@@ -1,0 +1,196 @@
+"""A wrapper env that handles multiple tasks from different envs.
+
+Useful while training multi-task reinforcement learning algorithms.
+It provides observations augmented with one-hot representation of tasks.
+"""
+
+import random
+
+import akro
+import gym
+import numpy as np
+
+
+def round_robin_strategy(num_tasks, last_task=None):
+    """A function for sampling tasks in round robin fashion.
+
+    Args:
+        num_tasks (int): Total number of tasks.
+        last_task (int): Previously sampled task.
+
+    Returns:
+        int: task id.
+
+    """
+    if last_task is None:
+        return 0
+
+    return (last_task + 1) % num_tasks
+
+
+def uniform_random_strategy(num_tasks, _):
+    """A function for sampling tasks uniformly at random.
+
+    Args:
+        num_tasks (int): Total number of tasks.
+        _ (object): Ignored by this sampling strategy.
+
+    Returns:
+        int: task id.
+
+    """
+    return random.randint(0, num_tasks - 1)
+
+
+class MultiEnvWrapper(gym.Wrapper):
+    """A wrapper class to handle multiple gym environments.
+
+    Args:
+        envs (list(gym.Env)):
+            A list of objects implementing gym.Env.
+        sample_strategy (function(int, int)):
+            Sample strategy to be used when sampling a new task.
+
+    """
+
+    def __init__(self, envs, sample_strategy=uniform_random_strategy):
+
+        self._sample_strategy = sample_strategy
+        self._num_tasks = len(envs)
+        self._active_task_index = None
+        self._observation_space = None
+
+        super().__init__(envs[0])
+
+        self._task_envs = []
+        for env in envs:
+            if (env.observation_space.shape !=
+                    self.env.observation_space.shape):
+                raise ValueError(
+                    'Observation space of all envs should be same.')
+            if env.action_space.shape != self.env.action_space.shape:
+                raise ValueError('Action space of all envs should be same.')
+            self._task_envs.append(env)
+
+        self.env.spec.observation_space = self.observation_space
+
+    @property
+    def num_tasks(self):
+        """Total number of tasks.
+
+        Returns:
+            int: number of tasks.
+
+        """
+        return len(self._task_envs)
+
+    @property
+    def task_space(self):
+        """Task Space.
+
+        Returns:
+            akro.Box: Task space.
+
+        """
+        one_hot_ub = np.ones(self.num_tasks)
+        one_hot_lb = np.zeros(self.num_tasks)
+        return akro.Box(one_hot_lb, one_hot_ub)
+
+    @property
+    def active_task_index(self):
+        """Index of active task env.
+
+        Returns:
+            int: Index of active task.
+
+        """
+        return self._active_task_index
+
+    @property
+    def observation_space(self):
+        """Observation space.
+
+        Returns:
+            akro.Box: Observation space.
+
+        """
+        task_lb, task_ub = self.task_space.bounds
+        env_lb, env_ub = self._observation_space.bounds
+        return akro.Box(np.concatenate([task_lb, env_lb]),
+                        np.concatenate([task_ub, env_ub]))
+
+    @observation_space.setter
+    def observation_space(self, observation_space):
+        """Observation space setter.
+
+        Args:
+            observation_space (akro.Box): Observation space.
+
+        """
+        self._observation_space = observation_space
+
+    @property
+    def active_task_one_hot(self):
+        """One-hot representation of active task.
+
+        Returns:
+            numpy.ndarray: one-hot representation of active task
+
+        """
+        one_hot = np.zeros(self.task_space.shape)
+        index = self.active_task_index or 0
+        one_hot[index] = self.task_space.high[index]
+        return one_hot
+
+    def reset(self, **kwargs):
+        """Sample new task and call reset on new task env.
+
+        Args:
+            kwargs (dict): Keyword arguments to be passed to gym.Env.reset
+
+        Returns:
+            numpy.ndarray: active task one-hot representation + observation
+
+        """
+        self._active_task_index = self._sample_strategy(
+            self._num_tasks, self._active_task_index)
+        self.env = self._task_envs[self._active_task_index]
+        obs = self.env.reset(**kwargs)
+        oh_obs = self._obs_with_one_hot(obs)
+        return oh_obs
+
+    def step(self, action):
+        """gym.Env step for the active task env.
+
+        Args:
+            action (object): object to be passed in gym.Env.reset(action)
+
+        Returns:
+            object: agent's observation of the current environment
+            float: amount of reward returned after previous action
+            bool: whether the episode has ended
+            dict: contains auxiliary diagnostic information
+
+        """
+        obs, reward, done, info = self.env.step(action)
+        oh_obs = self._obs_with_one_hot(obs)
+        info['task_id'] = self._active_task_index
+        return oh_obs, reward, done, info
+
+    def close(self):
+        """Close all task envs."""
+        for env in self._task_envs:
+            env.close()
+
+    def _obs_with_one_hot(self, obs):
+        """Concatenate active task one-hot representation with observation.
+
+        Args:
+            obs (numpy.ndarray): observation
+
+        Returns:
+            numpy.ndarray: active task one-hot + observation
+
+        """
+        oh_obs = np.concatenate([self.active_task_one_hot, obs])
+        return oh_obs

--- a/src/garage/envs/wrappers/__init__.py
+++ b/src/garage/envs/wrappers/__init__.py
@@ -1,5 +1,4 @@
-"""
-gym.Env wrappers.
+"""gym.Env wrappers.
 
 Used to transform an environment in a modular way.
 It is also possible to apply multiple wrappers at the same
@@ -7,6 +6,7 @@ time.
 
 Example:
     StackFrames(GrayScale(gym.make('env')))
+
 """
 from garage.envs.wrappers.atari_env import AtariEnv
 from garage.envs.wrappers.clip_reward import ClipReward

--- a/tests/garage/envs/test_multi_env_wrapper.py
+++ b/tests/garage/envs/test_multi_env_wrapper.py
@@ -1,0 +1,145 @@
+"""Tests for garage.envs.multi_env_wrapper"""
+import akro
+import numpy as np
+import pytest
+
+from garage.envs.multi_env_wrapper import (MultiEnvWrapper,
+                                           round_robin_strategy,
+                                           uniform_random_strategy)
+from garage.tf.envs import TfEnv
+
+
+class TestMultiEnvWrapper:
+    """Tests for garage.envs.multi_env_wrapper"""
+
+    def test_tasks_from_same_env(self):
+        """test init with multiple tasks from same env"""
+        envs = ['CartPole-v0', 'CartPole-v0']
+        mt_env = self._init_multi_env_wrapper(envs)
+        assert mt_env.num_tasks == 2
+
+    def test_tasks_from_different_envs(self):
+        """test init with multiple tasks from different env"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(envs)
+        assert mt_env.num_tasks == 2
+
+    def test_raise_exception_when_different_obs_space(self):
+        """test if exception is raised when using tasks with different obs space"""  # noqa: E501
+        envs = ['CartPole-v0', 'Blackjack-v0']
+        with pytest.raises(ValueError):
+            _ = self._init_multi_env_wrapper(envs)
+
+    def test_raise_exception_when_different_action_space(self):
+        """test if exception is raised when using tasks with different action space"""  # noqa: E501
+        envs = ['LunarLander-v2', 'LunarLanderContinuous-v2']
+        with pytest.raises(ValueError):
+            _ = self._init_multi_env_wrapper(envs)
+
+    def test_default_active_task_is_none(self):
+        """test if default active task is none"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(
+            envs, sample_strategy=round_robin_strategy)
+        assert mt_env.active_task_index is None
+
+    def test_one_hot_observation_space(self):
+        """test one hot representation of observation space"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(envs)
+        cartpole = TfEnv(env_name='CartPole-v0')
+        cartpole_lb, cartpole_ub = cartpole.observation_space.bounds
+        obs_space = akro.Box(np.concatenate([np.zeros(2), cartpole_lb]),
+                             np.concatenate([np.ones(2), cartpole_ub]))
+        assert mt_env.observation_space.shape == obs_space.shape
+        assert (
+            mt_env.observation_space.bounds[0] == obs_space.bounds[0]).all()
+        assert (
+            mt_env.observation_space.bounds[1] == obs_space.bounds[1]).all()
+
+    def test_action_space(self):
+        """test action space"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(envs)
+        task1 = TfEnv(env_name='CartPole-v0')
+        assert mt_env.action_space.shape == task1.action_space.shape
+
+    def test_round_robin_sample_strategy(self):
+        """test round robin samping strategy"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(
+            envs, sample_strategy=round_robin_strategy)
+        tasks = []
+        for _ in envs:
+            mt_env.reset()
+            _, _, _, info = mt_env.step(1)
+            tasks.append(info['task_id'])
+
+        assert tasks[0] == 0 and tasks[1] == 1
+
+    def test_uniform_random_sample_strategy(self):
+        """test uniform_random sampling strategy"""
+        envs = ['CartPole-v0', 'CartPole-v1', 'CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(
+            envs, sample_strategy=uniform_random_strategy)
+        tasks = []
+        for _ in envs:
+            mt_env.reset()
+            _, _, _, info = mt_env.step(1)
+            tasks.append(info['task_id'])
+
+        for task in tasks:
+            assert 0 <= task < 4
+
+    def test_task_remains_same_between_multiple_step_calls(self):
+        """test if active_task remains same between multiple step calls"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(
+            envs, sample_strategy=round_robin_strategy)
+        mt_env.reset()
+        tasks = []
+        for _ in envs:
+            _, _, _, info = mt_env.step(1)
+            tasks.append(info['task_id'])
+
+        assert tasks[0] == 0 and tasks[1] == 0
+
+    def test_task_space(self):
+        """test task space"""
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(envs)
+        bounds = mt_env.task_space.bounds
+        lb = np.zeros(2)
+        ub = np.ones(2)
+        assert (bounds[0] == lb).all() and (bounds[1] == ub).all()
+
+    def test_one_hot_observation(self):
+        """test if output of step function is correct"""
+        envs = ['CartPole-v0', 'CartPole-v0']
+        mt_env = self._init_multi_env_wrapper(
+            envs, sample_strategy=round_robin_strategy)
+
+        obs = mt_env.reset()
+        assert (obs[:2] == np.array([1., 0.])).all()
+        obs = mt_env.step(1)[0]
+        assert (obs[:2] == np.array([1., 0.])).all()
+
+        obs = mt_env.reset()
+        assert (obs[:2] == np.array([0., 1.])).all()
+        obs = mt_env.step(1)[0]
+        assert (obs[:2] == np.array([0., 1.])).all()
+
+    def _init_multi_env_wrapper(self,
+                                env_names,
+                                sample_strategy=uniform_random_strategy):
+        """helper function to initialize multi_env_wrapper
+
+        Args:
+            env_names (list(str)): List of gym.Env names.
+            sample_strategy (func): A sampling strategy.
+
+        Returns:
+            garage.envs.multi_env_wrapper: Multi env wrapper.
+        """
+        task_envs = [TfEnv(env_name=name) for name in env_names]
+        return MultiEnvWrapper(task_envs, sample_strategy=sample_strategy)


### PR DESCRIPTION
This PR does following.

- Add `MultiEnvWrapper`: A wrapper that handles multiple envs and provides observations augmented with one-hot representation of tasks..
- Add tests for `MultiEnvWrapper`.
- Add example for `MultiEnvWrapper`.
