### PR TITLE
Rename self.evaluate for off-policy algos

### DIFF
--- a/src/garage/np/algos/off_policy_rl_algorithm.py
+++ b/src/garage/np/algos/off_policy_rl_algorithm.py
@@ -66,7 +66,6 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
         self.min_buffer_size = min_buffer_size
         self.rollout_batch_size = rollout_batch_size
         self.reward_scale = reward_scale
-        self.evaluate = False
         self.input_include_goal = input_include_goal
         self.smooth_return = smooth_return
         self.max_path_length = max_path_length
@@ -97,7 +96,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
                     path['rewards'] *= self.reward_scale
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)
-                if cycle == 0 and self.evaluate:
+                if cycle == 0 and self._buffer_prefilled:
                     log_performance(runner.step_itr,
                                     self._obtain_evaluation_samples(
                                         runner.get_env_copy()),
@@ -205,3 +204,8 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
                            deterministic=True)
             paths.append(path)
         return TrajectoryBatch.from_trajectory_list(self.env_spec, paths)
+
+    @property
+    def _buffer_prefilled(self):
+        """bool: Whether first min buffer size steps is done."""
+        return self.replay_buffer.n_transitions_stored >= self.min_buffer_size

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -269,9 +269,7 @@ class DDPG(OffPolicyRLAlgorithm):
         last_average_return = np.mean(self.episode_rewards)
         self.log_diagnostics(paths)
         for _ in range(self.n_train_steps):
-            if (self.replay_buffer.n_transitions_stored >=
-                    self.min_buffer_size):
-                self.evaluate = True
+            if self._buffer_prefilled:
                 qf_loss, y_s, qval, policy_loss = self.optimize_policy(
                     itr, paths)
 
@@ -283,10 +281,8 @@ class DDPG(OffPolicyRLAlgorithm):
         if itr % self.steps_per_epoch == 0:
             logger.log('Training finished')
 
-            if self.evaluate:
+            if self._buffer_prefilled:
                 tabular.record('Epoch', epoch)
-                tabular.record('AverageReturn', np.mean(self.episode_rewards))
-                tabular.record('StdReturn', np.std(self.episode_rewards))
                 tabular.record('Policy/AveragePolicyLoss',
                                np.mean(self.episode_policy_losses))
                 tabular.record('QFunction/AverageQFunctionLoss',

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -196,24 +196,20 @@ class DQN(OffPolicyRLAlgorithm):
         self.episode_rewards.extend(paths['undiscounted_returns'])
         last_average_return = np.mean(self.episode_rewards)
         for _ in range(self.n_train_steps):
-            if (self.replay_buffer.n_transitions_stored >=
-                    self.min_buffer_size):
-                self.evaluate = True
+            if self._buffer_prefilled:
                 qf_loss = self.optimize_policy(epoch, None)
                 self.episode_qf_losses.append(qf_loss)
 
-        if self.evaluate:
+        if self._buffer_prefilled:
             if itr % self.target_network_update_freq == 0:
                 self._qf_update_ops()
 
         if itr % self.steps_per_epoch == 0:
-            if self.evaluate:
+            if self._buffer_prefilled:
                 mean100ep_rewards = round(np.mean(self.episode_rewards[-100:]),
                                           1)
                 mean100ep_qf_loss = np.mean(self.episode_qf_losses[-100:])
                 tabular.record('Epoch', epoch)
-                tabular.record('AverageReturn', np.mean(self.episode_rewards))
-                tabular.record('StdReturn', np.std(self.episode_rewards))
                 tabular.record('Episode100RewardMean', mean100ep_rewards)
                 tabular.record('{}/Episode100LossMean'.format(self.qf.name),
                                mean100ep_qf_loss)


### PR DESCRIPTION
- also removes duplicate performance recording after `evaluate_performance()` being introduced.