### PR TITLE
Remove atari-py dep;Skip Defender envs in nightly tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ GYM_VERSION = '==0.15.4'
 REQUIRED = [
     # Please keep alphabetized
     'akro==0.0.6',
-    'atari-py<0.2.0',
     'cached_property',
     'click',
     'cloudpickle',

--- a/tests/garage/tf/envs/test_base.py
+++ b/tests/garage/tf/envs/test_base.py
@@ -17,12 +17,18 @@ class TestTfEnv:
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs(self, spec):
+        if spec._env_name.startswith('Defender'):
+            pytest.skip(
+                'Defender-* envs bundled in atari-py 0.2.x don\'t load')
         env = TfEnv(spec.make())
         step_env_with_gym_quirks(env, spec)
 
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs_pickleable(self, spec):
+        if spec._env_name.startswith('Defender'):
+            pytest.skip(
+                'Defender-* envs bundled in atari-py 0.2.x don\'t load')
         env = TfEnv(env_name=spec.id)
         step_env_with_gym_quirks(env,
                                  spec,


### PR DESCRIPTION
gym 0.13.0+ depends on atari-py~=0.2.0 which refuses to load the Defender-*. Downgrading atari-py brings additional headaches like breaking pipenv, which in itself is an issue, so dropping test support for those envs instead.

If really required, one can workaround the original issue of Defender envs not loading by replacing defender.bin in atari-py installation directory with the one from http://www.atarimania.com/rom_collection_archive_atari_2600_roms.html

Link to nightly tests run: https://travis-ci.com/rlworkgroup/garage/jobs/295193384