### PR TITLE
Remove get_itr_snapshot()

### DIFF
--- a/src/garage/np/algos/batch_polopt.py
+++ b/src/garage/np/algos/batch_polopt.py
@@ -144,19 +144,3 @@ class BatchPolopt(RLAlgorithm):
         tabular.record('MinReturn', np.min(undiscounted_returns))
 
         return samples_data
-
-    def get_itr_snapshot(self, itr, samples_data):
-        # pylint: disable=no-self-use
-        """Return data saved in the snapshot for this iteration.
-
-        Args:
-            itr (int): Iteration number.
-            samples_data (list[dict]): A list of collected paths
-
-        Returns:
-            dict: A dict of saved data in snapshot.
-
-        """
-        del itr
-        del samples_data
-        return {}

--- a/src/garage/np/algos/nop.py
+++ b/src/garage/np/algos/nop.py
@@ -1,20 +1,28 @@
+"""NOP (no optimization performed) policy search algorithm."""
 from garage.np.algos.base import RLAlgorithm
 
 
 class NOP(RLAlgorithm):
-    """NOP (no optimization performed) policy search algorithm"""
-
-    def __init__(self, **kwargs):
-        super(NOP, self).__init__(**kwargs)
+    """NOP (no optimization performed) policy search algorithm."""
 
     def init_opt(self):
-        pass
+        """Initialize the optimization procedure."""
 
-    def optimize_policy(self, itr, samples_data):
-        pass
+    def optimize_policy(self, itr, paths):
+        """Optimize the policy using the samples.
 
-    def get_itr_snapshot(self, itr, samples_data):
-        return dict()
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
 
-    def train(self):
-        pass
+        """
+
+    def train(self, runner):
+        """Obtain samplers and start actual training for each epoch.
+
+        Args:
+            runner (LocalRunner): LocalRunner is passed to give algorithm
+                the access to runner.step_epochs(), which provides services
+                such as snapshotting and sampler control.
+
+        """

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -361,15 +361,3 @@ class DDPG(OffPolicyRLAlgorithm):
         self.f_update_target()
 
         return qval_loss, ys, qval, action_loss
-
-    def get_itr_snapshot(self, itr):
-        """Return data saved in the snapshot for this iteration.
-
-        Args:
-            itr (int): Current iteration.
-
-        Returns:
-            dict: dictionary of iteration number and policy.
-
-        """
-        return dict(itr=itr, policy=self.policy)

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -169,10 +169,6 @@ class NPO(BatchPolopt):
             samples_data (dict): Processed sample data.
                 See process_samples() for details.
 
-        Raises:
-            NotImplementedError: Raise when child class
-                does not overwrite this method.
-
         """
         policy_opt_input_values = self._policy_opt_input_values(samples_data)
         # Train policy network

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -699,10 +699,10 @@ class NPO(BatchPolopt):
         data = self.__dict__.copy()
         del data['_name_scope']
         del data['_policy_opt_inputs']
-        del data['f_policy_entropy']
-        del data['f_policy_kl']
-        del data['f_rewards']
-        del data['f_returns']
+        del data['_f_policy_entropy']
+        del data['_f_policy_kl']
+        del data['_f_rewards']
+        del data['_f_returns']
         return data
 
     def __setstate__(self, state):

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -497,6 +497,7 @@ class REPS(BatchPolopt):  # noqa: D416
             for k in self.policy.distribution.dist_info_keys
         ]
 
+        # pylint: disable=unexpected-keyword-arg
         dual_opt_input_values = self._dual_opt_inputs._replace(
             reward_var=samples_data['rewards'],
             valid_var=samples_data['valids'],

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -129,9 +129,9 @@ class REPS(BatchPolopt):  # noqa: D416
         del data['_name_scope']
         del data['_policy_opt_inputs']
         del data['_dual_opt_inputs']
-        del data['f_dual']
-        del data['f_dual_grad']
-        del data['f_policy_kl']
+        del data['_f_dual']
+        del data['_f_dual_grad']
+        del data['_f_policy_kl']
         return data
 
     def __setstate__(self, state):

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
@@ -102,6 +102,7 @@ class TestBenchmarkPPO:
                 garage_pytorch_dir = trial_dir + '/garage/pytorch'
                 baselines_dir = trial_dir + '/baselines'
 
+                # pylint: disable=not-context-manager
                 with tf.Graph().as_default():
                     # Run baselines algorithms
                     baseline_env.reset()

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
@@ -85,6 +85,7 @@ class TestBenchmarkVPG:
                 garage_tf_dir = trial_dir + '/garage/tf'
                 garage_pytorch_dir = trial_dir + '/garage/pytorch'
 
+                # pylint: disable=not-context-manager
                 with tf.Graph().as_default():
                     # Run garage algorithms
                     env.reset()

--- a/tests/fixtures/algos/dummy_tf_algo.py
+++ b/tests/fixtures/algos/dummy_tf_algo.py
@@ -1,17 +1,28 @@
+"""Dummy algorithm."""
 from garage.tf.algos import BatchPolopt
 
 
 class DummyTFAlgo(BatchPolopt):
-    """Dummy algo for test."""
-
-    def __init__(self, env_spec, policy, baseline):
-        super().__init__(env_spec=env_spec, policy=policy, baseline=baseline)
+    """Dummy algorithm."""
 
     def init_opt(self):
-        pass
+        """Initialize the optimization procedure.
+
+        If using tensorflow, this may include declaring all the variables and
+        compiling functions.
+
+        """
 
     def optimize_policy(self, itr, samples_data):
-        pass
+        """Optimize the policy using the samples.
 
-    def get_itr_snapshot(self, itr):
-        pass
+        Args:
+            itr (int): Iteration number.
+            samples_data (dict): Processed sample data.
+                See process_samples() for details.
+
+        Raises:
+            NotImplementedError: Raise when child class
+                does not overwrite this method.
+
+        """

--- a/tests/fixtures/algos/dummy_tf_algo.py
+++ b/tests/fixtures/algos/dummy_tf_algo.py
@@ -21,8 +21,4 @@ class DummyTFAlgo(BatchPolopt):
             samples_data (dict): Processed sample data.
                 See process_samples() for details.
 
-        Raises:
-            NotImplementedError: Raise when child class
-                does not overwrite this method.
-
         """

--- a/tests/fixtures/algos/instrumented_nop.py
+++ b/tests/fixtures/algos/instrumented_nop.py
@@ -1,4 +1,4 @@
-"""
+"""Copy of NOP (no optimization performed) policy search algorithm.
 This file is a copy of garage/algos/nop.py
 The only difference is the use of InstrumentedBatchPolopt to notify the test of
 the different stages in the experiment lifecycle.
@@ -9,18 +9,25 @@ from tests.fixtures.algos.instrumented_batch_polopt import (
 
 
 class InstrumentedNOP(InstrumentedBatchPolopt):
-    """
-    NOP (no optimization performed) policy search algorithm
-    """
-
-    def __init__(self, **kwargs):
-        super(InstrumentedNOP, self).__init__(**kwargs)
+    """NOP (no optimization performed) policy search algorithm."""
 
     def init_opt(self):
-        pass
+        """Initialize the optimization procedure."""
 
-    def optimize_policy(self, itr, samples_data):
-        pass
+    def optimize_policy(self, itr, paths):
+        """Optimize the policy using the samples.
 
-    def get_itr_snapshot(self, itr, samples_data):
-        return dict()
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        """
+
+    def train_once(self, itr, paths):
+        """Perform one step of policy optimization given one batch of samples.
+
+        Args:
+            itr (int): Iteration number.
+            paths (list[dict]): A list of collected paths.
+
+        """


### PR DESCRIPTION
This PR addresses #1016 . It removes all `get_itr_snapshot()` from algorithms. This interface was a legacy from rllab to do snapshotting and is deprecated because we now require an algorithm to be pickable/unpickable by rewriting `__setstate__()` and `__getstate__()`.

Some outdated files in fixtures are not touched. They are used by the sigint test and have diverged from the other parts of the codebase for long. I think we should make an investigation to see if zombie processes are still a problem. If not then just remove this test. 