### PR TITLE
Add TrajectoryBatch data type

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions*/
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,6 +176,11 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# See https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
+html_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+]
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,9 @@ per-file-ignores =
 
 # Docstring style checks
 docstring-convention = google
-extend-ignore = D107  # We document __init__ in the class docstring
+extend-ignore =
+    D107  # We document __init__ in the class docstring
+    F841  # Unused variables are checked by pylint
 
 [tool:pytest]
 addopts = -rfE -s --strict-markers

--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,1 +1,4 @@
 """Garage Base."""
+from garage._dtypes import TrajectoryBatch
+
+__all__ = ['TrajectoryBatch']

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -1,0 +1,169 @@
+"""Data types for agent-based learning."""
+import collections
+
+import numpy as np
+
+
+class TrajectoryBatch(
+        collections.namedtuple('TrajectoryBatch', [
+            'env_spec',
+            'observations',
+            'actions',
+            'rewards',
+            'terminals',
+            'env_infos',
+            'agent_infos',
+            'lengths',
+        ])):
+    # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
+    r"""A tuple representing a batch of whole trajectories.
+
+    A :class:`TrajectoryBatch` represents a batch of whole trajectories
+    produced when one or more agents interacts with one or more environments.
+
+    +-----------------------+-------------------------------------------------+
+    | Symbol                | Description                                     |
+    +=======================+=================================================+
+    | :math:`N`             | Trajectory index dimension                      |
+    +-----------------------+-------------------------------------------------+
+    | :math:`[T]`           | Variable-length time dimension of each          |
+    |                       | trajectory                                      |
+    +-----------------------+-------------------------------------------------+
+    | :math:`S^*`           | Single-step shape of a time-series tensor       |
+    +-----------------------+-------------------------------------------------+
+    | :math:`N \bullet [T]` | A dimension computed by flattening a            |
+    |                       | variable-length time dimension :math:`[T]` into |
+    |                       | a single batch dimension with length            |
+    |                       | :math:`sum_{i \in N} [T]_i`                     |
+    +-----------------------+-------------------------------------------------+
+
+    Attributes:
+        env_spec (garage.envs.EnvSpec): Specification for the environment from
+            which this data was sampled.
+        observations (numpy.ndarray): A numpy array of shape
+            :math:`(N \bullet [T], O^*)` containing the (possibly
+            multi-dimensional) observations for all time steps in this batch.
+            These must conform to :obj:`env_spec.observation_space`.
+        actions (numpy.ndarray): A  numpy array of shape
+            :math:`(N \bullet [T], A^*)` containing the (possibly
+            multi-dimensional) actions for all time steps in this batch. These
+            must conform to :obj:`env_spec.action_space`.
+        rewards (numpy.ndarray): A numpy array of shape
+            :math:`(N \bullet [T])` containing the rewards for all time steps
+            in this batch.
+        terminals (numpy.ndarray): A boolean numpy array of shape
+            :math:`(N \bullet [T])` containing the termination signals for all
+            time steps in this batch.
+        env_infos (dict): A dict of numpy arrays arbitrary environment state
+            information. Each value of this dict should be a numpy array of
+            shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
+        agent_infos (numpy.ndarray): A dict of numpy arrays arbitrary agent
+            state information. Each value of this dict should be a numpy array
+            of shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
+            For example, this may contain the hidden states from an RNN policy.
+        lengths (numpy.ndarray): An integer numpy array of shape :math:`(N,)`
+            containing the length of each trajectory in this batch. This may be
+            used to reconstruct the individual trajectories.
+
+    Raises:
+        ValueError: If any of the above attributes do not conform to their
+            prescribed types and shapes.
+
+    """
+    __slots__ = ()
+
+    def __new__(cls, env_spec, observations, actions, rewards, terminals,
+                env_infos, agent_infos, lengths):  # noqa: D102
+        # pylint: disable=too-many-branches
+
+        first_observation = observations[0]
+        first_action = actions[0]
+        inferred_batch_size = lengths.sum()
+
+        # lengths
+        if len(lengths.shape) != 1:
+            raise ValueError(
+                'Lengths tensor must be a tensor of shape (N,), but got a '
+                'tensor of shape {} instead'.format(lengths.shape))
+
+        if not (lengths.dtype.kind == 'u' or lengths.dtype.kind == 'i'):
+            raise ValueError(
+                'Lengths tensor must have an integer dtype, but got dtype {} '
+                'instead.'.format(lengths.dtype))
+
+        # observations
+        if not env_spec.observation_space.contains(first_observation):
+            raise ValueError(
+                'observations must conform to observation_space {}, but got '
+                'data with shape {} instead.'.format(
+                    env_spec.observation_space, first_observation))
+
+        if observations.shape[0] != inferred_batch_size:
+            raise ValueError(
+                'Expected batch dimension of observations to be length {}, '
+                'but got length {} instead.'.format(inferred_batch_size,
+                                                    observations.shape[0]))
+
+        # actions
+        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
+        if not (env_spec.action_space.contains(first_action)
+                and first_action.shape == env_spec.action_space.shape):
+            raise ValueError(
+                'actions must conform to action_space {}, but got data with '
+                'shape {} instead.'.format(env_spec.action_space,
+                                           first_action))
+
+        if actions.shape[0] != inferred_batch_size:
+            raise ValueError(
+                'Expected batch dimension of actions to be length {}, but got '
+                'length {} instead.'.format(inferred_batch_size,
+                                            actions.shape[0]))
+
+        # rewards
+        if rewards.shape != (inferred_batch_size, ):
+            raise ValueError(
+                'Rewards tensor must have shape {}, but got shape {} '
+                'instead.'.format(inferred_batch_size, rewards.shape))
+
+        # terminals
+        if terminals.shape != (inferred_batch_size, ):
+            raise ValueError(
+                'Terminals tensor must have shape {}, but got shape {} '
+                'instead.'.format(inferred_batch_size, terminals.shape))
+
+        if terminals.dtype != np.bool:
+            raise ValueError(
+                'Terminals tensor must be dtype np.bool, but got tensor '
+                'of dtype {} instead.'.format(terminals.dtype))
+
+        # env_infos
+        for key, val in env_infos.items():
+            if not isinstance(val, np.ndarray):
+                raise ValueError(
+                    'Each entry in env_infos must be a numpy array, but got '
+                    'key {} with value type {} instead.'
+                    'instead'.format(key, type(val)))
+
+            if val.shape[0] != inferred_batch_size:
+                raise ValueError(
+                    'Each entry in env_infos must have a batch dimension of '
+                    'length {}, but got key {} with batch size {} instead.'.
+                    format(inferred_batch_size, key, val.shape[0]))
+
+        # agent_infos
+        for key, val in agent_infos.items():
+            if not isinstance(val, np.ndarray):
+                raise ValueError(
+                    'Each entry in agent_infos must be a numpy array, but got '
+                    'key {} with value type {} instead.'
+                    'instead'.format(key, type(val)))
+
+            if val.shape[0] != inferred_batch_size:
+                raise ValueError(
+                    'Each entry in agent_infos must have a batch dimension of '
+                    'length {}, but got key {} with batch size {} instead.'.
+                    format(inferred_batch_size, key, val.shape[0]))
+
+        return super().__new__(TrajectoryBatch, env_spec, observations,
+                               actions, rewards, terminals, env_infos,
+                               agent_infos, lengths)

--- a/tests/garage/.pylintrc
+++ b/tests/garage/.pylintrc
@@ -39,6 +39,7 @@ disable =
     missing-type-doc,
     no-self-use,
     protected-access,
+    redefined-outer-name,
     too-few-public-methods,
 
 

--- a/tests/garage/test_dtypes.py
+++ b/tests/garage/test_dtypes.py
@@ -1,0 +1,158 @@
+import gym.spaces
+import numpy as np
+import pytest
+
+from garage import TrajectoryBatch
+from garage.envs import EnvSpec
+
+
+@pytest.fixture
+def traj_data():
+    # spaces
+    obs_space = gym.spaces.Box(low=1,
+                               high=np.inf,
+                               shape=(4, 3, 2),
+                               dtype=np.float32)
+    act_space = gym.spaces.MultiDiscrete([2, 5])
+    env_spec = EnvSpec(obs_space, act_space)
+
+    # generate data
+    lens = np.array([10, 20, 7, 25, 25, 40, 10, 5])
+    n_t = lens.sum()
+    obs = np.stack([obs_space.low] * n_t)
+    act = np.stack([[1, 3]] * n_t)
+    rew = np.arange(n_t)
+    terms = np.zeros(n_t, dtype=np.bool)
+    terms[np.cumsum(lens) - 1] = True  # set terminal bits
+
+    # env_infos
+    env_infos = dict()
+    env_infos['goal'] = np.stack([[1, 1]] * n_t)
+    env_infos['foo'] = np.arange(n_t)
+
+    # agent_infos
+    agent_infos = dict()
+    agent_infos['prev_action'] = act
+    agent_infos['hidden'] = np.arange(n_t)
+
+    return {
+        'env_spec': env_spec,
+        'observations': obs,
+        'actions': act,
+        'rewards': rew,
+        'terminals': terms,
+        'env_infos': env_infos,
+        'agent_infos': agent_infos,
+        'lengths': lens,
+    }
+
+
+def test_new(traj_data):
+    t = TrajectoryBatch(**traj_data)
+    assert t.env_spec is traj_data['env_spec']
+    assert t.observations is traj_data['observations']
+    assert t.actions is traj_data['actions']
+    assert t.rewards is traj_data['rewards']
+    assert t.terminals is traj_data['terminals']
+    assert t.env_infos is traj_data['env_infos']
+    assert t.agent_infos is traj_data['agent_infos']
+    assert t.lengths is traj_data['lengths']
+
+
+def test_lengths_shape_mismatch(traj_data):
+    with pytest.raises(ValueError,
+                       match='Lengths tensor must be a tensor of shape'):
+        traj_data['lengths'] = traj_data['lengths'].reshape((4, -1))
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_lengths_dtype_mismatch(traj_data):
+    with pytest.raises(ValueError,
+                       match='Lengths tensor must have an integer dtype'):
+        traj_data['lengths'] = traj_data['lengths'].astype(np.float32)
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_obs_env_spec_mismatch(traj_data):
+    with pytest.raises(ValueError, match='observations must conform'):
+        traj_data['observations'] = traj_data['observations'][:, :, :, :1]
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_obs_batch_mismatch(traj_data):
+    with pytest.raises(ValueError, match='batch dimension of observations'):
+        traj_data['observations'] = traj_data['observations'][:-1]
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_act_env_spec_mismatch(traj_data):
+    with pytest.raises(ValueError, match='actions must conform'):
+        traj_data['actions'] = traj_data['actions'][:, 0]
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_act_batch_mismatch(traj_data):
+    with pytest.raises(ValueError, match='batch dimension of actions'):
+        traj_data['actions'] = traj_data['actions'][:-1]
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_rewards_shape_mismatch(traj_data):
+    with pytest.raises(ValueError, match='Rewards tensor'):
+        traj_data['rewards'] = traj_data['rewards'].reshape((2, -1))
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_terminals_shape_mismatch(traj_data):
+    with pytest.raises(ValueError, match='Terminals tensor must have shape'):
+        traj_data['terminals'] = traj_data['terminals'].reshape((2, -1))
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_terminals_dtype_mismatch(traj_data):
+    with pytest.raises(ValueError, match='Terminals tensor must be dtype'):
+        traj_data['terminals'] = traj_data['terminals'].astype(np.float32)
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_env_infos_not_ndarray(traj_data):
+    with pytest.raises(ValueError,
+                       match='entry in env_infos must be a numpy array'):
+        traj_data['env_infos']['bar'] = dict()
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_env_infos_batch_mismatch(traj_data):
+    with pytest.raises(ValueError,
+                       match='entry in env_infos must have a batch dimension'):
+        traj_data['env_infos']['goal'] = traj_data['env_infos']['goal'][:-1]
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_agent_infos_not_ndarray(traj_data):
+    with pytest.raises(ValueError,
+                       match='entry in agent_infos must be a numpy array'):
+        traj_data['agent_infos']['bar'] = list()
+        t = TrajectoryBatch(**traj_data)
+        del t
+
+
+def test_agent_infos_batch_mismatch(traj_data):
+    with pytest.raises(
+            ValueError,
+            match='entry in agent_infos must have a batch dimension'):
+        traj_data['agent_infos']['hidden'] = traj_data['agent_infos'][
+            'hidden'][:-1]
+        t = TrajectoryBatch(**traj_data)
+        del t


### PR DESCRIPTION
Recent experience has shown that many bugs and API ambiguities could
be avoided if some of the abstract data types passed around by
components of garage were well-defined. This PR attempts to define one
such data type, TrajectoryBatch, which represents trajectory data in
the form frequently used by on-policy RL algorithms.

An advantage of this approach is that documenting the inputs and
outputs of various parts of the data processing pipeline becomes much
simpler. In the future, we can also add validation checks and other
helpers to these classes to make data type creation and conversion
more predictable and safer.