### PR TITLE
Revert "Set fixed conda version temporarily(#947)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ci-verify-conda: CONDA_ROOT := $$HOME/miniconda
 ci-verify-conda: CONDA := $(CONDA_ROOT)/bin/conda
 ci-verify-conda: GARAGE_BIN = $(CONDA_ROOT)/envs/garage/bin
 ci-verify-conda:
-	wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O miniconda.sh
+	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 	bash miniconda.sh -b -p $(CONDA_ROOT)
 	hash -r
 	$(CONDA) config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
Closes #951 

This reverts commit e91685e1b22c8fbc19b0f3780f90ae8d69605d86.

https://github.com/conda/conda/issues/9345 was fixed in miniconda 4.7.12.1