### PR TITLE
Refactor n_epoch_cycles

### DIFF
--- a/examples/np/cem_cartpole.py
+++ b/examples/np/cem_cartpole.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with Cross Entropy Method.
+"""This is an example to train a task with Cross Entropy Method.
 
 Here it runs CartPole-v1 environment with 100 epoches.
 
@@ -18,7 +17,14 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
-    """Train CEM with Cartpole-v1 environment."""
+    """Train CEM with Cartpole-v1 environment.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+        *_ (object): Ignored by this function.
+
+    """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
@@ -38,8 +44,7 @@ def run_task(snapshot_config, *_):
                    n_samples=n_samples)
 
         runner.setup(algo, env, sampler_cls=OnPolicyVectorizedSampler)
-        # NOTE: make sure that n_epoch_cycles == n_samples !
-        runner.train(n_epochs=100, batch_size=1000, n_epoch_cycles=n_samples)
+        runner.train(n_epochs=100, batch_size=1000)
 
 
 run_experiment(

--- a/examples/np/cma_es_cartpole.py
+++ b/examples/np/cma_es_cartpole.py
@@ -18,7 +18,14 @@ from garage.tf.policies import CategoricalMLPPolicy
 
 
 def run_task(snapshot_config, *_):
-    """Train CMA_ES with Cartpole-v1 environment."""
+    """Train CMA_ES with Cartpole-v1 environment.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+        *_ (object): Ignored by this function.
+
+    """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
@@ -37,8 +44,7 @@ def run_task(snapshot_config, *_):
                      n_samples=n_samples)
 
         runner.setup(algo, env, sampler_cls=OnPolicyVectorizedSampler)
-        # NOTE: make sure that n_epoch_cycles == n_samples !
-        runner.train(n_epochs=100, batch_size=1000, n_epoch_cycles=n_samples)
+        runner.train(n_epochs=100, batch_size=1000)
 
 
 run_experiment(

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with DDPG algorithm.
+"""This is an example to train a task with DDPG algorithm.
 
 Here it creates a gym environment InvertedDoublePendulum. And uses a DDPG with
 1M steps.
@@ -23,7 +22,14 @@ from garage.tf.q_functions import ContinuousMLPQFunction
 
 
 def run_task(snapshot_config, *_):
-    """Run task."""
+    """Run task.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+        *_ (object): Ignored by this function.
+
+    """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('InvertedDoublePendulum-v2'))
 
@@ -48,6 +54,7 @@ def run_task(snapshot_config, *_):
                     qf_lr=1e-3,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=20,
                     target_update_tau=1e-2,
                     n_train_steps=50,
                     discount=0.9,
@@ -58,7 +65,7 @@ def run_task(snapshot_config, *_):
 
         runner.setup(algo=ddpg, env=env)
 
-        runner.train(n_epochs=500, n_epoch_cycles=20, batch_size=100)
+        runner.train(n_epochs=500, batch_size=100)
 
 
 run_experiment(

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-An example to train a task with DQN algorithm.
+"""An example to train a task with DQN algorithm.
 
 Here it creates a gym environment CartPole, and trains a DQN with 50k steps.
 """
@@ -17,12 +16,19 @@ from garage.tf.q_functions import DiscreteMLPQFunction
 
 
 def run_task(snapshot_config, *_):
-    """Run task."""
+    """Run task.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+        *_ (object): Ignored by this function.
+
+    """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         n_epochs = 10
-        n_epoch_cycles = 10
+        steps_per_epoch = 10
         sampler_batch_size = 500
-        num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+        num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
         env = TfEnv(gym.make('CartPole-v0'))
         replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
                                            size_in_transitions=int(1e4),
@@ -40,19 +46,17 @@ def run_task(snapshot_config, *_):
                    qf=qf,
                    exploration_strategy=epilson_greedy_strategy,
                    replay_buffer=replay_buffer,
+                   steps_per_epoch=steps_per_epoch,
                    qf_lr=1e-4,
                    discount=1.0,
                    min_buffer_size=int(1e3),
                    double_q=True,
                    n_train_steps=500,
-                   n_epoch_cycles=n_epoch_cycles,
                    target_network_update_freq=1,
                    buffer_batch_size=32)
 
         runner.setup(algo, env)
-        runner.train(n_epochs=n_epochs,
-                     n_epoch_cycles=n_epoch_cycles,
-                     batch_size=sampler_batch_size)
+        runner.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
 
 
 run_experiment(run_task, snapshot_mode='last', seed=1)

--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -30,17 +30,15 @@ def run_task(snapshot_config, variant_data, *_):
     Args:
         snapshot_config (garage.experiment.SnapshotConfig): The snapshot
             configuration used by LocalRunner to create the snapshotter.
-
         variant_data (dict): Custom arguments for the task.
-
         *_ (object): Ignored by this function.
 
     """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         n_epochs = 100
-        n_epoch_cycles = 20
+        steps_per_epoch = 20
         sampler_batch_size = 500
-        num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+        num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
 
         env = gym.make('PongNoFrameskip-v4')
         env = Noop(env, noop_max=30)
@@ -84,14 +82,12 @@ def run_task(snapshot_config, variant_data, *_):
                    min_buffer_size=int(1e4),
                    double_q=False,
                    n_train_steps=500,
-                   n_epoch_cycles=n_epoch_cycles,
+                   steps_per_epoch=steps_per_epoch,
                    target_network_update_freq=2,
                    buffer_batch_size=32)
 
         runner.setup(algo, env)
-        runner.train(n_epochs=n_epochs,
-                     n_epoch_cycles=n_epoch_cycles,
-                     batch_size=sampler_batch_size)
+        runner.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
 
 
 @click.command()

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with DDPG + HER algorithm.
+"""This is an example to train a task with DDPG + HER algorithm.
 
 Here it creates a gym environment FetchReach.
 
@@ -22,7 +21,14 @@ from garage.tf.q_functions import ContinuousMLPQFunction
 
 
 def run_task(snapshot_config, *_):
-    """Run task."""
+    """Run task.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+            configuration used by LocalRunner to create the snapshotter.
+        *_ (object): Ignored by this function.
+
+    """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
         env = TfEnv(gym.make('FetchReach-v1'))
 
@@ -59,7 +65,7 @@ def run_task(snapshot_config, *_):
             qf=qf,
             replay_buffer=replay_buffer,
             target_update_tau=0.05,
-            n_epoch_cycles=20,
+            steps_per_epoch=20,
             max_path_length=100,
             n_train_steps=40,
             discount=0.9,
@@ -72,7 +78,7 @@ def run_task(snapshot_config, *_):
 
         runner.setup(algo=ddpg, env=env)
 
-        runner.train(n_epochs=50, batch_size=100, n_epoch_cycles=20)
+        runner.train(n_epochs=50, batch_size=100)
 
 
 run_experiment(run_task, snapshot_mode='last', seed=1)

--- a/examples/tf/td3_pendulum.py
+++ b/examples/tf/td3_pendulum.py
@@ -64,7 +64,7 @@ def run_task(snapshot_config, *_):
                   qf2=qf2,
                   replay_buffer=replay_buffer,
                   target_update_tau=1e-2,
-                  n_epoch_cycles=20,
+                  steps_per_epoch=20,
                   n_train_steps=1,
                   smooth_return=False,
                   discount=0.99,
@@ -75,7 +75,7 @@ def run_task(snapshot_config, *_):
                   qf_optimizer=tf.train.AdamOptimizer)
 
         runner.setup(td3, env)
-        runner.train(n_epochs=500, n_epoch_cycles=20, batch_size=250)
+        runner.train(n_epochs=500, batch_size=250)
 
 
 run_experiment(

--- a/examples/torch/ddpg_pendulum.py
+++ b/examples/torch/ddpg_pendulum.py
@@ -53,6 +53,7 @@ def run_task(snapshot_config, *_):
                 policy=policy,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                steps_per_epoch=20,
                 n_train_steps=50,
                 min_buffer_size=int(1e4),
                 exploration_strategy=action_noise,
@@ -63,7 +64,7 @@ def run_task(snapshot_config, *_):
 
     runner.setup(algo=ddpg, env=env)
 
-    runner.train(n_epochs=500, n_epoch_cycles=20, batch_size=100)
+    runner.train(n_epochs=500, batch_size=100)
 
 
 run_experiment(

--- a/src/garage/np/algos/off_policy_rl_algorithm.py
+++ b/src/garage/np/algos/off_policy_rl_algorithm.py
@@ -19,7 +19,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
         replay_buffer (garage.replay_buffer.ReplayBuffer): Replay buffer.
         use_target (bool): Whether to use target.
         discount(float): Discount factor for the cumulative return.
-        n_epoch_cycles (int): Number of train_once calls per epoch.
+        steps_per_epoch (int): Number of train_once calls per epoch.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
         n_train_steps (int): Training steps.
@@ -42,7 +42,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
                  replay_buffer,
                  use_target=False,
                  discount=0.99,
-                 n_epoch_cycles=20,
+                 steps_per_epoch=20,
                  max_path_length=None,
                  n_train_steps=50,
                  buffer_batch_size=64,
@@ -56,7 +56,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
         self.policy = policy
         self.qf = qf
         self.replay_buffer = replay_buffer
-        self.n_epoch_cycles = n_epoch_cycles
+        self.steps_per_epoch = steps_per_epoch
         self.n_train_steps = n_train_steps
         self.buffer_batch_size = buffer_batch_size
         self.use_target = use_target
@@ -89,7 +89,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
         last_return = None
 
         for _ in runner.step_epochs():
-            for cycle in range(self.n_epoch_cycles):
+            for cycle in range(self.steps_per_epoch):
                 runner.step_path = runner.obtain_samples(runner.step_itr)
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -27,7 +27,7 @@ class DDPG(OffPolicyRLAlgorithm):
         policy (garage.tf.policies.base.Policy): Policy.
         qf (object): The q value network.
         replay_buffer (garage.replay_buffer.ReplayBuffer): Replay buffer.
-        n_epoch_cycles (int): Number of train_once calls per epoch.
+        steps_per_epoch (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
@@ -64,7 +64,7 @@ class DDPG(OffPolicyRLAlgorithm):
                  policy,
                  qf,
                  replay_buffer,
-                 n_epoch_cycles=20,
+                 steps_per_epoch=20,
                  n_train_steps=50,
                  max_path_length=None,
                  buffer_batch_size=64,
@@ -113,7 +113,7 @@ class DDPG(OffPolicyRLAlgorithm):
                                    policy=policy,
                                    qf=qf,
                                    n_train_steps=n_train_steps,
-                                   n_epoch_cycles=n_epoch_cycles,
+                                   steps_per_epoch=steps_per_epoch,
                                    max_path_length=max_path_length,
                                    buffer_batch_size=buffer_batch_size,
                                    min_buffer_size=min_buffer_size,
@@ -255,7 +255,7 @@ class DDPG(OffPolicyRLAlgorithm):
         """
         paths = self.process_samples(itr, paths)
 
-        epoch = itr / self.n_epoch_cycles
+        epoch = itr / self.steps_per_epoch
 
         self.episode_rewards.extend([
             path for path, complete in zip(paths['undiscounted_returns'],
@@ -280,7 +280,7 @@ class DDPG(OffPolicyRLAlgorithm):
                 self.epoch_ys.append(y_s)
                 self.epoch_qs.append(qval)
 
-        if itr % self.n_epoch_cycles == 0:
+        if itr % self.steps_per_epoch == 0:
             logger.log('Training finished')
 
             if self.evaluate:

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -25,7 +25,7 @@ class DQN(OffPolicyRLAlgorithm):
         exploration_strategy
             (garage.np.exploration_strategies.ExplorationStrategy):
             Exploration strategy.
-        n_epoch_cycles (int): Epoch cycles.
+        steps_per_epoch (int): Number of train_once calls per epoch.
         min_buffer_size (int): The minimum buffer size for replay buffer.
         buffer_batch_size (int): Batch size for replay buffer.
         rollout_batch_size (int): Roll out batch size.
@@ -55,7 +55,7 @@ class DQN(OffPolicyRLAlgorithm):
                  qf,
                  replay_buffer,
                  exploration_strategy=None,
-                 n_epoch_cycles=20,
+                 steps_per_epoch=20,
                  min_buffer_size=int(1e4),
                  buffer_batch_size=64,
                  rollout_batch_size=1,
@@ -87,7 +87,7 @@ class DQN(OffPolicyRLAlgorithm):
                                   exploration_strategy=exploration_strategy,
                                   min_buffer_size=min_buffer_size,
                                   n_train_steps=n_train_steps,
-                                  n_epoch_cycles=n_epoch_cycles,
+                                  steps_per_epoch=steps_per_epoch,
                                   buffer_batch_size=buffer_batch_size,
                                   rollout_batch_size=rollout_batch_size,
                                   replay_buffer=replay_buffer,
@@ -191,7 +191,7 @@ class DQN(OffPolicyRLAlgorithm):
 
         """
         paths = self.process_samples(itr, paths)
-        epoch = itr / self.n_epoch_cycles
+        epoch = itr / self.steps_per_epoch
 
         self.episode_rewards.extend(paths['undiscounted_returns'])
         last_average_return = np.mean(self.episode_rewards)
@@ -206,7 +206,7 @@ class DQN(OffPolicyRLAlgorithm):
             if itr % self.target_network_update_freq == 0:
                 self._qf_update_ops()
 
-        if itr % self.n_epoch_cycles == 0:
+        if itr % self.steps_per_epoch == 0:
             if self.evaluate:
                 mean100ep_rewards = round(np.mean(self.episode_rewards[-100:]),
                                           1)

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -1,5 +1,4 @@
-"""
-This module implements a TD3 model.
+"""This module implements a TD3 model.
 
 TD3, or Twin Delayed Deep Deterministic Policy Gradient, uses actor-critic
 method to optimize the policy and reward prediction. Notably, it uses the
@@ -22,43 +21,46 @@ class TD3(DDPG):
         $ python garage/examples/tf/td3_pendulum.py
 
     Args:
-        env_spec(garage.envs.EnvSpec): Environment.
-        policy(garage.tf.policies.base.Policy): Policy.
-        qf(garage.tf.q_functions.QFunction): Q-function.
-        qf2(garage.tf.q_functions.QFunction): Q function to use
-        target_update_tau(float): Interpolation parameter for doing the
+        env_spec (garage.envs.EnvSpec): Environment.
+        policy (garage.tf.policies.base.Policy): Policy.
+        qf (garage.tf.q_functions.QFunction): Q-function.
+        qf2 (garage.tf.q_functions.QFunction): Q function to use
+        replay_buffer (garage.replay_buffer.ReplayBuffer): Replay buffer.
+        target_update_tau (float): Interpolation parameter for doing the
             soft target update.
-        policy_lr(float): Learning rate for training policy network.
-        qf_lr(float): Learning rate for training q value network.
-        policy_weight_decay(float): L2 weight decay factor for parameters
+        policy_lr (float): Learning rate for training policy network.
+        qf_lr (float): Learning rate for training q value network.
+        policy_weight_decay (float): L2 weight decay factor for parameters
             of the policy network.
-        qf_weight_decay(float): L2 weight decay factor for parameters
+        qf_weight_decay (float): L2 weight decay factor for parameters
             of the q value network.
-        policy_optimizer(tf.python.training.optimizer.Optimizer):
+        policy_optimizer (tf.python.training.optimizer.Optimizer):
             Optimizer for training policy network.
-        qf_optimizer(tf.python.training.optimizer.Optimizer):
+        qf_optimizer (tf.python.training.optimizer.Optimizer):
             Optimizer for training q function network.
-        clip_pos_returns(boolean): Whether or not clip positive returns.
-        clip_return(float): Clip return to be in [-clip_return,
+        clip_pos_returns (boolean): Whether or not clip positive returns.
+        clip_return (float): Clip return to be in [-clip_return,
             clip_return].
-        discount(float): Discount factor for the cumulative return.
-        max_action(float): Maximum action magnitude.
-        name(str): Name of the algorithm shown in computation graph.
-        n_epoch_cycles(int): Number of batches of samples in each epoch.
-        max_path_length(int): Maximum length of a path.
-        n_train_steps(int): Number of optimizations in each epoch cycle.
-        buffer_batch_size(int): Size of replay buffer.
-        min_buffer_size(int):
+        discount (float): Discount factor for the cumulative return.
+        max_action (float): Maximum action magnitude.
+        name (str): Name of the algorithm shown in computation graph.
+        steps_per_epoch (int): Number of batches of samples in each epoch.
+        max_path_length (int): Maximum length of a path.
+        n_train_steps (int): Number of optimizations in each epoch cycle.
+        buffer_batch_size (int): Size of replay buffer.
+        min_buffer_size (int):
             Number of samples in replay buffer before first optimization.
-        rollout_batch_size(int):
-        reward_scale(float): Scale to reward.
-        input_include_goal(bool):
+        rollout_batch_size (int): Roll out batch size.
+        reward_scale (float): Scale to reward.
+        action_noise_sigma (float): Action noise sigma.
+        action_noise_clip (float): Action noise clip.
+        actor_update_period (int): Action update period.
+        input_include_goal (bool):
             True if the environment entails a goal in observation.
-        smooth_return(bool):
+        smooth_return (bool):
             If True, do statistics on all samples collection.
             Otherwise do statistics on one batch.
-        exploration_strategy(
-            garage.np.exploration_strategies.ExplorationStrategy):
+        exploration_strategy (garage.np.exploration_strategies.ExplorationStrategy): # noqa: E501
             Exploration strategy.
 
     """
@@ -81,7 +83,7 @@ class TD3(DDPG):
                  discount=0.99,
                  max_action=None,
                  name=None,
-                 n_epoch_cycles=20,
+                 steps_per_epoch=20,
                  max_path_length=None,
                  n_train_steps=50,
                  buffer_batch_size=64,
@@ -118,7 +120,7 @@ class TD3(DDPG):
                                   discount=discount,
                                   max_action=max_action,
                                   name=name,
-                                  n_epoch_cycles=n_epoch_cycles,
+                                  steps_per_epoch=steps_per_epoch,
                                   max_path_length=max_path_length,
                                   n_train_steps=n_train_steps,
                                   buffer_batch_size=buffer_batch_size,
@@ -228,7 +230,12 @@ class TD3(DDPG):
             self.f_train_qf2 = f_train_qf2
 
     def __getstate__(self):
-        """Object.__getstate__."""
+        """Object.__getstate__.
+
+        Returns:
+            dict: State dictionary.
+
+        """
         data = self.__dict__.copy()
         del data['target_policy_f_prob_online']
         del data['target_qf_f_prob_online']
@@ -241,7 +248,12 @@ class TD3(DDPG):
         return data
 
     def __setstate__(self, state):
-        """Object.__setstate__."""
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Current state.
+
+        """
         self.__dict__ = state
         self.init_opt()
 

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -25,7 +25,7 @@ class DDPG(OffPolicyRLAlgorithm):
         policy (garage.torch.policies.base.Policy): Policy.
         qf (object): Q-value network.
         replay_buffer (garage.replay_buffer.ReplayBuffer): Replay buffer.
-        n_epoch_cycles (int): Number of train_once calls per epoch.
+        steps_per_epoch (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
@@ -67,7 +67,7 @@ class DDPG(OffPolicyRLAlgorithm):
                  policy,
                  qf,
                  replay_buffer,
-                 n_epoch_cycles=20,
+                 steps_per_epoch=20,
                  n_train_steps=50,
                  max_path_length=None,
                  buffer_batch_size=64,
@@ -107,7 +107,7 @@ class DDPG(OffPolicyRLAlgorithm):
                          policy=policy,
                          qf=qf,
                          n_train_steps=n_train_steps,
-                         n_epoch_cycles=n_epoch_cycles,
+                         steps_per_epoch=steps_per_epoch,
                          max_path_length=max_path_length,
                          buffer_batch_size=buffer_batch_size,
                          min_buffer_size=min_buffer_size,
@@ -139,7 +139,7 @@ class DDPG(OffPolicyRLAlgorithm):
         """
         paths = self.process_samples(itr, paths)
 
-        epoch = itr / self.n_epoch_cycles
+        epoch = itr / self.steps_per_epoch
 
         self._episode_rewards.extend([
             path for path, complete in zip(paths['undiscounted_returns'],
@@ -164,7 +164,7 @@ class DDPG(OffPolicyRLAlgorithm):
                 self._epoch_ys.append(y)
                 self._epoch_qs.append(q)
 
-        if itr % self.n_epoch_cycles == 0:
+        if itr % self.steps_per_epoch == 0:
             logger.log('Training finished')
 
             if self._evaluate:

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ddpg.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ddpg.py
@@ -47,7 +47,7 @@ params = {
     'policy_hidden_sizes': [64, 64],
     'qf_hidden_sizes': [64, 64],
     'n_epochs': 500,
-    'n_epoch_cycles': 20,
+    'steps_per_epoch': 20,
     'n_rollout_steps': 100,
     'n_train_steps': 50,
     'discount': 0.9,
@@ -151,7 +151,7 @@ class TestBenchmarkDDPG:
                 g_y='AverageReturn',
                 b_x='total/epochs',
                 b_y='rollout/return',
-                factor_g=params['n_epoch_cycles'] * params['n_rollout_steps'],
+                factor_g=params['steps_per_epoch'] * params['n_rollout_steps'],
                 factor_b=1)
 
         Rh.write_file(result_json, 'DDPG')
@@ -192,6 +192,7 @@ def run_garage(env, seed, log_dir):
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=params['steps_per_epoch'],
                     policy_lr=params['policy_lr'],
                     qf_lr=params['qf_lr'],
                     target_update_tau=params['tau'],
@@ -211,7 +212,6 @@ def run_garage(env, seed, log_dir):
 
         runner.setup(ddpg, env)
         runner.train(n_epochs=params['n_epochs'],
-                     n_epoch_cycles=params['n_epoch_cycles'],
                      batch_size=params['n_rollout_steps'])
 
         dowel_logger.remove_all()
@@ -259,7 +259,7 @@ def run_baselines(env, seed, log_dir):
                    critic=critic,
                    memory=memory,
                    nb_epochs=params['n_epochs'],
-                   nb_epoch_cycles=params['n_epoch_cycles'],
+                   nb_epoch_cycles=params['steps_per_epoch'],
                    render_eval=False,
                    reward_scale=1.,
                    render=False,

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_her.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_her.py
@@ -34,7 +34,7 @@ params = {
     'policy_hidden_sizes': [256, 256, 256],
     'qf_hidden_sizes': [256, 256, 256],
     'n_epochs': 50,
-    'n_epoch_cycles': 20,
+    'steps_per_epoch': 20,
     'n_rollout_steps': 100,
     'n_train_steps': 40,
     'discount': 0.9,
@@ -150,6 +150,7 @@ def run_garage(env, seed, log_dir):
             policy=policy,
             qf=qf,
             replay_buffer=replay_buffer,
+            steps_per_epoch=params['steps_per_epoch'],
             policy_lr=params['policy_lr'],
             qf_lr=params['qf_lr'],
             target_update_tau=params['tau'],
@@ -170,7 +171,6 @@ def run_garage(env, seed, log_dir):
 
         runner.setup(algo, env)
         runner.train(n_epochs=params['n_epochs'],
-                     n_epoch_cycles=params['n_epoch_cycles'],
                      batch_size=params['n_rollout_steps'])
 
         logger.remove_all()

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_td3.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_td3.py
@@ -58,7 +58,7 @@ params = {
     'policy_hidden_sizes': [400, 300],
     'qf_hidden_sizes': [400, 300],
     'n_epochs': 1000,
-    'n_epoch_cycles': 20,
+    'steps_per_epoch': 20,
     'n_rollout_steps': 250,
     'n_train_steps': 1,
     'discount': 0.99,
@@ -209,10 +209,10 @@ def run_garage(env, seed, log_dir):
                   qf=qf,
                   qf2=qf2,
                   replay_buffer=replay_buffer,
+                  steps_per_epoch=params['steps_per_epoch'],
                   policy_lr=params['policy_lr'],
                   qf_lr=params['qf_lr'],
                   target_update_tau=params['tau'],
-                  n_epoch_cycles=params['n_epoch_cycles'],
                   n_train_steps=params['n_train_steps'],
                   discount=params['discount'],
                   smooth_return=params['smooth_return'],
@@ -230,8 +230,7 @@ def run_garage(env, seed, log_dir):
 
         runner.setup(td3, env)
         runner.train(n_epochs=params['n_epochs'],
-                     batch_size=params['n_rollout_steps'],
-                     n_epoch_cycles=params['n_epoch_cycles'])
+                     batch_size=params['n_rollout_steps'])
 
         dowel_logger.remove_all()
 
@@ -308,7 +307,7 @@ def run_rlkit(env, seed, log_dir):
         evaluation_data_collector=eval_path_collector,
         replay_buffer=replay_buffer,
         num_epochs=params['n_epochs'],
-        num_train_loops_per_epoch=params['n_epoch_cycles'],
+        num_train_loops_per_epoch=params['steps_per_epoch'],
         num_trains_per_train_loop=params['n_train_steps'],
         num_expl_steps_per_train_loop=params['n_rollout_steps'],
         num_eval_steps_per_epoch=params['n_rollout_steps'],

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_continuous_mlp_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_continuous_mlp_policy.py
@@ -29,7 +29,7 @@ params = {
     'policy_hidden_sizes': [64, 64],
     'qf_hidden_sizes': [64, 64],
     'n_epochs': 300,
-    'n_epoch_cycles': 20,
+    'steps_per_epoch': 20,
     'n_rollout_steps': 100,
     'n_train_steps': 50,
     'discount': 0.9,
@@ -132,6 +132,7 @@ def run_garage(env, seed, log_dir):
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=params['steps_per_epoch'],
                     policy_lr=params['policy_lr'],
                     qf_lr=params['qf_lr'],
                     target_update_tau=params['tau'],
@@ -150,7 +151,6 @@ def run_garage(env, seed, log_dir):
 
         runner.setup(ddpg, env, sampler_args=dict(n_envs=12))
         runner.train(n_epochs=params['n_epochs'],
-                     n_epoch_cycles=params['n_epoch_cycles'],
                      batch_size=params['n_rollout_steps'])
 
         dowel_logger.remove_all()

--- a/tests/benchmarks/garage/tf/q_functions/test_benchmark_continuous_mlp_q_function.py
+++ b/tests/benchmarks/garage/tf/q_functions/test_benchmark_continuous_mlp_q_function.py
@@ -29,7 +29,7 @@ params = {
     'policy_hidden_sizes': [64, 64],
     'qf_hidden_sizes': [64, 64],
     'n_epochs': 300,
-    'n_epoch_cycles': 20,
+    'steps_per_epoch': 20,
     'n_rollout_steps': 100,
     'n_train_steps': 50,
     'discount': 0.9,
@@ -132,6 +132,7 @@ def run_garage(env, seed, log_dir):
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=params['steps_per_epoch'],
                     policy_lr=params['policy_lr'],
                     qf_lr=params['qf_lr'],
                     target_update_tau=params['tau'],
@@ -150,7 +151,6 @@ def run_garage(env, seed, log_dir):
 
         runner.setup(ddpg, env, sampler_args=dict(n_envs=12))
         runner.train(n_epochs=params['n_epochs'],
-                     n_epoch_cycles=params['n_epoch_cycles'],
                      batch_size=params['n_rollout_steps'])
 
         dowel_logger.remove_all()

--- a/tests/garage/experiment/test_resume.py
+++ b/tests/garage/experiment/test_resume.py
@@ -38,7 +38,6 @@ class TestResume(TfGraphTestCase):
                 'Last experiment should end at 5th iterations')
 
             batch_size = runner._train_args.batch_size
-            n_epoch_cycles = runner._train_args.n_epoch_cycles
 
             runner.resume(n_epochs=10,
                           plot=False,
@@ -47,7 +46,6 @@ class TestResume(TfGraphTestCase):
 
             assert runner._train_args.n_epochs == 10
             assert runner._train_args.batch_size == batch_size
-            assert runner._train_args.n_epoch_cycles == n_epoch_cycles
             assert not runner._train_args.plot
             assert runner._train_args.store_paths
             assert not runner._train_args.pause_for_plot

--- a/tests/garage/np/algos/test_cem.py
+++ b/tests/garage/np/algos/test_cem.py
@@ -33,9 +33,7 @@ class TestCEM(TfGraphTestCase):
                        n_samples=n_samples)
 
             runner.setup(algo, env, sampler_cls=OnPolicyVectorizedSampler)
-            rtn = runner.train(n_epochs=10,
-                               batch_size=2048,
-                               n_epoch_cycles=n_samples)
+            rtn = runner.train(n_epochs=10, batch_size=2048)
             assert rtn > 40
 
             env.close()

--- a/tests/garage/np/algos/test_cma_es.py
+++ b/tests/garage/np/algos/test_cma_es.py
@@ -29,7 +29,7 @@ class TestCMAES(TfGraphTestCase):
                          n_samples=n_samples)
 
             runner.setup(algo, env, sampler_cls=OnPolicyVectorizedSampler)
-            runner.train(n_epochs=1, batch_size=1000, n_epoch_cycles=n_samples)
+            runner.train(n_epochs=1, batch_size=1000)
             # No assertion on return because CMAES is not stable.
 
             env.close()

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -42,7 +42,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
-                n_epoch_cycles=20,
+                steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,
                 discount=0.9,
@@ -50,9 +50,7 @@ class TestDDPG(TfGraphTestCase):
                 exploration_strategy=action_noise,
             )
             runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10,
-                                        n_epoch_cycles=20,
-                                        batch_size=100)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=100)
             assert last_avg_ret > 60
 
             env.close()
@@ -83,6 +81,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,
                 discount=0.9,
@@ -90,9 +89,7 @@ class TestDDPG(TfGraphTestCase):
                 exploration_strategy=action_noise,
             )
             runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10,
-                                        n_epoch_cycles=20,
-                                        batch_size=100)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=100)
             assert last_avg_ret > 10
 
             env.close()
@@ -123,6 +120,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,
                 discount=0.9,
@@ -132,9 +130,7 @@ class TestDDPG(TfGraphTestCase):
                 exploration_strategy=action_noise,
             )
             runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10,
-                                        n_epoch_cycles=20,
-                                        batch_size=100)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=100)
             assert last_avg_ret > 10
 
             env.close()

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -26,9 +26,9 @@ class TestDQN(TfGraphTestCase):
         """Test DQN with CartPole environment."""
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             n_epochs = 10
-            n_epoch_cycles = 10
+            steps_per_epoch = 10
             sampler_batch_size = 500
-            num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+            num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
             replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
                                                size_in_transitions=int(1e4),
@@ -51,13 +51,12 @@ class TestDQN(TfGraphTestCase):
                        min_buffer_size=int(1e3),
                        double_q=False,
                        n_train_steps=500,
-                       n_epoch_cycles=n_epoch_cycles,
+                       steps_per_epoch=steps_per_epoch,
                        target_network_update_freq=1,
                        buffer_batch_size=32)
 
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=n_epochs,
-                                        n_epoch_cycles=n_epoch_cycles,
                                         batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
@@ -68,9 +67,9 @@ class TestDQN(TfGraphTestCase):
         """Test DQN with CartPole environment."""
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             n_epochs = 10
-            n_epoch_cycles = 10
+            steps_per_epoch = 10
             sampler_batch_size = 500
-            num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+            num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
             replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
                                                size_in_transitions=int(1e4),
@@ -93,13 +92,12 @@ class TestDQN(TfGraphTestCase):
                        min_buffer_size=int(1e3),
                        double_q=True,
                        n_train_steps=500,
-                       n_epoch_cycles=n_epoch_cycles,
+                       steps_per_epoch=steps_per_epoch,
                        target_network_update_freq=1,
                        buffer_batch_size=32)
 
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=n_epochs,
-                                        n_epoch_cycles=n_epoch_cycles,
                                         batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
@@ -110,9 +108,9 @@ class TestDQN(TfGraphTestCase):
         """Test DQN with CartPole environment."""
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             n_epochs = 10
-            n_epoch_cycles = 10
+            steps_per_epoch = 10
             sampler_batch_size = 500
-            num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+            num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
             replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
                                                size_in_transitions=int(1e4),
@@ -136,13 +134,12 @@ class TestDQN(TfGraphTestCase):
                        double_q=False,
                        n_train_steps=500,
                        grad_norm_clipping=5.0,
-                       n_epoch_cycles=n_epoch_cycles,
+                       steps_per_epoch=steps_per_epoch,
                        target_network_update_freq=1,
                        buffer_batch_size=32)
 
             runner.setup(algo, env)
             last_avg_ret = runner.train(n_epochs=n_epochs,
-                                        n_epoch_cycles=n_epoch_cycles,
                                         batch_size=sampler_batch_size)
             assert last_avg_ret > 15
 
@@ -152,9 +149,9 @@ class TestDQN(TfGraphTestCase):
         """Test DQN with CartPole environment."""
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             n_epochs = 10
-            n_epoch_cycles = 10
+            steps_per_epoch = 10
             sampler_batch_size = 500
-            num_timesteps = n_epochs * n_epoch_cycles * sampler_batch_size
+            num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
             replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
                                                size_in_transitions=int(1e4),
@@ -178,7 +175,7 @@ class TestDQN(TfGraphTestCase):
                        double_q=False,
                        n_train_steps=500,
                        grad_norm_clipping=5.0,
-                       n_epoch_cycles=n_epoch_cycles,
+                       steps_per_epoch=steps_per_epoch,
                        target_network_update_freq=1,
                        buffer_batch_size=32)
             runner.setup(algo, env)

--- a/tests/garage/tf/algos/test_td3.py
+++ b/tests/garage/tf/algos/test_td3.py
@@ -53,8 +53,8 @@ class TestTD3(TfGraphTestCase):
                        qf=qf,
                        qf2=qf2,
                        replay_buffer=replay_buffer,
+                       steps_per_epoch=20,
                        target_update_tau=0.005,
-                       n_epoch_cycles=20,
                        n_train_steps=50,
                        discount=0.99,
                        smooth_return=False,
@@ -67,7 +67,5 @@ class TestTD3(TfGraphTestCase):
                        qf_optimizer=tf.compat.v1.train.AdamOptimizer)
 
             runner.setup(algo, env)
-            last_avg_ret = runner.train(n_epochs=10,
-                                        n_epoch_cycles=20,
-                                        batch_size=250)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=250)
             assert last_avg_ret > 400

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -43,6 +43,7 @@ class TestDDPG:
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=20,
                     n_train_steps=50,
                     min_buffer_size=int(1e4),
                     exploration_strategy=action_noise,
@@ -50,9 +51,7 @@ class TestDDPG:
                     discount=0.9)
 
         runner.setup(algo, env)
-        last_avg_ret = runner.train(n_epochs=10,
-                                    n_epoch_cycles=20,
-                                    batch_size=100)
+        last_avg_ret = runner.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 45
 
         env.close()
@@ -85,6 +84,7 @@ class TestDDPG:
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    steps_per_epoch=20,
                     n_train_steps=50,
                     min_buffer_size=int(1e4),
                     exploration_strategy=action_noise,
@@ -92,9 +92,7 @@ class TestDDPG:
                     discount=0.9)
 
         runner.setup(algo, env)
-        last_avg_ret = runner.train(n_epochs=10,
-                                    n_epoch_cycles=20,
-                                    batch_size=100)
+        last_avg_ret = runner.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 10
 
         env.close()


### PR DESCRIPTION
#948.

For Runner:
- removed `n_epoch_cycles` from the `Runner`.

For algorithms:
- evolution strategy algorithms (CEM, CMAES) now uses `n_samples`
- renamed `n_epoch_cycles` to `steps_per_epoch` for fff-policy algorithms (DDPG, TD3) and Q-learning algorithm (DQN, DDQN)