### PR TITLE
Remove optimizer_args from torch algos

### DIFF
--- a/examples/torch/ddpg_pendulum.py
+++ b/examples/torch/ddpg_pendulum.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with DDPG algorithm written in PyTorch.
+"""This is an example to train a task with DDPG algorithm written in PyTorch.
 
 Here it creates a gym environment InvertedDoublePendulum. And uses a DDPG with
 1M steps.
@@ -21,7 +20,15 @@ from garage.torch.q_functions import ContinuousMLPQFunction
 
 
 def run_task(snapshot_config, *_):
-    """Set up environment and algorithm and run the task."""
+    """Set up environment and algorithm and run the task.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+            If None, it will create one with default settings.
+        _ : Unused parameters
+
+    """
     runner = LocalRunner(snapshot_config)
     env = GarageEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
 
@@ -40,6 +47,8 @@ def run_task(snapshot_config, *_):
                                        size_in_transitions=int(1e6),
                                        time_horizon=100)
 
+    policy_optimizer = (torch.optim.Adagrad, {'lr': 1e-4, 'lr_decay': 0.99})
+
     ddpg = DDPG(env_spec=env.spec,
                 policy=policy,
                 qf=qf,
@@ -48,10 +57,9 @@ def run_task(snapshot_config, *_):
                 min_buffer_size=int(1e4),
                 exploration_strategy=action_noise,
                 target_update_tau=1e-2,
-                policy_lr=1e-4,
-                qf_lr=1e-3,
                 discount=0.9,
-                optimizer=torch.optim.Adam)
+                policy_optimizer=policy_optimizer,
+                qf_optimizer=torch.optim.Adam)
 
     runner.setup(algo=ddpg, env=env)
 

--- a/examples/torch/ppo_pendulum.py
+++ b/examples/torch/ppo_pendulum.py
@@ -35,12 +35,10 @@ def run_task(snapshot_config, *_):
 
     algo = PPO(env_spec=env.spec,
                policy=policy,
-               optimizer=torch.optim.Adam,
                baseline=baseline,
                max_path_length=100,
                discount=0.99,
-               center_adv=False,
-               policy_lr=3e-4)
+               center_adv=False)
 
     runner.setup(algo, env)
     runner.train(n_epochs=100, batch_size=10000)

--- a/examples/torch/vpg_pendulum.py
+++ b/examples/torch/vpg_pendulum.py
@@ -38,12 +38,10 @@ def run_task(snapshot_config, *_):
 
     algo = VPG(env_spec=env.spec,
                policy=policy,
-               optimizer=torch.optim.Adam,
                baseline=baseline,
                max_path_length=100,
                discount=0.99,
-               center_adv=False,
-               policy_lr=1e-2)
+               center_adv=False)
 
     runner.setup(algo, env)
     runner.train(n_epochs=100, batch_size=10000)

--- a/src/garage/torch/algos/__init__.py
+++ b/src/garage/torch/algos/__init__.py
@@ -1,4 +1,9 @@
 """PyTorch algorithms."""
+from garage.torch.algos._utils import _Default  # noqa: F401
+from garage.torch.algos._utils import compute_advantages  # noqa: F401
+from garage.torch.algos._utils import filter_valids  # noqa: F401
+from garage.torch.algos._utils import make_optimizer  # noqa: F401
+from garage.torch.algos._utils import pad_to_last  # noqa: F401
 from garage.torch.algos.ddpg import DDPG
 from garage.torch.algos.vpg import VPG
 from garage.torch.algos.ppo import PPO  # noqa: I100

--- a/src/garage/torch/algos/_utils.py
+++ b/src/garage/torch/algos/_utils.py
@@ -1,6 +1,56 @@
-"""Differentiable utils typically used when computing loss functions."""
+"""Utility functions used by PyTorch algorithms."""
 import torch
 import torch.nn.functional as F
+
+
+class _Default:  # pylint: disable=too-few-public-methods
+    """A wrapper class to represent default arguments.
+
+    Args:
+        val (object): Argument value.
+
+    """
+
+    def __init__(self, val):
+        self.val = val
+
+
+def make_optimizer(optimizer_type, module, **kwargs):
+    """Create an optimizer for PyTorch algos.
+
+    Args:
+        optimizer_type (Union[type, tuple[type, dict]]): Type of optimizer.
+            This can be an optimizer type such as 'torch.optim.Adam' or a
+            tuple of type and dictionary, where dictionary contains arguments
+            to initialize the optimizer e.g. (torch.optim.Adam, {'lr' = 1e-3})
+        module (torch.nn.Module): The module whose parameters needs to be
+            optimized.
+        kwargs (dict): Other keyword arguments to initialize optimizer. This
+            is not used when `optimizer_type` is tuple.
+
+    Returns:
+        torch.optim.Optimizer: Constructed optimizer.
+
+    Raises:
+        ValueError: Raises value error when `optimizer_type` is tuple, and
+            non-default argument is passed in `kwargs`.
+
+    """
+    if isinstance(optimizer_type, tuple):
+        opt_type, opt_args = optimizer_type
+        for name, arg in kwargs.items():
+            if not isinstance(arg, _Default):
+                raise ValueError('Should not specify {} and explicit \
+                    optimizer args at the same time'.format(name))
+        return opt_type(module.parameters(), **opt_args)
+
+    opt_args = {}
+    for name, arg in kwargs.items():
+        if isinstance(arg, _Default):
+            opt_args[name] = arg.val
+        else:
+            opt_args[name] = arg
+    return optimizer_type(module.parameters(), **opt_args)
 
 
 def compute_advantages(discount, gae_lambda, max_path_length, baselines,

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 
 from garage.np.algos.off_policy_rl_algorithm import OffPolicyRLAlgorithm
+from garage.torch.algos import _Default, make_optimizer
 from garage.torch.utils import np_to_torch, torch_to_np
 
 
@@ -22,37 +23,42 @@ class DDPG(OffPolicyRLAlgorithm):
     Args:
         env_spec (EnvSpec): Environment specification.
         policy (garage.torch.policies.base.Policy): Policy.
-        target_policy (garage.torch.policies.base.Policy): Copy of policy.
         qf (object): Q-value network.
-        target_qf (object): Copy of Q-value network.
         replay_buffer (garage.replay_buffer.ReplayBuffer): Replay buffer.
         n_epoch_cycles (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
+        buffer_batch_size (int): Batch size of replay buffer.
         min_buffer_size (int): The minimum buffer size for replay buffer.
         rollout_batch_size (int): Roll out batch size.
-        exploration_strategy (garage.np.exploration_strategies.
-            ExplorationStrategy): Exploration strategy.
+        exploration_strategy (garage.np.exploration_strategies.ExplorationStrategy): # noqa: E501
+                Exploration strategy.
         target_update_tau (float): Interpolation parameter for doing the
             soft target update.
-        policy_lr (float): Learning rate for training policy network.
-        qf_lr (float): Learning rate for training Q-value network.
         discount(float): Discount factor for the cumulative return.
         policy_weight_decay (float): L2 weight decay factor for parameters
             of the policy network.
         qf_weight_decay (float): L2 weight decay factor for parameters
             of the q value network.
-        optimizer (torch.optimizer): Optimizer for training policy network
-            and Q-vaule network.
-        criterion (torch.nn.modules.loss): Loss function for Q-value newtork.
+        policy_optimizer (Union[type, tuple[type, dict]]): Type of optimizer
+            for training policy network. This can be an optimizer type such as
+            `torch.optim.Adam` or a tuple of type and dictionary, where
+            dictionary contains arguments to initialize the optimizer
+            e.g. `(torch.optim.Adam, {'lr' = 1e-3})`.
+        qf_optimizer (Union[type, tuple[type, dict]]): Type of optimizer
+            for training Q-value network. This can be an optimizer type such
+            as `torch.optim.Adam` or a tuple of type and dictionary, where
+            dictionary contains arguments to initialize the optimizer
+            e.g. `(torch.optim.Adam, {'lr' = 1e-3})`.
+        policy_lr (float): Learning rate for policy network parameters.
+        qf_lr (float): Learning rate for Q-value network parameters.
         clip_pos_returns (bool): Whether or not clip positive returns.
         clip_return (float): Clip return to be in [-clip_return,
             clip_return].
         max_action (float): Maximum action magnitude.
         reward_scale (float): Reward scale.
         smooth_return (bool): Whether to smooth the return for logging.
-        name (str): Name of the algorithm shown in computation graph.
 
     """
 
@@ -69,34 +75,33 @@ class DDPG(OffPolicyRLAlgorithm):
                  rollout_batch_size=1,
                  exploration_strategy=None,
                  target_update_tau=0.01,
-                 policy_lr=1e-4,
-                 qf_lr=1e-3,
                  discount=0.99,
                  policy_weight_decay=0,
                  qf_weight_decay=0,
-                 optimizer=torch.optim.Adam,
+                 policy_optimizer=torch.optim.Adam,
+                 qf_optimizer=torch.optim.Adam,
+                 policy_lr=_Default(1e-4),
+                 qf_lr=_Default(1e-3),
                  clip_pos_returns=False,
                  clip_return=np.inf,
                  max_action=None,
                  reward_scale=1.,
                  smooth_return=True):
         action_bound = env_spec.action_space.high
-        self.tau = target_update_tau
-        self.policy_lr = policy_lr
-        self.qf_lr = qf_lr
-        self.policy_weight_decay = policy_weight_decay
-        self.qf_weight_decay = qf_weight_decay
-        self.clip_pos_returns = clip_pos_returns
-        self.clip_return = clip_return
-        self.max_action = action_bound if max_action is None else max_action
-        self.evaluate = False
+        self._tau = target_update_tau
+        self._policy_weight_decay = policy_weight_decay
+        self._qf_weight_decay = qf_weight_decay
+        self._clip_pos_returns = clip_pos_returns
+        self._clip_return = clip_return
+        self._max_action = action_bound if max_action is None else max_action
+        self._evaluate = False
 
-        self.success_history = deque(maxlen=100)
-        self.episode_rewards = []
-        self.episode_policy_losses = []
-        self.episode_qf_losses = []
-        self.epoch_ys = []
-        self.epoch_qs = []
+        self._success_history = deque(maxlen=100)
+        self._episode_rewards = []
+        self._episode_policy_losses = []
+        self._episode_qf_losses = []
+        self._epoch_ys = []
+        self._epoch_qs = []
 
         super().__init__(env_spec=env_spec,
                          policy=policy,
@@ -114,76 +119,90 @@ class DDPG(OffPolicyRLAlgorithm):
                          reward_scale=reward_scale,
                          smooth_return=smooth_return)
 
-        self.target_policy = copy.deepcopy(self.policy)
-        self.target_qf = copy.deepcopy(self.qf)
-        self.policy_optimizer = optimizer(self.policy.parameters(),
-                                          lr=self.policy_lr)
-        self.qf_optimizer = optimizer(self.qf.parameters(), lr=self.qf_lr)
+        self._target_policy = copy.deepcopy(self.policy)
+        self._target_qf = copy.deepcopy(self.qf)
+        self._policy_optimizer = make_optimizer(policy_optimizer,
+                                                self.policy,
+                                                lr=policy_lr)
+        self._qf_optimizer = make_optimizer(qf_optimizer, self.qf, lr=qf_lr)
 
     def train_once(self, itr, paths):
-        """Perform one iteration of training."""
+        """Perform one iteration of training.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths
+
+        Returns:
+            float: Average return.
+
+        """
         paths = self.process_samples(itr, paths)
 
         epoch = itr / self.n_epoch_cycles
 
-        self.episode_rewards.extend([
+        self._episode_rewards.extend([
             path for path, complete in zip(paths['undiscounted_returns'],
                                            paths['complete']) if complete
         ])
-        self.success_history.extend([
+        self._success_history.extend([
             path for path, complete in zip(paths['success_history'],
                                            paths['complete']) if complete
         ])
 
-        last_average_return = np.mean(self.episode_rewards)
-        for train_itr in range(self.n_train_steps):
-            if self.replay_buffer.n_transitions_stored >= self.min_buffer_size:  # noqa: E501
-                self.evaluate = True
+        last_average_return = np.mean(self._episode_rewards)
+        for _ in range(self.n_train_steps):
+            if (self.replay_buffer.n_transitions_stored >=
+                    self.min_buffer_size):
+                self._evaluate = True
                 samples = self.replay_buffer.sample(self.buffer_batch_size)
                 qf_loss, y, q, policy_loss = torch_to_np(
                     self.optimize_policy(itr, samples))
 
-                self.episode_policy_losses.append(policy_loss)
-                self.episode_qf_losses.append(qf_loss)
-                self.epoch_ys.append(y)
-                self.epoch_qs.append(q)
+                self._episode_policy_losses.append(policy_loss)
+                self._episode_qf_losses.append(qf_loss)
+                self._epoch_ys.append(y)
+                self._epoch_qs.append(q)
 
         if itr % self.n_epoch_cycles == 0:
             logger.log('Training finished')
 
-            if self.evaluate:
+            if self._evaluate:
                 tabular.record('Epoch', epoch)
-                tabular.record('AverageReturn', np.mean(self.episode_rewards))
-                tabular.record('StdReturn', np.std(self.episode_rewards))
+                tabular.record('AverageReturn', np.mean(self._episode_rewards))
+                tabular.record('StdReturn', np.std(self._episode_rewards))
                 tabular.record('Policy/AveragePolicyLoss',
-                               np.mean(self.episode_policy_losses))
+                               np.mean(self._episode_policy_losses))
                 tabular.record('QFunction/AverageQFunctionLoss',
-                               np.mean(self.episode_qf_losses))
-                tabular.record('QFunction/AverageQ', np.mean(self.epoch_qs))
-                tabular.record('QFunction/MaxQ', np.max(self.epoch_qs))
+                               np.mean(self._episode_qf_losses))
+                tabular.record('QFunction/AverageQ', np.mean(self._epoch_qs))
+                tabular.record('QFunction/MaxQ', np.max(self._epoch_qs))
                 tabular.record('QFunction/AverageAbsQ',
-                               np.mean(np.abs(self.epoch_qs)))
-                tabular.record('QFunction/AverageY', np.mean(self.epoch_ys))
-                tabular.record('QFunction/MaxY', np.max(self.epoch_ys))
+                               np.mean(np.abs(self._epoch_qs)))
+                tabular.record('QFunction/AverageY', np.mean(self._epoch_ys))
+                tabular.record('QFunction/MaxY', np.max(self._epoch_ys))
                 tabular.record('QFunction/AverageAbsY',
-                               np.mean(np.abs(self.epoch_ys)))
+                               np.mean(np.abs(self._epoch_ys)))
                 tabular.record('AverageSuccessRate',
-                               np.mean(self.success_history))
+                               np.mean(self._success_history))
 
             if not self.smooth_return:
-                self.episode_rewards = []
-                self.episode_policy_losses = []
-                self.episode_qf_losses = []
-                self.epoch_ys = []
-                self.epoch_qs = []
+                self._episode_rewards = []
+                self._episode_policy_losses = []
+                self._episode_qf_losses = []
+                self._epoch_ys = []
+                self._epoch_qs = []
 
-            self.success_history.clear()
+            self._success_history.clear()
 
         return last_average_return
 
-    def optimize_policy(self, itr, samples):
-        """
-        Perform algorithm optimizing.
+    def optimize_policy(self, itr, samples_data):
+        """Perform algorithm optimizing.
+
+        Args:
+            itr (int): Iteration number.
+            samples_data (dict): Processed batch data.
 
         Returns:
             action_loss: Loss of action predicted by the policy network.
@@ -192,7 +211,7 @@ class DDPG(OffPolicyRLAlgorithm):
             qval: Q-value predicted by the Q-network.
 
         """
-        transitions = np_to_torch(samples)
+        transitions = np_to_torch(samples_data)
         observations = transitions['observation']
         rewards = transitions['reward']
         actions = transitions['action']
@@ -205,11 +224,11 @@ class DDPG(OffPolicyRLAlgorithm):
         next_inputs = next_observations
         inputs = observations
         with torch.no_grad():
-            next_actions = self.target_policy(next_inputs)
-            target_qvals = self.target_qf(next_inputs, next_actions)
+            next_actions = self._target_policy(next_inputs)
+            target_qvals = self._target_qf(next_inputs, next_actions)
 
-        clip_range = (-self.clip_return,
-                      0. if self.clip_pos_returns else self.clip_return)
+        clip_range = (-self._clip_return,
+                      0. if self._clip_pos_returns else self._clip_return)
 
         y_target = rewards + (1.0 - terminals) * self.discount * target_qvals
         y_target = torch.clamp(y_target, clip_range[0], clip_range[1])
@@ -218,16 +237,16 @@ class DDPG(OffPolicyRLAlgorithm):
         qval = self.qf(inputs, actions)
         qf_loss = torch.nn.MSELoss()
         qval_loss = qf_loss(qval, y_target)
-        self.qf_optimizer.zero_grad()
+        self._qf_optimizer.zero_grad()
         qval_loss.backward()
-        self.qf_optimizer.step()
+        self._qf_optimizer.step()
 
         # optimize actor
         actions = self.policy(inputs)
         action_loss = -1 * self.qf(inputs, actions).mean()
-        self.policy_optimizer.zero_grad()
+        self._policy_optimizer.zero_grad()
         action_loss.backward()
-        self.policy_optimizer.step()
+        self._policy_optimizer.step()
 
         # update target networks
         self.update_target()
@@ -236,12 +255,12 @@ class DDPG(OffPolicyRLAlgorithm):
 
     def update_target(self):
         """Update parameters in the target policy and Q-value network."""
-        for t_param, param in zip(self.target_qf.parameters(),
+        for t_param, param in zip(self._target_qf.parameters(),
                                   self.qf.parameters()):
-            t_param.data.copy_(t_param.data * (1.0 - self.tau) +
-                               param.data * self.tau)
+            t_param.data.copy_(t_param.data * (1.0 - self._tau) +
+                               param.data * self._tau)
 
-        for t_param, param in zip(self.target_policy.parameters(),
+        for t_param, param in zip(self._target_policy.parameters(),
                                   self.policy.parameters()):
-            t_param.data.copy_(t_param.data * (1.0 - self.tau) +
-                               param.data * self.tau)
+            t_param.data.copy_(t_param.data * (1.0 - self._tau) +
+                               param.data * self._tau)

--- a/src/garage/torch/algos/ppo.py
+++ b/src/garage/torch/algos/ppo.py
@@ -1,7 +1,7 @@
 """Proximal Policy Optimization (PPO)."""
 import torch
 
-from garage.torch.algos import VPG
+from garage.torch.algos import _Default, VPG
 
 
 class PPO(VPG):
@@ -11,11 +11,15 @@ class PPO(VPG):
         env_spec (garage.envs.EnvSpec): Environment specification.
         policy (garage.torch.policies.base.Policy): Policy.
         baseline (garage.np.baselines.Baseline): The baseline.
+        optimizer (Union[type, tuple[type, dict]]): Type of optimizer.
+            This can be an optimizer type such as `torch.optim.Adam` or a
+            tuple of type and dictionary, where dictionary contains arguments
+            to initialize the optimizer e.g. `(torch.optim.Adam, {'lr' = 1e-3})`  # noqa: E501
+        policy_lr (float): Learning rate for policy parameters.
         max_path_length (int): Maximum length of a single rollout.
-        policy_lr (float): Learning rate for training policy network.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies.
-        n_samples (int): Number of train_once calls per epoch.
+        num_train_per_epoch (int): Number of train_once calls per epoch.
         discount (float): Discount.
         gae_lambda (float): Lambda used for generalized advantage
             estimation.
@@ -25,9 +29,6 @@ class PPO(VPG):
             so that they are always positive. When used in
             conjunction with center_adv the advantages will be
             standardized before shifting.
-        optimizer (object): The optimizer of the algorithm. Should be the
-            optimizers in torch.optim.
-        optimizer_args (dict): Arguments required to initialize the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
             Setting it to zero would mean no entropy regularization.
         use_softplus_entropy (bool): Whether to estimate the softmax
@@ -46,25 +47,35 @@ class PPO(VPG):
                  env_spec,
                  policy,
                  baseline,
+                 optimizer=torch.optim.Adam,
+                 policy_lr=_Default(3e-4),
                  max_path_length=500,
-                 policy_lr=3e-4,
                  lr_clip_range=2e-1,
-                 n_samples=1,
+                 num_train_per_epoch=1,
                  discount=0.99,
                  gae_lambda=0.97,
                  center_adv=True,
                  positive_adv=False,
-                 optimizer=None,
-                 optimizer_args=None,
                  policy_ent_coeff=0.0,
                  use_softplus_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy'):
-        super().__init__(env_spec, policy, baseline, max_path_length,
-                         policy_lr, n_samples, discount, gae_lambda,
-                         center_adv, positive_adv, optimizer, optimizer_args,
-                         policy_ent_coeff, use_softplus_entropy,
-                         stop_entropy_gradient, entropy_method)
+
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         optimizer=optimizer,
+                         policy_lr=policy_lr,
+                         max_path_length=max_path_length,
+                         num_train_per_epoch=num_train_per_epoch,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method)
 
         self._lr_clip_range = lr_clip_range
 

--- a/src/garage/torch/algos/trpo.py
+++ b/src/garage/torch/algos/trpo.py
@@ -13,23 +13,20 @@ class TRPO(VPG):
         policy (garage.torch.policies.base.Policy): Policy.
         baseline (garage.np.baselines.Baseline): The baseline.
         max_path_length (int): Maximum length of a single rollout.
-        policy_lr (float): Learning rate for training policy network.
         num_train_per_epoch (int): Number of train_once calls per epoch.
         discount (float): Discount.
         gae_lambda (float): Lambda used for generalized advantage
             estimation.
-        max_kl (float): Maximum KL divergence between old and new policies.
         center_adv (bool): Whether to rescale the advantages
             so that they have mean 0 and standard deviation 1.
         positive_adv (bool): Whether to shift the advantages
             so that they are always positive. When used in
             conjunction with center_adv the advantages will be
             standardized before shifting.
-        optimizer (object): The optimizer of the algorithm. Should be the
-            optimizers in torch.optim.
-        optimizer_args (dict): Arguments required to initialize the optimizer.
         policy_ent_coeff (float): The coefficient of the policy entropy.
             Setting it to zero would mean no entropy regularization.
+        max_kl_step (float): The maximum KL divergence between old and new
+            policies.
         use_softplus_entropy (bool): Whether to estimate the softmax
             distribution of the entropy to prevent the entropy from being
             negative.
@@ -47,30 +44,35 @@ class TRPO(VPG):
                  policy,
                  baseline,
                  max_path_length=100,
-                 policy_lr=3e-4,
                  num_train_per_epoch=1,
                  discount=0.99,
                  gae_lambda=0.98,
-                 max_kl=0.01,
                  center_adv=True,
                  positive_adv=False,
-                 optimizer=None,
-                 optimizer_args=None,
                  policy_ent_coeff=0.0,
+                 max_kl_step=0.01,
                  use_softplus_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy'):
-        if optimizer is None:
-            optimizer = ConjugateGradientOptimizer
-            optimizer_args = {'max_constraint_value': max_kl}
 
-        super().__init__(env_spec, policy, baseline, max_path_length,
-                         policy_lr, num_train_per_epoch, discount, gae_lambda,
-                         center_adv, positive_adv, optimizer, optimizer_args,
-                         policy_ent_coeff, use_softplus_entropy,
-                         stop_entropy_gradient, entropy_method)
+        optimizer = (ConjugateGradientOptimizer, {
+            'max_constraint_value': max_kl_step
+        })
 
-        self._kl = None
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         optimizer=optimizer,
+                         max_path_length=max_path_length,
+                         num_train_per_epoch=num_train_per_epoch,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method)
 
     def _compute_objective(self, advantages, valids, obs, actions, rewards):
         """Compute the surrogate objective.

--- a/src/garage/torch/utils.py
+++ b/src/garage/torch/utils.py
@@ -27,10 +27,8 @@ def torch_to_np(value_in):
         tuple[numpy.ndarray]: Tuple of data in numpy arrays.
 
     """
-    value_out = []
-    for v in value_in:
-        value_out.append(v.numpy())
-    return tuple(value_out)
+    value_out = tuple(v.numpy() for v in value_in)
+    return value_out
 
 
 def flatten_batch(tensor):

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
@@ -171,13 +171,13 @@ def run_garage_pytorch(env, seed, log_dir):
 
     algo = PyTorch_PPO(env_spec=env.spec,
                        policy=policy,
-                       optimizer=torch.optim.Adam,
                        baseline=baseline,
+                       optimizer=torch.optim.Adam,
+                       policy_lr=hyper_parameters['learning_rate'],
                        max_path_length=hyper_parameters['max_path_length'],
                        discount=hyper_parameters['discount'],
                        gae_lambda=hyper_parameters['gae_lambda'],
                        center_adv=hyper_parameters['center_adv'],
-                       policy_lr=hyper_parameters['learning_rate'],
                        lr_clip_range=hyper_parameters['lr_clip_range'])
 
     # Set up logger since we are not using run_experiment

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
@@ -149,15 +149,13 @@ def run_garage_pytorch(env, seed, log_dir):
 
     baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-    algo = PyTorch_TRPO(
-        env_spec=env.spec,
-        policy=policy,
-        baseline=baseline,
-        max_path_length=hyper_parameters['max_path_length'],
-        discount=hyper_parameters['discount'],
-        gae_lambda=hyper_parameters['gae_lambda'],
-        max_kl=hyper_parameters['max_kl'],
-    )
+    algo = PyTorch_TRPO(env_spec=env.spec,
+                        policy=policy,
+                        baseline=baseline,
+                        max_kl_step=hyper_parameters['max_kl'],
+                        max_path_length=hyper_parameters['max_path_length'],
+                        discount=hyper_parameters['discount'],
+                        gae_lambda=hyper_parameters['gae_lambda'])
 
     # Set up logger since we are not using run_experiment
     tabular_log_file = osp.join(log_dir, 'progress.csv')

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
@@ -147,11 +147,11 @@ def run_garage_pytorch(env, seed, log_dir):
     algo = PyTorch_VPG(env_spec=env.spec,
                        policy=policy,
                        optimizer=torch.optim.Adam,
+                       policy_lr=hyper_parameters['learning_rate'],
                        baseline=baseline,
                        max_path_length=hyper_parameters['max_path_length'],
                        discount=hyper_parameters['discount'],
-                       center_adv=hyper_parameters['center_adv'],
-                       policy_lr=hyper_parameters['learning_rate'])
+                       center_adv=hyper_parameters['center_adv'])
 
     # Set up logger since we are not using run_experiment
     tabular_log_file = osp.join(log_dir, 'progress.csv')

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -1,7 +1,4 @@
-"""
-This script creates a test that fails when garage.tf.algos.DDPG performance is
-too low.
-"""
+"""This script creates a test that fails when DDPG performance is too low."""
 import gym
 import pytest
 import torch
@@ -9,7 +6,7 @@ from torch.nn import functional as F  # NOQA
 
 from garage.envs import normalize
 from garage.envs.base import GarageEnv
-from garage.experiment import LocalRunner
+from garage.experiment import deterministic, LocalRunner
 from garage.np.exploration_strategies import OUStrategy
 from garage.replay_buffer import SimpleReplayBuffer
 from garage.torch.algos import DDPG
@@ -19,10 +16,12 @@ from tests.fixtures import snapshot_config
 
 
 class TestDDPG:
+    """Test class for DDPG."""
 
     @pytest.mark.large
     def test_ddpg_double_pendulum(self):
         """Test DDPG with Pendulum environment."""
+        deterministic.set_seed(0)
         runner = LocalRunner(snapshot_config)
         env = GarageEnv(gym.make('InvertedDoublePendulum-v2'))
         action_noise = OUStrategy(env.spec, sigma=0.2)
@@ -48,8 +47,6 @@ class TestDDPG:
                     min_buffer_size=int(1e4),
                     exploration_strategy=action_noise,
                     target_update_tau=1e-2,
-                    policy_lr=1e-4,
-                    qf_lr=1e-3,
                     discount=0.9)
 
         runner.setup(algo, env)
@@ -62,11 +59,11 @@ class TestDDPG:
 
     @pytest.mark.large
     def test_ddpg_pendulum(self):
-        """
-        Test DDPG with Pendulum environment.
+        """Test DDPG with Pendulum environment.
 
         This environment has a [-3, 3] action_space bound.
         """
+        deterministic.set_seed(0)
         runner = LocalRunner(snapshot_config)
         env = GarageEnv(normalize(gym.make('InvertedPendulum-v2')))
         action_noise = OUStrategy(env.spec, sigma=0.2)
@@ -92,8 +89,6 @@ class TestDDPG:
                     min_buffer_size=int(1e4),
                     exploration_strategy=action_noise,
                     target_update_tau=1e-2,
-                    policy_lr=1e-4,
-                    qf_lr=1e-3,
                     discount=0.9)
 
         runner.setup(algo, env)

--- a/tests/garage/torch/algos/test_ppo.py
+++ b/tests/garage/torch/algos/test_ppo.py
@@ -1,7 +1,4 @@
-"""
-This script creates a test that fails when garage.tf.algos.PPO performance is
-too low.
-"""
+"""This script creates a test that fails when PPO performance is too low."""
 import gym
 import torch
 
@@ -15,8 +12,10 @@ from tests.fixtures import snapshot_config
 
 
 class TestPPO:
+    """Test class for PPO."""
 
     def setup_method(self):
+        """Setup method which is called before every test."""
         self.env = GarageEnv(normalize(gym.make('InvertedDoublePendulum-v2')))
         self.policy = GaussianMLPPolicy(
             env_spec=self.env.spec,
@@ -27,6 +26,7 @@ class TestPPO:
         self.baseline = LinearFeatureBaseline(env_spec=self.env.spec)
 
     def teardown_method(self):
+        """Teardown method which is called after every test."""
         self.env.close()
 
     def test_ppo_pendulum(self):
@@ -37,12 +37,10 @@ class TestPPO:
         algo = PPO(env_spec=self.env.spec,
                    policy=self.policy,
                    baseline=self.baseline,
-                   optimizer=torch.optim.Adam,
                    max_path_length=100,
                    discount=0.99,
                    gae_lambda=0.97,
-                   lr_clip_range=2e-1,
-                   policy_lr=3e-4)
+                   lr_clip_range=2e-1)
 
         runner.setup(algo, self.env)
         last_avg_ret = runner.train(n_epochs=10, batch_size=100)

--- a/tests/garage/torch/algos/test_torch_algo_utils.py
+++ b/tests/garage/torch/algos/test_torch_algo_utils.py
@@ -1,3 +1,4 @@
+"""Test torch algo utility functions."""
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -5,11 +6,12 @@ import torch
 import torch.nn.functional as F
 
 import garage.tf.misc.tensor_utils as tf_utils
-import garage.torch.algos.loss_function_utils as torch_loss_utils
+import garage.torch.algos._utils as torch_algo_utils
 from tests.fixtures import TfGraphTestCase
 
 
 def stack(d, arr):
+    """Stack 'arr' 'd' times."""
     return np.repeat(np.expand_dims(arr, axis=0), repeats=d, axis=0)
 
 
@@ -25,7 +27,8 @@ nums_2d = np.arange(0, 4).astype(float).reshape(2, 2)
 nums_3d = np.arange(0, 8).astype(float).reshape(2, 2, 2)
 
 
-class TestLossFunctionUtils(TfGraphTestCase):
+class TestTorchAlgoUtils(TfGraphTestCase):
+    """Test class for torch algo utility functions."""
     # yapf: disable
     @pytest.mark.parametrize('gae_lambda, rewards_val, baselines_val', [
         (0.4, ONES, ZEROS),
@@ -34,11 +37,12 @@ class TestLossFunctionUtils(TfGraphTestCase):
         (1.7, E_DIGITS, PI_DIGITS),
     ])
     # yapf: enable
-    def test_compute_advantages(self, gae_lambda, rewards_val, baselines_val):
+    def testcompute_advantages(self, gae_lambda, rewards_val, baselines_val):
+        """Test compute_advantage function."""
         discount = 0.99
         max_len = rewards_val.shape[-1]
 
-        torch_advs = torch_loss_utils.compute_advantages(
+        torch_advs = torch_algo_utils.compute_advantages(
             discount, gae_lambda, max_len, torch.Tensor(baselines_val),
             torch.Tensor(rewards_val))
 
@@ -61,36 +65,38 @@ class TestLossFunctionUtils(TfGraphTestCase):
                            atol=1e-5)
 
     def test_add_padding_last_1d(self):
+        """Test pad_to_last function for 1d."""
         max_length = 10
 
         expected = F.pad(torch.Tensor(nums_1d),
                          (0, max_length - nums_1d.shape[-1]))
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_1d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_1d,
                                                       total_length=max_length)
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_1d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_1d,
                                                       total_length=10,
                                                       axis=0)
         assert expected.eq(tensor_padding).all()
 
     def test_add_padding_last_2d(self):
+        """Test pad_to_last function for 2d."""
         max_length = 10
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_2d, total_length=10)
+        tensor_padding = torch_algo_utils.pad_to_last(nums_2d, total_length=10)
         expected = F.pad(torch.Tensor(nums_2d),
                          (0, max_length - nums_2d.shape[-1]))
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_2d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_2d,
                                                       total_length=10,
                                                       axis=0)
         expected = F.pad(torch.Tensor(nums_2d),
                          (0, 0, 0, max_length - nums_2d.shape[0]))
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_2d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_2d,
                                                       total_length=10,
                                                       axis=1)
         expected = F.pad(torch.Tensor(nums_2d),
@@ -98,28 +104,29 @@ class TestLossFunctionUtils(TfGraphTestCase):
         assert expected.eq(tensor_padding).all()
 
     def test_add_padding_last_3d(self):
+        """Test pad_to_last function for 3d."""
         max_length = 10
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_3d, total_length=10)
+        tensor_padding = torch_algo_utils.pad_to_last(nums_3d, total_length=10)
         expected = F.pad(torch.Tensor(nums_3d),
                          (0, max_length - nums_3d.shape[-1], 0, 0, 0, 0))
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_3d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_3d,
                                                       total_length=10,
                                                       axis=0)
         expected = F.pad(torch.Tensor(nums_3d),
                          (0, 0, 0, 0, 0, max_length - nums_3d.shape[0]))
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_3d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_3d,
                                                       total_length=10,
                                                       axis=1)
         expected = F.pad(torch.Tensor(nums_3d),
                          (0, 0, 0, max_length - nums_3d.shape[-1], 0, 0))
         assert expected.eq(tensor_padding).all()
 
-        tensor_padding = torch_loss_utils.pad_to_last(nums_3d,
+        tensor_padding = torch_algo_utils.pad_to_last(nums_3d,
                                                       total_length=10,
                                                       axis=2)
         expected = F.pad(torch.Tensor(nums_3d),
@@ -128,7 +135,36 @@ class TestLossFunctionUtils(TfGraphTestCase):
 
     @pytest.mark.parametrize('nums', [nums_1d, nums_2d, nums_3d])
     def test_out_of_index_error(self, nums):
+        """Test pad_to_last raises IndexError."""
         with pytest.raises(IndexError):
-            torch_loss_utils.pad_to_last(nums,
+            torch_algo_utils.pad_to_last(nums,
                                          total_length=10,
                                          axis=len(nums.shape))
+
+    def testmake_optimizer_with_type(self):
+        """Test make_optimizer function with type as first argument."""
+        optimizer_type = torch.optim.Adam
+        module = torch.nn.Linear(2, 1)
+        lr = 0.123
+        optimizer = torch_algo_utils.make_optimizer(optimizer_type,
+                                                    module,
+                                                    lr=lr)
+        assert isinstance(optimizer, optimizer_type)
+        assert optimizer.defaults['lr'] == lr
+
+    def testmake_optimizer_with_tuple(self):
+        """Test make_optimizer function with tuple as first argument."""
+        optimizer_type = (torch.optim.Adam, {'lr': 0.1})
+        module = torch.nn.Linear(2, 1)
+        optimizer = torch_algo_utils.make_optimizer(optimizer_type, module)
+        assert isinstance(optimizer, optimizer_type)
+        assert optimizer.defaults['lr'] == optimizer_type[1]['lr']
+
+    def testmake_optimizer_raise_value_error(self):
+        """Test make_optimizer raises value error."""
+        optimizer_type = (torch.optim.Adam, {'lr': 0.1})
+        module = torch.nn.Linear(2, 1)
+        with pytest.raises(ValueError):
+            _ = torch_algo_utils.make_optimizer(optimizer_type,
+                                                module,
+                                                lr=0.123)

--- a/tests/garage/torch/algos/test_trpo.py
+++ b/tests/garage/torch/algos/test_trpo.py
@@ -26,7 +26,7 @@ class TestTRPO:
         self.baseline = LinearFeatureBaseline(env_spec=self.env.spec)
 
     def teardown_method(self):
-        """Teardown method which is called after eevery test."""
+        """Teardown method which is called after every test."""
         self.env.close()
 
     def test_trpo_pendulum(self):

--- a/tests/garage/torch/algos/test_vpg.py
+++ b/tests/garage/torch/algos/test_vpg.py
@@ -1,3 +1,4 @@
+"""This script creates a test that fails when VPG performance is too low."""
 import gym
 import pytest
 import torch
@@ -29,30 +30,32 @@ INVALID_ENTROPY_CONFIG = [
 
 
 class TestVPG:
+    """Test class for VPG."""
 
     @classmethod
     def setup_class(cls):
+        """Setup method which is called once before all tests in this class."""
         deterministic.set_seed(0)
 
     def setup_method(self):
+        """Setup method which is called before every test."""
         self._env = GarageEnv(gym.make('InvertedDoublePendulum-v2'))
         self._runner = LocalRunner(snapshot_config)
 
-        policy = GaussianMLPPolicy(env_spec=self._env.spec,
-                                   hidden_sizes=[64, 64],
-                                   hidden_nonlinearity=torch.tanh,
-                                   output_nonlinearity=None)
+        self._policy = GaussianMLPPolicy(env_spec=self._env.spec,
+                                         hidden_sizes=[64, 64],
+                                         hidden_nonlinearity=torch.tanh,
+                                         output_nonlinearity=None)
         self._params = {
             'env_spec': self._env.spec,
-            'policy': policy,
-            'optimizer': torch.optim.Adam,
+            'policy': self._policy,
             'baseline': LinearFeatureBaseline(env_spec=self._env.spec),
             'max_path_length': 100,
             'discount': 0.99,
-            'policy_lr': 1e-2
         }
 
     def teardown_method(self):
+        """Teardown method which is called after every test."""
         self._env.close()
 
     def test_vpg_no_entropy(self):
@@ -87,6 +90,7 @@ class TestVPG:
 
     @pytest.mark.parametrize('algo_param, error, msg', INVALID_ENTROPY_CONFIG)
     def test_invalid_entropy_config(self, algo_param, error, msg):
+        """Test VPG with invalid entropy config."""
         self._params.update(algo_param)
         with pytest.raises(error, match=msg):
             VPG(**self._params)


### PR DESCRIPTION
This PR removes `optimizer_args` pattern from torch algorithm constructors. ~All torch algorithms now accept a constructed optimizer instead of an optimizer class.~

All torch algorithms now accept a optimizer type or a tuple of optimizer type and optimizer args. The algorithm internally constructs an optimizer using a new utility function `_make_optimizer`.