### PR TITLE
Eliminate unnecessary worker startup

### DIFF
--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -108,7 +108,6 @@ def _args(buffer_size):
 replay_buffer_size = _args.main(standalone_mode=False)
 run_experiment(
     run_task,
-    n_parallel=1,
     snapshot_mode='last',
     seed=1,
     plot=False,

--- a/src/garage/experiment/experiment_wrapper.py
+++ b/src/garage/experiment/experiment_wrapper.py
@@ -20,7 +20,6 @@ import psutil
 
 from garage.experiment import deterministic, SnapshotConfig
 import garage.plotter
-from garage.sampler import parallel_sampler
 import garage.tf.plotter
 
 
@@ -43,12 +42,6 @@ def run_experiment(argv):
 
     default_exp_name = 'experiment_%s_%s' % (timestamp, rand_id)
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--n_parallel',
-        type=int,
-        default=1,
-        help=('Number of parallel workers to perform rollouts. '
-              "0 => don't start any workers"))
     parser.add_argument('--exp_name',
                         type=str,
                         default=default_exp_name,
@@ -125,11 +118,6 @@ def run_experiment(argv):
     if args.seed is not None:
         deterministic.set_seed(args.seed)
 
-    if args.n_parallel > 0:
-        parallel_sampler.initialize(n_parallel=args.n_parallel)
-        if args.seed is not None:
-            parallel_sampler.set_seed(args.seed)
-
     if not args.plot:
         garage.plotter.Plotter.disable()
         garage.tf.plotter.Plotter.disable()
@@ -171,8 +159,6 @@ def run_experiment(argv):
     except BaseException:
         children = garage.plotter.Plotter.get_plotters()
         children += garage.tf.plotter.Plotter.get_plotters()
-        if args.n_parallel > 0:
-            children += [parallel_sampler]
         child_proc_shutdown(children)
         raise
 

--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -7,6 +7,7 @@ from dowel import logger, tabular
 
 from garage.experiment.deterministic import get_seed, set_seed
 from garage.experiment.snapshotter import Snapshotter
+from garage.sampler import parallel_sampler
 
 
 class ExperimentStats:
@@ -114,10 +115,12 @@ class LocalRunner:
                                         snapshot_config.snapshot_mode,
                                         snapshot_config.snapshot_gap)
 
-        if max_cpus > 1:
-            # pylint: disable=import-outside-toplevel
-            from garage.sampler import singleton_pool
-            singleton_pool.initialize(max_cpus)
+        parallel_sampler.initialize(max_cpus)
+
+        seed = get_seed()
+        if seed is not None:
+            parallel_sampler.set_seed(seed)
+
         self._has_setup = False
         self._plot = False
 

--- a/src/garage/sampler/base.py
+++ b/src/garage/sampler/base.py
@@ -1,35 +1,39 @@
+"""Base class of Sampler."""
 import abc
 
 
 class Sampler(abc.ABC):
+    """Sampler interface."""
+
     @abc.abstractmethod
     def start_worker(self):
-        """Initialize the sampler,
+        """Initialize the sampler.
 
         e.g. launching parallel workers if necessary.
+
         """
-        pass
 
     @abc.abstractmethod
-    def obtain_samples(self, itr):
+    def obtain_samples(self, itr, batch_size, whole_paths):
         """Collect samples for the given iteration number.
 
         Args:
-            itr (int): Iteration number.
+            itr (int): Number of iteration.
+            batch_size (int): Number of environment steps in one batch.
+            whole_paths (bool): Whether to use whole path or truncated.
 
         Returns:
             list[dict]: A list of paths.
 
         """
-        pass
 
     @abc.abstractmethod
     def shutdown_worker(self):
         """Terminate workers if necessary."""
-        pass
 
 
 class BaseSampler(Sampler):
+    # pylint: disable=abstract-method
     """Base class for sampler.
 
     Args:

--- a/src/garage/sampler/batch_sampler.py
+++ b/src/garage/sampler/batch_sampler.py
@@ -1,5 +1,4 @@
 """Class with batch-based sampling."""
-
 from garage.sampler import parallel_sampler
 from garage.sampler.base import BaseSampler
 from garage.sampler.utils import truncate_paths
@@ -14,9 +13,6 @@ class BatchSampler(BaseSampler):
 
     """
 
-    def __init__(self, algo, env):
-        super().__init__(algo, env)
-
     def start_worker(self):
         """Start workers."""
         parallel_sampler.populate_task(self.env,
@@ -28,7 +24,17 @@ class BatchSampler(BaseSampler):
         parallel_sampler.terminate_task(scope=self.algo.scope)
 
     def obtain_samples(self, itr, batch_size=None, whole_paths=True):
-        """Obtain samples."""
+        """Obtain samples.
+
+        Args:
+            itr (int): Number of iteration.
+            batch_size (int): Number of environment steps in one batch.
+            whole_paths (bool): Whether to use whole path or truncated.
+
+        Returns:
+            list[dict]: A list of paths.
+
+        """
         if not batch_size:
             batch_size = self.algo.max_path_length
 

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -2,9 +2,9 @@
 
 Uses a data parallel design.
 Included is a sampler that deploys sampler workers.
-
 The sampler workers must implement some type of set agent parameters
-function, and a rollout function
+function, and a rollout function.
+
 """
 from collections import defaultdict
 import pickle
@@ -222,12 +222,12 @@ class SamplerWorker:
 
         The following value for the following keys will be a 2D array,
         with the first dimension corresponding to the time dimension.
-
         - observations
         - actions
         - rewards
         - next_observations
         - terminals
+
         The next two elements will be lists of dictionaries, with
         the index into the list being the index into the time
         - agent_infos

--- a/src/garage/tf/experiment/local_tf_runner.py
+++ b/src/garage/tf/experiment/local_tf_runner.py
@@ -1,5 +1,4 @@
-"""
-The local runner for TensorFlow algorithms.
+"""The local runner for TensorFlow algorithms.
 
 A runner setup context for algorithms during initialization and
 pipelines data between sampler and algorithm during training.
@@ -82,7 +81,7 @@ class LocalTFRunner(LocalRunner):
         """Set self.sess as the default session.
 
         Returns:
-            This local runner.
+            LocalTFRunner: This local runner.
 
         """
         if tf.compat.v1.get_default_session() is not self.sess:
@@ -91,7 +90,14 @@ class LocalTFRunner(LocalRunner):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Leave session."""
+        """Leave session.
+
+        Args:
+            exc_type (str): Type.
+            exc_val (object): Value.
+            exc_tb (object): Traceback.
+
+        """
         if tf.compat.v1.get_default_session(
         ) is self.sess and self.sess_entered:
             self.sess.__exit__(exc_type, exc_val, exc_tb)

--- a/tests/garage/sampler/test_is_sampler.py
+++ b/tests/garage/sampler/test_is_sampler.py
@@ -49,7 +49,7 @@ class TestISSampler(TfGraphTestCase):
             with unittest.mock.patch.object(ISSampler,
                                             '_obtain_is_samples') as mocked:
                 runner._sampler.n_is_pretrain = 5
-                runner._sampler.n_backtrack = 'all'
+                runner._sampler.n_backtrack = None
                 runner._sampler.obtain_samples(4)
 
                 mocked.assert_called_once_with(4, None, True)

--- a/tests/garage/sampler/test_sampler.py
+++ b/tests/garage/sampler/test_sampler.py
@@ -1,13 +1,7 @@
 from dowel import logger
-import pytest
+import numpy as np
 
-from garage.np.baselines import LinearFeatureBaseline
-from garage.tf.algos import VPG
-from garage.tf.envs import TfEnv
-from garage.tf.experiment import LocalTFRunner
-from garage.tf.policies import CategoricalMLPPolicy
-from garage.tf.samplers import BatchSampler
-from tests.fixtures import snapshot_config
+from garage.sampler.utils import truncate_paths
 from tests.fixtures.logger import NullOutput
 
 
@@ -19,47 +13,28 @@ class TestSampler:
     def teardown_method(self):
         logger.remove_all()
 
-    # Note:
-    #   test_batch_sampler should pass if tested independently
-    #   from other tests, but cannot be tested on CI.
-    #
-    #   This is because nose2 runs all tests in a single process,
-    #   when this test is running, tensorflow has already been initialized,
-    #   and later singleton_pool will hang because tensorflow is not fork-safe.
-    @pytest.mark.flaky
-    def test_tf_batch_sampler(self):
-        max_cpus = 8
-        with LocalTFRunner(snapshot_config, max_cpus=max_cpus) as runner:
-            env = TfEnv(env_name='CartPole-v1')
+    def test_truncate_paths(self):
+        paths = [
+            dict(
+                observations=np.zeros((100, 1)),
+                actions=np.zeros((100, 1)),
+                rewards=np.zeros(100),
+                env_infos=dict(),
+                agent_infos=dict(lala=np.zeros(100)),
+            ),
+            dict(
+                observations=np.zeros((50, 1)),
+                actions=np.zeros((50, 1)),
+                rewards=np.zeros(50),
+                env_infos=dict(),
+                agent_infos=dict(lala=np.zeros(50)),
+            ),
+        ]
 
-            policy = CategoricalMLPPolicy(name='policy',
-                                          env_spec=env.spec,
-                                          hidden_sizes=(32, 32))
-
-            baseline = LinearFeatureBaseline(env_spec=env.spec)
-
-            algo = VPG(env_spec=env.spec,
-                       policy=policy,
-                       baseline=baseline,
-                       max_path_length=1,
-                       discount=0.99)
-
-            runner.setup(algo,
-                         env,
-                         sampler_cls=BatchSampler,
-                         sampler_args={'n_envs': max_cpus})
-
-            try:
-                runner.initialize_tf_vars()
-            except BaseException:
-                raise AssertionError(
-                    'LocalRunner should be able to initialize tf variables.')
-
-            runner._start_worker()
-
-            paths = runner._sampler.obtain_samples(0,
-                                                   batch_size=8,
-                                                   whole_paths=True)
-            assert len(paths) >= max_cpus, (
-                'BatchSampler should sample more than max_cpus={} '
-                'trajectories'.format(max_cpus))
+        truncated = truncate_paths(paths, 130)
+        assert len(truncated) == 2
+        assert len(truncated[-1]['observations']) == 30
+        assert len(truncated[0]['observations']) == 100
+        # make sure not to change the original one
+        assert len(paths) == 2
+        assert len(paths[-1]['observations']) == 50

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -108,7 +108,7 @@ class TestTRPO(TfGraphTestCase):
 
             env.close()
 
-    @pytest.mark.large
+    @pytest.mark.flaky
     def test_trpo_gru_cartpole(self):
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             env = TfEnv(normalize(gym.make('CartPole-v1')))

--- a/tests/garage/tf/samplers/test_tf_batch_sampler.py
+++ b/tests/garage/tf/samplers/test_tf_batch_sampler.py
@@ -1,0 +1,54 @@
+import pytest
+
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import VPG
+from garage.tf.envs import TfEnv
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.policies import CategoricalMLPPolicy
+from garage.tf.samplers import BatchSampler
+from tests.fixtures import snapshot_config
+
+
+class TestTFSampler:
+    # Note:
+    #   test_batch_sampler should pass if tested independently
+    #   from other tests, but cannot be tested on CI.
+    #
+    #   This is because tensorflow is not fork-safe.
+    @pytest.mark.flaky
+    def test_tf_batch_sampler(self):
+        max_cpus = 8
+        with LocalTFRunner(snapshot_config, max_cpus=max_cpus) as runner:
+            env = TfEnv(env_name='CartPole-v1')
+
+            policy = CategoricalMLPPolicy(name='policy',
+                                          env_spec=env.spec,
+                                          hidden_sizes=(32, 32))
+
+            baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+            algo = VPG(env_spec=env.spec,
+                       policy=policy,
+                       baseline=baseline,
+                       max_path_length=1,
+                       discount=0.99)
+
+            runner.setup(algo,
+                         env,
+                         sampler_cls=BatchSampler,
+                         sampler_args={'n_envs': max_cpus})
+
+            try:
+                runner.initialize_tf_vars()
+            except BaseException:
+                raise AssertionError(
+                    'LocalRunner should be able to initialize tf variables.')
+
+            runner._start_worker()
+
+            paths = runner._sampler.obtain_samples(0,
+                                                   batch_size=8,
+                                                   whole_paths=True)
+            assert len(paths) >= max_cpus, (
+                'BatchSampler should sample more than max_cpus={} '
+                'trajectories'.format(max_cpus))


### PR DESCRIPTION
#865.

Before this PR:
1. `n_parallel` is passed as a parameter to experiment API to set `parallel_sampler`
2. `LocalRunner` set `max_cpus`, which is the same as above

This PR addresses:

1. remove `n_parallel` setup from `experiment.py`
2. for tf algorithms, `LocalTFRunner` sets `max_cpus` to initialize `parallel_sampler`. (this is due to tf session not being fork safe, therefore `parallel_sampler` must be initialized before setting sessions)
3. for all other algorithms, remove `max_cpus` from `LocalRuner` and move it to `batch_sampler`, so that it is only initialized when in need

Also addresses:
- relocate and rename a test for `tf_batch_sampler`

In order to pass pylint, also does:
- remove `BaseSampler` which is unnecessary, use `Sampler` as base class directly
- update docs, set initialization inside `__init()__`..., for `LocalRunner`, `RaySampler`, etc.

