### PR TITLE
Meta RL sampler improvements

### DIFF
--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -36,8 +36,8 @@ class LocalSampler(Sampler):
             worker_factory(i) for i in range(worker_factory.n_workers)
         ]
         for worker, agent, env in zip(self._workers, self._agents, self._envs):
-            worker.agent = agent
-            worker.env = env
+            worker.update_agent(agent)
+            worker.update_env(env)
 
     @classmethod
     def from_worker_factory(cls, worker_factory, agents, envs):

--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -63,6 +63,27 @@ class LocalSampler(Sampler):
         """
         return cls(worker_factory, agents, envs)
 
+    def _update_workers(self, agent_update, env_update):
+        """Apply updates to the workers.
+
+        Args:
+            agent_update(object): Value which will be passed into the
+                `agent_update_fn` before doing rollouts. If a list is passed
+                in, it must have length exactly `factory.n_workers`, and will
+                be spread across the workers.
+            env_update(object): Value which will be passed into the
+                `env_update_fn` before doing rollouts. If a list is passed in,
+                it must have length exactly `factory.n_workers`, and will be
+                spread across the workers.
+
+        """
+        agent_updates = self._factory.prepare_worker_messages(agent_update)
+        env_updates = self._factory.prepare_worker_messages(env_update)
+        for worker, agent_up, env_up in zip(self._workers, agent_updates,
+                                            env_updates):
+            worker.update_agent(agent_up)
+            worker.update_env(env_up)
+
     def obtain_samples(self, itr, num_samples, agent_update, env_update=None):
         """Collect at least a given number transitions (timesteps).
 
@@ -84,12 +105,7 @@ class LocalSampler(Sampler):
             garage.TrajectoryBatch: The batch of collected trajectories.
 
         """
-        agent_updates = self._factory.prepare_worker_messages(agent_update)
-        env_updates = self._factory.prepare_worker_messages(env_update)
-        for worker, agent_up, env_up in zip(self._workers, agent_updates,
-                                            env_updates):
-            worker.update_agent(agent_up)
-            worker.update_env(env_up)
+        self._update_workers(agent_update, env_update)
         batches = []
         completed_samples = 0
         while True:
@@ -99,6 +115,38 @@ class LocalSampler(Sampler):
                 batches.append(batch)
                 if completed_samples > num_samples:
                     return TrajectoryBatch.concatenate(*batches)
+
+    def obtain_exact_trajectories(self,
+                                  n_traj_per_worker,
+                                  agent_update,
+                                  env_update=None):
+        """Sample an exact number of trajectories per worker.
+
+        Args:
+            n_traj_per_worker (int): Exact number of trajectories to gather for
+                each worker.
+            agent_update(object): Value which will be passed into the
+                `agent_update_fn` before doing rollouts. If a list is passed
+                in, it must have length exactly `factory.n_workers`, and will
+                be spread across the workers.
+            env_update(object): Value which will be passed into the
+                `env_update_fn` before doing rollouts. If a list is passed in,
+                it must have length exactly `factory.n_workers`, and will be
+                spread across the workers.
+
+        Returns:
+            TrajectoryBatch: Batch of gathered trajectories. Always in worker
+                order. In other words, first all trajectories from worker 0,
+                then all trajectories from worker 1, etc.
+
+        """
+        self._update_workers(agent_update, env_update)
+        batches = []
+        for worker in self._workers:
+            for _ in range(n_traj_per_worker):
+                batch = worker.rollout()
+                batches.append(batch)
+        return TrajectoryBatch.concatenate(*batches)
 
     def shutdown_worker(self):
         """Shutdown the workers."""

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -8,8 +8,8 @@ function, and a rollout function.
 """
 from collections import defaultdict
 import itertools
-import pickle
 
+import cloudpickle
 import ray
 
 from garage import TrajectoryBatch
@@ -71,7 +71,7 @@ class RaySampler(Sampler):
         # We need to pickle the agent so that we can e.g. set up the TF.Session
         # in the worker *before* unpickling it.
         agent_pkls = self._worker_factory.prepare_worker_messages(
-            self._agents, pickle.dumps)
+            self._agents, cloudpickle.dumps)
         for worker_id in range(self._worker_factory.n_workers):
             self._all_workers[worker_id] = self._sampler_worker.remote(
                 worker_id, self._envs[worker_id], agent_pkls[worker_id],
@@ -268,7 +268,7 @@ class SamplerWorker:
         self.inner_worker = worker_factory(worker_id)
         self.worker_id = worker_id
         self.inner_worker.update_env(env)
-        self.inner_worker.update_agent(pickle.loads(agent_pkl))
+        self.inner_worker.update_agent(cloudpickle.loads(agent_pkl))
 
     def update(self, agent_update, env_update):
         """Update the agent and environment.

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -264,10 +264,11 @@ class SamplerWorker:
     """
 
     def __init__(self, worker_id, env, agent_pkl, worker_factory):
+        # Must be called before pickle.loads below.
         self.inner_worker = worker_factory(worker_id)
         self.worker_id = worker_id
-        self.inner_worker.env = env
-        self.inner_worker.agent = pickle.loads(agent_pkl)
+        self.inner_worker.update_env(env)
+        self.inner_worker.update_agent(pickle.loads(agent_pkl))
 
     def update(self, agent_update, env_update):
         """Update the agent and environment.

--- a/src/garage/sampler/worker.py
+++ b/src/garage/sampler/worker.py
@@ -178,7 +178,8 @@ class DefaultWorker(Worker):
             if isinstance(env_update, EnvUpdate):
                 self.env = env_update(self.env)
             elif isinstance(env_update, gym.Env):
-                self.env.close()
+                if self.env is not None:
+                    self.env.close()
                 self.env = env_update
             else:
                 raise TypeError('Uknown environment update type.')

--- a/tests/garage/sampler/test_local_sampler.py
+++ b/tests/garage/sampler/test_local_sampler.py
@@ -109,6 +109,26 @@ def test_update_envs_env_update():
                                env_update=tasks.sample(n_workers + 1))
 
 
+def test_init_with_env_updates():
+    max_path_length = 16
+    env = TfEnv(PointEnv())
+    policy = FixedPolicy(env.spec,
+                         scripted_actions=[
+                             env.action_space.sample()
+                             for _ in range(max_path_length)
+                         ])
+    tasks = SetTaskSampler(lambda: TfEnv(PointEnv()))
+    n_workers = 8
+    workers = WorkerFactory(seed=100,
+                            max_path_length=max_path_length,
+                            n_workers=n_workers)
+    sampler = LocalSampler.from_worker_factory(workers,
+                                               policy,
+                                               envs=tasks.sample(n_workers))
+    rollouts = sampler.obtain_samples(0, 160, policy)
+    assert sum(rollouts.lengths) >= 160
+
+
 def test_obtain_exact_trajectories():
     max_path_length = 15
     n_workers = 8

--- a/tests/garage/sampler/test_local_sampler.py
+++ b/tests/garage/sampler/test_local_sampler.py
@@ -107,3 +107,30 @@ def test_update_envs_env_update():
                                10,
                                np.asarray(policy.get_param_values()),
                                env_update=tasks.sample(n_workers + 1))
+
+
+def test_obtain_exact_trajectories():
+    max_path_length = 15
+    n_workers = 8
+    env = TfEnv(PointEnv())
+    per_worker_actions = [env.action_space.sample() for _ in range(n_workers)]
+    policies = [
+        FixedPolicy(env.spec, [action] * max_path_length)
+        for action in per_worker_actions
+    ]
+    workers = WorkerFactory(seed=100,
+                            max_path_length=max_path_length,
+                            n_workers=n_workers)
+    sampler = LocalSampler.from_worker_factory(workers, policies, envs=env)
+    n_traj_per_worker = 3
+    rollouts = sampler.obtain_exact_trajectories(n_traj_per_worker,
+                                                 agent_update=policies)
+    # At least one action per trajectory.
+    assert sum(rollouts.lengths) >= n_workers * n_traj_per_worker
+    # All of the trajectories.
+    assert len(rollouts.lengths) == n_workers * n_traj_per_worker
+    worker = -1
+    for count, rollout in enumerate(rollouts.split()):
+        if count % n_traj_per_worker == 0:
+            worker += 1
+        assert (rollout.actions == per_worker_actions[worker]).all()

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -112,19 +112,15 @@ def test_update_envs_env_update():
                                env_update=tasks.sample(n_workers + 1))
 
 
-def make_wrapped_env():
-    return TfEnv(PointEnv())
-
-
 def test_init_with_env_updates():
     max_path_length = 16
-    env = make_wrapped_env()
+    env = TfEnv(PointEnv())
     policy = FixedPolicy(env.spec,
                          scripted_actions=[
                              env.action_space.sample()
                              for _ in range(max_path_length)
                          ])
-    tasks = SetTaskSampler(make_wrapped_env)
+    tasks = SetTaskSampler(lambda: TfEnv(PointEnv()))
     n_workers = 8
     workers = WorkerFactory(seed=100,
                             max_path_length=max_path_length,


### PR DESCRIPTION
This PR contains a few improvements that I think are essential for easily using the new sampler architecture for meta (and multi-task) RL. They are:
 - Allow passing multiple environments / `EnvUpdate`s to sampler init methods. This means that, if the set of tasks is known ahead of time, the environments can potentially just be set once, when the sampler is initialized.
 - Allow sampling exactly `n` trajectories per worker. This makes gather, e.g. three trajectories per environment easy. See the `RaySampler` or `LocalSampler` tests for examples.
 - Using lambda's inside `EnvUpdate`s for `RaySampler` (this was already possible in `LocalSampler`). This ensures that e.g. `SetTaskSampler` or `ConstructEnvsSampler` can easily be used with environment wrappers with `RaySampler`.

I believe that @ahtsan might need some of these changes for his more efficient RL^2 sampling.