### PR TITLE
Revert "Set fixed conda version temporarily(#949)"

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -68,7 +68,7 @@ RUN mkdir /root/.mujoco && \
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mjpro150/bin
 
 # conda
-RUN wget https://repo.continuum.io/miniconda/Miniconda2-4.7.10-Linux-x86_64.sh -O miniconda.sh && \
+RUN wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh && \
   bash miniconda.sh -b -p /opt/conda && \
   rm miniconda.sh && \
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -190,7 +190,7 @@ fi
 CONDA_SH="${HOME}/miniconda2/etc/profile.d/conda.sh"
 if [[ ! -d "${HOME}/miniconda2" ]]; then
   CONDA_INSTALLER="$(mktemp -d)/miniconda.sh"
-  wget https://repo.continuum.io/miniconda/Miniconda2-4.7.10-Linux-x86_64.sh \
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh \
     -O "${CONDA_INSTALLER}"
   chmod u+x "${CONDA_INSTALLER}"
   bash "${CONDA_INSTALLER}" -b -u

--- a/scripts/setup_macos.sh
+++ b/scripts/setup_macos.sh
@@ -213,7 +213,7 @@ fi
 CONDA_SH="${HOME}/miniconda2/etc/profile.d/conda.sh"
 if [[ ! -d "${HOME}/miniconda2" ]]; then
   CONDA_INSTALLER="$(mktemp -d)/miniconda.sh"
-  wget https://repo.continuum.io/miniconda/Miniconda2-4.7.10-MacOSX-x86_64.sh \
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh \
     -O "${CONDA_INSTALLER}"
   chmod u+x "${CONDA_INSTALLER}"
   bash "${CONDA_INSTALLER}" -b -u


### PR DESCRIPTION
This reverts commit 0e3a627a3adf08d66447149c5d677d5d7adb581e.

https://github.com/conda/conda/issues/9345 was fixed in miniconda 4.7.12.1