### PR TITLE
Modify BatchPolopt to return flattened sample paths

### DIFF
--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -24,6 +24,19 @@ class OnPolicyVectorizedSampler(BatchSampler):
         n_envs (int): Number of environment instances to setup.
             This parameter has effect on sampling performance.
 
+    In obtain_samples(), N paths are generated. Each path is a dictionary,
+    with keys and values as following:
+    - observations : numpy.ndarray with shape [Batch, *obs_dims]
+    - actions      : numpy.ndarray with shape [Batch, *act_dims]
+    - rewards      : numpy.ndarray with shape [Batch, ]
+    - env_infos    : A dictionary with each key representing one environment
+        info, value being a numpy.ndarray with shape [Batch, ?]. One example
+        is "ale.lives" for atari environments.
+    - agent_infos  : A dictionary with each key representing one agent info,
+        value being a numpy.ndarray with shape [Batch, ?]. One example is
+        "prev_action", which is used for recurrent policy as previous action
+        input, merged with the observation input as the state input.
+
     """
 
     def __init__(self, algo, env, n_envs=None):

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -76,11 +76,13 @@ class OnPolicyVectorizedSampler(BatchSampler):
                 * rewards: numpy.ndarray with shape [Batch, ]
                 * env_infos: A dictionary with each key representing one
                   environment info, value being a numpy.ndarray with shape
-                  [Batch, ?]. One example is "ale.lives" for atari environments.
-                * agent_infos: A dictionary with each key representing one agent
-                  info, value being a numpy.ndarray with shape [Batch, ?]. One example
-                  is "prev_action", which is used for recurrent policy as previous
-                  action input, merged with the observation input as the state input.
+                  [Batch, ?]. One example is "ale.lives" for atari
+                  environments.
+                * agent_infos: A dictionary with each key representing one
+                  agent info, value being a numpy.ndarray with shape
+                  [Batch, ?]. One example is "prev_action", which is used
+                  for recurrent policy as previous action input, merged with
+                  the observation input as the state input.
 
         """
         logger.log('Obtaining samples for iteration %d...' % itr)

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -24,19 +24,6 @@ class OnPolicyVectorizedSampler(BatchSampler):
         n_envs (int): Number of environment instances to setup.
             This parameter has effect on sampling performance.
 
-    In obtain_samples(), N paths are generated. Each path is a dictionary,
-    with keys and values as following:
-    - observations : numpy.ndarray with shape [Batch, *obs_dims]
-    - actions      : numpy.ndarray with shape [Batch, *act_dims]
-    - rewards      : numpy.ndarray with shape [Batch, ]
-    - env_infos    : A dictionary with each key representing one environment
-        info, value being a numpy.ndarray with shape [Batch, ?]. One example
-        is "ale.lives" for atari environments.
-    - agent_infos  : A dictionary with each key representing one agent info,
-        value being a numpy.ndarray with shape [Batch, ?]. One example is
-        "prev_action", which is used for recurrent policy as previous action
-        input, merged with the observation input as the state input.
-
     """
 
     def __init__(self, algo, env, n_envs=None):
@@ -80,12 +67,20 @@ class OnPolicyVectorizedSampler(BatchSampler):
                 this flag is true.
 
         Returns:
-            list[dict]: Sample paths, each path with key
-                * observations: (numpy.ndarray)
-                * actions: (numpy.ndarray)
-                * rewards: (numpy.ndarray)
-                * agent_infos: (dict)
-                * env_infos: (dict)
+            list[dict]: Sample paths.
+
+        Note:
+            Each path is a dictionary, with keys and values as following:
+                * observations: numpy.ndarray with shape [Batch, *obs_dims]
+                * actions: numpy.ndarray with shape [Batch, *act_dims]
+                * rewards: numpy.ndarray with shape [Batch, ]
+                * env_infos: A dictionary with each key representing one environment
+                  info, value being a numpy.ndarray with shape [Batch, ?]. One example
+                  is "ale.lives" for atari environments.
+                * agent_infos: A dictionary with each key representing one agent info,
+                  value being a numpy.ndarray with shape [Batch, ?]. One example is
+                  "prev_action", which is used for recurrent policy as previous action
+                  input, merged with the observation input as the state input.
 
         """
         logger.log('Obtaining samples for iteration %d...' % itr)

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -74,13 +74,13 @@ class OnPolicyVectorizedSampler(BatchSampler):
                 * observations: numpy.ndarray with shape [Batch, *obs_dims]
                 * actions: numpy.ndarray with shape [Batch, *act_dims]
                 * rewards: numpy.ndarray with shape [Batch, ]
-                * env_infos: A dictionary with each key representing one environment
+                * env_infos: A dictionary with each key representing one
+                  environment info, value being a numpy.ndarray with shape
+                  [Batch, ?]. One example is "ale.lives" for atari environments.
+                * agent_infos: A dictionary with each key representing one agent
                   info, value being a numpy.ndarray with shape [Batch, ?]. One example
-                  is "ale.lives" for atari environments.
-                * agent_infos: A dictionary with each key representing one agent info,
-                  value being a numpy.ndarray with shape [Batch, ?]. One example is
-                  "prev_action", which is used for recurrent policy as previous action
-                  input, merged with the observation input as the state input.
+                  is "prev_action", which is used for recurrent policy as previous
+                  action input, merged with the observation input as the state input.
 
         """
         logger.log('Obtaining samples for iteration %d...' % itr)

--- a/src/garage/tf/algos/__init__.py
+++ b/src/garage/tf/algos/__init__.py
@@ -1,5 +1,6 @@
 """Tensorflow implementation of reinforcement learning algorithms."""
 from garage.tf.algos.batch_polopt import BatchPolopt
+from garage.tf.algos.batch_polopt2 import BatchPolopt2
 from garage.tf.algos.ddpg import DDPG
 from garage.tf.algos.dqn import DQN
 from garage.tf.algos.erwr import ERWR
@@ -13,6 +14,7 @@ from garage.tf.algos.vpg import VPG
 
 __all__ = [
     'BatchPolopt',
+    'BatchPolopt2',
     'DDPG',
     'DQN',
     'ERWR',

--- a/src/garage/tf/algos/batch_polopt2.py
+++ b/src/garage/tf/algos/batch_polopt2.py
@@ -1,0 +1,281 @@
+"""Base class for batch sampling-based policy optimization methods."""
+
+import collections
+
+from dowel import logger, tabular
+import numpy as np
+
+from garage.misc import tensor_utils as np_tensor_utils
+from garage.np.algos import RLAlgorithm
+from garage.sampler import OnPolicyVectorizedSampler
+from garage.tf.misc import tensor_utils
+from garage.tf.samplers import BatchSampler
+
+
+class BatchPolopt2(RLAlgorithm):
+    """Base class for batch sampling-based policy optimization methods.
+
+    This includes various policy gradient methods like VPG, NPG, PPO, TRPO,
+    etc.
+
+    Args:
+        env_spec (garage.envs.EnvSpec): Environment specification.
+        policy (garage.tf.policies.base.Policy): Policy.
+        baseline (garage.tf.baselines.Baseline): The baseline.
+        scope (str): Scope for identifying the algorithm.
+            Must be specified if running multiple algorithms
+            simultaneously, each using different environments
+            and policies.
+        max_path_length (int): Maximum length of a single rollout.
+        discount (float): Discount.
+        gae_lambda (float): Lambda used for generalized advantage
+            estimation.
+        center_adv (bool): Whether to rescale the advantages
+            so that they have mean 0 and standard deviation 1.
+        positive_adv (bool): Whether to shift the advantages
+            so that they are always positive. When used in
+            conjunction with center_adv the advantages will be
+            standardized before shifting.
+        fixed_horizon (bool): Whether to fix horizon.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
+
+    """
+
+    def __init__(self,
+                 env_spec,
+                 policy,
+                 baseline,
+                 scope=None,
+                 max_path_length=500,
+                 discount=0.99,
+                 gae_lambda=1,
+                 center_adv=True,
+                 positive_adv=False,
+                 fixed_horizon=False,
+                 flatten_input=True):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.baseline = baseline
+        self.scope = scope
+        self.max_path_length = max_path_length
+        self.discount = discount
+        self.gae_lambda = gae_lambda
+        self.center_adv = center_adv
+        self.positive_adv = positive_adv
+        self.fixed_horizon = fixed_horizon
+        self.flatten_input = flatten_input
+
+        self.episode_reward_mean = collections.deque(maxlen=100)
+        if policy.vectorized:
+            self.sampler_cls = OnPolicyVectorizedSampler
+        else:
+            self.sampler_cls = BatchSampler
+
+        self.init_opt()
+
+    def train(self, runner):
+        """Obtain samplers and start actual training for each epoch.
+
+        Args:
+            runner (LocalRunner): LocalRunner is passed to give algorithm
+                the access to runner.step_epochs(), which provides services
+                such as snapshotting and sampler control.
+
+        Returns:
+            float: The average return in last epoch cycle.
+
+        """
+        last_return = None
+
+        for _ in runner.step_epochs():
+            runner.step_path = runner.obtain_samples(runner.step_itr)
+            last_return = self.train_once(runner.step_itr, runner.step_path)
+            runner.step_itr += 1
+
+        return last_return
+
+    def train_once(self, itr, paths):
+        """Perform one step of policy optimization given one batch of samples.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        Returns:
+            float: The average return in last epoch cycle.
+
+        """
+        paths = self.process_samples(itr, paths)
+        self.log_diagnostics(paths)
+        logger.log('Optimizing policy...')
+        self.optimize_policy(itr, paths)
+        return paths['average_return']
+
+    def log_diagnostics(self, paths):
+        """Log diagnostic information.
+
+        Args:
+            paths (list[dict]): A list of collected paths.
+
+        """
+        logger.log('Logging diagnostics...')
+        self.policy.log_diagnostics(paths)
+        self.baseline.log_diagnostics(paths)
+
+    def process_samples(self, itr, paths):
+        """Return processed sample data based on the collected paths.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        Returns:
+            dict: Processed sample data, with key
+                * observations  : (numpy.ndarray), shape [B * (T), *obs_dims]
+                * actions       : (numpy.ndarray), shape [B * (T), *act_dims]
+                * rewards       : (numpy.ndarray), shape [B * (T), ]
+                * baselines     : (numpy.ndarray), shape [B * (T), ]
+                * returns       : (numpy.ndarray), shape [B * (T), ]
+                * agent_infos   : (dict), see
+                    OnPolicyVectorizedSampler.obtain_samples()
+                * env_infos     : (dict), see
+                    OnPolicyVectorizedSampler.obtain_samples()
+                * paths         : (list[dict]) The original path with
+                    observation or action flattened
+                * average_return: (numpy.float64)
+                where B = batch size, (T) = variable-length of each trajectory
+
+        """
+        baselines = []
+        returns = []
+
+        max_path_length = self.max_path_length
+
+        if self.flatten_input:
+            paths = [
+                dict(
+                    observations=(self.env_spec.observation_space.flatten_n(
+                        path['observations'])),
+                    actions=(
+                        self.env_spec.action_space.flatten_n(  # noqa: E126
+                            path['actions'])),
+                    rewards=path['rewards'],
+                    env_infos=path['env_infos'],
+                    agent_infos=path['agent_infos']) for path in paths
+            ]
+        else:
+            paths = [
+                dict(
+                    observations=path['observations'],
+                    actions=(
+                        self.env_spec.action_space.flatten_n(  # noqa: E126
+                            path['actions'])),
+                    rewards=path['rewards'],
+                    env_infos=path['env_infos'],
+                    agent_infos=path['agent_infos']) for path in paths
+            ]
+
+        if hasattr(self.baseline, 'predict_n'):
+            all_path_baselines = self.baseline.predict_n(paths)
+        else:
+            all_path_baselines = [
+                self.baseline.predict(path) for path in paths
+            ]
+
+        for idx, path in enumerate(paths):
+            path_baselines = np.append(all_path_baselines[idx], 0)
+            deltas = (path['rewards'] + self.discount * path_baselines[1:] -
+                      path_baselines[:-1])
+            path['advantages'] = np_tensor_utils.discount_cumsum(
+                deltas, self.discount * self.gae_lambda)
+            path['deltas'] = deltas
+
+        for idx, path in enumerate(paths):
+            # baselines
+            path['baselines'] = all_path_baselines[idx]
+            baselines.append(path['baselines'])
+
+            # returns
+            path['returns'] = np_tensor_utils.discount_cumsum(
+                path['rewards'], self.discount)
+            returns.append(path['returns'])
+
+        obs = np.concatenate([path['observations'] for path in paths])
+        actions = np.concatenate([path['actions'] for path in paths])
+        rewards = np.concatenate([path['rewards'] for path in paths])
+        returns = np.concatenate(returns)
+        baselines = np.concatenate(baselines)
+
+        agent_infos_path = [path['agent_infos'] for path in paths]
+        agent_infos = dict()
+        for key in self.policy.state_info_keys:
+            agent_infos[key] = np.concatenate(
+                [infos[key] for infos in agent_infos_path])
+
+        env_infos = [path['env_infos'] for path in paths]
+        env_infos = tensor_utils.stack_tensor_dict_list([
+            tensor_utils.pad_tensor_dict(p, max_path_length) for p in env_infos
+        ])
+
+        valids = [np.ones_like(path['returns']) for path in paths]
+        lengths = [v.sum() for v in valids]
+
+        average_discounted_return = (np.mean(
+            [path['returns'][0] for path in paths]))
+
+        undiscounted_returns = [sum(path['rewards']) for path in paths]
+        self.episode_reward_mean.extend(undiscounted_returns)
+
+        samples_data = dict(
+            observations=obs,
+            actions=actions,
+            rewards=rewards,
+            baselines=baselines,
+            returns=returns,
+            lengths=lengths,
+            agent_infos=agent_infos,
+            env_infos=env_infos,
+            paths=paths,
+            average_return=np.mean(undiscounted_returns),
+        )
+
+        tabular.record('Iteration', itr)
+        tabular.record('AverageDiscountedReturn', average_discounted_return)
+        tabular.record('AverageReturn', np.mean(undiscounted_returns))
+        tabular.record('Extras/EpisodeRewardMean',
+                       np.mean(self.episode_reward_mean))
+        tabular.record('NumTrajs', len(paths))
+        tabular.record('StdReturn', np.std(undiscounted_returns))
+        tabular.record('MaxReturn', np.max(undiscounted_returns))
+        tabular.record('MinReturn', np.min(undiscounted_returns))
+
+        return samples_data
+
+    def init_opt(self):
+        """Initialize the optimization procedure.
+
+        If using tensorflow, this may include declaring all the variables and
+        compiling functions.
+        """
+        raise NotImplementedError
+
+    def get_itr_snapshot(self, itr):
+        """Get all the data that should be saved in this snapshot iteration.
+
+        Args:
+            itr (int): Iteration.
+
+        """
+        raise NotImplementedError
+
+    def optimize_policy(self, itr, samples_data):
+        """Optimize the policy using the samples.
+
+        Args:
+            itr (int): Iteration number.
+            samples_data (dict[numpy.ndarray]): Sample data.
+
+        """
+        raise NotImplementedError

--- a/src/garage/tf/algos/batch_polopt2.py
+++ b/src/garage/tf/algos/batch_polopt2.py
@@ -156,29 +156,30 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
     def process_samples(self, itr, paths):
         """Return processed sample data based on the collected paths.
 
-        The returned samples is a dictionary with keys
-        - observations: (numpy.ndarray), shape [B * (T), *obs_dims]
-        - actions: (numpy.ndarray), shape [B * (T), *act_dims]
-        - rewards : (numpy.ndarray), shape [B * (T), ]
-        - baselines: (numpy.ndarray), shape [B * (T), ]
-        - returns: (numpy.ndarray), shape [B * (T), ]
-        - lengths: (numpy.ndarray), shape [P, ], i-th entry represents
-            the length of i-th path.
-        - agent_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
-        - env_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
-        - paths: (list[dict]) The original path with observation or action
-            flattened
-        - average_return: (numpy.float64)
-
-        where B = batch size, (T) = variable-length of each trajectory,
-            P = number of paths
-
         Args:
             itr (int): Iteration number.
             paths (list[dict]): A list of collected paths.
 
         Returns:
-            dict: Processed sample data
+            dict: Processed sample data.
+
+        Note:
+            The returned samples is a dictionary with keys
+                - observations: (numpy.ndarray), shape [B * (T), *obs_dims]
+                - actions: (numpy.ndarray), shape [B * (T), *act_dims]
+                - rewards : (numpy.ndarray), shape [B * (T), ]
+                - baselines: (numpy.ndarray), shape [B * (T), ]
+                - returns: (numpy.ndarray), shape [B * (T), ]
+                - lengths: (numpy.ndarray), shape [P, ], i-th entry represents
+                  the length of i-th path.
+                - agent_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
+                - env_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
+                - paths: (list[dict]) The original path with observation or action
+                  flattened
+                - average_return: (numpy.float64)
+
+            where B = batch size, (T) = variable-length of each trajectory,
+            P = number of paths
 
         """
         baselines = []

--- a/src/garage/tf/algos/batch_polopt2.py
+++ b/src/garage/tf/algos/batch_polopt2.py
@@ -172,10 +172,12 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
                 - returns: (numpy.ndarray), shape [B * (T), ]
                 - lengths: (numpy.ndarray), shape [P, ], i-th entry represents
                   the length of i-th path.
-                - agent_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
-                - env_infos: (dict), see OnPolicyVectorizedSampler.obtain_samples()
-                - paths: (list[dict]) The original path with observation or action
-                  flattened
+                - agent_infos: (dict), see
+                  OnPolicyVectorizedSampler.obtain_samples()
+                - env_infos: (dict), see
+                  OnPolicyVectorizedSampler.obtain_samples()
+                - paths: (list[dict]) The original path with observation or
+                  action flattened
                 - average_return: (numpy.float64)
 
             where B = batch size, (T) = variable-length of each trajectory,

--- a/src/garage/tf/algos/batch_polopt2.py
+++ b/src/garage/tf/algos/batch_polopt2.py
@@ -183,7 +183,8 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
                 - average_return: (numpy.float64)
 
             where B = batch size, (T) = variable-length of each trajectory,
-            P = number of paths
+            P = number of paths. Notice that B * T equals to the total number
+            of environment steps in all trajectories.
 
         """
         baselines = []

--- a/src/garage/tf/algos/batch_polopt2.py
+++ b/src/garage/tf/algos/batch_polopt2.py
@@ -172,6 +172,8 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
                 - returns: (numpy.ndarray), shape [B * (T), ]
                 - lengths: (numpy.ndarray), shape [P, ], i-th entry represents
                   the length of i-th path.
+                - valids: (numpy.ndarray), shape [P, ], [i, j] entry is 1 if
+                  the j-th sample in i-th path is valid, otherwise 0.
                 - agent_infos: (dict), see
                   OnPolicyVectorizedSampler.obtain_samples()
                 - env_infos: (dict), see
@@ -251,7 +253,7 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
             env_infos[key] = np.concatenate(
                 [infos[key] for infos in env_infos_path])
 
-        valids = [np.ones_like(path['returns']) for path in paths]
+        valids = np.asarray([np.ones_like(path['returns']) for path in paths])
         lengths = np.asarray([v.sum() for v in valids])
 
         average_discounted_return = (np.mean(
@@ -267,6 +269,7 @@ class BatchPolopt2(RLAlgorithm, abc.ABC):
             baselines=baselines,
             returns=returns,
             lengths=lengths,
+            valids=valids,
             agent_infos=agent_infos,
             env_infos=env_infos,
             paths=paths,

--- a/tests/garage/tf/algos/test_batch_polopt2.py
+++ b/tests/garage/tf/algos/test_batch_polopt2.py
@@ -1,0 +1,162 @@
+from unittest import mock
+
+import numpy as np
+
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import BatchPolopt2
+from garage.tf.baselines import GaussianMLPBaseline
+from garage.tf.envs import TfEnv
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.policies import CategoricalLSTMPolicy
+from garage.tf.policies import CategoricalMLPPolicy
+from garage.tf.policies import GaussianLSTMPolicy
+from garage.tf.policies import GaussianMLPPolicy
+from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyBoxEnv
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+
+class TestBatchPolopt2(TfGraphTestCase):
+
+    @mock.patch.multiple(BatchPolopt2, __abstractmethods__=set())
+    # pylint: disable=abstract-class-instantiated, no-member
+    def test_process_samples_continuous_non_recurrent(self):
+        env = TfEnv(DummyBoxEnv())
+        policy = GaussianMLPPolicy(env_spec=env.spec)
+        baseline = GaussianMLPBaseline(env_spec=env.spec)
+        max_path_length = 100
+        with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
+            algo = BatchPolopt2(env_spec=env.spec,
+                                policy=policy,
+                                baseline=baseline,
+                                max_path_length=max_path_length,
+                                flatten_input=True)
+            runner.setup(algo, env, sampler_args=dict(n_envs=1))
+            runner.train(n_epochs=1, batch_size=max_path_length)
+            paths = runner.obtain_samples(0)
+            samples = algo.process_samples(0, paths)
+            # Since there is only 1 vec_env in the sampler and DummyBoxEnv
+            # never terminate until it reaches max_path_length, batch size
+            # must be max_path_length, i.e. 100
+            assert samples['observations'].shape == (
+                max_path_length, env.observation_space.flat_dim)
+            assert samples['actions'].shape == (max_path_length,
+                                                env.action_space.flat_dim)
+            assert samples['rewards'].shape == (max_path_length, )
+            assert samples['baselines'].shape == (max_path_length, )
+            assert samples['returns'].shape == (max_path_length, )
+            # there is only 1 path
+            assert samples['lengths'].shape == (1, )
+            # non-recurrent policy has empty agent info
+            assert samples['agent_infos'] == {}
+            # DummyBoxEnv has env_info dummy
+            assert samples['env_infos']['dummy'].shape == (max_path_length, )
+            assert isinstance(samples['average_return'], float)
+
+    # pylint: disable=abstract-class-instantiated, no-member
+    @mock.patch.multiple(BatchPolopt2, __abstractmethods__=set())
+    def test_process_samples_continuous_recurrent(self):
+        env = TfEnv(DummyBoxEnv())
+        policy = GaussianLSTMPolicy(env_spec=env.spec)
+        baseline = GaussianMLPBaseline(env_spec=env.spec)
+        max_path_length = 100
+        with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
+            algo = BatchPolopt2(env_spec=env.spec,
+                                policy=policy,
+                                baseline=baseline,
+                                max_path_length=max_path_length,
+                                flatten_input=True)
+            runner.setup(algo, env, sampler_args=dict(n_envs=1))
+            runner.train(n_epochs=1, batch_size=max_path_length)
+            paths = runner.obtain_samples(0)
+            samples = algo.process_samples(0, paths)
+            # Since there is only 1 vec_env in the sampler and DummyBoxEnv
+            # never terminate until it reaches max_path_length, batch size
+            # must be max_path_length, i.e. 100
+            assert samples['observations'].shape == (
+                max_path_length, env.observation_space.flat_dim)
+            assert samples['actions'].shape == (max_path_length,
+                                                env.action_space.flat_dim)
+            assert samples['rewards'].shape == (max_path_length, )
+            assert samples['baselines'].shape == (max_path_length, )
+            assert samples['returns'].shape == (max_path_length, )
+            # there is only 1 path
+            assert samples['lengths'].shape == (1, )
+            for key, shape in policy.state_info_specs:
+                assert samples['agent_infos'][key].shape == (max_path_length,
+                                                             np.prod(shape))
+            # DummyBoxEnv has env_info dummy
+            assert samples['env_infos']['dummy'].shape == (max_path_length, )
+            assert isinstance(samples['average_return'], float)
+
+    # pylint: disable=abstract-class-instantiated, no-member
+    @mock.patch.multiple(BatchPolopt2, __abstractmethods__=set())
+    def test_process_samples_discrete_non_recurrent(self):
+        env = TfEnv(DummyDiscreteEnv())
+        policy = CategoricalMLPPolicy(env_spec=env.spec)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+        max_path_length = 100
+        with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
+            algo = BatchPolopt2(env_spec=env.spec,
+                                policy=policy,
+                                baseline=baseline,
+                                max_path_length=max_path_length,
+                                flatten_input=True)
+            runner.setup(algo, env, sampler_args=dict(n_envs=1))
+            runner.train(n_epochs=1, batch_size=max_path_length)
+            paths = runner.obtain_samples(0)
+            samples = algo.process_samples(0, paths)
+            # Since there is only 1 vec_env in the sampler and DummyDiscreteEnv
+            # always terminate, number of paths must be max_path_length, and
+            # batch size must be max_path_length as well, i.e. 100
+            assert samples['observations'].shape == (
+                max_path_length, env.observation_space.flat_dim)
+            assert samples['actions'].shape == (max_path_length,
+                                                env.action_space.n)
+            assert samples['rewards'].shape == (max_path_length, )
+            assert samples['baselines'].shape == (max_path_length, )
+            assert samples['returns'].shape == (max_path_length, )
+            # there is 100 path
+            assert samples['lengths'].shape == (max_path_length, )
+            # non-recurrent policy has empty agent info
+            assert samples['agent_infos'] == {}
+            # non-recurrent policy has empty env info
+            assert samples['env_infos'] == {}
+            assert isinstance(samples['average_return'], float)
+
+    # pylint: disable=abstract-class-instantiated, no-member
+    @mock.patch.multiple(BatchPolopt2, __abstractmethods__=set())
+    def test_process_samples_discrete_recurrent(self):
+        env = TfEnv(DummyDiscreteEnv())
+        policy = CategoricalLSTMPolicy(env_spec=env.spec)
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+        max_path_length = 100
+        with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
+            algo = BatchPolopt2(env_spec=env.spec,
+                                policy=policy,
+                                baseline=baseline,
+                                max_path_length=max_path_length,
+                                flatten_input=True)
+            runner.setup(algo, env, sampler_args=dict(n_envs=1))
+            runner.train(n_epochs=1, batch_size=max_path_length)
+            paths = runner.obtain_samples(0)
+            samples = algo.process_samples(0, paths)
+            # Since there is only 1 vec_env in the sampler and DummyDiscreteEnv
+            # always terminate, number of paths must be max_path_length, and
+            # batch size must be max_path_length as well, i.e. 100
+            assert samples['observations'].shape == (
+                max_path_length, env.observation_space.flat_dim)
+            assert samples['actions'].shape == (max_path_length,
+                                                env.action_space.n)
+            assert samples['rewards'].shape == (max_path_length, )
+            assert samples['baselines'].shape == (max_path_length, )
+            assert samples['returns'].shape == (max_path_length, )
+            # there is 100 path
+            assert samples['lengths'].shape == (max_path_length, )
+            # non-recurrent policy has empty agent info
+            for key, shape in policy.state_info_specs:
+                assert samples['agent_infos'][key].shape == (max_path_length,
+                                                             np.prod(shape))
+            # non-recurrent policy has empty env info
+            assert samples['env_infos'] == {}
+            assert isinstance(samples['average_return'], float)


### PR DESCRIPTION
This is the first PR for a series of 3 PRs, aiming to replace garage distribution with tfp.Distribution.

Currently we are generating dense samples ([batch, time_step, *dims]) with a "valids" array in the base class BatchPolopt. The valids array indicates whether an index is valid in a path, i.e. valids[i][j] is 1 if the j-th step in i-path is valid, otherwise 0.
When we construct loss in most of other on-policy algorithms, we feed the dense samples directly for recurrent policies, or have to perform reshaping and filtering for non-recurrent policies.

By changing to feed flattened sample paths and valid, we instead feed the flattened samples directly for non-recurrent policies, or reshape to dense from the flattened samples with valids.

This PR modifies BatchPolpot to return flattened sample paths, [B * (T), *dims], where T is the variable-length of each batch.