### PR TITLE
Wrap experiment

### DIFF
--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -2,5 +2,6 @@
 from garage._dtypes import TimeStep
 from garage._dtypes import TrajectoryBatch
 from garage._functions import log_performance
+from garage.experiment.experiment import wrap_experiment
 
-__all__ = ['TimeStep', 'TrajectoryBatch', 'log_performance']
+__all__ = ['wrap_experiment', 'TimeStep', 'TrajectoryBatch', 'log_performance']

--- a/src/garage/experiment/__init__.py
+++ b/src/garage/experiment/__init__.py
@@ -1,13 +1,12 @@
 """Experiment functions."""
 from garage.experiment.experiment import run_experiment
 from garage.experiment.experiment import to_local_command
-from garage.experiment.experiment import variant
-from garage.experiment.experiment import VariantGenerator
+from garage.experiment.experiment import wrap_experiment
 from garage.experiment.local_runner import LocalRunner
 from garage.experiment.snapshotter import SnapshotConfig, Snapshotter
 from garage.experiment.task_sampler import TaskSampler
 
 __all__ = [
-    'run_experiment', 'to_local_command', 'variant', 'VariantGenerator',
-    'LocalRunner', 'Snapshotter', 'SnapshotConfig', 'TaskSampler'
+    'run_experiment', 'to_local_command', 'wrap_experiment', 'LocalRunner',
+    'Snapshotter', 'SnapshotConfig', 'TaskSampler'
 ]

--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -1,158 +1,21 @@
+"""Tools for running experiments with Garage."""
 # flake8: noqa
 import base64
-import collections
 import datetime
-import inspect
+import enum
+import functools
+import json
 import os
 import os.path as osp
+import pathlib
 import pickle
 import re
 import subprocess
 
 import cloudpickle
+import dowel
+from dowel import logger
 import dateutil.tz
-import numpy as np
-
-
-class AttrDict(dict):
-
-    def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
-        self.__dict__ = self
-
-
-class VariantDict(AttrDict):
-
-    def __init__(self, d, hidden_keys):
-        super(VariantDict, self).__init__(d)
-        self._hidden_keys = hidden_keys
-
-    def dump(self):
-        return {k: v for k, v in self.items() if k not in self._hidden_keys}
-
-
-class VariantGenerator:
-    """
-    Usage:
-
-    | vg = VariantGenerator()
-    | vg.add("param1", [1, 2, 3])
-    | vg.add("param2", ['x', 'y'])
-    | vg.variants() => # all combinations of [1,2,3] x ['x','y']
-
-    Supports noncyclic dependency among parameters:
-    | vg = VariantGenerator()
-    | vg.add("param1", [1, 2, 3])
-    | vg.add("param2", lambda param1: [param1+1, param1+2])
-    | vg.variants() => # ..
-    """
-
-    def __init__(self):
-        self._variants = []
-        self._populate_variants()
-        self._hidden_keys = []
-        for k, vs, cfg in self._variants:
-            if cfg.get('hide', False):
-                self._hidden_keys.append(k)
-
-    def add(self, key, vals, **kwargs):
-        self._variants.append((key, vals, kwargs))
-
-    def _populate_variants(self):
-        methods = inspect.getmembers(
-            self.__class__,
-            predicate=lambda x: inspect.isfunction(x) or inspect.ismethod(x))
-        methods = [
-            x[1].__get__(self, self.__class__) for x in methods
-            if getattr(x[1], '__is_variant', False)
-        ]
-        for m in methods:
-            self.add(m.__name__, m, **getattr(m, '__variant_config', dict()))
-
-    def variants(self, randomized=False):
-        ret = list(self.ivariants())
-        if randomized:
-            np.random.shuffle(ret)
-        return list(map(self.variant_dict, ret))
-
-    def variant_dict(self, variant):
-        return VariantDict(variant, self._hidden_keys)
-
-    def to_name_suffix(self, variant):
-        suffix = []
-        for k, vs, cfg in self._variants:
-            if not cfg.get('hide', False):
-                suffix.append(k + '_' + str(variant[k]))
-        return '_'.join(suffix)
-
-    def ivariants(self):
-        dependencies = list()
-        for key, vals, _ in self._variants:
-            if hasattr(vals, '__call__'):
-                args = inspect.getfullargspec(vals).args
-                if hasattr(vals, 'im_self') or hasattr(vals, '__self__'):
-                    # remove the first 'self' parameter
-                    args = args[1:]
-                dependencies.append((key, set(args)))
-            else:
-                dependencies.append((key, set()))
-        sorted_keys = []
-        # topo sort all nodes
-        while len(sorted_keys) < len(self._variants):
-            # get all nodes with zero in-degree
-            free_nodes = [k for k, v in dependencies if not v]
-            if not free_nodes:
-                error_msg = 'Invalid parameter dependency: \n'
-                for k, v in dependencies:
-                    if v:
-                        error_msg += k + ' depends on ' + ' & '.join(v) + '\n'
-                raise ValueError(error_msg)
-            dependencies = [(k, v) for k, v in dependencies
-                            if k not in free_nodes]
-            # remove the free nodes from the remaining dependencies
-            for _, v in dependencies:
-                v.difference_update(free_nodes)
-            sorted_keys += free_nodes
-        return self._ivariants_sorted(sorted_keys)
-
-    def _ivariants_sorted(self, sorted_keys):
-        if not sorted_keys:
-            yield dict()
-        else:
-            first_keys = sorted_keys[:-1]
-            first_variants = self._ivariants_sorted(first_keys)
-            last_key = sorted_keys[-1]
-            last_vals = [v for k, v, _ in self._variants if k == last_key][0]
-            if hasattr(last_vals, '__call__'):
-                last_val_keys = inspect.getfullargspec(last_vals).args
-                if hasattr(last_vals, 'im_self') or hasattr(
-                        last_vals, '__self__'):
-                    last_val_keys = last_val_keys[1:]
-            else:
-                last_val_keys = None
-            for variant in first_variants:
-                if hasattr(last_vals, '__call__'):
-                    last_variants = last_vals(
-                        **{k: variant[k]
-                           for k in last_val_keys})
-                    for last_choice in last_variants:
-                        yield AttrDict(variant, **{last_key: last_choice})
-                else:
-                    for last_choice in last_vals:
-                        yield AttrDict(variant, **{last_key: last_choice})
-
-
-def variant(*args, **kwargs):
-
-    def _variant(fn):
-        fn.__is_variant = True
-        fn.__variant_config = kwargs
-        return fn
-
-    if len(args) == 1 and isinstance(args[0], collections.Callable):
-        return _variant(args[0])
-    return _variant
-
 
 exp_count = 0
 now = datetime.datetime.now(dateutil.tz.tzlocal())
@@ -190,8 +53,10 @@ def run_experiment(method_call=None,
         force_cpu (bool): Whether to set all GPU devices invisible
             to force use CPU.
         pre_commands (str): Pre commands to run the experiment.
+        kwargs (dict): Additional parameters.
 
     """
+    # pylint: disable=missing-raises-doc,global-statement,too-many-branches
     if method_call is None and batch_tasks is None:
         raise Exception(
             'Must provide at least either method_call or batch_tasks')
@@ -271,7 +136,15 @@ _find_unsafe = re.compile(r'[a-zA-Z0-9_^@%+=:,./-]').search
 
 
 def _shellquote(s):
-    """Return a shell-escaped version of the string *s*."""
+    """Return a shell-escaped version of the string *s*.
+
+    Args:
+        s (str): String to shell quote.
+
+    Returns:
+        str: The shell-quoted string.
+
+    """
     if not s:
         return "''"
 
@@ -285,6 +158,15 @@ def _shellquote(s):
 
 
 def _to_param_val(v):
+    """Return a shell-escaped version of v.
+
+    Args:
+        v (object): object to shell quote
+
+    Returns:
+        str: The shell-quoted string.
+
+    """
     if v is None:
         return ''
     elif isinstance(v, list):
@@ -296,6 +178,7 @@ def _to_param_val(v):
 def to_local_command(params,
                      python_command='python',
                      script='garage.experiment.experiment_wrapper'):
+    # pylint: disable=eval-used,missing-return-doc,missing-return-type-doc,missing-function-docstring
     command = python_command + ' -m ' + script
 
     garage_env = eval(os.environ.get('GARAGE_ENV', '{}'))
@@ -318,3 +201,279 @@ def to_local_command(params,
         else:
             command += '  --{} {}'.format(k, _to_param_val(v))
     return command
+
+
+def _make_sequential_log_dir(log_dir):
+    """Creates log_dir, appending a number if necessary.
+
+    Attempts to create the directory `log_dir`. If it already exists, appends
+    "_1". If that already exists, appends "_2" instead, etc.
+
+    Args:
+        log_dir (str): The log directory to attempt to create.
+
+    Returns:
+        str: The log directory actually created.
+
+    """
+    i = 0
+    while True:
+        try:
+            if i == 0:
+                os.makedirs(log_dir)
+            else:
+                possible_log_dir = '{}_{}'.format(log_dir, i)
+                os.makedirs(possible_log_dir)
+                log_dir = possible_log_dir
+            return log_dir
+        except FileExistsError:
+            i += 1
+
+
+class ExperimentContext:
+    """Context in which an experiment is being run.
+
+    Currently, this class implements the same interface as SnapshotConfig, but
+    it will be extended in the future.
+
+    Args:
+        snapshot_dir (str): The full directory to put snapshots in.
+        snapshot_mode (str): Policy for which snapshots to keep (or make at
+            all). Can be either "all" (all iterations will be saved), "last"
+            (only the last iteration will be saved), "gap" (every snapshot_gap
+            iterations are saved), or "none" (do not save snapshots).
+        snapshot_gap (int): Gap between snapshot iterations. Waits this number
+            of iterations before taking another snapshot.
+
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, *, snapshot_dir, snapshot_mode, snapshot_gap):
+        self.snapshot_dir = snapshot_dir
+        self.snapshot_mode = snapshot_mode
+        self.snapshot_gap = snapshot_gap
+
+
+class ExperimentTemplate:
+    """Creates experiment log directories and runs an experiment.
+
+    This class should only be created by calling garage.wrap_experiment.
+    Generally, it's used as a decorator like this:
+
+        @wrap_experiment(snapshot_mode='all')
+        def my_experiment(ctxt, seed, lr=0.5):
+            ...
+
+        my_experiment(seed=1)
+
+    Even though this class could be implemented as a closure in
+    wrap_experiment(), it's more readable (and easier to pickle) implemented as
+    a class.
+
+    Note that the full path that will be created is
+    f'{data}/local/{prefix}/{name}'.
+
+    Args:
+        function (callable or None): The experiment function to wrap.
+        log_dir (str or None): The full log directory to log to. Will be
+            computed from `name` if omitted.
+        name (str or None): The name of this experiment template. Will be
+            filled from the wrapped function's name if omitted.
+        prefix (str): Directory under data/local in which to place the
+            experiment directory.
+        snapshot_mode (str): Policy for which snapshots to keep (or make at
+            all). Can be either "all" (all iterations will be saved), "last"
+            (only the last iteration will be saved), "gap" (every snapshot_gap
+            iterations are saved), or "none" (do not save snapshots).
+        snapshot_gap (int): Gap between snapshot iterations. Waits this number
+            of iterations before taking another snapshot.
+
+    """
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, *, function, log_dir, name, prefix, snapshot_mode,
+                 snapshot_gap):
+        self.function = function
+        self.log_dir = log_dir
+        self.name = name
+        self.prefix = prefix
+        self.snapshot_mode = snapshot_mode
+        self.snapshot_gap = snapshot_gap
+
+    def _make_context(self, *args, **kwargs):
+        """Make a context from the template information and variant args.
+
+        Currently, all arguments should be keyword arguments.
+
+        Args:
+            args (list): Should be empty.
+            kwargs (dict): Keyword arguments for the wrapped function. Will be
+                logged to `variant.json`
+
+        Returns:
+            ExperimentContext: The created experiment context.
+
+        Raises:
+            ValueError: If args is not empty.
+
+        """
+        if args:
+            raise ValueError('garage.experiment currently only supports '
+                             'keyword arguments')
+        log_dir = self.log_dir
+        if log_dir is None:
+            name = self.name
+            if name is None:
+                name = self.function.__name__
+            log_dir = ('{data}/local/{prefix}/{name}'.format(
+                data=osp.join(os.getcwd(), 'data'),
+                prefix=self.prefix,
+                name=name))
+        log_dir = _make_sequential_log_dir(log_dir)
+
+        tabular_log_file = os.path.join(log_dir, 'progress.csv')
+        text_log_file = os.path.join(log_dir, 'debug.log')
+        variant_log_file = os.path.join(log_dir, 'variant.json')
+
+        dump_json(variant_log_file, kwargs)
+
+        logger.add_output(dowel.TextOutput(text_log_file))
+        logger.add_output(dowel.CsvOutput(tabular_log_file))
+        logger.add_output(dowel.TensorBoardOutput(log_dir))
+        logger.add_output(dowel.StdOutput())
+
+        logger.push_prefix('[%s] ' % self.name)
+
+        return ExperimentContext(snapshot_dir=log_dir,
+                                 snapshot_mode=self.snapshot_mode,
+                                 snapshot_gap=self.snapshot_gap)
+
+    def __call__(self, *args, **kwargs):
+        """Wrap a function to turn it into an ExperimentTemplate.
+
+        Note that this docstring will be overriden to match the function's
+        docstring on the ExperimentTemplate once a function is passed in.
+
+        Args:
+            args (list): If no function has been set yet, must be a list
+                containing a single callable.
+            kwargs (dict): Arguments passed onto the wrapped function.
+
+        Returns:
+            object: The returned value of the wrapped function.
+
+        Raises:
+            ValueError: If not passed a single callable argument.
+
+        """
+        if self.function is None:
+            if len(args) != 1 or len(kwargs) != 0 or not callable(args[0]):
+                raise ValueError('Please apply the result of '
+                                 'wrap_experiment() to a single function')
+            # Apply ourselves as a decorator
+            self.function = args[0]
+            functools.update_wrapper(self, self.function)
+            return self
+        else:
+            ctxt = self._make_context(*args, **kwargs)
+            return self.function(ctxt, *args, **kwargs)
+
+
+def wrap_experiment(function=None,
+                    *,
+                    log_dir=None,
+                    prefix='experiment',
+                    name=None,
+                    snapshot_mode='last',
+                    snapshot_gap=1):
+    """Decorate a function to turn it into an ExperimentTemplate.
+
+    When invoked, the wrapped function will receive an ExperimentContext, which
+    will contain the log directory into which the experiment should log
+    information.
+
+    This decorator can be invoked in two differed ways.
+
+    Without arguments, like this:
+
+        @wrap_experiment
+        def my_experiment(ctxt, seed, lr=0.5):
+            ...
+
+    Or with arguments:
+
+        @wrap_experiment(snapshot_mode='all')
+        def my_experiment(ctxt, seed, lr=0.5):
+            ...
+
+    All arguments must be keyword arguments.
+
+    Args:
+        function (callable or None): The experiment function to wrap.
+        log_dir (str or None): The full log directory to log to. Will be
+            computed from `name` if omitted.
+        name (str or None): The name of this experiment template. Will be
+            filled from the wrapped function's name if omitted.
+        prefix (str): Directory under data/local in which to place the
+            experiment directory.
+        snapshot_mode (str): Policy for which snapshots to keep (or make at
+            all). Can be either "all" (all iterations will be saved), "last"
+            (only the last iteration will be saved), "gap" (every snapshot_gap
+            iterations are saved), or "none" (do not save snapshots).
+        snapshot_gap (int): Gap between snapshot iterations. Waits this number
+            of iterations before taking another snapshot.
+
+    Returns:
+        callable: The wrapped function.
+
+    """
+    return ExperimentTemplate(function=function,
+                              log_dir=log_dir,
+                              prefix=prefix,
+                              name=name,
+                              snapshot_mode=snapshot_mode,
+                              snapshot_gap=snapshot_gap)
+
+
+def dump_json(filename, data):
+    """Dump a dictionary to a file in JSON format.]
+
+    Args:
+        filename(str): Filename for the file.
+        data(dict): Data to save to file.
+
+    """
+    pathlib.Path(os.path.dirname(filename)).mkdir(parents=True, exist_ok=True)
+    with open(filename, 'w') as f:
+        json.dump(data, f, indent=2, sort_keys=True, cls=LogEncoder)
+
+
+class LogEncoder(json.JSONEncoder):
+    """Encoder to be used as cls in json.dump."""
+
+    def default(self, o):
+        """Perform JSON encoding.
+
+        Args:
+            o (object): Object to encode.
+
+        Returns:
+            str: Object encoded in JSON.
+
+        """
+
+        # Why is this method hidden? What does that mean?
+        # pylint: disable=method-hidden
+
+        if isinstance(o, type):
+            return {'$class': o.__module__ + '.' + o.__name__}
+        elif isinstance(o, enum.Enum):
+            return {
+                '$enum':
+                o.__module__ + '.' + o.__class__.__name__ + '.' + o.name
+            }
+        elif callable(o):
+            return {'$function': o.__module__ + '.' + o.__name__}
+        return json.JSONEncoder.default(self, o)

--- a/src/garage/experiment/experiment_wrapper.py
+++ b/src/garage/experiment/experiment_wrapper.py
@@ -118,10 +118,6 @@ def run_experiment(argv):
     if args.seed is not None:
         deterministic.set_seed(args.seed)
 
-    if not args.plot:
-        garage.plotter.Plotter.disable()
-        garage.tf.plotter.Plotter.disable()
-
     if args.log_dir is None:
         log_dir = os.path.join(os.path.join(os.getcwd(), 'data'),
                                args.exp_name)

--- a/src/garage/experiment/experiment_wrapper.py
+++ b/src/garage/experiment/experiment_wrapper.py
@@ -4,7 +4,6 @@ import argparse
 import ast
 import base64
 import datetime
-import enum
 import json
 import os
 import pathlib
@@ -18,7 +17,7 @@ import dowel
 from dowel import logger
 import psutil
 
-from garage.experiment import deterministic, SnapshotConfig
+import garage.experiment
 import garage.plotter
 import garage.tf.plotter
 
@@ -116,7 +115,7 @@ def run_experiment(argv):
     args = parser.parse_args(argv[1:])
 
     if args.seed is not None:
-        deterministic.set_seed(args.seed)
+        garage.experiment.deterministic.set_seed(args.seed)
 
     if args.log_dir is None:
         log_dir = os.path.join(os.path.join(os.getcwd(), 'data'),
@@ -131,7 +130,7 @@ def run_experiment(argv):
     if args.variant_data is not None:
         variant_data = pickle.loads(base64.b64decode(args.variant_data))
         variant_log_file = os.path.join(log_dir, args.variant_log_file)
-        dump_variant(variant_log_file, variant_data)
+        garage.experiment.experiment.dump_json(variant_log_file, variant_data)
     else:
         variant_data = None
 
@@ -144,9 +143,10 @@ def run_experiment(argv):
 
     logger.push_prefix('[%s] ' % args.exp_name)
 
-    snapshot_config = SnapshotConfig(snapshot_dir=log_dir,
-                                     snapshot_mode=args.snapshot_mode,
-                                     snapshot_gap=args.snapshot_gap)
+    snapshot_config = \
+        garage.experiment.SnapshotConfig(snapshot_dir=log_dir,
+                                         snapshot_mode=args.snapshot_mode,
+                                         snapshot_gap=args.snapshot_gap)
 
     method_call = cloudpickle.loads(base64.b64decode(args.args_data))
     try:
@@ -218,45 +218,12 @@ def log_parameters(log_file, args):
         log_params['json_args'] = dict()
     pathlib.Path(os.path.dirname(log_file)).mkdir(parents=True, exist_ok=True)
     with open(log_file, 'w') as f:
-        json.dump(log_params, f, indent=2, sort_keys=True, cls=LogEncoder)
-
-
-def dump_variant(log_file, variant_data):
-    """Dump the variant file.
-
-    Args:
-        log_file (str): Log filename.
-        variant_data (object): Variant data.
-
-    """
-    pathlib.Path(os.path.dirname(log_file)).mkdir(parents=True, exist_ok=True)
-    with open(log_file, 'w') as f:
-        json.dump(variant_data, f, indent=2, sort_keys=True, cls=LogEncoder)
-
-
-class LogEncoder(json.JSONEncoder):
-    """Encoder to be used as cls in json.dump."""
-
-    def default(self, o):  # pylint: disable=method-hidden
-        """Perform JSON encoding.
-
-        Args:
-            o (object): Object to encode.
-
-        Returns:
-            str: Object encoded in JSON.
-
-        """
-        if isinstance(o, type):
-            return {'$class': o.__module__ + '.' + o.__name__}
-        if isinstance(o, enum.Enum):
-            return {
-                '$enum':
-                o.__module__ + '.' + o.__class__.__name__ + '.' + o.name
-            }
-        if callable(o):
-            return {'$function': o.__module__ + '.' + o.__name__}
-        return json.JSONEncoder.default(self, o)
+        json.dump(log_params,
+                  f,
+                  indent=2,
+                  sort_keys=True,
+                  cls=garage.experiment.experiment.LogEncoder)
+    garage.experiment.experiment.dump_json(log_file, log_params)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a minimal version of the interface described in #1049.
It has a few limitations and doesn't implement every feature we might
need, but it's already probably better than run_experiment.

I believe this implementation can be cleanly extended to provide
everything we want from the interface.

The most important difference (besides all the new features) is that it
doesn't call garage.deterministic.set_seed. Since this is a parameter
that should be logged in variant.json, it should actually be passed into
the experiment function. Perhaps the runner should call this function
instead?

Since I want comments, I'm pushing this up before updating the examples.