### PR TITLE
Set fixed conda version temporarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ci-verify-conda: CONDA_ROOT := $$HOME/miniconda
 ci-verify-conda: CONDA := $(CONDA_ROOT)/bin/conda
 ci-verify-conda: GARAGE_BIN = $(CONDA_ROOT)/envs/garage/bin
 ci-verify-conda:
-	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+	wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O miniconda.sh
 	bash miniconda.sh -b -p $(CONDA_ROOT)
 	hash -r
 	$(CONDA) config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
Bug: https://github.com/conda/conda/issues/9345
Due to this bug in the latest conda installer (4.7.12), our conda builds keep breaking on CI.

This PR sets miniconda to last working version (4.7.10) until the bug gets fixed.