### PR TITLE
Needs review Sample vs Sample batch

### DIFF
--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,4 +1,5 @@
 """Garage Base."""
+from garage._dtypes import Sample
 from garage._dtypes import TrajectoryBatch
 
-__all__ = ['TrajectoryBatch']
+__all__ = ['Sample', 'TrajectoryBatch']

--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,5 +1,6 @@
 """Garage Base."""
 from garage._dtypes import Sample
+from garage._dtypes import SamplesBatch
 from garage._dtypes import TrajectoryBatch
 
-__all__ = ['Sample', 'TrajectoryBatch']
+__all__ = ['Sample', 'SamplesBatch', 'TrajectoryBatch']

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -167,3 +167,199 @@ class TrajectoryBatch(
         return super().__new__(TrajectoryBatch, env_spec, observations,
                                actions, rewards, terminals, env_infos,
                                agent_infos, lengths)
+
+class SamplesBatch(
+        collections.namedtuple('SamplesBatch', [
+            'env_spec',
+            'observations',
+            'actions',
+            'rewards',
+            'next_observations',
+            'terminals',
+            'env_infos',
+            'agent_infos',
+        ])):
+    # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
+    r"""A tuple representing a batch of whole trajectories.
+
+    A :class:`SamplesBatch` represents a batch of samples
+    produced when one or more agents interacts with one or more environments.
+
+    Attributes:
+        env_spec (garage.envs.EnvSpec): Specification for the environment from
+            which this data was sampled.
+        observations (numpy.ndarray): A numpy array of shape
+            :math:`(N \bullet [T], O^*)` containing the (possibly
+            multi-dimensional) observations for all time steps in this batch.
+            These must conform to :obj:`env_spec.observation_space`.
+        actions (numpy.ndarray): A  numpy array of shape
+            :math:`(N \bullet [T], A^*)` containing the (possibly
+            multi-dimensional) actions for all time steps in this batch. These
+            must conform to :obj:`env_spec.action_space`.
+        rewards (numpy.ndarray): A numpy array of shape
+            :math:`(N \bullet [T])` containing the rewards for all time steps
+            in this batch.
+        terminals (numpy.ndarray): A boolean numpy array of shape
+            :math:`(N \bullet [T])` containing the termination signals for all
+            time steps in this batch.
+        env_infos (dict): A dict of numpy arrays arbitrary environment state
+            information. Each value of this dict should be a numpy array of
+            shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
+        agent_infos (numpy.ndarray): A dict of numpy arrays arbitrary agent
+            state information. Each value of this dict should be a numpy array
+            of shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
+            For example, this may contain the hidden states from an RNN policy.
+
+    Raises:
+        ValueError: If any of the above attributes do not conform to their
+            prescribed types and shapes.
+
+    """
+    __slots__ = ()
+
+    def __new__(cls, env_spec, observations, actions, rewards, next_observations,
+                 terminals, env_infos, agent_infos):  # noqa: D102
+        # pylint: disable=too-many-branches
+
+        first_observation = observations[0]
+        first_next_observation =  next_observation[0]
+        first_action = actions[0]
+
+        # observations
+        if not env_spec.observation_space.contains(first_observation):
+            raise ValueError(
+                'observations must conform to observation_space {}, but got '
+                'data with shape {} instead.'.format(
+                    env_spec.observation_space, first_observation))
+
+        if not env_spec.observation_space.contains(first_next_observation):
+            raise ValueError(
+                'next_observations must conform to observation_space {}, but got '
+                'data with shape {} instead.'.format(
+                    env_spec.observation_space, first_next_observation))
+
+        # actions
+        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
+        if not (env_spec.action_space.contains(first_action)
+                and first_action.shape == env_spec.action_space.shape):
+            raise ValueError(
+                'actions must conform to action_space {}, but got data with '
+                'shape {} instead.'.format(env_spec.action_space,
+                                           first_action))
+
+        if terminals.dtype != np.bool:
+            raise ValueError(
+                'Terminals tensor must be dtype np.bool, but got tensor '
+                'of dtype {} instead.'.format(terminals.dtype))
+
+        # env_infos
+        for key, val in env_infos.items():
+            if not isinstance(val, np.ndarray):
+                raise ValueError(
+                    'Each entry in env_infos must be a numpy array, but got '
+                    'key {} with value type {} instead.'
+                    'instead'.format(key, type(val)))
+
+        # agent_infos
+        for key, val in agent_infos.items():
+            if not isinstance(val, np.ndarray):
+                raise ValueError(
+                    'Each entry in agent_infos must be a numpy array, but got '
+                    'key {} with value type {} instead.'
+                    'instead'.format(key, type(val)))
+
+        return super().__new__(SamplesBatch, env_spec, observations,
+                               actions, rewards, next_observations, terminals,
+                               env_infos, agent_infos)
+
+
+class Sample(
+        collections.namedtuple('Sample', [
+            'env_spec',
+            'observation',
+            'action',
+            'reward',
+            'next_observation',
+            'terminal',
+            'env_info',
+            'agent_info',
+        ])):
+    # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
+    r"""A tuple representing a batch of whole trajectories.
+
+    A :class:`Sample` represents single sample sampled from the environment.
+
+    Attributes:
+        env_spec (garage.envs.EnvSpec): Specification for the environment from
+            which this data was sampled.
+        observation (float): Observation at the current time step in the
+            environment.
+        action (float): Action sampled from the policy given the observation
+            at the current time step.
+        reward (float): The reward for taking the action at the current state.
+        terminals (boolean): A boolean representing the termination signal for
+            the current time step.
+        env_info (dict): A dict containing the env_info returned from the
+            environment. For example, this may contain whether the termination
+            of the environment is due to the time step limit expiration or a
+            terminal state.
+        agent_info (dict): A dict of containing the agent_info returned by the
+            agent/policy. For example, this may contain the hidden states from 
+            an RNN policy.
+
+
+    Raises:
+        ValueError: If any of the above attributes do not conform to their
+            prescribed types and shapes.
+
+    """
+    __slots__ = ()
+
+    def __new__(cls, env_spec, observation, action, reward, next_observation,
+                terminal, env_info, agent_info):  # noqa: D102
+        # pylint: disable=too-many-branches
+
+        if type(observation) != float:
+            raise ValueError(
+                'observation must be type {}, but got type {} '
+                'instead.'.format(float, type(observation)))
+        # observation
+        if not env_spec.observation_space.contains(observation):
+            raise ValueError(
+                'observation must conform to observation_space {}, but got '
+                'data with shape {} instead.'.format(
+                    env_spec.observation_space, observation))
+
+        if type(next_observation) != float:
+            raise ValueError(
+                'next_observation must be type {}, but got type {} '
+                'instead.'.format(float, type(next_observation)))
+        # next_observation
+        if not env_spec.observation_space.contains(next_observation):
+            raise ValueError(
+                'next_observation must conform to observation_space {}, but got '
+                'data with shape {} instead.'.format(
+                    env_spec.observation_space, next_observation))
+
+        # action
+        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
+        if not (env_spec.action_space.contains(action)
+                and action.shape == env_spec.action_space.shape):
+            raise ValueError(
+                'action must conform to action_space {}, but got data with '
+                'shape {} instead.'.format(env_spec.action_space,
+                                           action))
+
+        # rewards
+        if type(reward) != float:
+            raise ValueError(
+                'Rewards must be type {}, but got type {} '
+                'instead.'.format(float, type(reward)))
+
+        if type(terminal) != bool:
+            raise ValueError(
+                'Terminal must be dtype bool, but  got dtype {} instead.'.format(type(terminal)))
+
+        return super().__new__(Sample, env_spec, observation,
+                               action, reward, terminal, next_observation,
+                               env_info, agent_info)

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -105,7 +105,6 @@ class TrajectoryBatch(
                                                     observations.shape[0]))
 
         # actions
-        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
         if not (env_spec.action_space.contains(first_action)
                 and first_action.shape == env_spec.action_space.shape):
             raise ValueError(
@@ -168,110 +167,6 @@ class TrajectoryBatch(
                                actions, rewards, terminals, env_infos,
                                agent_infos, lengths)
 
-class SamplesBatch(
-        collections.namedtuple('SamplesBatch', [
-            'env_spec',
-            'observations',
-            'actions',
-            'rewards',
-            'next_observations',
-            'terminals',
-            'env_infos',
-            'agent_infos',
-        ])):
-    # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
-    r"""A tuple representing a batch of whole trajectories.
-
-    A :class:`SamplesBatch` represents a batch of samples
-    produced when one or more agents interacts with one or more environments.
-
-    Attributes:
-        env_spec (garage.envs.EnvSpec): Specification for the environment from
-            which this data was sampled.
-        observations (numpy.ndarray): A numpy array of shape
-            :math:`(N \bullet [T], O^*)` containing the (possibly
-            multi-dimensional) observations for all time steps in this batch.
-            These must conform to :obj:`env_spec.observation_space`.
-        actions (numpy.ndarray): A  numpy array of shape
-            :math:`(N \bullet [T], A^*)` containing the (possibly
-            multi-dimensional) actions for all time steps in this batch. These
-            must conform to :obj:`env_spec.action_space`.
-        rewards (numpy.ndarray): A numpy array of shape
-            :math:`(N \bullet [T])` containing the rewards for all time steps
-            in this batch.
-        terminals (numpy.ndarray): A boolean numpy array of shape
-            :math:`(N \bullet [T])` containing the termination signals for all
-            time steps in this batch.
-        env_infos (dict): A dict of numpy arrays arbitrary environment state
-            information. Each value of this dict should be a numpy array of
-            shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
-        agent_infos (numpy.ndarray): A dict of numpy arrays arbitrary agent
-            state information. Each value of this dict should be a numpy array
-            of shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
-            For example, this may contain the hidden states from an RNN policy.
-
-    Raises:
-        ValueError: If any of the above attributes do not conform to their
-            prescribed types and shapes.
-
-    """
-    __slots__ = ()
-
-    def __new__(cls, env_spec, observations, actions, rewards, next_observations,
-                 terminals, env_infos, agent_infos):  # noqa: D102
-        # pylint: disable=too-many-branches
-
-        first_observation = observations[0]
-        first_next_observation =  next_observation[0]
-        first_action = actions[0]
-
-        # observations
-        if not env_spec.observation_space.contains(first_observation):
-            raise ValueError(
-                'observations must conform to observation_space {}, but got '
-                'data with shape {} instead.'.format(
-                    env_spec.observation_space, first_observation))
-
-        if not env_spec.observation_space.contains(first_next_observation):
-            raise ValueError(
-                'next_observations must conform to observation_space {}, but got '
-                'data with shape {} instead.'.format(
-                    env_spec.observation_space, first_next_observation))
-
-        # actions
-        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
-        if not (env_spec.action_space.contains(first_action)
-                and first_action.shape == env_spec.action_space.shape):
-            raise ValueError(
-                'actions must conform to action_space {}, but got data with '
-                'shape {} instead.'.format(env_spec.action_space,
-                                           first_action))
-
-        if terminals.dtype != np.bool:
-            raise ValueError(
-                'Terminals tensor must be dtype np.bool, but got tensor '
-                'of dtype {} instead.'.format(terminals.dtype))
-
-        # env_infos
-        for key, val in env_infos.items():
-            if not isinstance(val, np.ndarray):
-                raise ValueError(
-                    'Each entry in env_infos must be a numpy array, but got '
-                    'key {} with value type {} instead.'
-                    'instead'.format(key, type(val)))
-
-        # agent_infos
-        for key, val in agent_infos.items():
-            if not isinstance(val, np.ndarray):
-                raise ValueError(
-                    'Each entry in agent_infos must be a numpy array, but got '
-                    'key {} with value type {} instead.'
-                    'instead'.format(key, type(val)))
-
-        return super().__new__(SamplesBatch, env_spec, observations,
-                               actions, rewards, next_observations, terminals,
-                               env_infos, agent_infos)
-
 
 class Sample(
         collections.namedtuple('Sample', [
@@ -287,25 +182,27 @@ class Sample(
     # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
     r"""A tuple representing a batch of whole trajectories.
 
-    A :class:`Sample` represents single sample sampled from the environment.
+    A :class:`Sample` represents a single sample when an agent interacts with
+        an environment.
 
     Attributes:
         env_spec (garage.envs.EnvSpec): Specification for the environment from
             which this data was sampled.
-        observation (float): Observation at the current time step in the
-            environment.
-        action (float): Action sampled from the policy given the observation
-            at the current time step.
-        reward (float): The reward for taking the action at the current state.
-        terminals (boolean): A boolean representing the termination signal for
-            the current time step.
-        env_info (dict): A dict containing the env_info returned from the
-            environment. For example, this may contain whether the termination
-            of the environment is due to the time step limit expiration or a
-            terminal state.
-        agent_info (dict): A dict of containing the agent_info returned by the
-            agent/policy. For example, this may contain the hidden states from 
-            an RNN policy.
+        observation (numpy.ndarray): A numpy array of shape
+            :math:`(O^*)` containing the observation for the current time step
+            in the environment. These must conform to
+            :obj:`env_spec.observation_space`.
+            actions (numpy.ndarray): A numpy array of shape
+            :math:`(A^*)` containing the action for the current time step.
+            These must conform to :obj:`env_spec.action_space`.
+        reward (float): A float representing the reward for taking
+            the action given the observation, at the current time step.
+        terminals (bool): The termination signal for the current time step.
+        env_info (dict): A dict arbitrary environment state
+            information.
+        agent_infos (numpy.ndarray): A dict of arbitrary agent
+            state information. For example, this may contain the hidden states
+            from an RNN policy.
 
 
     Raises:
@@ -313,53 +210,47 @@ class Sample(
             prescribed types and shapes.
 
     """
-    __slots__ = ()
 
     def __new__(cls, env_spec, observation, action, reward, next_observation,
                 terminal, env_info, agent_info):  # noqa: D102
-        # pylint: disable=too-many-branches
 
-        if type(observation) != float:
-            raise ValueError(
-                'observation must be type {}, but got type {} '
-                'instead.'.format(float, type(observation)))
-        # observation
+        # observations
         if not env_spec.observation_space.contains(observation):
             raise ValueError(
-                'observation must conform to observation_space {}, but got '
+                'observations must conform to observation_space {}, but got '
                 'data with shape {} instead.'.format(
                     env_spec.observation_space, observation))
 
-        if type(next_observation) != float:
-            raise ValueError(
-                'next_observation must be type {}, but got type {} '
-                'instead.'.format(float, type(next_observation)))
-        # next_observation
         if not env_spec.observation_space.contains(next_observation):
             raise ValueError(
-                'next_observation must conform to observation_space {}, but got '
-                'data with shape {} instead.'.format(
+                'next_observation must conform to observation_space {},'
+                ' but got data with shape {} instead.'.format(
                     env_spec.observation_space, next_observation))
 
         # action
-        # TODO: Shape check can be removed for gym>=0.15.4 # pylint: disable=fixme # noqa: E501
-        if not (env_spec.action_space.contains(action)
-                and action.shape == env_spec.action_space.shape):
+        if not env_spec.action_space.contains(action):
             raise ValueError(
                 'action must conform to action_space {}, but got data with '
-                'shape {} instead.'.format(env_spec.action_space,
-                                           action))
+                'shape {} instead.'.format(env_spec.action_space, action))
+
+        if not isinstance(agent_info, dict):
+            raise ValueError('Agent_info must be type {}, but got type {} '
+                             'instead.'.format(dict, type(agent_info)))
+
+        if not isinstance(env_info, dict):
+            raise ValueError('Env_info must be type {}, but got type {} '
+                             'instead.'.format(dict, type(env_info)))
 
         # rewards
-        if type(reward) != float:
-            raise ValueError(
-                'Rewards must be type {}, but got type {} '
-                'instead.'.format(float, type(reward)))
+        if not isinstance(reward, float):
+            raise ValueError('Rewards must be type {}, but got type {} '
+                             'instead.'.format(float, type(reward)))
 
-        if type(terminal) != bool:
+        if not isinstance(terminal, bool):
             raise ValueError(
-                'Terminal must be dtype bool, but  got dtype {} instead.'.format(type(terminal)))
+                'Terminal must be dtype bool, but got dtype {} instead.'.
+                format(type(terminal)))
 
-        return super().__new__(Sample, env_spec, observation,
-                               action, reward, terminal, next_observation,
-                               env_info, agent_info)
+        return super().__new__(Sample, env_spec, observation, action, reward,
+                               next_observation, terminal, env_info,
+                               agent_info)

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -180,7 +180,7 @@ class Sample(
             'agent_info',
         ])):
     # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
-    r"""A tuple representing a batch of whole trajectories.
+    r"""A tuple representing a single sample.
 
     A :class:`Sample` represents a single sample when an agent interacts with
         an environment.
@@ -254,3 +254,40 @@ class Sample(
         return super().__new__(Sample, env_spec, observation, action, reward,
                                next_observation, terminal, env_info,
                                agent_info)
+
+
+class SamplesBatch(collections.namedtuple('SamplesBatch', [
+        'samples',
+])):
+    # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc, bad-docstring-quotes  # noqa: E501
+    r"""A tuple representing a batch of samples. # noqa: 410 411
+
+    A :class:`SampleBatch` represents a batch of :class:`Sample`s when
+        an agent interacts with an environment.
+
+    Attributes:
+        samples(list): an array of :class:`Sample`s that are
+            collected when an agent makes multiple interactions with
+            its environment.
+    Raises:
+        ValueError: If any of the above attributes do not conform to their
+            prescribed types.
+
+    """
+
+    def __new__(cls, samples):  # noqa: D102
+        if not isinstance(samples, list):
+            raise ValueError('Samples must be of type {}, but got argument of '
+                             'type {} instead.'.format(list, type(samples)))
+
+        if len(samples) == 0:
+            raise ValueError('samples must contain at least 1 element '
+                             'but got list of size 0.')
+
+        first_sample = samples[0]
+        if not isinstance(first_sample, Sample):
+            raise ValueError('samples should be of type garage.Sample but got '
+                             'argument of {} instead.'.format(
+                                 type(first_sample)))
+
+        return super().__new__(SamplesBatch, tuple(samples))

--- a/tests/garage/test_dtypes.py
+++ b/tests/garage/test_dtypes.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from garage import Sample
+from garage import SamplesBatch
 from garage import TrajectoryBatch
 from garage.envs import EnvSpec
 
@@ -266,6 +267,39 @@ def test_env_info_dtype_mismatch_sample(sample_data):
         sample_data['env_info'] = []
         s = Sample(**sample_data)
         del s
+
+
+# ========================================================================== #
+
+
+# =============================SamplesBatch-Test============================ #
+def test_new_sample_batch(sample_data):
+    samples_batch = [Sample(**sample_data)] * 5
+    ret = SamplesBatch(samples_batch)
+    for i in range(5):
+        assert samples_batch[i] == ret.samples[i]
+
+
+def test_new_empty_sample_batch():
+    with pytest.raises(ValueError,
+                       match='samples must contain at least 1 element'):
+        samples_batch = []
+        SamplesBatch(samples_batch)
+
+
+def test_new_sample_batch_dtype(sample_data):
+    with pytest.raises(ValueError, match='Samples must be of type'):
+        samples_batch = [Sample(**sample_data)] * 5
+        samples_batch = tuple(samples_batch)
+        SamplesBatch(samples_batch)
+
+
+def test_new_sample_batch_element_dtype():
+    with pytest.raises(
+            ValueError,
+            match='samples should be of type garage.Sample but got'):
+        samples_batch = [1, 2]
+        SamplesBatch(samples_batch)
 
 
 # ========================================================================== #


### PR DESCRIPTION
This isn't a complete pr (needs some further error checking and unit tests). 

For off-policy algorithms, we need to support different return dtypes. 

I propose 2 types.

Either we have a dtype `SampleBatch` which is a tuple containing the necessary values for off policy, and each value of the tuple is a dict or nd array where each element of the dict or ndarray belongs to a specific transition

OR

We have a dtype `Sample` which is a tuple and each element of the tuple is some info about the transition (single observation, single action, single reward, single agent_env info) and then we can have the user return a sample or a list of samples from the sampler. 

Which design works better in the context of garage?
I think both work, but the second is better because it ends up being more versatile. Furthermore its less ambiguous if all of the components of a single sample are grouped together, as opposed to the first design where each element of the tuple is an array of all of some element (e.g an array of all the rewards) and each index of that array corresponds to an individual sample.

