### PR TITLE
Add evaluation interface

### DIFF
--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -1,6 +1,7 @@
 """Provides algorithms with access to most of garage's features."""
 import copy
 import os
+import pickle
 import time
 
 from dowel import logger, tabular
@@ -431,6 +432,15 @@ class LocalRunner:
             self._train_args.pause_for_plot = pause_for_plot
 
         return self._algo.train(self)
+
+    def get_env_copy(self):
+        """Get a copy of the environment.
+
+        Returns:
+            garage.envs.GarageEnv: An environement instance.
+
+        """
+        return pickle.loads(pickle.dumps(self._env))
 
     @property
     def total_env_steps(self):

--- a/src/garage/misc/tensor_utils.py
+++ b/src/garage/misc/tensor_utils.py
@@ -16,7 +16,7 @@ def discount_cumsum(x, discount):
         discount (float): Discount factor.
 
     Returns:
-        float: Discounted cumulative sum.
+        np.ndarrary: Discounted cumulative sum.
 
     """
     return scipy.signal.lfilter([1], [1, float(-discount)], x[::-1],

--- a/src/garage/np/algos/base.py
+++ b/src/garage/np/algos/base.py
@@ -1,6 +1,11 @@
 """Interface of RLAlgorithm."""
 import abc
 
+from dowel import tabular
+import numpy as np
+
+from garage.misc import tensor_utils as np_tensor_utils
+
 
 class RLAlgorithm(abc.ABC):
     """Base class for all the algorithms.
@@ -25,4 +30,56 @@ class RLAlgorithm(abc.ABC):
             The average return in last epoch cycle or None.
 
         """
-        pass
+
+    def evaluate_performance(self, itr, batch):
+        # pylint: disable=no-self-use
+        r"""Evaluate the performance of the algorithm.
+
+        Args:
+            itr (int): Iteration number.
+            batch (dict): Evaluation trajectories, representing
+                the best current performance of the algorithm, with keys:
+                * env_spec (garage.envs.EnvSpec): Specification for the
+                environment from which this data was sampled.
+                * observations (numpy.ndarray): A numpy array containing the
+                    observations for all time steps in this batch.
+                * actions (numpy.ndarray): A  numpy array containing the
+                    actions for all time steps in this batch.
+                * rewards (numpy.ndarray): A numpy array containing the
+                    rewards for all time steps in this batch.
+                * terminals (numpy.ndarray): A boolean numpy array
+                    containing the termination signals for all time steps
+                    in this batch.
+                * env_infos (dict): A dict of numpy arrays arbitrary
+                    environment state information.
+                * agent_infos (numpy.ndarray): A dict of numpy arrays
+                    arbitrary agent state information.
+                * lengths (numpy.ndarray): An integer numpy array
+                    containing the length of each trajectory in this batch.
+                * discount (float): Discount value, from algorithm's property.
+
+        Returns:
+            numpy.ndarray: Undiscounted returns.
+
+        """
+        returns = []
+        for reward in batch['rewards']:
+            rtn = np_tensor_utils.discount_cumsum(reward, batch['discount'])
+            returns.append(rtn)
+
+        average_discounted_return = np.mean([rtn[0] for rtn in returns])
+
+        undiscounted_returns = [sum(reward) for reward in batch['rewards']]
+
+        tabular.record('Iteration', itr)
+        tabular.record('Evaluation/NumTrajs', len(returns))
+
+        tabular.record('Evaluation/AverageDiscountedReturn',
+                       average_discounted_return)
+        tabular.record('Evaluation/AverageReturn',
+                       np.mean(undiscounted_returns))
+        tabular.record('Evaluation/StdReturn', np.std(undiscounted_returns))
+        tabular.record('Evaluation/MaxReturn', np.max(undiscounted_returns))
+        tabular.record('Evaluation/MinReturn', np.min(undiscounted_returns))
+
+        return undiscounted_returns

--- a/src/garage/np/algos/batch_polopt.py
+++ b/src/garage/np/algos/batch_polopt.py
@@ -111,36 +111,55 @@ class BatchPolopt(RLAlgorithm):
                 path['rewards'], self.discount)
             returns.append(path['returns'])
 
+        obs = [path['observations'] for path in paths]
+        obs = tensor_utils.pad_tensor_n(obs, max_path_length)
+
+        actions = [path['actions'] for path in paths]
+        actions = tensor_utils.pad_tensor_n(actions, max_path_length)
+
+        rewards = [path['rewards'] for path in paths]
+        rewards = tensor_utils.pad_tensor_n(rewards, max_path_length)
+
         agent_infos = [path['agent_infos'] for path in paths]
         agent_infos = tensor_utils.stack_tensor_dict_list([
             tensor_utils.pad_tensor_dict(p, max_path_length)
             for p in agent_infos
         ])
 
+        env_infos = [path['env_infos'] for path in paths]
+        env_infos = tensor_utils.stack_tensor_dict_list([
+            tensor_utils.pad_tensor_dict(p, max_path_length) for p in env_infos
+        ])
+
+        terminals = [path['dones'] for path in paths]
+
         valids = [np.ones_like(path['returns']) for path in paths]
         valids = tensor_utils.pad_tensor_n(valids, max_path_length)
 
-        average_discounted_return = (np.mean(
-            [path['returns'][0] for path in paths]))
-
-        undiscounted_returns = [sum(path['rewards']) for path in paths]
-        self.episode_reward_mean.extend(undiscounted_returns)
+        lengths = np.asarray([v.sum() for v in valids])
 
         ent = np.sum(self.policy.distribution.entropy(agent_infos) *
                      valids) / np.sum(valids)
 
-        samples_data = dict(average_return=np.mean(undiscounted_returns))
+        undiscounted_returns = self.evaluate_performance(
+            itr,
+            dict(env_spec=None,
+                 observations=obs,
+                 actions=actions,
+                 rewards=rewards,
+                 terminals=terminals,
+                 env_infos=env_infos,
+                 agent_infos=agent_infos,
+                 lengths=lengths,
+                 discount=self.discount))
 
-        tabular.record('Iteration', itr)
-        tabular.record('AverageDiscountedReturn', average_discounted_return)
-        tabular.record('AverageReturn', np.mean(undiscounted_returns))
-        tabular.record('Extras/EpisodeRewardMean',
-                       np.mean(self.episode_reward_mean))
-        tabular.record('NumTrajs', len(paths))
+        self.episode_reward_mean.extend(undiscounted_returns)
+
         tabular.record('Entropy', ent)
         tabular.record('Perplexity', np.exp(ent))
-        tabular.record('StdReturn', np.std(undiscounted_returns))
-        tabular.record('MaxReturn', np.max(undiscounted_returns))
-        tabular.record('MinReturn', np.min(undiscounted_returns))
+        tabular.record('Extras/EpisodeRewardMean',
+                       np.mean(self.episode_reward_mean))
+
+        samples_data = dict(average_return=np.mean(undiscounted_returns))
 
         return samples_data

--- a/src/garage/np/exploration_strategies/epsilon_greedy_strategy.py
+++ b/src/garage/np/exploration_strategies/epsilon_greedy_strategy.py
@@ -1,5 +1,4 @@
-"""
-ϵ-greedy exploration strategy.
+"""ϵ-greedy exploration strategy.
 
 Random exploration according to the value of epsilon.
 """
@@ -9,8 +8,7 @@ from garage.np.exploration_strategies.base import ExplorationStrategy
 
 
 class EpsilonGreedyStrategy(ExplorationStrategy):
-    """
-    ϵ-greedy exploration strategy.
+    """ϵ-greedy exploration strategy.
 
     Select action based on the value of ϵ. ϵ will decrease from
     max_epsilon to min_epsilon within decay_ratio * total_timesteps.
@@ -26,6 +24,7 @@ class EpsilonGreedyStrategy(ExplorationStrategy):
         max_epsilon (float): The maximum(starting) value of epsilon.
         min_epsilon (float): The minimum(terminal) value of epsilon.
         decay_ratio (float): Fraction of total steps for epsilon decay.
+
     """
 
     def __init__(self,
@@ -44,19 +43,20 @@ class EpsilonGreedyStrategy(ExplorationStrategy):
                            self._min_epsilon) / self._decay_period
 
     def get_action(self, t, observation, policy, **kwargs):
-        """
-        Get action from this policy for the input observation.
+        """Get action from this policy for the input observation.
 
         Args:
-            t: Iteration.
-            observation: Observation from the environment.
-            policy: Policy network to predict action based on the observation.
+            t (int): Iteration.
+            observation (numpy.ndarray): Observation from the environment.
+            policy (garage.tf.policies.base.Policy): Policy network to
+                predict action based on the observation.
+            kwargs (dict): Unused here.
 
         Returns:
             opt_action: optimal action from this policy.
 
         """
-        opt_action = policy.get_action(observation)
+        opt_action, _ = policy.get_action(observation)
         self._decay()
         if np.random.random() < self._epsilon:
             opt_action = self._action_space.sample()
@@ -64,20 +64,21 @@ class EpsilonGreedyStrategy(ExplorationStrategy):
         return opt_action, dict()
 
     def get_actions(self, t, observations, policy, **kwargs):
-        """
-        Get actions from this policy for the input observations.
+        """Get actions from this policy for the input observations.
 
         Args:
-            t: Iteration.
-            observation: Observation from the environment.
-            policy: Policy network to predict action based on the observation.
+            t (int): Iteration.
+            observations (numpy.ndarray): Observation from the environment.
+            policy (garage.tf.policies.base.Policy): Policy network to
+                predict action based on the observation.
+            kwargs (dict): Unused here.
 
         Returns:
             opt_action: optimal actions from this policy.
 
         """
-        opt_actions = policy.get_actions(observations)
-        for itr in range(len(opt_actions)):
+        opt_actions, _ = policy.get_actions(observations)
+        for itr, _ in enumerate(opt_actions):
             self._decay()
             if np.random.random() < self._epsilon:
                 opt_actions[itr] = self._action_space.sample()

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -83,6 +83,7 @@ class OnPolicyVectorizedSampler(BatchSampler):
                   [Batch, ?]. One example is "prev_action", which is used
                   for recurrent policy as previous action input, merged with
                   the observation input as the state input.
+                * dones: numpy.ndarray with shape [Batch, ]
 
         """
         logger.log('Obtaining samples for iteration %d...' % itr)
@@ -125,18 +126,18 @@ class OnPolicyVectorizedSampler(BatchSampler):
                     itertools.count(), obses, actions, rewards, env_infos,
                     agent_infos, dones):
                 if running_paths[idx] is None:
-                    running_paths[idx] = dict(
-                        observations=[],
-                        actions=[],
-                        rewards=[],
-                        env_infos=[],
-                        agent_infos=[],
-                    )
+                    running_paths[idx] = dict(observations=[],
+                                              actions=[],
+                                              rewards=[],
+                                              env_infos=[],
+                                              agent_infos=[],
+                                              dones=[])
                 running_paths[idx]['observations'].append(observation)
                 running_paths[idx]['actions'].append(action)
                 running_paths[idx]['rewards'].append(reward)
                 running_paths[idx]['env_infos'].append(env_info)
                 running_paths[idx]['agent_infos'].append(agent_info)
+                running_paths[idx]['dones'].append(done)
                 if done:
                     obs = np.asarray(running_paths[idx]['observations'])
                     actions = np.asarray(running_paths[idx]['actions'])
@@ -147,7 +148,8 @@ class OnPolicyVectorizedSampler(BatchSampler):
                              env_infos=tensor_utils.stack_tensor_dict_list(
                                  running_paths[idx]['env_infos']),
                              agent_infos=tensor_utils.stack_tensor_dict_list(
-                                 running_paths[idx]['agent_infos'])))
+                                 running_paths[idx]['agent_infos']),
+                             dones=np.asarray(running_paths[idx]['dones'])))
                     n_samples += len(running_paths[idx]['rewards'])
                     running_paths[idx] = None
 

--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -44,6 +44,7 @@ def rollout(env,
                 non-flattened `agent_info` arrays.
             * env_infos(Dict[str, np.array]): Dictionary of stacked,
                 non-flattened `env_info` arrays.
+            * dones(np.array): Array of termination signals.
 
     """
     observations = []
@@ -51,6 +52,7 @@ def rollout(env,
     rewards = []
     agent_infos = []
     env_infos = []
+    dones = []
     o = env.reset()
     agent.reset()
     path_length = 0
@@ -58,7 +60,7 @@ def rollout(env,
         env.render()
     while path_length < max_path_length:
         a, agent_info = agent.get_action(o)
-        if deterministic:
+        if deterministic and 'mean' in agent_infos:
             a = agent_info['mean']
         next_o, r, d, env_info = env.step(a)
         observations.append(o)
@@ -66,6 +68,7 @@ def rollout(env,
         actions.append(a)
         agent_infos.append(agent_info)
         env_infos.append(env_info)
+        dones.append(d)
         path_length += 1
         if d:
             break
@@ -81,6 +84,7 @@ def rollout(env,
         rewards=np.array(rewards),
         agent_infos=tensor_utils.stack_tensor_dict_list(agent_infos),
         env_infos=tensor_utils.stack_tensor_dict_list(env_infos),
+        dones=np.array(dones),
     )
 
 

--- a/src/garage/tf/algos/batch_polopt.py
+++ b/src/garage/tf/algos/batch_polopt.py
@@ -163,7 +163,8 @@ class BatchPolopt(RLAlgorithm):
                             path['actions'])),
                     rewards=path['rewards'],
                     env_infos=path['env_infos'],
-                    agent_infos=path['agent_infos']) for path in paths
+                    agent_infos=path['agent_infos'],
+                    dones=path['dones']) for path in paths
             ]
         else:
             paths = [
@@ -174,7 +175,8 @@ class BatchPolopt(RLAlgorithm):
                             path['actions'])),
                     rewards=path['rewards'],
                     env_infos=path['env_infos'],
-                    agent_infos=path['agent_infos']) for path in paths
+                    agent_infos=path['agent_infos'],
+                    dones=path['dones']) for path in paths
             ]
 
         if hasattr(self.baseline, 'predict_n'):
@@ -218,6 +220,8 @@ class BatchPolopt(RLAlgorithm):
 
         baselines = tensor_utils.pad_tensor_n(baselines, max_path_length)
 
+        terminals = [path['dones'] for path in paths]
+
         agent_infos = [path['agent_infos'] for path in paths]
         agent_infos = tensor_utils.stack_tensor_dict_list([
             tensor_utils.pad_tensor_dict(p, max_path_length)
@@ -232,14 +236,30 @@ class BatchPolopt(RLAlgorithm):
         valids = [np.ones_like(path['returns']) for path in paths]
         valids = tensor_utils.pad_tensor_n(valids, max_path_length)
 
-        average_discounted_return = (np.mean(
-            [path['returns'][0] for path in paths]))
-
-        undiscounted_returns = [sum(path['rewards']) for path in paths]
-        self.episode_reward_mean.extend(undiscounted_returns)
+        lengths = np.asarray([v.sum() for v in valids])
 
         ent = np.sum(self.policy.distribution.entropy(agent_infos) *
                      valids) / np.sum(valids)
+
+        undiscounted_returns = self.evaluate_performance(
+            itr,
+            dict(env_spec=self.env_spec,
+                 observations=obs,
+                 actions=actions,
+                 rewards=rewards,
+                 terminals=terminals,
+                 env_infos=env_infos,
+                 agent_infos=agent_infos,
+                 lengths=lengths,
+                 discount=self.discount,
+                 episode_reward_mean=self.episode_reward_mean))
+
+        self.episode_reward_mean.extend(undiscounted_returns)
+
+        tabular.record('Entropy', ent)
+        tabular.record('Perplexity', np.exp(ent))
+        tabular.record('Extras/EpisodeRewardMean',
+                       np.mean(self.episode_reward_mean))
 
         samples_data = dict(
             observations=obs,
@@ -248,23 +268,12 @@ class BatchPolopt(RLAlgorithm):
             baselines=baselines,
             returns=returns,
             valids=valids,
+            lengths=lengths,
             agent_infos=agent_infos,
             env_infos=env_infos,
             paths=paths,
             average_return=np.mean(undiscounted_returns),
         )
-
-        tabular.record('Iteration', itr)
-        tabular.record('AverageDiscountedReturn', average_discounted_return)
-        tabular.record('AverageReturn', np.mean(undiscounted_returns))
-        tabular.record('Extras/EpisodeRewardMean',
-                       np.mean(self.episode_reward_mean))
-        tabular.record('NumTrajs', len(paths))
-        tabular.record('Entropy', ent)
-        tabular.record('Perplexity', np.exp(ent))
-        tabular.record('StdReturn', np.std(undiscounted_returns))
-        tabular.record('MaxReturn', np.max(undiscounted_returns))
-        tabular.record('MinReturn', np.min(undiscounted_returns))
 
         return samples_data
 

--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -16,6 +16,7 @@ class DiscreteQfDerivedPolicy(Policy):
         env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
         qf (garage.q_functions.QFunction): The q-function used.
         name (str): Name of the policy.
+
     """
 
     def __init__(self, env_spec, qf, name='DiscreteQfDerivedPolicy'):
@@ -34,7 +35,12 @@ class DiscreteQfDerivedPolicy(Policy):
 
     @property
     def vectorized(self):
-        """Vectorized or not."""
+        """Vectorized or not.
+
+        Returns:
+            Bool: True if primitive supports vectorized operations.
+
+        """
         return True
 
     def get_action(self, observation):
@@ -44,13 +50,15 @@ class DiscreteQfDerivedPolicy(Policy):
             observation (numpy.ndarray): Observation from environment.
 
         Returns:
-            Single optimal action from this policy.
+            numpy.ndarray: Single optimal action from this policy.
+            dict: Predicted action and agent information. It returns an empty
+                dict since there is no parameterization.
 
         """
         q_vals = self._f_qval([observation])
         opt_action = np.argmax(q_vals)
 
-        return opt_action
+        return opt_action, dict()
 
     def get_actions(self, observations):
         """Get actions from this policy for the input observations.
@@ -59,21 +67,33 @@ class DiscreteQfDerivedPolicy(Policy):
             observations (numpy.ndarray): Observations from environment.
 
         Returns:
-            Optimal actions from this policy.
+            numpy.ndarray: Optimal actions from this policy.
+            dict: Predicted action and agent information. It returns an empty
+                dict since there is no parameterization.
 
         """
         q_vals = self._f_qval(observations)
         opt_actions = np.argmax(q_vals, axis=1)
 
-        return opt_actions
+        return opt_actions, dict()
 
     def __getstate__(self):
-        """Object.__getstate__."""
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
         new_dict = self.__dict__.copy()
         del new_dict['_f_qval']
         return new_dict
 
     def __setstate__(self, state):
-        """Object.__setstate__."""
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
         self.__dict__.update(state)
         self._initialize()

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ddpg.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ddpg.py
@@ -115,7 +115,7 @@ class TestBenchmarkDDPG:
             Rh.plot(b_csvs=baselines_csvs,
                     g_csvs=garage_csvs,
                     g_x='Epoch',
-                    g_y='AverageReturn',
+                    g_y='Evaluation/AverageReturn',
                     g_z='Garage',
                     b_x='total/epochs',
                     b_y='rollout/return',
@@ -125,12 +125,12 @@ class TestBenchmarkDDPG:
                     plt_file=plt_file,
                     env_id=env_id,
                     x_label='Epoch',
-                    y_label='AverageReturn')
+                    y_label='Evaluation/AverageReturn')
 
             Rh.relplot(g_csvs=garage_csvs,
                        b_csvs=baselines_csvs,
                        g_x='Epoch',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x='total/epochs',
                        b_y='rollout/return',
@@ -140,7 +140,7 @@ class TestBenchmarkDDPG:
                        plt_file=relplt_file,
                        env_id=env_id,
                        x_label='Epoch',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
             result_json[env_id] = Rh.create_json(
                 b_csvs=baselines_csvs,
@@ -148,7 +148,7 @@ class TestBenchmarkDDPG:
                 seeds=seeds,
                 trails=task['trials'],
                 g_x='Epoch',
-                g_y='AverageReturn',
+                g_y='Evaluation/AverageReturn',
                 b_x='total/epochs',
                 b_y='rollout/return',
                 factor_g=params['steps_per_epoch'] * params['n_rollout_steps'],

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_her.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_her.py
@@ -237,7 +237,7 @@ def plot(b_csvs, g_csvs, g_x, g_y, b_x, b_y, trials, seeds, plt_file, env_id):
 
     plt.legend()
     plt.xlabel('Iteration')
-    plt.ylabel('AverageReturn')
+    plt.ylabel('Evaluation/AverageReturn')
     plt.title(env_id)
 
     plt.savefig(plt_file)

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
@@ -125,11 +125,14 @@ class TestBenchmarkPPO:
 
             benchmark_helper.plot_average_over_trials(
                 [baselines_csvs, garage_tf_csvs, garage_pytorch_csvs],
-                ['eprewmean', 'AverageReturn', 'AverageReturn'],
+                [
+                    'eprewmean', 'Evaluation/AverageReturn',
+                    'Evaluation/AverageReturn'
+                ],
                 plt_file=plt_file,
                 env_id=env_id,
                 x_label='Iteration',
-                y_label='AverageReturn',
+                y_label='Evaluation/AverageReturn',
                 names=['baseline', 'garage-TensorFlow', 'garage-PyTorch'],
             )
 
@@ -138,7 +141,10 @@ class TestBenchmarkPPO:
                 seeds=seeds,
                 trials=hyper_parameters['n_trials'],
                 xs=['nupdates', 'Iteration', 'Iteration'],
-                ys=['eprewmean', 'AverageReturn', 'AverageReturn'],
+                ys=[
+                    'eprewmean', 'Evaluation/AverageReturn',
+                    'Evaluation/AverageReturn'
+                ],
                 factors=[hyper_parameters['batch_size']] * 3,
                 names=['baseline', 'garage-TF', 'garage-PT'])
 

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_td3.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_td3.py
@@ -132,7 +132,7 @@ class TestBenchmarkTD3:
             Rh.plot(b_csvs=rlkit_csvs,
                     g_csvs=garage_csvs,
                     g_x='Epoch',
-                    g_y='AverageReturn',
+                    g_y='Evaluation/AverageReturn',
                     g_z='garage',
                     b_x='Epoch',
                     b_y='evaluation/Average Returns',
@@ -142,7 +142,7 @@ class TestBenchmarkTD3:
                     plt_file=plt_file,
                     env_id=env_id,
                     x_label='Iteration',
-                    y_label='AverageReturn')
+                    y_label='Evaluation/AverageReturn')
 
             result_json[env_id] = Rh.create_json(
                 b_csvs=rlkit_csvs,
@@ -150,7 +150,7 @@ class TestBenchmarkTD3:
                 seeds=seeds,
                 trails=task['trials'],
                 g_x='Epoch',
-                g_y='AverageReturn',
+                g_y='Evaluation/AverageReturn',
                 b_x='Epoch',
                 b_y='evaluation/Average Returns',
                 factor_g=1,

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_trpo.py
@@ -104,11 +104,14 @@ class TestBenchmarkPPO:  # pylint: disable=too-few-public-methods
 
             benchmark_helper.plot_average_over_trials(
                 [baselines_csvs, garage_tf_csvs, garage_pytorch_csvs],
-                ['eprewmean', 'AverageReturn', 'AverageReturn'],
+                [
+                    'eprewmean', 'Evaluation/AverageReturn',
+                    'Evaluation/AverageReturn'
+                ],
                 plt_file=plt_file,
                 env_id=env_id,
                 x_label='Iteration',
-                y_label='AverageReturn',
+                y_label='Evaluation/AverageReturn',
                 names=['baseline', 'garage-TensorFlow', 'garage-PyTorch'],
             )
 
@@ -117,7 +120,10 @@ class TestBenchmarkPPO:  # pylint: disable=too-few-public-methods
                 seeds=seeds,
                 trials=hyper_parameters['n_trials'],
                 xs=['nupdates', 'Iteration', 'Iteration'],
-                ys=['eprewmean', 'AverageReturn', 'AverageReturn'],
+                ys=[
+                    'eprewmean', 'Evaluation/AverageReturn',
+                    'Evaluation/AverageReturn'
+                ],
                 factors=[hyper_parameters['batch_size']] * 3,
                 names=['baseline', 'garage-TF', 'garage-PT'])
 

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_vpg.py
@@ -101,11 +101,12 @@ class TestBenchmarkVPG:
             env.close()
 
             benchmark_helper.plot_average_over_trials(
-                [garage_tf_csvs, garage_pytorch_csvs], ['AverageReturn'] * 2,
+                [garage_tf_csvs, garage_pytorch_csvs],
+                ['Evaluation/AverageReturn'] * 2,
                 plt_file=plt_file,
                 env_id=env_id,
                 x_label='Iteration',
-                y_label='AverageReturn',
+                y_label='Evaluation/AverageReturn',
                 names=['garage-TensorFlow', 'garage-PyTorch'])
 
             result_json[env_id] = benchmark_helper.create_json(
@@ -113,7 +114,7 @@ class TestBenchmarkVPG:
                 seeds=seeds,
                 trials=hyper_parameters['n_trials'],
                 xs=['Iteration'] * 2,
-                ys=['AverageReturn'] * 2,
+                ys=['Evaluation/AverageReturn'] * 2,
                 factors=[hyper_parameters['batch_size']] * 2,
                 names=['garage-tf', 'garage-pytorch'])
 

--- a/tests/benchmarks/garage/tf/baselines/test_benchmark_gaussian_cnn_baseline.py
+++ b/tests/benchmarks/garage/tf/baselines/test_benchmark_gaussian_cnn_baseline.py
@@ -66,17 +66,17 @@ class TestBenchmarkGaussianCNNBaseline:
             Rh.relplot(g_csvs=garage_csvs,
                        b_csvs=[],
                        g_x='Iteration',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x='Iteration',
-                       b_y='AverageReturn',
+                       b_y='Evaluation/AverageReturn',
                        b_z='GarageWithModel',
                        trials=num_of_trials,
                        seeds=seeds,
                        plt_file=plt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
 
 def run_garage(env, seed, log_dir):

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_cnn_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_cnn_policy.py
@@ -70,32 +70,32 @@ class TestBenchmarkCategoricalCNNPolicy:
             Rh.relplot(g_csvs=garage_csvs,
                        b_csvs=garage_model_csvs,
                        g_x='Iteration',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x='Iteration',
-                       b_y='AverageReturn',
+                       b_y='Evaluation/AverageReturn',
                        b_z='GarageWithModel',
                        trials=num_of_trials,
                        seeds=seeds,
                        plt_file=relplt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
             Rh.plot(g_csvs=garage_csvs,
                     b_csvs=garage_model_csvs,
                     g_x='Iteration',
-                    g_y='AverageReturn',
+                    g_y='Evaluation/AverageReturn',
                     g_z='Garage',
                     b_x='Iteration',
-                    b_y='AverageReturn',
+                    b_y='Evaluation/AverageReturn',
                     b_z='GarageWithModel',
                     trials=num_of_trials,
                     seeds=seeds,
                     plt_file=plt_file,
                     env_id=env_id,
                     x_label='Iteration',
-                    y_label='AverageReturn')
+                    y_label='Evaluation/AverageReturn')
 
 
 def run_garage(env, seed, log_dir):

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_gru_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_gru_policy.py
@@ -69,26 +69,26 @@ def test_benchmark_categorical_gru_policy():
         Rh.plot(b_csvs=baselines_csvs,
                 g_csvs=garage_csvs,
                 g_x='Iteration',
-                g_y='AverageReturn',
+                g_y='Evaluation/AverageReturn',
                 g_z='garage',
                 b_x='Iteration',
-                b_y='AverageReturn',
+                b_y='Evaluation/AverageReturn',
                 b_z='baselines',
                 trials=3,
                 seeds=seeds,
                 plt_file=plt_file,
                 env_id=env_id,
                 x_label='Iteration',
-                y_label='AverageReturn')
+                y_label='Evaluation/AverageReturn')
 
         result_json[env_id] = Rh.create_json(b_csvs=baselines_csvs,
                                              g_csvs=garage_csvs,
                                              seeds=seeds,
                                              trails=3,
                                              g_x='Iteration',
-                                             g_y='AverageReturn',
+                                             g_y='Evaluation/AverageReturn',
                                              b_x='Iteration',
-                                             b_y='AverageReturn',
+                                             b_y='Evaluation/AverageReturn',
                                              factor_g=2048,
                                              factor_b=2048)
 

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_lstm_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_lstm_policy.py
@@ -73,43 +73,44 @@ class TestBenchmarkCategoricalLSTMPolicy:
             Rh.plot(b_csvs=garage_models_csvs,
                     g_csvs=garage_csvs,
                     g_x='Iteration',
-                    g_y='AverageReturn',
+                    g_y='Evaluation/AverageReturn',
                     g_z='garage',
                     b_x='Iteration',
-                    b_y='AverageReturn',
+                    b_y='Evaluation/AverageReturn',
                     b_z='garage_model',
                     trials=3,
                     seeds=seeds,
                     plt_file=plt_file,
                     env_id=env_id,
                     x_label='Iteration',
-                    y_label='AverageReturn')
+                    y_label='Evaluation/AverageReturn')
 
             Rh.relplot(b_csvs=garage_models_csvs,
                        g_csvs=garage_csvs,
                        g_x='Iteration',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='garage',
                        b_x='Iteration',
-                       b_y='AverageReturn',
+                       b_y='Evaluation/AverageReturn',
                        b_z='garage_model',
                        trials=3,
                        seeds=seeds,
                        plt_file=mean_plt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
-            result_json[env_id] = Rh.create_json(b_csvs=garage_models_csvs,
-                                                 g_csvs=garage_csvs,
-                                                 seeds=seeds,
-                                                 trails=3,
-                                                 g_x='Iteration',
-                                                 g_y='AverageReturn',
-                                                 b_x='Iteration',
-                                                 b_y='AverageReturn',
-                                                 factor_g=2048,
-                                                 factor_b=2048)
+            result_json[env_id] = Rh.create_json(
+                b_csvs=garage_models_csvs,
+                g_csvs=garage_csvs,
+                seeds=seeds,
+                trails=3,
+                g_x='Iteration',
+                g_y='Evaluation/AverageReturn',
+                b_x='Iteration',
+                b_y='Evaluation/AverageReturn',
+                factor_g=2048,
+                factor_b=2048)
 
         Rh.write_file(result_json, 'PPO')
 

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_mlp_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_categorical_mlp_policy.py
@@ -74,43 +74,44 @@ class TestBenchmarkCategoricalMLPPolicy:
             Rh.plot(b_csvs=garage_csvs,
                     g_csvs=garage_csvs,
                     g_x='Iteration',
-                    g_y='AverageReturn',
+                    g_y='Evaluation/AverageReturn',
                     g_z='Garage',
                     b_x='Iteration',
-                    b_y='AverageReturn',
+                    b_y='Evaluation/AverageReturn',
                     b_z='Garage',
                     trials=trials,
                     seeds=seeds,
                     plt_file=plt_file,
                     env_id=env_id,
                     x_label='Iteration',
-                    y_label='AverageReturn')
+                    y_label='Evaluation/AverageReturn')
 
             Rh.relplot(b_csvs=garage_csvs,
                        g_csvs=garage_csvs,
                        g_x='Iteration',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x='Iteration',
-                       b_y='AverageReturn',
+                       b_y='Evaluation/AverageReturn',
                        b_z='Garage',
                        trials=trials,
                        seeds=seeds,
                        plt_file=relplt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
-            result_json[env_id] = Rh.create_json(b_csvs=garage_csvs,
-                                                 g_csvs=garage_csvs,
-                                                 seeds=seeds,
-                                                 trails=trials,
-                                                 g_x='Iteration',
-                                                 g_y='AverageReturn',
-                                                 b_x='Iteration',
-                                                 b_y='AverageReturn',
-                                                 factor_g=2048,
-                                                 factor_b=2048)
+            result_json[env_id] = Rh.create_json(
+                b_csvs=garage_csvs,
+                g_csvs=garage_csvs,
+                seeds=seeds,
+                trails=trials,
+                g_x='Iteration',
+                g_y='Evaluation/AverageReturn',
+                b_x='Iteration',
+                b_y='Evaluation/AverageReturn',
+                factor_g=2048,
+                factor_b=2048)
 
         Rh.write_file(result_json, 'PPO')
 

--- a/tests/benchmarks/garage/tf/policies/test_benchmark_continuous_mlp_policy.py
+++ b/tests/benchmarks/garage/tf/policies/test_benchmark_continuous_mlp_policy.py
@@ -79,7 +79,7 @@ class TestBenchmarkContinuousMLPPolicy:
             Rh.relplot(g_csvs=garage_csvs,
                        b_csvs=[],
                        g_x='Epoch',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x=None,
                        b_y=None,
@@ -89,7 +89,7 @@ class TestBenchmarkContinuousMLPPolicy:
                        plt_file=plt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
 
 def run_garage(env, seed, log_dir):

--- a/tests/benchmarks/garage/tf/q_functions/test_benchmark_continuous_mlp_q_function.py
+++ b/tests/benchmarks/garage/tf/q_functions/test_benchmark_continuous_mlp_q_function.py
@@ -1,3 +1,4 @@
+"""Benchmark for continuous MLP Q function."""
 import datetime
 import os
 import os.path as osp
@@ -42,10 +43,13 @@ num_of_trials = 5
 
 
 class TestBenchmarkContinuousMLPQFunction:
-    '''Benchmark ContinuousMLPQFunction.'''
+    # pylint: disable=too-few-public-methods
+    """Benchmark ContinuousMLPQFunction."""
 
     @pytest.mark.huge
     def test_benchmark_continuous_mlp_q_function(self):
+        # pylint: disable=no-self-use
+        """Test Continuous MLP QFunction Benchmarking."""
         mujoco1m = benchmarks.get_benchmark('Mujoco1M')
 
         timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
@@ -79,7 +83,7 @@ class TestBenchmarkContinuousMLPQFunction:
             Rh.relplot(g_csvs=garage_csvs,
                        b_csvs=[],
                        g_x='Epoch',
-                       g_y='AverageReturn',
+                       g_y='Evaluation/AverageReturn',
                        g_z='Garage',
                        b_x=None,
                        b_y=None,
@@ -89,18 +93,23 @@ class TestBenchmarkContinuousMLPQFunction:
                        plt_file=plt_file,
                        env_id=env_id,
                        x_label='Iteration',
-                       y_label='AverageReturn')
+                       y_label='Evaluation/AverageReturn')
 
 
 def run_garage(env, seed, log_dir):
-    '''
-    Create garage model and training.
+    """Create garage model and training.
+
     Replace the ddpg with the algorithm you want to run.
-    :param env: Environment of the task.
-    :param seed: Random seed for the trial.
-    :param log_dir: Log dir path.
-    :return:
-    '''
+
+    Args:
+        env (gym.Env): Environment of the task.
+        seed (int): Random seed for the trial.
+        log_dir (str): Log dir path.
+
+    Returns:
+        str: Log file path.
+
+    """
     deterministic.set_seed(seed)
     config = tf.ConfigProto(allow_soft_placement=True,
                             intra_op_parallelism_threads=12,

--- a/tests/garage/np/exploration_strategies/test_epsilon_greedy_strategy.py
+++ b/tests/garage/np/exploration_strategies/test_epsilon_greedy_strategy.py
@@ -13,14 +13,16 @@ class SimplePolicy:
     def __init__(self, env_spec):
         self.env_spec = env_spec
 
-    def get_action(self, observation):
-        return self.env_spec.action_space.sample()
+    def get_action(self, _):
+        return self.env_spec.action_space.sample(), dict()
 
     def get_actions(self, observations):
-        return np.full(len(observations), self.env_spec.action_space.sample())
+        return np.full(len(observations),
+                       self.env_spec.action_space.sample()), dict()
 
 
 class TestEpsilonGreedyStrategy:
+
     def setup_method(self):
         self.env = DummyDiscreteEnv()
         self.policy = SimplePolicy(env_spec=self.env)

--- a/tests/garage/tf/policies/test_qf_derived_policy.py
+++ b/tests/garage/tf/policies/test_qf_derived_policy.py
@@ -10,34 +10,35 @@ from tests.fixtures.q_functions import SimpleQFunction
 
 
 class TestQfDerivedPolicy(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.env = TfEnv(DummyDiscreteEnv())
         self.qf = SimpleQFunction(self.env.spec)
-        self.policy = DiscreteQfDerivedPolicy(
-            env_spec=self.env.spec, qf=self.qf)
+        self.policy = DiscreteQfDerivedPolicy(env_spec=self.env.spec,
+                                              qf=self.qf)
         self.sess.run(tf.compat.v1.global_variables_initializer())
         self.env.reset()
 
     def test_discrete_qf_derived_policy(self):
         obs, _, _, _ = self.env.step(1)
-        action = self.policy.get_action(obs)
+        action, _ = self.policy.get_action(obs)
         assert self.env.action_space.contains(action)
-        actions = self.policy.get_actions([obs])
+        actions, _ = self.policy.get_actions([obs])
         for action in actions:
             assert self.env.action_space.contains(action)
 
     def test_is_pickleable(self):
-        with tf.compat.v1.variable_scope(
-                'SimpleQFunction/SimpleMLPModel', reuse=True):
+        with tf.compat.v1.variable_scope('SimpleQFunction/SimpleMLPModel',
+                                         reuse=True):
             return_var = tf.compat.v1.get_variable('return_var')
         # assign it to all one
         return_var.load(tf.ones_like(return_var).eval())
         obs, _, _, _ = self.env.step(1)
-        action1 = self.policy.get_action(obs)
+        action1, _ = self.policy.get_action(obs)
 
         p = pickle.dumps(self.policy)
         with tf.compat.v1.Session(graph=tf.Graph()):
             policy_pickled = pickle.loads(p)
-            action2 = policy_pickled.get_action(obs)
+            action2, _ = policy_pickled.get_action(obs)
             assert action1 == action2


### PR DESCRIPTION
This PR covers part of #1091.

What it has:
-  add an `evaluate_performance()` method which can be used by all algorithms to report performance
- add an evaluation sampler for off-policy algos to collect rollouts, created by LocalRunner when in need
- clean up some code in cem and cma_es

Next steps:
- refactor `process_samples()`, maybe into a pure function, so that variables such as `ent`
https://github.com/rlworkgroup/garage/blob/c55683cd383ec00f008e5871fece772e96ee93e2/src/garage/np/algos/batch_polopt.py#L140 can be added to `evaluate_performance(). Currently it's hard to separate it.
- add log success rate ( #1015). Add `dones` to `OnPolicyVectorizedSampler`'s return paths?
- use `TrajectoryBatch`? This definitely needs refactoring `process_samples()`
- move total environment steps https://github.com/rlworkgroup/garage/blob/c55683cd383ec00f008e5871fece772e96ee93e2/src/garage/np/algos/batch_polopt.py#L73 into `evaluate_performance()`? (#1021) Maybe this will make the code more complicated.

Opening this draft for feedback.