### PR TITLE
Remove flaky marks on integration tests

### DIFF
--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -73,7 +73,6 @@ def test_dqn_pong():
         env=env).returncode == 0
 
 
-@pytest.mark.flaky  # see https://github.com/rlworkgroup/garage/issues/1147
 @pytest.mark.no_cover
 @pytest.mark.timeout(30)
 def test_ppo_memorize_digits():
@@ -89,7 +88,6 @@ def test_ppo_memorize_digits():
     assert subprocess.run(command, check=False, env=env).returncode == 0
 
 
-@pytest.mark.flaky  # see https://github.com/rlworkgroup/garage/issues/1147
 @pytest.mark.no_cover
 @pytest.mark.timeout(40)
 def test_trpo_cubecrash():


### PR DESCRIPTION
Testing out if `test_ppo_memorize_digits` and `test_trpo_cubecrash` are working.