### PR TITLE
Change API for halfcheetah envs

### DIFF
--- a/src/garage/envs/half_cheetah_dir_env.py
+++ b/src/garage/envs/half_cheetah_dir_env.py
@@ -92,7 +92,7 @@ class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):
         tasks = [{'direction': direction} for direction in directions]
         return tasks
 
-    def reset_task(self, task):
+    def set_task(self, task):
         """Reset with a task.
 
         Args:

--- a/src/garage/envs/half_cheetah_vel_env.py
+++ b/src/garage/envs/half_cheetah_vel_env.py
@@ -91,7 +91,7 @@ class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):
         tasks = [{'velocity': velocity} for velocity in velocities]
         return tasks
 
-    def reset_task(self, task):
+    def set_task(self, task):
         """Reset with a task.
 
         Args:

--- a/tests/garage/envs/test_half_cheetah_meta_envs.py
+++ b/tests/garage/envs/test_half_cheetah_meta_envs.py
@@ -11,6 +11,6 @@ class TestMetaHalfCheetahEnvs:
     def test_can_sim(self, env_type):
         env = env_type()
         task = env.sample_tasks(1)[0]
-        env.reset_task(task)
+        env.set_task(task)
         for _ in range(3):
             env.step(env.action_space.sample())


### PR DESCRIPTION
Change `reset_task` to `set_task` since `set_task` is a more commonly used AP, which is used in meta-world (https://github.com/rlworkgroup/metaworld) and ProMP (https://github.com/rlworkgroup/metaworld).