### PR TITLE
Fix observation_space error in MultiEnvWrapper

### DIFF
--- a/src/garage/envs/multi_env_wrapper.py
+++ b/src/garage/envs/multi_env_wrapper.py
@@ -157,6 +157,7 @@ class MultiEnvWrapper(gym.Wrapper):
         self.env = self._task_envs[self._active_task_index]
         obs = self.env.reset(**kwargs)
         oh_obs = self._obs_with_one_hot(obs)
+        self.env.spec.observation_space = self.observation_space
         return oh_obs
 
     def step(self, action):


### PR DESCRIPTION
MultiEnvWrapper didn't reset its env.spec.observation_space in reset(),
this caused an error of imcompatible shape in sampler. Fixed it.