### PR TITLE
Fix flaky tests for ray sampler

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,8 +3,8 @@ import pytest
 import ray
 
 
-@pytest.fixture(scope='module')
-def ray_local_test_fixture():
+@pytest.fixture(scope='function')
+def ray_local_session_fixture():
     """Initializes Ray and shuts down Ray in local mode.
 
     Yields:
@@ -22,8 +22,8 @@ def ray_local_test_fixture():
         ray.shutdown()
 
 
-@pytest.fixture(scope='module')
-def ray_test_fixture():
+@pytest.fixture(scope='function')
+def ray_session_fixture():
     """Initializes Ray and shuts down Ray.
 
     Yields:

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,25 @@ import ray
 
 
 @pytest.fixture(scope='module')
+def ray_local_test_fixture():
+    """Initializes Ray and shuts down Ray in local mode.
+
+    Yields:
+        None: Yield is for purposes of pytest module style.
+            All statements before the yield are apart of module setup, and all
+            statements after the yield are apart of module teardown.
+    """
+    if not ray.is_initialized():
+        ray.init(local_mode=True,
+                 ignore_reinit_error=True,
+                 log_to_driver=False,
+                 include_webui=False)
+    yield
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+@pytest.fixture(scope='module')
 def ray_test_fixture():
     """Initializes Ray and shuts down Ray.
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,23 @@
+"""Place Pytest fixtures to be used across all tests here."""
+import pytest
+import ray
+
+
+@pytest.fixture(scope='module')
+def ray_test_fixture():
+    """Initializes Ray and shuts down Ray.
+
+    Yields:
+        None: Yield is for purposes of pytest module style.
+            All statements before the yield are apart of module setup, and all
+            statements after the yield are apart of module teardown.
+    """
+    if not ray.is_initialized():
+        ray.init(memory=52428800,
+                 object_store_memory=78643200,
+                 ignore_reinit_error=True,
+                 log_to_driver=False,
+                 include_webui=False)
+    yield
+    if ray.is_initialized():
+        ray.shutdown()

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -6,8 +6,10 @@ sampler.
 Here it runs Swimmer-v2 environment with 40 iterations.
 """
 import gym
+import ray
 
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
@@ -15,19 +17,28 @@ from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import GaussianMLPPolicy
 
-seed = 100
 
-
-def run_task(snapshot_config, *_):
-    """Run task.
+@wrap_experiment
+def tf_trpo_swimmer(ctxt=None, seed=1):
+    """tf_trpo_swimmer.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): Configuration
-            values for snapshotting.
-        *_ (object): Hyperparameters (unused).
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    # Since this is an example, we are running ray in a reduced state.
+    # One can comment this line out in order to run ray at full capacity
+    ray.init(memory=52428800,
+             object_store_memory=78643200,
+             ignore_reinit_error=True,
+             log_to_driver=False,
+             include_webui=False)
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
+        set_seed(seed)
         env = TfEnv(gym.make('Swimmer-v2'))
 
         policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(32, 32))
@@ -48,8 +59,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=40, batch_size=4000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=seed,
-)
+tf_trpo_swimmer(seed=100)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ extend-ignore =
     F841  # Unused variables are checked by pylint
 
 [tool:pytest]
-addopts = -n auto -rfE -s --strict-markers
+addopts = -n 0 -rfE -s --strict-markers
 markers =
     nightly
     huge

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ extend-ignore =
     F841  # Unused variables are checked by pylint
 
 [tool:pytest]
-addopts = -n 0 -rfE -s --strict-markers
+addopts = -n auto -rfE -s --strict-markers
 markers =
     nightly
     huge

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -46,7 +46,7 @@ class TestSampler:
     def teardown_method(self):
         self.env.close()
 
-    def test_ray_batch_sampler(self, ray_test_fixture):
+    def test_ray_batch_sampler(self, ray_local_test_fixture):
         # pylint: disable=unused-argument
         assert ray.is_initialized()
         workers = WorkerFactory(seed=100,
@@ -80,7 +80,7 @@ class TestSampler:
         sampler2.shutdown_worker()
 
 
-def test_update_envs_env_update(ray_test_fixture):
+def test_update_envs_env_update(ray_local_test_fixture):
     # pylint: disable=unused-argument
     assert ray.is_initialized()
     max_path_length = 16
@@ -114,7 +114,7 @@ def test_update_envs_env_update(ray_test_fixture):
                                env_update=tasks.sample(n_workers + 1))
 
 
-def test_obtain_exact_trajectories(ray_test_fixture):
+def test_obtain_exact_trajectories(ray_local_test_fixture):
     # pylint: disable=unused-argument
     assert ray.is_initialized()
     max_path_length = 15
@@ -142,7 +142,7 @@ def test_obtain_exact_trajectories(ray_test_fixture):
         assert (rollout.actions == per_worker_actions[worker]).all()
 
 
-def test_init_with_env_updates(ray_test_fixture):
+def test_init_with_env_updates(ray_local_test_fixture):
     # pylint: disable=unused-argument
     assert ray.is_initialized()
     max_path_length = 16

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -13,75 +13,46 @@ from garage.sampler import OnPolicyVectorizedSampler, RaySampler, WorkerFactory
 from garage.tf.envs import TfEnv
 
 
-class TestSampler:
-    """
-    Uses mock policy for 4x4 gridworldenv
-    '4x4': [
-        'SFFF',
-        'FHFH',
-        'FFFH',
-        'HFFG'
-    ]
-    0: left
-    1: down
-    2: right
-    3: up
-    -1: no move
-    'S' : starting point
-    'F' or '.': free space
-    'W' or 'x': wall
-    'H' or 'o': hole (terminates episode)
-    'G' : goal
-    [2,2,1,0,3,1,1,1,2,2,1,1,1,2,2,1]
-    """
+def test_ray_batch_sampler(ray_local_session_fixture):
+    del ray_local_session_fixture
+    env = TfEnv(GridWorldEnv(desc='4x4'))
+    policy = ScriptedPolicy(
+        scripted_actions=[2, 2, 1, 0, 3, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1])
+    algo = Mock(env_spec=env.spec, policy=policy, max_path_length=16)
+    assert ray.is_initialized()
+    workers = WorkerFactory(seed=100, max_path_length=algo.max_path_length)
+    sampler1 = RaySampler(workers, policy, env)
+    sampler1.start_worker()
+    sampler2 = OnPolicyVectorizedSampler(algo, env)
+    sampler2.start_worker()
+    trajs1 = sampler1.obtain_samples(0, 1000,
+                                     tuple(algo.policy.get_param_values()))
+    trajs2 = sampler2.obtain_samples(0, 1000)
+    # pylint: disable=superfluous-parens
+    assert trajs1.observations.shape[0] >= 1000
+    assert trajs1.actions.shape[0] >= 1000
+    assert (sum(trajs1.rewards[:trajs1.lengths[0]]) == sum(
+        trajs2[0]['rewards']) == 1)
 
-    def setup_method(self):
-        self.env = TfEnv(GridWorldEnv(desc='4x4'))
-        self.policy = ScriptedPolicy(
-            scripted_actions=[2, 2, 1, 0, 3, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1])
-        self.algo = Mock(env_spec=self.env.spec,
-                         policy=self.policy,
-                         max_path_length=16)
-
-    def teardown_method(self):
-        self.env.close()
-
-    def test_ray_batch_sampler(self, ray_local_test_fixture):
-        # pylint: disable=unused-argument
-        assert ray.is_initialized()
-        workers = WorkerFactory(seed=100,
-                                max_path_length=self.algo.max_path_length)
-        sampler1 = RaySampler(workers, self.policy, self.env)
-        sampler1.start_worker()
-        sampler2 = OnPolicyVectorizedSampler(self.algo, self.env)
-        sampler2.start_worker()
-        trajs1 = sampler1.obtain_samples(
-            0, 1000, tuple(self.algo.policy.get_param_values()))
-        trajs2 = sampler2.obtain_samples(0, 1000)
-        # pylint: disable=superfluous-parens
-        assert trajs1.observations.shape[0] >= 1000
-        assert trajs1.actions.shape[0] >= 1000
-        assert (sum(trajs1.rewards[:trajs1.lengths[0]]) == sum(
-            trajs2[0]['rewards']) == 1)
-
-        true_obs = np.array([0, 1, 2, 6, 10, 14])
-        true_actions = np.array([2, 2, 1, 1, 1, 2])
-        true_rewards = np.array([0, 0, 0, 0, 0, 1])
-        start = 0
-        for length in trajs1.lengths:
-            observations = trajs1.observations[start:start + length]
-            actions = trajs1.actions[start:start + length]
-            rewards = trajs1.rewards[start:start + length]
-            assert np.array_equal(observations, true_obs)
-            assert np.array_equal(actions, true_actions)
-            assert np.array_equal(rewards, true_rewards)
-            start += length
-        sampler1.shutdown_worker()
-        sampler2.shutdown_worker()
+    true_obs = np.array([0, 1, 2, 6, 10, 14])
+    true_actions = np.array([2, 2, 1, 1, 1, 2])
+    true_rewards = np.array([0, 0, 0, 0, 0, 1])
+    start = 0
+    for length in trajs1.lengths:
+        observations = trajs1.observations[start:start + length]
+        actions = trajs1.actions[start:start + length]
+        rewards = trajs1.rewards[start:start + length]
+        assert np.array_equal(observations, true_obs)
+        assert np.array_equal(actions, true_actions)
+        assert np.array_equal(rewards, true_rewards)
+        start += length
+    sampler1.shutdown_worker()
+    sampler2.shutdown_worker()
+    env.close()
 
 
-def test_update_envs_env_update(ray_local_test_fixture):
-    # pylint: disable=unused-argument
+def test_update_envs_env_update(ray_local_session_fixture):
+    del ray_local_session_fixture
     assert ray.is_initialized()
     max_path_length = 16
     env = TfEnv(PointEnv())
@@ -114,8 +85,8 @@ def test_update_envs_env_update(ray_local_test_fixture):
                                env_update=tasks.sample(n_workers + 1))
 
 
-def test_obtain_exact_trajectories(ray_local_test_fixture):
-    # pylint: disable=unused-argument
+def test_obtain_exact_trajectories(ray_local_session_fixture):
+    del ray_local_session_fixture
     assert ray.is_initialized()
     max_path_length = 15
     n_workers = 8
@@ -142,8 +113,8 @@ def test_obtain_exact_trajectories(ray_local_test_fixture):
         assert (rollout.actions == per_worker_actions[worker]).all()
 
 
-def test_init_with_env_updates(ray_local_test_fixture):
-    # pylint: disable=unused-argument
+def test_init_with_env_updates(ray_local_session_fixture):
+    del ray_local_session_fixture
     assert ray.is_initialized()
     max_path_length = 16
     env = TfEnv(PointEnv())

--- a/tests/garage/tf/experiment/test_local_tf_runner.py
+++ b/tests/garage/tf/experiment/test_local_tf_runner.py
@@ -140,8 +140,8 @@ class TestLocalRunner(TfGraphTestCase):
             assert isinstance(runner._sampler, LocalSampler)
             runner.train(n_epochs=1, batch_size=10)
 
-    def test_make_sampler_ray_sampler(self, ray_test_fixture):
-        # pylint: disable=unused-argument
+    def test_make_sampler_ray_sampler(self, ray_session_fixture):
+        del ray_session_fixture
         assert ray.is_initialized()
         with LocalTFRunner(snapshot_config) as runner:
             env = TfEnv(env_name='CartPole-v1')

--- a/tests/garage/tf/experiment/test_local_tf_runner.py
+++ b/tests/garage/tf/experiment/test_local_tf_runner.py
@@ -1,4 +1,5 @@
 import pytest
+import ray
 import tensorflow as tf
 
 from garage.np.baselines import LinearFeatureBaseline
@@ -139,7 +140,9 @@ class TestLocalRunner(TfGraphTestCase):
             assert isinstance(runner._sampler, LocalSampler)
             runner.train(n_epochs=1, batch_size=10)
 
-    def test_make_sampler_ray_sampler(self):
+    def test_make_sampler_ray_sampler(self, ray_test_fixture):
+        # pylint: disable=unused-argument
+        assert ray.is_initialized()
         with LocalTFRunner(snapshot_config) as runner:
             env = TfEnv(env_name='CartPole-v1')
 

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -39,8 +39,6 @@ class TestRaySamplerTF():
     """
 
     def setup_method(self):
-        ray.init(local_mode=True, ignore_reinit_error=True)
-
         self.env = TfEnv(GridWorldEnv(desc='4x4'))
         self.policy = ScriptedPolicy(
             scripted_actions=[2, 2, 1, 0, 3, 1, 1, 1, 2, 2, 1, 1, 1, 2, 2, 1])
@@ -51,7 +49,9 @@ class TestRaySamplerTF():
     def teardown_method(self):
         self.env.close()
 
-    def test_ray_batch_sampler(self):
+    def test_ray_batch_sampler(self, ray_test_fixture):
+        # pylint: disable=unused-argument
+        assert ray.is_initialized()
         workers = WorkerFactory(seed=100,
                                 max_path_length=self.algo.max_path_length)
         sampler1 = RaySampler(workers, self.policy, self.env)

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -49,8 +49,8 @@ class TestRaySamplerTF():
     def teardown_method(self):
         self.env.close()
 
-    def test_ray_batch_sampler(self, ray_local_test_fixture):
-        # pylint: disable=unused-argument
+    def test_ray_batch_sampler(self, ray_local_session_fixture):
+        del ray_local_session_fixture
         assert ray.is_initialized()
         workers = WorkerFactory(seed=100,
                                 max_path_length=self.algo.max_path_length)

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -49,7 +49,7 @@ class TestRaySamplerTF():
     def teardown_method(self):
         self.env.close()
 
-    def test_ray_batch_sampler(self, ray_test_fixture):
+    def test_ray_batch_sampler(self, ray_local_test_fixture):
         # pylint: disable=unused-argument
         assert ray.is_initialized()
         workers = WorkerFactory(seed=100,


### PR DESCRIPTION
- Ray sampler would routinely fail Travis CI and cause subsequent
  tests to fail.
- This is because the ray server would be reinited during
  newly added tests in non local ray mode. Local mode in ray makes
  code act serially, which is sufficient for our test suite.
- The newly added tests from the new sampler refactor were not apart of the ray_sampler test class,
  so ray would be inited in standard mode for these tests.
- Standard mode ray consumes more memory than is feasible for our
  travis compute instance.
- The fix was made by adding the tests to the ray_sampler test class,
  as opposed to them being standalone test functions.