### PR TITLE
Add separate Travis job for pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 fail_fast: false # set to true to have pre-commit stop running hooks after the first failure.
+default_stages: [commit, push]
 
 repos:
 -   repo: local

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,12 @@ env:
 
 jobs:
   include:
-    - name: "Normal tests and pre-commit checks"
+    # pre-commit checks only run for pull requests
+    - if: type = pull_request
+      name: "Pre-commit checks"
+      env:
+        - JOB_RUN_CMD="make ci-job-precommit"
+    - name: "Normal tests and docs"
       env:
         - JOB_RUN_CMD="make ci-job-normal"
         - DEPLOY_FROM_THIS_JOB="true"

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ docs:  ## Build HTML documentation
 docs:
 	@pushd docs && make html && popd
 
-ci-precommit-check:
+ci-job-precommit:
 	scripts/travisci/check_precommit.sh
 
-ci-job-normal: ci-precommit-check docs
+ci-job-normal: docs
 	pytest -n $$(nproc) --cov=garage -v -m \
 	    'not nightly and not huge and not flaky and not large'
 	coverage xml

--- a/scripts/travisci/check_precommit.sh
+++ b/scripts/travisci/check_precommit.sh
@@ -7,24 +7,21 @@ ORIGIN="${TRAVIS_COMMIT_RANGE#*...}"
 pre-commit run --source "${SOURCE}" --origin "${ORIGIN}"
 status="$((${status} | ${?}))"
 
-# Check commit messages for pull requests only
-if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then
-  while read commit; do
-    echo "Checking commit message for ${commit}"
-    commit_msg="$(mktemp)"
-    git log --format=%B -n 1 "${commit}" > "${commit_msg}"
-    scripts/check_commit_message "${commit_msg}"
-    pass=$?
-    status="$((${status} | ${pass}))"
+while read commit; do
+  echo "Checking commit message for ${commit}"
+  commit_msg="$(mktemp)"
+  git log --format=%B -n 1 "${commit}" > "${commit_msg}"
+  scripts/check_commit_message "${commit_msg}"
+  pass=$?
+  status="$((${status} | ${pass}))"
 
-    # Print message if it fails
-    if [[ "${pass}" -ne 0 ]]; then
-      echo "Failing commit message:"
-      cat "${commit_msg}"
-    fi
+  # Print message if it fails
+  if [[ "${pass}" -ne 0 ]]; then
+    echo "Failing commit message:"
+    cat "${commit_msg}"
+  fi
 
-  done < <(git log --cherry-pick --left-only --pretty="%H" \
-                   "${ORIGIN}...${SOURCE}")
-fi
+done < <(git log --cherry-pick --left-only --pretty="%H" \
+                 "${ORIGIN}...${SOURCE}")
 
 exit "${status}"


### PR DESCRIPTION
This PR adds a separate CI job for pre-commit checks. This makes it
easier to distinguish at a glance pre-commit failures from test
failures. It also allows us to disable this job for non-PR builds.

The downside of this PR is that it adds an additionao build job and
~5 minutes of overhead to the PR build process, because it must pull
the Docker cache. For builds which update the Docker container, this
will add an additional ~10 minutes to rebuild the container. This can
be addressed in a later PR by adding a separate build stage to build
and cache the container.