### PR TITLE
Remove reward scaling from OffPolicySampler

### DIFF
--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -138,7 +138,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
                 self.algo.replay_buffer.add_transitions(
                     observation=obses,
                     action=actions,
-                    reward=rewards * self.algo.reward_scale,
+                    reward=rewards,
                     terminal=dones,
                     next_observation=next_obses,
                 )


### PR DESCRIPTION
Currently the when adding rewards to transitions in the replay buffer,
we add the reward scaled by the reward factor. This is something that should
be handled in the algorithm, not in the sampler. Furthermore it was incredibly
ambiguous that this was the case.

reference #1095 