### PR TITLE
Add option for NPO to fit baseline first

### DIFF
--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -71,7 +71,7 @@ def tf_ppo_pendulum(ctxt=None, seed=1):
             entropy_method='max',
             policy_ent_coeff=0.02,
             center_adv=False,
-            fit_baseline_first=True,
+            fit_baseline_order='after',
         )
 
         runner.setup(algo, env)

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -71,6 +71,7 @@ def tf_ppo_pendulum(ctxt=None, seed=1):
             entropy_method='max',
             policy_ent_coeff=0.02,
             center_adv=False,
+            fit_baseline_first=True,
         )
 
         runner.setup(algo, env)

--- a/src/garage/misc/tensor_utils.py
+++ b/src/garage/misc/tensor_utils.py
@@ -23,7 +23,7 @@ def discount_cumsum(x, discount):
                                 axis=0)[::-1]
 
 
-def explained_variance_1d(ypred, y):
+def explained_variance_1d(ypred, y, valids):
     """Explained variation for 1D inputs.
 
     It is the proportion of the variance in one variable that is explained or
@@ -32,11 +32,14 @@ def explained_variance_1d(ypred, y):
     Args:
         ypred (np.ndarray): Sample data from the first variable.
         y (np.ndarray): Sample data from the second variable.
+        valids (np.ndarray): Array indicating valid indices.
 
     Returns:
         float: The explained variance.
 
     """
+    ypred = ypred[valids.astype(np.bool)]
+    y = y[valids.astype(np.bool)]
     assert y.ndim == 1 and ypred.ndim == 1
     vary = np.var(y)
     if np.isclose(vary, 0):

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -52,8 +52,9 @@ class PPO(NPO):
         flatten_input (bool): Whether to flatten input along the observation
             dimension. If True, for example, an observation with shape (2, 4)
             will be flattened to 8.
-        fit_baseline_first (bool): Whether to fit baseline first or after. If
-            true, baseline will be fitted before making prediction.
+        fit_baseline_order (str): Whether to fit baseline before or after,
+            either 'before' or 'after'. If 'before', baseline will be fitted
+            before making prediction. Default: 'after'.
         name (str): The name of the algorithm.
 
     """
@@ -80,7 +81,7 @@ class PPO(NPO):
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
                  flatten_input=True,
-                 fit_baseline_first=False,
+                 fit_baseline_order='after',
                  name='PPO'):
         if optimizer is None:
             optimizer = FirstOrderOptimizer
@@ -107,5 +108,5 @@ class PPO(NPO):
                          stop_entropy_gradient=stop_entropy_gradient,
                          entropy_method=entropy_method,
                          flatten_input=flatten_input,
-                         fit_baseline_first=fit_baseline_first,
+                         fit_baseline_order=fit_baseline_order,
                          name=name)

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -52,7 +52,10 @@ class PPO(NPO):
         flatten_input (bool): Whether to flatten input along the observation
             dimension. If True, for example, an observation with shape (2, 4)
             will be flattened to 8.
+        fit_baseline_first (bool): Whether to fit baseline first or after. If
+            true, baseline will be fitted before making prediction.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -77,6 +80,7 @@ class PPO(NPO):
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
                  flatten_input=True,
+                 fit_baseline_first=False,
                  name='PPO'):
         if optimizer is None:
             optimizer = FirstOrderOptimizer
@@ -103,4 +107,5 @@ class PPO(NPO):
                          stop_entropy_gradient=stop_entropy_gradient,
                          entropy_method=entropy_method,
                          flatten_input=flatten_input,
+                         fit_baseline_first=fit_baseline_first,
                          name=name)

--- a/src/garage/tf/algos/tnpg.py
+++ b/src/garage/tf/algos/tnpg.py
@@ -1,3 +1,4 @@
+"""Truncated Natural Policy Gradient."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import ConjugateGradientOptimizer
 
@@ -48,7 +49,14 @@ class TNPG(NPO):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
+        fit_baseline_order (str): Whether to fit baseline before or after,
+            either 'before' or 'after'. If 'before', baseline will be fitted
+            before making prediction. Default: 'after'.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -72,6 +80,8 @@ class TNPG(NPO):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
+                 fit_baseline_order='after',
                  name='TNPG'):
         if optimizer is None:
             optimizer = ConjugateGradientOptimizer
@@ -80,25 +90,26 @@ class TNPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss=pg_loss,
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         fit_baseline_order=fit_baseline_order,
+                         name=name)

--- a/src/garage/tf/algos/trpo.py
+++ b/src/garage/tf/algos/trpo.py
@@ -45,12 +45,20 @@ class TRPO(NPO):
         use_neg_logli_entropy (bool): Whether to estimate the entropy as the
             negative log likelihood of the action.
         stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        kl_constraint (str): KL constraint, either 'hard' or 'soft'.
         entropy_method (str): A string from: 'max', 'regularized',
             'no_entropy'. The type of entropy method to use. 'max' adds the
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
+        fit_baseline_order (str): Whether to fit baseline before or after,
+            either 'before' or 'after'. If 'before', baseline will be fitted
+            before making prediction. Default: 'after'.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -76,6 +84,7 @@ class TRPO(NPO):
                  kl_constraint='hard',
                  entropy_method='no_entropy',
                  flatten_input=True,
+                 fit_baseline_order='after',
                  name='TRPO'):
         if not optimizer:
             if kl_constraint == 'hard':
@@ -109,4 +118,5 @@ class TRPO(NPO):
                          stop_entropy_gradient=stop_entropy_gradient,
                          entropy_method=entropy_method,
                          flatten_input=flatten_input,
+                         fit_baseline_order=fit_baseline_order,
                          name=name)

--- a/src/garage/tf/algos/vpg.py
+++ b/src/garage/tf/algos/vpg.py
@@ -1,3 +1,4 @@
+"""Vanilla Policy Gradient."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import FirstOrderOptimizer
 
@@ -46,7 +47,14 @@ class VPG(NPO):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
+        fit_baseline_order (str): Whether to fit baseline before or after,
+            either 'before' or 'after'. If 'before', baseline will be fitted
+            before making prediction. Default: 'after'.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -70,6 +78,8 @@ class VPG(NPO):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
+                 fit_baseline_order='after',
                  name='VPG'):
         if optimizer is None:
             default_args = dict(
@@ -81,25 +91,26 @@ class VPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss=pg_loss,
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         fit_baseline_order=fit_baseline_order,
+                         name=name)

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -53,6 +53,22 @@ class TestPPO(TfGraphTestCase):
                        optimizer_args=dict(batch_size=32, max_epochs=10))
             runner.setup(algo, self.env)
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
+            print(last_avg_ret)
+            assert last_avg_ret > 35
+
+    def test_ppo_pendulum_fit_baseline_before(self):
+        """Test PPO with Pendulum environment and fit baseline before."""
+        with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
+            algo = PPO(env_spec=self.env.spec,
+                       policy=self.policy,
+                       baseline=self.baseline,
+                       max_path_length=100,
+                       discount=0.99,
+                       lr_clip_range=0.01,
+                       optimizer_args=dict(batch_size=32, max_epochs=10),
+                       fit_baseline_order='before')
+            runner.setup(algo, self.env)
+            last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 35
 
     # large marker removed to balance test jobs


### PR DESCRIPTION
Refactor NPO to support either fit baseline first or fit baseline after. Also, expose functions for calculating advantages and returns for NPO variants.