### PR TITLE
Move docs build to pre-commit job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       name: "Pre-commit checks"
       env:
         - JOB_RUN_CMD="make ci-job-precommit"
-    - name: "Normal tests and docs"
+    - name: "Normal tests"
       env:
         - JOB_RUN_CMD="make ci-job-normal"
         - DEPLOY_FROM_THIS_JOB="true"

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ docs:  ## Build HTML documentation
 docs:
 	@pushd docs && make html && popd
 
-ci-job-precommit:
+ci-job-precommit: docs
 	scripts/travisci/check_precommit.sh
 
-ci-job-normal: docs
+ci-job-normal:
 	pytest -n $$(nproc) --cov=garage -v -m \
 	    'not nightly and not huge and not flaky and not large'
 	coverage xml


### PR DESCRIPTION
Checks that the docs build in the pre-commit job, rather than the unit tests
job. This unclutters unit tests results.