### PR TITLE
Stop codecov from reporting too early

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,3 +4,7 @@ coverage:
     patch:
       default:
         target: 90%
+
+codecov:
+    notify:
+        after_n_builds: 2  # do not post a PR status until at least 2 coverage reports have been received


### PR DESCRIPTION
See https://docs.codecov.io/docs/notifications#section-preventing-notifications-until-after-n-builds