### PR TITLE
Make policy stateless

### DIFF
--- a/examples/tf/trpo_pendulum_recurrent.py
+++ b/examples/tf/trpo_pendulum_recurrent.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""This is an example to train a task with TRPO algorithm.
+
+It uses an LSTM-based recurrent policy.
+
+Here it runs CartPole-v1 environment with 100 iterations.
+
+Results:
+    AverageReturn: 100
+    RiseTime: itr 13
+"""
+from garage.experiment import run_experiment
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import TRPO
+from garage.tf.envs import TfEnv
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.optimizers import ConjugateGradientOptimizer
+from garage.tf.optimizers import FiniteDifferenceHvp
+from garage.tf.policies import GaussianGRUPolicy
+
+
+def run_task(snapshot_config, *_):
+    """Defines the main experiment routine.
+
+    Args:
+        snapshot_config (garage.experiment.SnapshotConfig): Configuration
+            values for snapshotting.
+        *_ (object): Hyperparameters (unused).
+
+    """
+    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+        env = TfEnv(env_name='InvertedDoublePendulum-v2')
+
+        policy = GaussianGRUPolicy(name='policy', env_spec=env.spec)
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_path_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01,
+                    optimizer=ConjugateGradientOptimizer,
+                    optimizer_args=dict(hvp_approach=FiniteDifferenceHvp(
+                        base_eps=1e-5)))
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=1024)
+
+
+run_experiment(
+    run_task,
+    snapshot_mode='last',
+    seed=1,
+)

--- a/src/garage/np/policies/base.py
+++ b/src/garage/np/policies/base.py
@@ -8,24 +8,57 @@ class Policy(abc.ABC):
     Args:
         env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
 
+    Note:
+        `policy_info` is passed as an argument in some APIs in Policy. This
+        is intended to allow policies to pass state to themselves between
+        calls. Users should consider its contents to be private, and should
+        never assume this variable contains anything in particular, or even
+        that its contents is consistent between calls to the same Policy
+        object. In most use cases for non-recurrent policies, `policy_info`
+        will be an empty dictionary while for recurrent-policies, it may
+        store its previous hidden/cell state as the policy state.
+
+        User should never mutate the contents of `policy_info` outside Policy,
+        and no policy should ever require the user inspect or mutate
+        `policy_info` as part of its interface.
+
+        Implementers of Policy may occasionally find it useful to store some
+        debugging information in `policy_info`, but any information
+        implementers would like to be consistently logged by users should be
+        exposed explicitly through the log_diagnostics interface.
+
     """
 
     def __init__(self, env_spec):
         self._env_spec = env_spec
 
     @abc.abstractmethod
-    def get_action(self, observation):
+    def get_action(self, observation, policy_info=None):
         """Get action sampled from the policy.
 
         Args:
             observation (np.ndarray): Observation from the environment.
+            policy_info (dict): Info for the policy.
 
         Returns:
-            (np.ndarray): Action sampled from the policy.
+            np.ndarray: Action sampled from the policy.
 
         """
 
-    def reset(self, dones=None):
+    @abc.abstractmethod
+    def get_actions(self, observations, policy_infos=None):
+        """Get actions sampled from the policy.
+
+        Args:
+            observations (list[np.ndarray]): Observations from the environment.
+            policy_infos (dict): Infos for the policy.
+
+        Returns:
+            np.ndarray: Actions sampled from the policy.
+
+        """
+
+    def reset(self, policy_infos, dones=None):
         """Reset the policy.
 
         If dones is None, it will be by default np.array([True]) which implies
@@ -33,18 +66,49 @@ class Policy(abc.ABC):
         environments for training data sampling = 1.
 
         Args:
+            policy_infos (dict): Infos for policy states.
             dones (numpy.ndarray): Bool that indicates terminal state(s).
+
+        """
+
+    def get_initial_state(self):
+        """Initial state.
+
+        Returns:
+            dict: Initial state.
+
+        """
+
+    def get_initial_states(self, batch_size):
+        """Initial states.
+
+        Args:
+            batch_size (int): Number of parallel environments for
+                training data sampling.
+
+        Returns:
+            dict: Initial states.
 
         """
 
     @property
     def observation_space(self):
-        """akro.Space: The observation space of the environment."""
+        """Observation space.
+
+        Returns:
+            akro.Space: The observation space of the environment.
+
+        """
         return self._env_spec.observation_space
 
     @property
     def action_space(self):
-        """akro.Space: The action space for the environment."""
+        """Action space.
+
+        Returns:
+            akro.Space: The action space of the environment.
+
+        """
         return self._env_spec.action_space
 
     @property
@@ -56,6 +120,28 @@ class Policy(abc.ABC):
 
         """
         return False
+
+    @property
+    def vectorized(self):
+        """Boolean for vectorized.
+
+        Returns:
+            bool: Indicates whether the policy is vectorized. If True, it
+                should implement get_actions(), and support resetting with
+                multiple simultaneous states.
+
+        """
+        return False
+
+    @property
+    def env_spec(self):
+        """Policy environment specification.
+
+        Returns:
+            garage.EnvSpec: Environment specification.
+
+        """
+        return self._env_spec
 
     def log_diagnostics(self, paths):
         """Log extra information per iteration based on the collected paths.

--- a/src/garage/tf/algos/batch_polopt.py
+++ b/src/garage/tf/algos/batch_polopt.py
@@ -141,7 +141,7 @@ class BatchPolopt(RLAlgorithm):
                 * baselines: (numpy.ndarray)
                 * returns: (numpy.ndarray)
                 * valids: (numpy.ndarray)
-                * agent_infos: (dict)
+                * policy_infos: (dict)
                 * env_infos: (dict)
                 * paths: (list[dict])
                 * average_return: (numpy.float64)
@@ -163,7 +163,7 @@ class BatchPolopt(RLAlgorithm):
                             path['actions'])),
                     rewards=path['rewards'],
                     env_infos=path['env_infos'],
-                    agent_infos=path['agent_infos']) for path in paths
+                    policy_infos=path['policy_infos']) for path in paths
             ]
         else:
             paths = [
@@ -174,7 +174,7 @@ class BatchPolopt(RLAlgorithm):
                             path['actions'])),
                     rewards=path['rewards'],
                     env_infos=path['env_infos'],
-                    agent_infos=path['agent_infos']) for path in paths
+                    policy_infos=path['policy_infos']) for path in paths
             ]
 
         if hasattr(self.baseline, 'predict_n'):
@@ -218,10 +218,10 @@ class BatchPolopt(RLAlgorithm):
 
         baselines = tensor_utils.pad_tensor_n(baselines, max_path_length)
 
-        agent_infos = [path['agent_infos'] for path in paths]
-        agent_infos = tensor_utils.stack_tensor_dict_list([
+        policy_infos = [path['policy_infos'] for path in paths]
+        policy_infos = tensor_utils.stack_tensor_dict_list([
             tensor_utils.pad_tensor_dict(p, max_path_length)
-            for p in agent_infos
+            for p in policy_infos
         ])
 
         env_infos = [path['env_infos'] for path in paths]
@@ -238,7 +238,7 @@ class BatchPolopt(RLAlgorithm):
         undiscounted_returns = [sum(path['rewards']) for path in paths]
         self.episode_reward_mean.extend(undiscounted_returns)
 
-        ent = np.sum(self.policy.distribution.entropy(agent_infos) *
+        ent = np.sum(self.policy.distribution.entropy(policy_infos) *
                      valids) / np.sum(valids)
 
         samples_data = dict(
@@ -248,7 +248,7 @@ class BatchPolopt(RLAlgorithm):
             baselines=baselines,
             returns=returns,
             valids=valids,
-            agent_infos=agent_infos,
+            policy_infos=policy_infos,
             env_infos=env_infos,
             paths=paths,
             average_return=np.mean(undiscounted_returns),

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -619,10 +619,11 @@ class NPO(BatchPolopt):
 
         """
         policy_state_info_list = [
-            samples_data['agent_infos'][k] for k in self.policy.state_info_keys
+            samples_data['policy_infos'][k]
+            for k in self.policy.state_info_keys
         ]
         policy_old_dist_info_list = [
-            samples_data['agent_infos'][k]
+            samples_data['policy_infos'][k]
             for k in self.policy.distribution.dist_info_keys
         ]
 

--- a/src/garage/tf/policies/base.py
+++ b/src/garage/tf/policies/base.py
@@ -23,11 +23,12 @@ class Policy(abc.ABC):
         self._cached_param_shapes = None
 
     @abc.abstractmethod
-    def get_action(self, observation):
+    def get_action(self, observation, agent_infos):
         """Get action sampled from the policy.
 
         Args:
             observation (np.ndarray): Observation from the environment.
+            agent_infos (dict): Infos for previous action and hidden states.
 
         Returns:
             (np.ndarray): Action sampled from the policy.
@@ -35,18 +36,19 @@ class Policy(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_actions(self, observations):
+    def get_actions(self, observations, agent_infos):
         """Get action sampled from the policy.
 
         Args:
             observations (list[np.ndarray]): Observations from the environment.
+            agent_infos (dict): Infos for previous action and hidden states.
 
         Returns:
             (np.ndarray): Actions sampled from the policy.
 
         """
 
-    def reset(self, dones=None):
+    def reset(self, agent_infos, dones=None):
         """Reset the policy.
 
         If dones is None, it will be by default np.array([True]) which implies
@@ -54,7 +56,32 @@ class Policy(abc.ABC):
         environments for training data sampling = 1.
 
         Args:
+            agent_infos (dict): Infos for previous action and hidden states.
             dones (numpy.ndarray): Bool that indicates terminal state(s).
+
+        """
+
+    def get_initial_state(self, dones=None):
+        """Initial state.
+
+        Note:
+            If `dones` is None, it will be by default `np.array([True])` which
+            implies the policy will not be "vectorized", i.e. number of
+            parallel environments for training data sampling = 1.
+
+        Args:
+            dones (list[bool]): Terminal signals with shape :math:`(P)`, where
+                P is the number of parallel environments for training data
+                sampling.
+
+        Returns:
+            dict: Initial state. For non-recurrent policies, it will be an
+                empty dict. For GRU, it includes previous action with shape
+                :math:`(P, S^*)` and previous hidden state with shape
+                :math:`(P, S^*)`. For LSTM, it will also have previous
+                cell state with shape :math:`(P, S^*)`, where
+                P is the number of parallel environments for training data
+                sampling.
 
         """
 


### PR DESCRIPTION
This PR makes recurrent policies stateless by decoupling agent info and policies.
Currently recurrent policies store the agent info, e.g. previous action and hidden state
which can be a problem if it's modified unexpectedly.

Proposed API: Call `policy.get_initial_state()` to retrieve the initial state and during sampling,
we pass the `agent_info` as an argument to both `policy.get_action()` and `policy.reset()`.
Consumer of policies will be responsible to modify the state given to policies, in this case
update the previous action in `agent_infos` before passing to policies, similar to update
`obses` with next observation.

Purpose of the first commit is only to demonstrate the API. When API is finalized, all policies will be applied with the same change.

An example is also added to demonstrate the policy is learning. Below is the average score for `GaussianGRUPolicy` in `InvertedDoublePendulum`.
<img width="360" alt="Screenshot 2019-12-21 at 5 35 48 PM" src="https://user-images.githubusercontent.com/10270515/71315886-d422f880-241b-11ea-9c84-29a82b2863bb.png">

