### PR TITLE
Fix an off-by-one error in LocalSampler

### DIFF
--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -113,7 +113,7 @@ class LocalSampler(Sampler):
                 batch = worker.rollout()
                 completed_samples += len(batch.actions)
                 batches.append(batch)
-                if completed_samples > num_samples:
+                if completed_samples >= num_samples:
                     return TrajectoryBatch.concatenate(*batches)
 
     def obtain_exact_trajectories(self,

--- a/tests/garage/sampler/test_local_sampler.py
+++ b/tests/garage/sampler/test_local_sampler.py
@@ -92,7 +92,7 @@ def test_update_envs_env_update():
                             n_workers=n_workers)
     sampler = LocalSampler.from_worker_factory(workers, policy, env)
     rollouts = sampler.obtain_samples(0,
-                                      160,
+                                      161,
                                       np.asarray(policy.get_param_values()),
                                       env_update=tasks.sample(n_workers))
     mean_rewards = []


### PR DESCRIPTION
Before, LocalSampler always gathered at least one more sample than
requested. This generally isn't a problem, but made sampling slightly
less predictable with LocalSampler.