### PR TITLE
Fix nightly tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       env: JOB_RUN_CMD="make ci-job-large"
     - name: "Verify conda and pipenv installations"
       env: JOB_RUN_CMD="make ci-job-verify-envs"
-    - if: type = cron AND false  # See https://github.com/rlworkgroup/garage/issues/1122
+    - if: type = cron
       name: "Nightly tests"
       env: JOB_RUN_CMD="make ci-job-nightly"
     # special deploy stage for tag builds ONLY

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ GYM_VERSION = '==0.15.4'
 REQUIRED = [
     # Please keep alphabetized
     'akro==0.0.6',
+    'atari-py<0.2.0',
     'cached_property',
     'click',
     'cloudpickle',

--- a/src/garage/envs/base.py
+++ b/src/garage/envs/base.py
@@ -92,7 +92,7 @@ class GarageEnv(gym.Wrapper):
         # We need to do some strange things here to fix-up flaws in gym
         # pylint: disable=protected-access, import-outside-toplevel
         if self.env.spec:
-            if any(package in getattr(self.env.spec, '_entry_point', '')
+            if any(package in getattr(self.env.spec, 'entry_point', '')
                    for package in KNOWN_GYM_NOT_CLOSE_MJ_VIEWER):
                 # This import is not in the header to avoid a MuJoCo dependency
                 # with non-MuJoCo environments that use this base class.
@@ -106,7 +106,7 @@ class GarageEnv(gym.Wrapper):
                 if (hasattr(self.env, 'viewer')
                         and isinstance(self.env.viewer, MjViewer)):
                     glfw.destroy_window(self.env.viewer.window)
-            elif any(package in getattr(self.env.spec, '_entry_point', '')
+            elif any(package in getattr(self.env.spec, 'entry_point', '')
                      for package in KNOWN_GYM_NOT_CLOSE_VIEWER):
                 if hasattr(self.env, 'viewer'):
                     from gym.envs.classic_control.rendering import (


### PR DESCRIPTION
- Fix gym viewer windows not closing due to attribute name change for `entry_point`
- Downgrade and pin atari-py dep to < 0.2.0 since 0.2.0+ fails to load `Defender-*` envs
- Re-enable nightly tests


Link to CI run passing nightly tests: https://travis-ci.com/rlworkgroup/garage/builds/146081240