### PR TITLE
Fix torch compute_advantages

### DIFF
--- a/src/garage/torch/algos/_utils.py
+++ b/src/garage/torch/algos/_utils.py
@@ -110,7 +110,7 @@ def compute_advantages(discount, gae_lambda, max_path_length, baselines,
     deltas = (rewards + discount * F.pad(baselines, (0, 1))[:, 1:] - baselines)
     deltas = F.pad(deltas, (0, max_path_length - 1)).unsqueeze(0).unsqueeze(0)
 
-    advantages = F.conv2d(deltas, adv_filter, stride=1).squeeze()
+    advantages = F.conv2d(deltas, adv_filter, stride=1).reshape(rewards.shape)
     return advantages
 
 
@@ -158,4 +158,4 @@ def filter_valids(tensor, valids):
         torch.Tensor: Filtered Tensor
 
     """
-    return [tensor[i][:valids[i]] for i in range(len(valids))]
+    return [tensor[i][:valid] for i, valid in enumerate(valids)]

--- a/tests/garage/torch/algos/test_torch_algo_utils.py
+++ b/tests/garage/torch/algos/test_torch_algo_utils.py
@@ -1,11 +1,9 @@
 """Test torch algo utility functions."""
 import numpy as np
 import pytest
-import tensorflow as tf
 import torch
 import torch.nn.functional as F
 
-import garage.tf.misc.tensor_utils as tf_utils
 import garage.torch.algos._utils as torch_algo_utils
 from tests.fixtures import TfGraphTestCase
 
@@ -15,12 +13,11 @@ def stack(d, arr):
     return np.repeat(np.expand_dims(arr, axis=0), repeats=d, axis=0)
 
 
-ONES = np.ones((4, 6))
-ZEROS = np.zeros((4, 6))
-ARRANGE = stack(4, np.arange(6))
-PI_DIGITS = stack(4, [3, 1, 4, 1, 5, 9])
-E_DIGITS = stack(4, [2, 7, 1, 8, 2, 8])
-FIBS = stack(4, [1, 1, 2, 3, 5, 8])
+ONES = np.ones((6, ))
+ZEROS = np.zeros((6, ))
+ARRANGE = np.arange(6)
+PI_DIGITS = np.array([3, 1, 4, 1, 5, 9])
+FIBS = np.array([1, 1, 2, 3, 5, 8])
 
 nums_1d = np.arange(0, 4).astype(float)
 nums_2d = np.arange(0, 4).astype(float).reshape(2, 2)
@@ -30,39 +27,38 @@ nums_3d = np.arange(0, 8).astype(float).reshape(2, 2, 2)
 class TestTorchAlgoUtils(TfGraphTestCase):
     """Test class for torch algo utility functions."""
     # yapf: disable
-    @pytest.mark.parametrize('gae_lambda, rewards_val, baselines_val', [
-        (0.4, ONES, ZEROS),
-        (0.8, PI_DIGITS, ARRANGE),
-        (1.2, ONES, FIBS),
-        (1.7, E_DIGITS, PI_DIGITS),
+    @pytest.mark.parametrize('discount', [1, 0.95])
+    @pytest.mark.parametrize('num_trajs', [1, 5])
+    @pytest.mark.parametrize('gae_lambda', [0, 0.5, 1])
+    @pytest.mark.parametrize('rewards_traj, baselines_traj', [
+        (ONES, ZEROS),
+        (PI_DIGITS, ARRANGE),
+        (ONES, FIBS),
     ])
     # yapf: enable
-    def testcompute_advantages(self, gae_lambda, rewards_val, baselines_val):
+    def test_compute_advantages(self, num_trajs, discount, gae_lambda,
+                                rewards_traj, baselines_traj):
         """Test compute_advantage function."""
-        discount = 0.99
-        max_len = rewards_val.shape[-1]
 
-        torch_advs = torch_algo_utils.compute_advantages(
-            discount, gae_lambda, max_len, torch.Tensor(baselines_val),
-            torch.Tensor(rewards_val))
+        def get_advantage(discount, gae_lambda, rewards, baselines):
+            adv = torch.zeros(rewards.shape)
+            for i in range(rewards.shape[0]):
+                acc = 0
+                for j in range(rewards.shape[1]):
+                    acc = acc * discount * gae_lambda
+                    acc += rewards[i][-j - 1] - baselines[i][-j - 1]
+                    acc += discount * baselines[i][-j] if j else 0
+                    adv[i][-j - 1] = acc
+            return adv
 
-        rewards = tf.compat.v1.placeholder(dtype=tf.float32,
-                                           name='reward',
-                                           shape=[None, None])
-        baselines = tf.compat.v1.placeholder(dtype=tf.float32,
-                                             name='baseline',
-                                             shape=[None, None])
-        adv = tf_utils.compute_advantages(discount, gae_lambda, max_len,
-                                          baselines, rewards)
-        tf_advs = self.sess.run(adv,
-                                feed_dict={
-                                    rewards: rewards_val,
-                                    baselines: baselines_val,
-                                })
+        length = len(rewards_traj)
 
-        assert np.allclose(torch_advs.numpy(),
-                           tf_advs.reshape(torch_advs.shape),
-                           atol=1e-5)
+        rewards = torch.Tensor(stack(num_trajs, rewards_traj))
+        baselines = torch.Tensor(stack(num_trajs, baselines_traj))
+        expected_adv = get_advantage(discount, gae_lambda, rewards, baselines)
+        computed_adv = torch_algo_utils.compute_advantages(
+            discount, gae_lambda, length, baselines, rewards)
+        assert torch.allclose(expected_adv, computed_adv)
 
     def test_add_padding_last_1d(self):
         """Test pad_to_last function for 1d."""


### PR DESCRIPTION
Fix a bug that breaks `compute_advantage()` when rewards has a shape 
of like (1, N).  The expected shape of advantages is the same of that of 
rewards, but the Tensor.seqeeze() will wrongly squeeze out the 
the first dimension in such a case.

@Mergifyio backport release-2019.10