### PR TITLE
Tanh Gaussian policy for torch

### DIFF
--- a/src/garage/torch/modules/__init__.py
+++ b/src/garage/torch/modules/__init__.py
@@ -7,6 +7,9 @@ from garage.torch.modules.mlp_module import MLPModule
 from garage.torch.modules.multi_headed_mlp_module import MultiHeadedMLPModule
 
 __all__ = [
-    'MLPModule', 'MultiHeadedMLPModule', 'GaussianMLPModule',
-    'GaussianMLPIndependentStdModule', 'GaussianMLPTwoHeadedModule'
+    'MLPModule',
+    'MultiHeadedMLPModule',
+    'GaussianMLPModule',
+    'GaussianMLPIndependentStdModule',
+    'GaussianMLPTwoHeadedModule',
 ]

--- a/src/garage/torch/policies/__init__.py
+++ b/src/garage/torch/policies/__init__.py
@@ -3,5 +3,12 @@ from garage.torch.policies.base import Policy
 from garage.torch.policies.deterministic_mlp_policy import (
     DeterministicMLPPolicy)
 from garage.torch.policies.gaussian_mlp_policy import GaussianMLPPolicy
+from garage.torch.policies.tanh_gaussian_mlp_policy import (
+    TanhGaussianMLPPolicy)
 
-__all__ = ['DeterministicMLPPolicy', 'GaussianMLPPolicy', 'Policy']
+__all__ = [
+    'DeterministicMLPPolicy',
+    'GaussianMLPPolicy',
+    'Policy',
+    'TanhGaussianMLPPolicy',
+]

--- a/src/garage/torch/policies/tanh_gaussian_mlp_policy.py
+++ b/src/garage/torch/policies/tanh_gaussian_mlp_policy.py
@@ -1,17 +1,19 @@
-"""GaussianMLPPolicy."""
+"""TanhGaussianMLPPolicy."""
+import numpy as np
 import torch
 from torch import nn
 
-from garage.torch.modules import GaussianMLPModule
+from garage.torch.distributions import TanhNormal
+from garage.torch.modules import GaussianMLPTwoHeadedModule
 from garage.torch.policies import Policy
 import garage.torch.utils as tu
 
 
-class GaussianMLPPolicy(Policy, GaussianMLPModule):
-    """MLP whose outputs are fed into a Normal distribution..
+class TanhGaussianMLPPolicy(Policy, GaussianMLPTwoHeadedModule):
+    """Multiheaded MLP whose outputs are fed into a TanhNormal distribution.
 
     A policy that contains a MLP to make prediction based on a gaussian
-    distribution.
+    distribution with a tanh transformation.
 
     Args:
         env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
@@ -36,57 +38,57 @@ class GaussianMLPPolicy(Policy, GaussianMLPModule):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             torch.Tensor.
-        learn_std (bool): Is std trainable.
         init_std (float): Initial value for std.
             (plain value - not log or exponentiated).
-        min_std (float): Minimum value for std.
-        max_std (float): Maximum value for std.
+        min_std (float): If not None, the std is at least the value of min_std,
+            to avoid numerical issues (plain value - not log or exponentiated).
+        max_std (float): If not None, the std is at most the value of max_std,
+            to avoid numerical issues (plain value - not log or exponentiated).
         std_parameterization (str): How the std should be parametrized. There
             are two options:
             - exp: the logarithm of the std will be stored, and applied a
                exponential transformation
             - softplus: the std will be computed as log(1+exp(x))
         layer_normalization (bool): Bool for using layer normalization or not.
-        name (str): Name of policy.
 
     """
 
     def __init__(self,
                  env_spec,
                  hidden_sizes=(32, 32),
-                 hidden_nonlinearity=torch.tanh,
+                 hidden_nonlinearity=nn.ReLU,
                  hidden_w_init=nn.init.xavier_uniform_,
                  hidden_b_init=nn.init.zeros_,
                  output_nonlinearity=None,
                  output_w_init=nn.init.xavier_uniform_,
                  output_b_init=nn.init.zeros_,
-                 learn_std=True,
                  init_std=1.0,
-                 min_std=1e-6,
-                 max_std=None,
+                 min_std=np.exp(-20.),
+                 max_std=np.exp(2.),
                  std_parameterization='exp',
-                 layer_normalization=False,
-                 name='GaussianMLPPolicy'):
+                 layer_normalization=False):
+
         self._obs_dim = env_spec.observation_space.flat_dim
         self._action_dim = env_spec.action_space.flat_dim
 
-        Policy.__init__(self, env_spec, name)
-        GaussianMLPModule.__init__(self,
-                                   input_dim=self._obs_dim,
-                                   output_dim=self._action_dim,
-                                   hidden_sizes=hidden_sizes,
-                                   hidden_nonlinearity=hidden_nonlinearity,
-                                   hidden_w_init=hidden_w_init,
-                                   hidden_b_init=hidden_b_init,
-                                   output_nonlinearity=output_nonlinearity,
-                                   output_w_init=output_w_init,
-                                   output_b_init=output_b_init,
-                                   learn_std=learn_std,
-                                   init_std=init_std,
-                                   min_std=min_std,
-                                   max_std=max_std,
-                                   std_parameterization=std_parameterization,
-                                   layer_normalization=layer_normalization)
+        Policy.__init__(self, env_spec, name='TanhGaussianPolicy')
+        GaussianMLPTwoHeadedModule.__init__(
+            self,
+            input_dim=self._obs_dim,
+            output_dim=self._action_dim,
+            hidden_sizes=hidden_sizes,
+            hidden_nonlinearity=hidden_nonlinearity,
+            hidden_w_init=hidden_w_init,
+            hidden_b_init=hidden_b_init,
+            output_nonlinearity=output_nonlinearity,
+            output_w_init=output_w_init,
+            output_b_init=output_b_init,
+            init_std=init_std,
+            min_std=min_std,
+            max_std=max_std,
+            std_parameterization=std_parameterization,
+            layer_normalization=layer_normalization,
+            normal_distribution_cls=TanhNormal)
 
     def get_action(self, observation):
         r"""Get a single action given an observation.
@@ -100,20 +102,21 @@ class GaussianMLPPolicy(Policy, GaussianMLPModule):
                 * np.ndarray: Predicted action. Shape is
                     :math:`env_spec.action_space`.
                 * dict:
-                    * np.ndarray[float]: Mean of the distribution
+                    * np.ndarray[float]: Mean of the distribution.
                     * np.ndarray[float]: Standard deviation of logarithmic
                         values of the distribution.
 
         """
         with torch.no_grad():
             if not isinstance(observation, torch.Tensor):
-                observation = torch.as_tensor(observation).float().to(
+                observation = torch.from_numpy(observation).to(
                     tu.global_device())
-            observation = torch.Tensor(observation).unsqueeze(0)
+            observation = observation.unsqueeze(0)
             dist = self.forward(observation)
-            return (dist.rsample().squeeze(0).numpy(),
-                    dict(mean=dist.mean.squeeze(0).numpy(),
-                         log_std=(dist.variance**.5).log().squeeze(0).numpy()))
+            ret_mean = dist.mean.squeeze(0).cpu().numpy()
+            ret_log_std = (dist.variance.sqrt()).log().squeeze(0).cpu().numpy()
+            return (dist.rsample().squeeze(0).cpu().numpy(),
+                    dict(mean=ret_mean, log_std=ret_log_std))
 
     def get_actions(self, observations):
         r"""Get actions given observations.
@@ -124,7 +127,7 @@ class GaussianMLPPolicy(Policy, GaussianMLPModule):
 
         Returns:
             tuple:
-                * np.ndarray: Predicted actions.
+                * np.ndarray: Predicted actions. Shape is
                     :math:`batch_dim \bullet env_spec.action_space`.
                 * dict:
                     * np.ndarray[float]: Mean of the distribution.
@@ -134,15 +137,16 @@ class GaussianMLPPolicy(Policy, GaussianMLPModule):
         """
         with torch.no_grad():
             if not isinstance(observations, torch.Tensor):
-                observations = torch.as_tensor(observations).float().to(
+                observations = torch.from_numpy(observations).to(
                     tu.global_device())
-            dist = self.forward(torch.Tensor(observations))
-            return (dist.rsample().numpy(),
-                    dict(mean=dist.mean.numpy(),
-                         log_std=(dist.variance.sqrt()).log().numpy()))
+            dist = self.forward(observations)
+            ret_mean = dist.mean.cpu().numpy()
+            ret_log_std = (dist.variance.sqrt()).log().cpu().numpy()
+            return (dist.rsample().cpu().numpy(),
+                    dict(mean=ret_mean, log_std=ret_log_std))
 
     def log_likelihood(self, observation, action):
-        """Compute log likelihood given observations and action.
+        r"""Compute log likelihood given observations and action.
 
         Args:
             observation (torch.Tensor): Observation from the environment.
@@ -159,14 +163,14 @@ class GaussianMLPPolicy(Policy, GaussianMLPModule):
         return dist.log_prob(action)
 
     def entropy(self, observation):
-        """Get entropy given observations.
+        r"""Get entropy given observations.
 
         Args:
             observation (torch.Tensor): Observation from the environment.
                 Shape is :math:`env_spec.observation_space`.
 
         Returns:
-             torch.Tensor: Calculated entropy values given observation.
+            torch.Tensor: Calculated entropy values given observation.
                 Shape is :math:`1`.
 
         """

--- a/tests/garage/torch/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_gaussian_mlp_policy.py
@@ -1,3 +1,4 @@
+"""Test Gaussian MLP Policy."""
 import pickle
 
 import numpy as np
@@ -11,11 +12,13 @@ from tests.fixtures.envs.dummy import DummyBoxEnv
 
 
 class TestGaussianMLPPolicies:
+    """Class for Testing Gaussian MlP Policy."""
     # yapf: disable
     @pytest.mark.parametrize('hidden_sizes', [
         (1, ), (2, ), (3, ), (1, 4), (3, 5)])
     # yapf: enable
     def test_get_action(self, hidden_sizes):
+        """Test get_action function."""
         env_spec = TfEnv(DummyBoxEnv())
         obs_dim = env_spec.observation_space.flat_dim
         act_dim = env_spec.action_space.flat_dim
@@ -41,6 +44,38 @@ class TestGaussianMLPPolicies:
         assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
         assert action.shape == (act_dim, )
 
+
+# yapf: disable
+    @pytest.mark.parametrize('hidden_sizes', [
+        (1, ), (2, ), (3, ), (1, 4), (3, 5)])
+    # yapf: enable
+    def test_get_action_np(self, hidden_sizes):
+        """Test get_action function with numpy inputs."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = np.ones(obs_dim, dtype=np.float32)
+        init_std = 2.
+
+        policy = GaussianMLPPolicy(env_spec=env_spec,
+                                   hidden_sizes=hidden_sizes,
+                                   init_std=init_std,
+                                   hidden_nonlinearity=None,
+                                   std_parameterization='exp',
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+
+        dist = policy(torch.from_numpy(obs))
+
+        expected_mean = torch.full(
+            (act_dim, ), obs_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        expected_variance = init_std**2
+        action, prob = policy.get_action(obs)
+
+        assert np.array_equal(prob['mean'], expected_mean.numpy())
+        assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
+        assert action.shape == (act_dim, )
+
     # yapf: disable
     @pytest.mark.parametrize('batch_size, hidden_sizes', [
         (1, (1, )),
@@ -51,6 +86,7 @@ class TestGaussianMLPPolicies:
     ])
     # yapf: enable
     def test_get_actions(self, batch_size, hidden_sizes):
+        """Test get_actions function."""
         env_spec = TfEnv(DummyBoxEnv())
         obs_dim = env_spec.observation_space.flat_dim
         act_dim = env_spec.action_space.flat_dim
@@ -81,6 +117,44 @@ class TestGaussianMLPPolicies:
     # yapf: disable
     @pytest.mark.parametrize('batch_size, hidden_sizes', [
         (1, (1, )),
+        (5, (3, )),
+        (8, (4, )),
+        (15, (1, 2)),
+        (30, (3, 4, 10)),
+    ])
+    # yapf: enable
+    def test_get_actions_np(self, batch_size, hidden_sizes):
+        """Test get_actions function with numpy inputs."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = np.ones((batch_size, obs_dim), dtype=np.float32)
+        init_std = 2.
+
+        policy = GaussianMLPPolicy(env_spec=env_spec,
+                                   hidden_sizes=hidden_sizes,
+                                   init_std=init_std,
+                                   hidden_nonlinearity=None,
+                                   std_parameterization='exp',
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+
+        dist = policy(torch.from_numpy(obs))
+
+        expected_mean = torch.full([batch_size, act_dim],
+                                   obs_dim *
+                                   (torch.Tensor(hidden_sizes).prod().item()))
+        expected_variance = init_std**2
+        action, prob = policy.get_actions(obs)
+
+        assert np.array_equal(prob['mean'], expected_mean.numpy())
+        assert dist.variance.equal(
+            torch.full((batch_size, act_dim), expected_variance))
+        assert action.shape == (batch_size, act_dim)
+
+    # yapf: disable
+    @pytest.mark.parametrize('batch_size, hidden_sizes', [
+        (1, (1, )),
         (6, (3, )),
         (11, (6, )),
         (25, (3, 5)),
@@ -88,6 +162,7 @@ class TestGaussianMLPPolicies:
     ])
     # yapf: enable
     def test_is_pickleable(self, batch_size, hidden_sizes):
+        """Test if policy is pickleable."""
         env_spec = TfEnv(DummyBoxEnv())
         obs_dim = env_spec.observation_space.flat_dim
         obs = torch.ones([batch_size, obs_dim], dtype=torch.float32)
@@ -109,3 +184,35 @@ class TestGaussianMLPPolicies:
 
         assert np.array_equal(output1_prob['mean'], output2_prob['mean'])
         assert output1_action.shape == output2_action.shape
+
+    def test_entropy(self):
+        """Test get_entropy method of the policy."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 1.
+        obs = torch.Tensor([0, 0, 0, 0]).float()
+        policy = GaussianMLPPolicy(env_spec=env_spec,
+                                   hidden_sizes=(1, ),
+                                   init_std=init_std,
+                                   hidden_nonlinearity=None,
+                                   std_parameterization='exp',
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+        dist = policy(obs)
+        assert torch.allclose(dist.entropy(), policy.entropy(obs))
+
+    def test_log_prob(self):
+        """Test log_prob method of the policy."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 1.
+        obs = torch.Tensor([0, 0, 0, 0]).float()
+        action = torch.Tensor([0, 0]).float()
+        policy = GaussianMLPPolicy(env_spec=env_spec,
+                                   hidden_sizes=(1, ),
+                                   init_std=init_std,
+                                   hidden_nonlinearity=None,
+                                   std_parameterization='exp',
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+        dist = policy(obs)
+        assert torch.allclose(dist.log_prob(action),
+                              policy.log_likelihood(obs, action))

--- a/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
@@ -1,0 +1,221 @@
+"""Tests for tanh gaussian mlp policy."""
+import pickle
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from garage.tf.envs import TfEnv
+from garage.torch.policies import TanhGaussianMLPPolicy
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestTanhGaussianMLPPolicy:
+    """Tests for TanhGaussianMLPPolicy."""
+    # yapf: disable
+    @pytest.mark.parametrize('hidden_sizes', [
+        (1, ), (2, ), (3, ), (1, 4), (3, 5)])
+    # yapf: enable
+    def test_get_action(self, hidden_sizes):
+        """Test Tanh Gaussian Policy get action function."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = torch.ones(obs_dim, dtype=torch.float32).unsqueeze(0)
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=hidden_sizes,
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        expected_mean = torch.full((act_dim, ), 1.0)
+        action, prob = policy.get_action(obs)
+        assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
+        assert action.squeeze(0).shape == (act_dim, )
+
+    # yapf: disable
+    @pytest.mark.parametrize('hidden_sizes', [
+        (1, ), (2, ), (3, ), (1, 4), (3, 5)])
+    # yapf: enable
+    def test_get_action_np(self, hidden_sizes):
+        """Test Policy get action function with numpy inputs."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = np.ones((obs_dim, ), dtype=np.float32)
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=hidden_sizes,
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        expected_mean = torch.full((act_dim, ), 1.0)
+        action, prob = policy.get_action(obs)
+        assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
+        assert action.shape == (act_dim, )
+
+    # yapf: disable
+    @pytest.mark.parametrize('batch_size, hidden_sizes', [
+        (1, (1, )),
+        (5, (3, )),
+        (8, (4, )),
+        (15, (1, 2)),
+        (30, (3, 4, 10)),
+    ])
+    # yapf: enable
+    def test_get_actions(self, batch_size, hidden_sizes):
+        """Test Tanh Gaussian Policy get actions function."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = torch.ones([batch_size, obs_dim], dtype=torch.float32)
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=hidden_sizes,
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+
+        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        action, prob = policy.get_actions(obs)
+        assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
+        assert action.shape == (batch_size, act_dim)
+
+    # yapf: disable
+    @pytest.mark.parametrize('batch_size, hidden_sizes', [
+        (1, (1, )),
+        (5, (3, )),
+        (8, (4, )),
+        (15, (1, 2)),
+        (30, (3, 4, 10)),
+    ])
+    # yapf: enable
+    def test_get_actions_np(self, batch_size, hidden_sizes):
+        """Test get actions with np.ndarray inputs."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        act_dim = env_spec.action_space.flat_dim
+        obs = np.ones((batch_size, obs_dim), dtype=np.float32)
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=hidden_sizes,
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+
+        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        action, prob = policy.get_actions(obs)
+        assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
+        assert action.shape == (batch_size, act_dim)
+
+    # yapf: disable
+    @pytest.mark.parametrize('batch_size, hidden_sizes', [
+        (1, (1, )),
+        (6, (3, )),
+        (11, (6, )),
+        (25, (3, 5)),
+        (34, (2, 10, 11)),
+    ])
+    # yapf: enable
+    def test_is_pickleable(self, batch_size, hidden_sizes):
+        """Test if policy is unchanged after pickling."""
+        env_spec = TfEnv(DummyBoxEnv())
+        obs_dim = env_spec.observation_space.flat_dim
+        obs = torch.ones([batch_size, obs_dim], dtype=torch.float32)
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=hidden_sizes,
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+
+        output1_action, output1_prob = policy.get_actions(obs)
+
+        p = pickle.dumps(policy)
+        policy_pickled = pickle.loads(p)
+        output2_action, output2_prob = policy_pickled.get_actions(obs)
+        assert np.allclose(output2_prob['mean'],
+                           output1_prob['mean'],
+                           rtol=1e-3)
+        assert output1_action.shape == output2_action.shape
+
+    def test_is_vectorized(self):
+        """Test Tanh Gaussian Policy is vectorized."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=(1, ),
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        assert policy.vectorized
+
+    def test_to(self):
+        """Test Tanh Gaussian Policy can be moved to cpu."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 2.
+
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=(1, ),
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        if torch.cuda.is_available():
+            policy.to(torch.device('cuda:0'))
+            assert str(next(policy.parameters()).device) == 'cuda:0'
+        else:
+            policy.to(None)
+            assert str(next(policy.parameters()).device) == 'cpu'
+
+    def test_entropy(self):
+        """Test get_entropy method of the policy."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 1.
+        obs = torch.Tensor([0, 0, 0, 0]).float()
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=(1, ),
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        dist = policy(obs)
+        assert torch.allclose(dist.entropy(), policy.entropy(obs))
+
+    def test_log_prob(self):
+        """Test log_prob method of the policy."""
+        env_spec = TfEnv(DummyBoxEnv())
+        init_std = 1.
+        obs = torch.Tensor([0, 0, 0, 0]).float()
+        action = torch.Tensor([0, 0]).float()
+        policy = TanhGaussianMLPPolicy(env_spec=env_spec,
+                                       hidden_sizes=(1, ),
+                                       init_std=init_std,
+                                       hidden_nonlinearity=None,
+                                       std_parameterization='exp',
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        dist = policy(obs)
+        assert torch.allclose(dist.log_prob(action),
+                              policy.log_likelihood(obs, action))


### PR DESCRIPTION
This PR is for the Tanh Gaussian Policy thats used in (mt)SAC.

It is a working product, but can use some refactor. I will bring the refactors in a later PR.