### PR TITLE
Use separate pylint configuration for unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,21 @@ repos:
         name: Check commit message
         language: script
         entry: scripts/check_commit_message
-    -   id: pylint
-        name: pylint
-        entry: pylint
+    -   id: check-pylint-normal
+        name: Check pylint (except unit tests)
+        types: [file, python]
+        exclude: ^tests/garage/.*$  # exclude unit tests
+        require_serial: true  # pylint does its own parallelism
         language: system
-        files: \.py$
+        entry: pylint
+    -   id: check-pylint-unit-tests
+        name: Check pylint for unit tests
+        types: [file, python]
+        files: ^tests/garage/.*$  # check only unit tests
+        require_serial: true  # pylint does its own parallelism
+        language: system
+        entry: pylint
+        args: [--rcfile=tests/garage/.pylintrc]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
@@ -48,7 +58,7 @@ repos:
     rev: v0.28.0
     hooks:
     -   id: yapf
-        name: Check format by yapf
+        name: Check format with yapf
         args: ['-vv', '-dpr']
 
 # Second pass: format in-place
@@ -56,5 +66,5 @@ repos:
     rev: v0.28.0
     hooks:
     -   id: yapf
-        name: Format in-place by yapf
+        name: Format in-place with yapf
         args: ['-vv', '-ipr']

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ EXTRAS['dev'] = [
     'pre-commit',
     'pycodestyle>=2.5.0',
     'pydocstyle>=4.0.0',
-    'pylint==1.9.2',
+    'pylint>=2.4.3',
     'pytest>=3.6',  # Required for pytest-cov on Python 3.6
     'pytest-cov',
     'pytest-xdist',

--- a/tests/garage/.pylintrc
+++ b/tests/garage/.pylintrc
@@ -27,6 +27,19 @@ disable =
     too-many-locals,
     # Detection seems buggy or unhelpful
     duplicate-code,
+    # Rules disabled *for unit tests only*
+    attribute-defined-outside-init,
+    differing-param-doc,
+    differing-type-doc,
+    docstring-first-line-empty,
+    missing-docstring,
+    missing-param-doc,
+    missing-return-doc,
+    missing-return-type-doc,
+    missing-type-doc,
+    no-self-use,
+    protected-access,
+    too-few-public-methods,
 
 
 [REPORTS]
@@ -37,12 +50,3 @@ output-format = colorized
 [TYPECHECK]
 # Packages which might not admit static analysis because they have C extensions
 generated-members = torch.*
-
-
-[PARAMETER_DOCUMENTATION]
-# Docstrings are required and should be complete
-accept-no-param-doc=no
-accept-no-raise-doc=no
-accept-no-return-doc=no
-accept-no-yields-doc=no
-default-docstring-type=google


### PR DESCRIPTION
* Makes a separate .pylintrc for unit tests
* Configures .pre-commit-config.yaml to run two different pylint jobs
* Updates pylint to the latest version (better C extension handling)
* Disables several more rules for all code