### PR TITLE
Fix VecEnvExecutor + off-policy algorithms

### DIFF
--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -83,7 +83,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
             obses = self._vec_env.reset()
         else:
             obses = self._last_obses
-        dones = np.asarray([True] * self._vec_env.num_envs)
+        completes = np.asarray([True] * self._vec_env.num_envs)
         running_paths = [None] * self._vec_env.num_envs
         n_samples = 0
 
@@ -92,7 +92,7 @@ class OffPolicyVectorizedSampler(BatchSampler):
             self.algo.es.reset()
 
         while n_samples < batch_size:
-            policy.reset(dones)
+            policy.reset(completes)
             if self.algo.input_include_goal:
                 obs = [obs['observation'] for obs in obses]
                 d_g = [obs['desired_goal'] for obs in obses]
@@ -109,7 +109,9 @@ class OffPolicyVectorizedSampler(BatchSampler):
                 actions, agent_infos = self.algo.policy.get_actions(
                     obs_normalized)
 
-            next_obses, rewards, dones, env_infos = self._vec_env.step(actions)
+            next_obses, rewards, dones, env_infos = \
+                self._vec_env.step(actions)
+            completes = env_infos['vec_env_executor.complete']
             self._last_obses = next_obses
             agent_infos = tensor_utils.split_tensor_dict_list(agent_infos)
             env_infos = tensor_utils.split_tensor_dict_list(env_infos)

--- a/src/garage/sampler/on_policy_vectorized_sampler.py
+++ b/src/garage/sampler/on_policy_vectorized_sampler.py
@@ -112,7 +112,8 @@ class OnPolicyVectorizedSampler(BatchSampler):
 
             policy_time += time.time() - t
             t = time.time()
-            next_obses, rewards, dones, env_infos = self._vec_env.step(actions)
+            next_obses, rewards, dones, env_infos = \
+                self._vec_env.step(actions)
             env_time += time.time() - t
             t = time.time()
 

--- a/tests/garage/tf/algos/test_batch_polopt2.py
+++ b/tests/garage/tf/algos/test_batch_polopt2.py
@@ -120,8 +120,6 @@ class TestBatchPolopt2(TfGraphTestCase):
             assert samples['lengths'].shape == (max_path_length, )
             # non-recurrent policy has empty agent info
             assert samples['agent_infos'] == {}
-            # non-recurrent policy has empty env info
-            assert samples['env_infos'] == {}
             assert isinstance(samples['average_return'], float)
 
     # pylint: disable=abstract-class-instantiated, no-member
@@ -157,6 +155,4 @@ class TestBatchPolopt2(TfGraphTestCase):
             for key, shape in policy.state_info_specs:
                 assert samples['agent_infos'][key].shape == (max_path_length,
                                                              np.prod(shape))
-            # non-recurrent policy has empty env info
-            assert samples['env_infos'] == {}
             assert isinstance(samples['average_return'], float)


### PR DESCRIPTION
This requires separating the done and path complete signals.

This is mostly a temporary measure, so that off policy algorithms are fixed for this release.