### PR TITLE
MetaEvaluate with multiple trajectories

### DIFF
--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -19,6 +19,9 @@ class MetaEvaluator:
         n_test_tasks (int or None): Number of test tasks to sample each time
             evaluation is performed. Note that tasks are sampled "without
             replacement". If None, is set to `test_task_sampler.n_tasks`.
+        n_exploration_traj (int): Number of trajectories to gather from the
+            exploration policy before requesting the meta algorithm to produce
+            an adapted policy.
         prefix (str): Prefix to use when logging. Defaults to MetaTest. For
             example, this results in logging the key 'MetaTest/SuccessRate'.
             If not set to `MetaTest`, it should probably be set to `MetaTrain`.
@@ -33,11 +36,13 @@ class MetaEvaluator:
                  test_task_sampler,
                  max_path_length,
                  n_test_tasks=None,
+                 n_exploration_traj=1,
                  prefix='MetaTest'):
         self._test_task_sampler = test_task_sampler
         if n_test_tasks is None:
             n_test_tasks = test_task_sampler.n_tasks
         self._n_test_tasks = n_test_tasks
+        self._n_exploration_traj = n_exploration_traj
         self._test_sampler = runner.make_sampler(
             LocalSampler, n_workers=1, max_path_length=max_path_length)
         self._eval_itr = 0
@@ -53,8 +58,11 @@ class MetaEvaluator:
         adapted_trajectories = []
         for env_up in self._test_task_sampler.sample(self._n_test_tasks):
             policy = algo.get_exploration_policy()
-            traj = self._test_sampler.obtain_samples(self._eval_itr, 1, policy,
-                                                     env_up)
+            traj = TrajectoryBatch.concatenate(*[
+                self._test_sampler.obtain_samples(self._eval_itr, 1, policy,
+                                                  env_up)
+                for _ in range(self._n_exploration_traj)
+            ])
             adapted_policy = algo.adapt_policy(policy, traj)
             adapted_traj = self._test_sampler.obtain_samples(
                 self._eval_itr, 1, adapted_policy)


### PR DESCRIPTION
This is necesary because some methods use multiple exploration
trajectories for each task.