### PR TITLE
Add stats of total env steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-pylint-normal
         name: Check pylint (except unit tests)
         types: [file, python]
-        exclude: ^tests/garage/.|tests/fixtures/.*$  # exclude unit tests
+        exclude: ^tests/garage/.*$  # exclude unit tests
         require_serial: true  # pylint does its own parallelism
         language: system
         entry: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-pylint-normal
         name: Check pylint (except unit tests)
         types: [file, python]
-        exclude: ^tests/garage/.*$  # exclude unit tests
+        exclude: ^tests/garage/.|tests/fixtures/.*$  # exclude unit tests
         require_serial: true  # pylint does its own parallelism
         language: system
         entry: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -26,7 +26,7 @@ disable =
     too-many-arguments,
     too-many-locals,
     # Detection seems buggy or unhelpful
-    duplicate-code,
+    duplicate-code
 
 [REPORTS]
 msg-template = {path}:{line:3d},{column}: {msg} ({symbol})

--- a/scripts/garage
+++ b/scripts/garage
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Script for resuming training from command line."""
+# pylint: disable=no-name-in-module
 import click
 
 from garage.experiment import run_experiment
@@ -8,23 +9,26 @@ from garage.tf.experiment import LocalTFRunner
 
 @click.group()
 def cli():  # noqa: D103
-    pass
+    """The main command group."""
 
 
 @cli.command()
 @click.argument('from_dir')
 @click.option(
-    '--from_epoch',
-    default='last',
-    help='Index of epoch to restore from. Can be "first", "last" or a number. '
-    'Not applicable when snapshot_mode="last"')
-@click.option(
     '--log_dir',
     default=None,
-    help='Path to save the log snapshot. If not specified, will be the same '
+    help='Log path for resumed experiment. If not specified, will be the same '
     'as from_dir.')
+# pylint: disable=bad-docstring-quotes
+@click.option('--from_epoch',
+              default='last',
+              help='When there are multiple snapshots, '
+              'specify the index of epoch to restore from. '
+              'Can be "first", "last" or a number. '
+              'Not applicable when snapshot_mode="last"')
 def resume(from_dir, from_epoch, log_dir):
-    """Resume from command line."""
+    # pylint: disable=missing-param-doc, missing-type-doc
+    """Resume from experiment saved in FROM_DIR."""
     if log_dir is None:
         log_dir = from_dir
 

--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -1,11 +1,75 @@
 """Provides algorithms with access to most of garage's features."""
 import copy
 import time
-import types
 
 from dowel import logger, tabular
 
+from garage.experiment.deterministic import get_seed, set_seed
 from garage.experiment.snapshotter import Snapshotter
+
+
+class ExperimentStats:
+    # pylint: disable=too-few-public-methods
+    """Statistics of a experiment.
+
+    Args:
+        total_epoch (int): Total epoches.
+        total_itr (int): Total Iterations.
+        total_env_steps (int): Total environment steps collected.
+        last_path (list[dict]): Last sampled paths.
+
+    """
+
+    def __init__(self, total_epoch, total_itr, total_env_steps, last_path):
+        self.total_epoch = total_epoch
+        self.total_itr = total_itr
+        self.total_env_steps = total_env_steps
+        self.last_path = last_path
+
+
+class SetupArgs:
+    # pylint: disable=too-few-public-methods
+    """Arguments to setup a runner.
+
+    Args:
+        sampler_cls (garage.sampler.Sampler): A sampler class.
+        sampler_args (dict): Arguments to be passed to sampler constructor.
+        seed (int): Random seed.
+
+    """
+
+    def __init__(self, sampler_cls, sampler_args, seed):
+        self.sampler_cls = sampler_cls
+        self.sampler_args = sampler_args
+        self.seed = seed
+
+
+class TrainArgs:
+    # pylint: disable=too-few-public-methods
+    """Arguments to call train() or resume().
+
+    Args:
+        n_epochs (int): Number of epochs.
+        n_epoch_cycles (int): Number of batches of samples in each epoch.
+            This is only useful for off-policy algorithm.
+            For on-policy algorithm this value should always be 1.
+        batch_size (int): Number of environment steps in one batch.
+        plot (bool): Visualize policy by doing rollout after each epoch.
+        store_paths (bool): Save paths in snapshot.
+        pause_for_plot (bool): Pause for plot.
+        start_epoch (int): The starting epoch. Used for resume().
+
+    """
+
+    def __init__(self, n_epochs, n_epoch_cycles, batch_size, plot, store_paths,
+                 pause_for_plot, start_epoch):
+        self.n_epochs = n_epochs
+        self.n_epoch_cycles = n_epoch_cycles
+        self.batch_size = batch_size
+        self.plot = plot
+        self.store_paths = store_paths
+        self.pause_for_plot = pause_for_plot
+        self.start_epoch = start_epoch
 
 
 class LocalRunner:
@@ -54,13 +118,29 @@ class LocalRunner:
                                         snapshot_config.snapshot_gap)
 
         if max_cpus > 1:
+            # pylint: disable=import-outside-toplevel
             from garage.sampler import singleton_pool
             singleton_pool.initialize(max_cpus)
-        self.has_setup = False
-        self.plot = False
+        self._has_setup = False
+        self._plot = False
 
         self._setup_args = None
-        self.train_args = None
+        self._train_args = None
+        self._stats = ExperimentStats(total_itr=0,
+                                      total_env_steps=0,
+                                      total_epoch=0,
+                                      last_path=None)
+
+        self._algo = None
+        self._env = None
+        self._policy = None
+        self._sampler = None
+        self._plotter = None
+
+        self._start_time = None
+        self._itr_start_time = None
+        self.step_itr = None
+        self.step_path = None
 
     def setup(self, algo, env, sampler_cls=None, sampler_args=None):
         """Set up runner for algorithm and environment.
@@ -79,77 +159,84 @@ class LocalRunner:
             sampler_args (dict): Arguments to be passed to sampler constructor.
 
         """
-        self.algo = algo
-        self.env = env
-        self.policy = self.algo.policy
+        self._algo = algo
+        self._env = env
+        self._policy = self._algo.policy
 
         if sampler_args is None:
             sampler_args = {}
         if sampler_cls is None:
             sampler_cls = algo.sampler_cls
-        self.sampler = sampler_cls(algo, env, **sampler_args)
+        self._sampler = sampler_cls(algo, env, **sampler_args)
 
-        self.has_setup = True
+        self._has_setup = True
 
-        self._setup_args = types.SimpleNamespace(sampler_cls=sampler_cls,
-                                                 sampler_args=sampler_args)
+        self._setup_args = SetupArgs(sampler_cls=sampler_cls,
+                                     sampler_args=sampler_args,
+                                     seed=get_seed())
 
     def _start_worker(self):
         """Start Plotter and Sampler workers."""
-        self.sampler.start_worker()
-        if self.plot:
+        self._sampler.start_worker()
+        if self._plot:
+            # pylint: disable=import-outside-toplevel
             from garage.tf.plotter import Plotter
-            self.plotter = Plotter(self.env, self.policy)
-            self.plotter.start()
+            self._plotter = Plotter(self._env, self._policy)
+            self._plotter.start()
 
     def _shutdown_worker(self):
         """Shutdown Plotter and Sampler workers."""
-        self.sampler.shutdown_worker()
-        if self.plot:
-            self.plotter.close()
+        self._sampler.shutdown_worker()
+        if self._plot:
+            self._plotter.close()
 
     def obtain_samples(self, itr, batch_size=None):
         """Obtain one batch of samples.
 
         Args:
-            itr(int): Index of iteration (epoch).
-            batch_size(int): Number of steps in batch.
+            itr (int): Index of iteration (epoch).
+            batch_size (int): Number of steps in batch.
                 This is a hint that the sampler may or may not respect.
 
         Returns:
-            One batch of samples.
+            list[dict]: One batch of samples.
 
         """
-        if self.train_args.n_epoch_cycles == 1:
+        if self._train_args.n_epoch_cycles == 1:
             logger.log('Obtaining samples...')
-        return self.sampler.obtain_samples(
-            itr, (batch_size or self.train_args.batch_size))
 
-    def save(self, epoch, paths=None):
+        paths = self._sampler.obtain_samples(
+            itr, (batch_size or self._train_args.batch_size))
+
+        self._stats.total_env_steps += sum([len(p['rewards']) for p in paths])
+
+        return paths
+
+    def save(self, epoch):
         """Save snapshot of current batch.
 
         Args:
-            itr(int): Index of iteration (epoch).
-            paths(dict): Batch of samples after preprocessed. If None,
-                no paths will be logged to the snapshot.
+            epoch (int): Epoch.
+
+        Raises:
+            NotSetupError: if save() is called before the runner is set up.
 
         """
-        if not self.has_setup:
-            raise Exception('Use setup() to setup runner before saving.')
+        if not self._has_setup:
+            raise NotSetupError('Use setup() to setup runner before saving.')
 
         logger.log('Saving snapshot...')
 
         params = dict()
         # Save arguments
         params['setup_args'] = self._setup_args
-        params['train_args'] = self.train_args
+        params['train_args'] = self._train_args
+        params['stats'] = self._stats
 
         # Save states
-        params['env'] = self.env
-        params['algo'] = self.algo
-        if paths:
-            params['paths'] = paths
-        params['last_epoch'] = epoch
+        params['env'] = self._env
+        params['algo'] = self._algo
+
         self._snapshotter.save_itr_params(epoch, params)
 
         logger.log('Saved')
@@ -165,52 +252,60 @@ class LocalRunner:
                 Not applicable when snapshot_mode='last'.
 
         Returns:
-            A SimpleNamespace for train()'s arguments.
+            types.SimpleNamespace: A SimpleNamespace for train()'s arguments.
 
         """
         saved = self._snapshotter.load(from_dir, from_epoch)
 
         self._setup_args = saved['setup_args']
-        self.train_args = saved['train_args']
+        self._train_args = saved['train_args']
+        self._stats = saved['stats']
+
+        set_seed(self._setup_args.seed)
 
         self.setup(env=saved['env'],
                    algo=saved['algo'],
                    sampler_cls=self._setup_args.sampler_cls,
                    sampler_args=self._setup_args.sampler_args)
 
-        n_epochs = self.train_args.n_epochs
-        last_epoch = saved['last_epoch']
-        n_epoch_cycles = self.train_args.n_epoch_cycles
-        batch_size = self.train_args.batch_size
-        store_paths = self.train_args.store_paths
-        pause_for_plot = self.train_args.pause_for_plot
+        n_epochs = self._train_args.n_epochs
+        last_epoch = self._stats.total_epoch
+        last_itr = self._stats.total_itr
+        total_env_steps = self._stats.total_env_steps
+        n_epoch_cycles = self._train_args.n_epoch_cycles
+        batch_size = self._train_args.batch_size
+        store_paths = self._train_args.store_paths
+        pause_for_plot = self._train_args.pause_for_plot
 
         fmt = '{:<20} {:<15}'
         logger.log('Restore from snapshot saved in %s' %
                    self._snapshotter.snapshot_dir)
-        logger.log(fmt.format('Train Args', 'Value'))
+        logger.log(fmt.format('-- Train Args --', '-- Value --'))
         logger.log(fmt.format('n_epochs', n_epochs))
         logger.log(fmt.format('last_epoch', last_epoch))
         logger.log(fmt.format('n_epoch_cycles', n_epoch_cycles))
         logger.log(fmt.format('batch_size', batch_size))
         logger.log(fmt.format('store_paths', store_paths))
         logger.log(fmt.format('pause_for_plot', pause_for_plot))
+        logger.log(fmt.format('-- Stats --', '-- Value --'))
+        logger.log(fmt.format('last_itr', last_itr))
+        logger.log(fmt.format('total_env_steps', total_env_steps))
 
-        self.train_args.start_epoch = last_epoch + 1
-        return copy.copy(self.train_args)
+        self._train_args.start_epoch = last_epoch + 1
+        return copy.copy(self._train_args)
 
     def log_diagnostics(self, pause_for_plot=False):
         """Log diagnostics.
 
         Args:
-            pause_for_plot(bool): Pause for plot.
+            pause_for_plot (bool): Pause for plot.
 
         """
         logger.log('Time %.2f s' % (time.time() - self._start_time))
         logger.log('EpochTime %.2f s' % (time.time() - self._itr_start_time))
         logger.log(tabular)
-        if self.plot:
-            self.plotter.update_plot(self.policy, self.algo.max_path_length)
+        if self._plot:
+            self._plotter.update_plot(self._policy, self._algo.max_path_length)
             if pause_for_plot:
                 input('Plotting evaluation run: Press Enter to " "continue...')
 
@@ -224,34 +319,37 @@ class LocalRunner:
         """Start training.
 
         Args:
-            n_epochs(int): Number of epochs.
-            batch_size(int): Number of environment steps in one batch.
-            n_epoch_cycles(int): Number of batches of samples in each epoch.
+            n_epochs (int): Number of epochs.
+            batch_size (int): Number of environment steps in one batch.
+            n_epoch_cycles (int): Number of batches of samples in each epoch.
                 This is only useful for off-policy algorithm.
                 For on-policy algorithm this value should always be 1.
-            plot(bool): Visualize policy by doing rollout after each epoch.
-            store_paths(bool): Save paths in snapshot.
-            pause_for_plot(bool): Pause for plot.
+            plot (bool): Visualize policy by doing rollout after each epoch.
+            store_paths (bool): Save paths in snapshot.
+            pause_for_plot (bool): Pause for plot.
+
+        Raises:
+            NotSetupError: If train() is called before setup().
 
         Returns:
-            The average return in last epoch cycle.
+            float: The average return in last epoch cycle.
 
         """
-        if not self.has_setup:
-            raise Exception('Use setup() to setup runner before training.')
+        if not self._has_setup:
+            raise NotSetupError('Use setup() to setup runner before training.')
 
         # Save arguments for restore
-        self.train_args = types.SimpleNamespace(n_epochs=n_epochs,
-                                                n_epoch_cycles=n_epoch_cycles,
-                                                batch_size=batch_size,
-                                                plot=plot,
-                                                store_paths=store_paths,
-                                                pause_for_plot=pause_for_plot,
-                                                start_epoch=0)
+        self._train_args = TrainArgs(n_epochs=n_epochs,
+                                     n_epoch_cycles=n_epoch_cycles,
+                                     batch_size=batch_size,
+                                     plot=plot,
+                                     store_paths=store_paths,
+                                     pause_for_plot=pause_for_plot,
+                                     start_epoch=0)
 
-        self.plot = plot
+        self._plot = plot
 
-        return self.algo.train(self)
+        return self._algo.train(self)
 
     def step_epochs(self):
         """Step through each epoch.
@@ -274,26 +372,27 @@ class LocalRunner:
                 runner.step_itr += 1
 
         """
-        try:
-            self._start_worker()
-            self._start_time = time.time()
-            self.step_itr = (self.train_args.start_epoch *
-                             self.train_args.n_epoch_cycles)
-            self.step_path = None
+        self._start_worker()
+        self._start_time = time.time()
+        self.step_itr = self._stats.total_itr
+        self.step_path = None
 
-            for epoch in range(self.train_args.start_epoch,
-                               self.train_args.n_epochs):
-                self._itr_start_time = time.time()
-                with logger.prefix('epoch #%d | ' % epoch):
-                    yield epoch
-                    save_path = (self.step_path
-                                 if self.train_args.store_paths else None)
-                    self.save(epoch, save_path)
-                    self.log_diagnostics(self.train_args.pause_for_plot)
-                    logger.dump_all(self.step_itr)
-                    tabular.clear()
-        finally:
-            self._shutdown_worker()
+        for epoch in range(self._train_args.start_epoch,
+                           self._train_args.n_epochs):
+            self._itr_start_time = time.time()
+            with logger.prefix('epoch #%d | ' % epoch):
+                yield epoch
+                save_path = (self.step_path
+                             if self._train_args.store_paths else None)
+
+                self._stats.last_path = save_path
+                self._stats.total_epoch = epoch
+                self._stats.total_itr = self.step_itr
+
+                self.save(epoch)
+                self.log_diagnostics(self._train_args.pause_for_plot)
+                logger.dump_all(self.step_itr)
+                tabular.clear()
 
     def resume(self,
                n_epochs=None,
@@ -309,23 +408,50 @@ class LocalRunner:
         If not specified, an argument will default to the
         saved arguments from the last call to train().
 
+        Args:
+            n_epochs (int): Number of epochs.
+            batch_size (int): Number of environment steps in one batch.
+            n_epoch_cycles (int): Number of batches of samples in each epoch.
+                This is only useful for off-policy algorithm.
+                For on-policy algorithm this value should always be 1.
+            plot (bool): Visualize policy by doing rollout after each epoch.
+            store_paths (bool): Save paths in snapshot.
+            pause_for_plot (bool): Pause for plot.
+
+        Raises:
+            NotSetupError: If resume() is called before restore().
+
         Returns:
-            The average return in last epoch cycle.
+            float: The average return in last epoch cycle.
 
         """
-        if self.train_args is None:
-            raise Exception('You must call restore() before resume().')
+        if self._train_args is None:
+            raise NotSetupError('You must call restore() before resume().')
 
-        self.train_args.n_epochs = n_epochs or self.train_args.n_epochs
-        self.train_args.batch_size = batch_size or self.train_args.batch_size
-        self.train_args.n_epoch_cycles = (n_epoch_cycles
-                                          or self.train_args.n_epoch_cycles)
+        self._train_args.n_epochs = n_epochs or self._train_args.n_epochs
+        self._train_args.batch_size = batch_size or self._train_args.batch_size
+        self._train_args.n_epoch_cycles = (n_epoch_cycles
+                                           or self._train_args.n_epoch_cycles)
 
         if plot is not None:
-            self.train_args.plot = plot
+            self._train_args.plot = plot
         if store_paths is not None:
-            self.train_args.store_paths = store_paths
+            self._train_args.store_paths = store_paths
         if pause_for_plot is not None:
-            self.train_args.pause_for_plot = pause_for_plot
+            self._train_args.pause_for_plot = pause_for_plot
 
-        return self.algo.train(self)
+        return self._algo.train(self)
+
+    @property
+    def total_env_steps(self):
+        """Total environment steps collected.
+
+        Returns:
+            int: Total environment steps collected.
+
+        """
+        return self._stats.total_env_steps
+
+
+class NotSetupError(Exception):
+    """Raise when an experiment is about to run without setup."""

--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -252,7 +252,7 @@ class LocalRunner:
                 Not applicable when snapshot_mode='last'.
 
         Returns:
-            types.SimpleNamespace: A SimpleNamespace for train()'s arguments.
+            TrainArgs: Arguments for train().
 
         """
         saved = self._snapshotter.load(from_dir, from_epoch)

--- a/src/garage/experiment/snapshotter.py
+++ b/src/garage/experiment/snapshotter.py
@@ -40,22 +40,46 @@ class Snapshotter:
         pathlib.Path(snapshot_dir).mkdir(parents=True, exist_ok=True)
 
     @property
-    def snapshot_dir(self, ):
-        """Return the directory of snapshot."""
+    def snapshot_dir(self):
+        """Return the directory of snapshot.
+
+        Returns:
+            str: The directory of snapshot
+
+        """
         return self._snapshot_dir
 
     @property
-    def snapshot_mode(self, ):
-        """Return the type of snapshot."""
+    def snapshot_mode(self):
+        """Return the type of snapshot.
+
+        Returns:
+            str: The type of snapshot. Can be "all", "last" or "gap"
+
+        """
         return self._snapshot_mode
 
     @property
-    def snapshot_gap(self, ):
-        """Return the wait number of snapshot."""
+    def snapshot_gap(self):
+        """Return the gap number of snapshot.
+
+        Returns:
+            int: The gap number of snapshot.
+
+        """
         return self._snapshot_gap
 
     def save_itr_params(self, itr, params):
-        """Save the parameters if at the right iteration."""
+        """Save the parameters if at the right iteration.
+
+        Args:
+            itr (int): Number of iterations. Used as the index of snapshot.
+            params (obj): Content of snapshot to be saved.
+
+        Raises:
+            ValueError: If snapshot_mode is not one of "all", "last" or "gap".
+
+        """
         file_name = None
 
         if self._snapshot_mode == 'all':
@@ -85,6 +109,7 @@ class Snapshotter:
                 pickle.dump(params, file)
 
     def load(self, load_dir, itr='last'):
+        # pylint: disable=no-self-use
         """Load one snapshot of parameters from disk.
 
         Args:
@@ -94,7 +119,13 @@ class Snapshotter:
                 Can be an integer, 'last' or 'first'.
 
         Returns:
-            dict: Loaded snapshot
+            dict: Loaded snapshot.
+
+        Raises:
+            ValueError: If itr is neither an integer nor
+                one of ("last", "first").
+            FileNotFoundError: If the snapshot file is not found in load_dir.
+            NotAFileError: If the snapshot exists but is not a file.
 
         """
         if isinstance(itr, int) or itr.isdigit():
@@ -116,7 +147,11 @@ class Snapshotter:
                 load_from_file = os.path.join(load_dir, load_from_file)
 
         if not os.path.isfile(load_from_file):
-            raise Exception('File not existing: ', load_from_file)
+            raise NotAFileError('File not existing: ', load_from_file)
 
         with open(load_from_file, 'rb') as file:
             return joblib.load(file)
+
+
+class NotAFileError(Exception):
+    """Raise when the snapshot is not a file."""

--- a/src/garage/np/algos/batch_polopt.py
+++ b/src/garage/np/algos/batch_polopt.py
@@ -146,7 +146,7 @@ class BatchPolopt(RLAlgorithm):
         return samples_data
 
     def get_itr_snapshot(self, itr, samples_data):
-        # pylint: disable=unused-argument, no-self-use
+        # pylint: disable=no-self-use
         """Return data saved in the snapshot for this iteration.
 
         Args:
@@ -157,4 +157,6 @@ class BatchPolopt(RLAlgorithm):
             dict: A dict of saved data in snapshot.
 
         """
+        del itr
+        del samples_data
         return {}

--- a/src/garage/np/algos/batch_polopt.py
+++ b/src/garage/np/algos/batch_polopt.py
@@ -62,14 +62,15 @@ class BatchPolopt(RLAlgorithm):
                 such as snapshotting and sampler control.
 
         Returns:
-            The average return in last epoch cycle.
+            float: The average return in last epoch cycle.
 
         """
         last_return = None
 
-        for epoch in runner.step_epochs():
-            for cycle in range(self.n_samples):
+        for _ in runner.step_epochs():
+            for _ in range(self.n_samples):
                 runner.step_path = runner.obtain_samples(runner.step_itr)
+                tabular.record('TotalEnvSteps', runner.total_env_steps)
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)
                 runner.step_itr += 1
@@ -145,5 +146,15 @@ class BatchPolopt(RLAlgorithm):
         return samples_data
 
     def get_itr_snapshot(self, itr, samples_data):
-        """Return data saved in the snapshot for this iteration."""
+        # pylint: disable=unused-argument, no-self-use
+        """Return data saved in the snapshot for this iteration.
+
+        Args:
+            itr (int): Iteration number.
+            samples_data (list[dict]): A list of collected paths
+
+        Returns:
+            dict: A dict of saved data in snapshot.
+
+        """
         return {}

--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -1,5 +1,4 @@
-"""
-This module implements a Vectorized Sampler used for OffPolicy Algorithms.
+"""This module implements a Vectorized Sampler used for OffPolicy Algorithms.
 
 It diffs from OnPolicyVectorizedSampler in two parts:
  - The num of envs is defined by rollout_batch_size. In

--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -1,4 +1,5 @@
-"""This module implements a Vectorized Sampler used for OffPolicy Algorithms.
+"""
+This module implements a Vectorized Sampler used for OffPolicy Algorithms.
 
 It diffs from OnPolicyVectorizedSampler in two parts:
  - The num of envs is defined by rollout_batch_size. In
@@ -33,51 +34,58 @@ class OffPolicyVectorizedSampler(BatchSampler):
         if n_envs is None:
             n_envs = int(algo.rollout_batch_size)
         super().__init__(algo, env)
-        self.n_envs = n_envs
-        self.no_reset = no_reset
+        self._n_envs = n_envs
+        self._no_reset = no_reset
+
+        self._vec_env = None
+        self._env_spec = self.env.spec
 
         self._last_obses = None
         self._last_uncounted_discount = [0] * n_envs
         self._last_running_length = [0] * n_envs
         self._last_success_count = [0] * n_envs
-        self.env_spec = self.env.spec
-        self.vec_env = None
 
     def start_worker(self):
         """Initialize the sampler."""
-        n_envs = self.n_envs
+        n_envs = self._n_envs
         envs = [pickle.loads(pickle.dumps(self.env)) for _ in range(n_envs)]
 
         # Deterministically set environment seeds based on the global seed.
-        for (i, e) in enumerate(envs):
-            e.seed(deterministic.get_seed() + i)
+        seed0 = deterministic.get_seed()
+        if seed0 is not None:
+            for (i, e) in enumerate(envs):
+                e.seed(seed0 + i)
 
-        self.vec_env = VecEnvExecutor(
+        self._vec_env = VecEnvExecutor(
             envs=envs, max_path_length=self.algo.max_path_length)
 
     def shutdown_worker(self):
         """Terminate workers if necessary."""
-        self.vec_env.close()
+        self._vec_env.close()
 
-    # pylint: disable=arguments-differ, too-many-statements, too-many-branches
-    def obtain_samples(self, itr, batch_size):
+    # pylint: disable=too-many-branches, too-many-statements
+    def obtain_samples(self, itr, batch_size=None, whole_paths=True):
         """Collect samples for the given iteration number.
 
         Args:
             itr(int): Iteration number.
             batch_size(int): Number of environment interactions in one batch.
+            whole_paths(bool): Not effective. Only keep here to comply
+                with base class.
 
         Returns:
             list: A list of paths.
 
         """
+        assert batch_size is not None
+
         paths = []
-        if not self.no_reset or self._last_obses is None:
-            obses = self.vec_env.reset()
+        if not self._no_reset or self._last_obses is None:
+            obses = self._vec_env.reset()
         else:
             obses = self._last_obses
-        dones = np.asarray([True] * self.vec_env.num_envs)
-        running_paths = [None] * self.vec_env.num_envs
+        dones = np.asarray([True] * self._vec_env.num_envs)
+        running_paths = [None] * self._vec_env.num_envs
         n_samples = 0
 
         policy = self.algo.policy
@@ -94,7 +102,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
             else:
                 input_obses = obses
             obs_normalized = tensor_utils.normalize_pixel_batch(
-                self.env_spec, input_obses)
+                self._env_spec, input_obses)
             if self.algo.es:
                 actions, agent_infos = self.algo.es.get_actions(
                     itr, obs_normalized, self.algo.policy)
@@ -102,16 +110,16 @@ class OffPolicyVectorizedSampler(BatchSampler):
                 actions, agent_infos = self.algo.policy.get_actions(
                     obs_normalized)
 
-            next_obses, rewards, dones, env_infos = self.vec_env.step(actions)
+            next_obses, rewards, dones, env_infos = self._vec_env.step(actions)
             self._last_obses = next_obses
             agent_infos = tensor_utils.split_tensor_dict_list(agent_infos)
             env_infos = tensor_utils.split_tensor_dict_list(env_infos)
             n_samples += len(next_obses)
 
             if agent_infos is None:
-                agent_infos = [dict() for _ in range(self.vec_env.num_envs)]
+                agent_infos = [dict() for _ in range(self._vec_env.num_envs)]
             if env_infos is None:
-                env_infos = [dict() for _ in range(self.vec_env.num_envs)]
+                env_infos = [dict() for _ in range(self._vec_env.num_envs)]
 
             if self.algo.input_include_goal:
                 self.algo.replay_buffer.add_transitions(

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
@@ -86,6 +86,7 @@ class TestBenchmarkPPO:  # pylint: disable=too-few-public-methods
                 garage_pytorch_csv = run_garage_pytorch(
                     env, seed, garage_pytorch_dir)
 
+                # pylint: disable=not-context-manager
                 with tf.Graph().as_default():
                     env.reset()
                     garage_tf_csv = run_garage(env, seed, garage_tf_dir)

--- a/tests/fixtures/tf/algos/dummy_off_policy_algo.py
+++ b/tests/fixtures/tf/algos/dummy_off_policy_algo.py
@@ -8,3 +8,9 @@ class DummyOffPolicyAlgo(OffPolicyRLAlgorithm):
 
     def train(self, runner):
         pass
+
+    def train_once(self, itr, paths):
+        pass
+
+    def optimize_policy(self, itr, samples_data):
+        pass

--- a/tests/fixtures/tf/algos/dummy_off_policy_algo.py
+++ b/tests/fixtures/tf/algos/dummy_off_policy_algo.py
@@ -1,16 +1,38 @@
+"""A dummy off-policy algorithm."""
 from garage.np.algos import OffPolicyRLAlgorithm
 
 
 class DummyOffPolicyAlgo(OffPolicyRLAlgorithm):
+    """A dummy off-policy algorithm."""
 
     def init_opt(self):
-        pass
+        """Initialize the optimization procedure."""
 
     def train(self, runner):
-        pass
+        """Obtain samplers and start actual training for each epoch.
+
+        Args:
+            runner (LocalRunner): LocalRunner is passed to give algorithm
+                the access to runner.step_epochs(), which provides services
+                such as snapshotting and sampler control.
+
+        """
 
     def train_once(self, itr, paths):
-        pass
+        """Perform one step of policy optimization given one batch of samples.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        """
 
     def optimize_policy(self, itr, samples_data):
-        pass
+        """Optimize the policy using the samples.
+
+        Args:
+            itr (int): Iteration number.
+            samples_data (dict): Processed sample data.
+                See process_samples() for details.
+
+        """

--- a/tests/garage/experiment/test_resume.py
+++ b/tests/garage/experiment/test_resume.py
@@ -30,24 +30,24 @@ class TestResume(TfGraphTestCase):
         with LocalTFRunner(self.snapshot_config, sess) as runner:
             args = runner.restore(self.temp_dir.name)
             assert np.equal(
-                runner.policy.get_param_values(),
+                runner._policy.get_param_values(),
                 self.policy_params).all(), 'Policy parameters should persist'
             assert args.n_epochs == 5, (
                 'Snapshot should save training parameters')
             assert args.start_epoch == 5, (
                 'Last experiment should end at 5th iterations')
 
-            batch_size = runner.train_args.batch_size
-            n_epoch_cycles = runner.train_args.n_epoch_cycles
+            batch_size = runner._train_args.batch_size
+            n_epoch_cycles = runner._train_args.n_epoch_cycles
 
             runner.resume(n_epochs=10,
                           plot=False,
                           store_paths=True,
                           pause_for_plot=False)
 
-            assert runner.train_args.n_epochs == 10
-            assert runner.train_args.batch_size == batch_size
-            assert runner.train_args.n_epoch_cycles == n_epoch_cycles
-            assert not runner.train_args.plot
-            assert runner.train_args.store_paths
-            assert not runner.train_args.pause_for_plot
+            assert runner._train_args.n_epochs == 10
+            assert runner._train_args.batch_size == batch_size
+            assert runner._train_args.n_epoch_cycles == n_epoch_cycles
+            assert not runner._train_args.plot
+            assert runner._train_args.store_paths
+            assert not runner._train_args.pause_for_plot

--- a/tests/garage/experiment/test_snapshotter_integration.py
+++ b/tests/garage/experiment/test_snapshotter_integration.py
@@ -13,13 +13,13 @@ configurations = [('last', 4), ('first', 0), (3, 3)]
 
 
 class TestSnapshot(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.temp_dir = tempfile.TemporaryDirectory()
-        snapshot_config = SnapshotConfig(
-            snapshot_dir=self.temp_dir.name,
-            snapshot_mode='all',
-            snapshot_gap=1)
+        snapshot_config = SnapshotConfig(snapshot_dir=self.temp_dir.name,
+                                         snapshot_mode='all',
+                                         snapshot_gap=1)
         fixture_exp(snapshot_config, self.sess)
         for c in self.graph.collections:
             self.graph.clear_collection(c)
@@ -36,7 +36,7 @@ class TestSnapshot(TfGraphTestCase):
         assert isinstance(saved['algo'], VPG)
         assert isinstance(saved['env'], TfEnv)
         assert isinstance(saved['algo'].policy, CategoricalMLPPolicy)
-        assert saved['last_epoch'] == last_epoch
+        assert saved['stats'].total_epoch == last_epoch
 
     def test_load_with_invalid_load_mode(self):
         snapshotter = Snapshotter()

--- a/tests/garage/sampler/test_is_sampler.py
+++ b/tests/garage/sampler/test_is_sampler.py
@@ -33,46 +33,46 @@ class TestISSampler(TfGraphTestCase):
                          sampler_args=dict(n_backtrack=1, init_is=1))
             runner._start_worker()
 
-            paths = runner.sampler.obtain_samples(1)
+            paths = runner._sampler.obtain_samples(1)
             assert paths == [], 'Should return empty paths if no history'
 
             # test importance and live sampling get called alternatively
             with unittest.mock.patch.object(ISSampler,
                                             '_obtain_is_samples') as mocked:
-                assert runner.sampler.obtain_samples(2, 20)
+                assert runner._sampler.obtain_samples(2, 20)
                 mocked.assert_not_called()
 
-                assert runner.sampler.obtain_samples(3)
+                assert runner._sampler.obtain_samples(3)
                 mocked.assert_called_once_with(3, None, True)
 
             # test importance sampling for first n_is_pretrain iterations
             with unittest.mock.patch.object(ISSampler,
                                             '_obtain_is_samples') as mocked:
-                runner.sampler.n_is_pretrain = 5
-                runner.sampler.n_backtrack = 'all'
-                runner.sampler.obtain_samples(4)
+                runner._sampler.n_is_pretrain = 5
+                runner._sampler.n_backtrack = 'all'
+                runner._sampler.obtain_samples(4)
 
                 mocked.assert_called_once_with(4, None, True)
 
-            runner.sampler.obtain_samples(5)
+            runner._sampler.obtain_samples(5)
 
             # test random draw important samples
-            runner.sampler.randomize_draw = True
-            assert runner.sampler.obtain_samples(6, 1)
-            runner.sampler.randomize_draw = False
+            runner._sampler.randomize_draw = True
+            assert runner._sampler.obtain_samples(6, 1)
+            runner._sampler.randomize_draw = False
 
-            runner.sampler.obtain_samples(7, 30)
+            runner._sampler.obtain_samples(7, 30)
 
             # test ess_threshold use
-            runner.sampler.ess_threshold = 500
-            paths = runner.sampler.obtain_samples(8, 30)
+            runner._sampler.ess_threshold = 500
+            paths = runner._sampler.obtain_samples(8, 30)
             assert paths == [], (
                 'Should return empty paths when ess_threshold is large')
-            runner.sampler.ess_threshold = 0
+            runner._sampler.ess_threshold = 0
 
             # test random sample selection when len(paths) > batch size
-            runner.sampler.n_is_pretrain = 15
-            runner.sampler.obtain_samples(9, 10)
-            runner.sampler.obtain_samples(10, 1)
+            runner._sampler.n_is_pretrain = 15
+            runner._sampler.obtain_samples(9, 10)
+            runner._sampler.obtain_samples(10, 1)
 
             runner._shutdown_worker()

--- a/tests/garage/sampler/test_on_policy_vectorized_sampler.py
+++ b/tests/garage/sampler/test_on_policy_vectorized_sampler.py
@@ -34,7 +34,7 @@ class TestOnPolicyVectorizedSampler(TfGraphTestCase):
 
             runner.setup(algo, env, sampler_args=dict(n_envs=n_envs))
 
-            assert isinstance(runner.sampler, OnPolicyVectorizedSampler)
-            assert runner.sampler.n_envs == expected_n_envs
+            assert isinstance(runner._sampler, OnPolicyVectorizedSampler)
+            assert runner._sampler._n_envs == expected_n_envs
 
             env.close()

--- a/tests/garage/sampler/test_sampler.py
+++ b/tests/garage/sampler/test_sampler.py
@@ -57,9 +57,9 @@ class TestSampler:
 
             runner._start_worker()
 
-            paths = runner.sampler.obtain_samples(0,
-                                                  batch_size=8,
-                                                  whole_paths=True)
+            paths = runner._sampler.obtain_samples(0,
+                                                   batch_size=8,
+                                                   whole_paths=True)
             assert len(paths) >= max_cpus, (
                 'BatchSampler should sample more than max_cpus={} '
                 'trajectories'.format(max_cpus))

--- a/tests/garage/tf/experiment/test_local_tf_runner.py
+++ b/tests/garage/tf/experiment/test_local_tf_runner.py
@@ -78,7 +78,7 @@ class TestLocalRunner(TfGraphTestCase):
             runner.setup(algo, env)
             runner.train(n_epochs=1, batch_size=100, plot=True)
 
-            assert isinstance(runner.plotter, Plotter), (
+            assert isinstance(runner._plotter, Plotter), (
                 'self.plotter in LocalTFRunner should be set to Plotter.')
 
     def test_call_train_before_set_up(self):


### PR DESCRIPTION
This PR adds a `TotalEnvSteps` to log. 

Changelist:
- Add a `ExperimentStats` class to LocalRunner. This class records statistics of an experiment. Currently there are `total_itr`, `total_env_steps`, `total_epoch` and `last_path`.
- Add `TrainArgs` and `SetupArgs` to LocalRunner. They keep arguments passed to `train()` and `setup()`. 
