### PR TITLE
Disable some pylint rules

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,5 +5,13 @@ load-plugins = pylint.extensions.docparams, pylint.extensions.docstyle
 # Go as fast as you can
 jobs = 0
 
+[MESSAGES CONTROL]
+disable =
+    # Algorithms and neural networks generally have a lot of variables
+    too-many-instance-attributes,
+    too-many-arguments,
+    too-many-locals,
+    invalid-name,  # let flake8 handle this
+
 [REPORTS]
 msg-template = {path}:{symbol}:{line:3d},{column}: {msg}


### PR DESCRIPTION
* Disable rules about numbers of variables and args, because neural network definitions and algorithm hyperparameters naturally create lots of attributes, locals, and function arguments
* Disable rules around naming because flake8 already does this (and is better at it)