### PR TITLE
Add flake8 exception for torch.nn.functional as F

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,11 @@
 import-order-style = google
 application-import-names = tests, garage, examples
 per-file-ignores =
-    ./src/garage/misc/krylov.py:N802,N803,N806
+    # interferes with idiomatic `from torch.nn import functional as F`
+    ./src/garage/torch/*:N812
+    ./tests/garage/torch/*:N812
+    ./examples/torch/*:N812
+    # tests don't need docstrings
     ./tests/*:D
 
 # Docstring style checks


### PR DESCRIPTION
This will prevent N812 errors when you attempt to do
```python
from torch.nn import functional as F
```