### PR TITLE
Disable Gym Time limits by default

### DIFF
--- a/src/garage/envs/base.py
+++ b/src/garage/envs/base.py
@@ -148,7 +148,19 @@ class GarageEnv(gym.Wrapper):
                 debugging, and sometimes learning)
 
         """
-        return self.env.step(action)
+        observation, reward, done, info = self.env.step(action)
+        # gym envs that are wrapped in TimeLimit wrapper modify
+        # the done/termination signal to be true whenever a time
+        # limit expiration occurs. The following statement sets
+        # the done signal to be True only if caused by an
+        # environment termination, and not a time limit
+        # termination. The time limit termination signal
+        # will be saved inside env_infos as
+        # 'GarageEnv.TimeLimitTerminated'
+        if 'TimeLimit.truncated' in info:
+            info['GarageEnv.TimeLimitTerminated'] = done  # done = True always
+            done = not info['TimeLimit.truncated']
+        return observation, reward, done, info
 
     def __getstate__(self):
         """See `Object.__getstate__.

--- a/tests/garage/envs/test_garage_env.py
+++ b/tests/garage/envs/test_garage_env.py
@@ -20,3 +20,12 @@ class TestGarageEnv:
         assert garage_env.env.viewer is not None
         garage_env.close()
         assert garage_env.env.viewer is None
+
+    def test_time_limit_env(self):
+        garage_env = GarageEnv(env_name='Pendulum-v0')
+        garage_env.reset()
+        for _ in range(200):
+            _, _, done, info = garage_env.step(
+                garage_env.spec.action_space.sample())
+        assert not done and info['TimeLimit.truncated']
+        assert info['GarageEnv.TimeLimitTerminated']


### PR DESCRIPTION
A little bit of background about the gym termination signal.

OpenAi gym environments are designed to set the done signal
of environment to True every time step is called, after a
certain number of certain number of environment steps.
This is bad because it changes the MDP of the environment
For gym environments that are time, limit terminated, when
they are terminated, they include an entry in the env_infos
called Timelimit.truncated. This entry is equal to the not
of the termination signal caused by the environment being
in a terminal state (aka the actual/True done signal).
The change I have made to garage/envs/base.py is to set
the done signal to the actual/true done signal whenever
the environment has been timelimit terminated.

This PR sets the done signal to be True only if caused by an
environment termination, and not a time limit termination. 
The time limit termination signal will be saved inside env_infos as 
'TimeLimitTerminated'.