### PR TITLE
Flatten env_info of HalfCheetah* environments

### DIFF
--- a/src/garage/envs/half_cheetah_dir_env.py
+++ b/src/garage/envs/half_cheetah_dir_env.py
@@ -31,7 +31,6 @@ class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):
 
     def __init__(self, task=None):
         task = task or {'direction': 1.}
-        self._task = task
         self._goal_dir = task['direction']
         super().__init__()
 
@@ -54,9 +53,8 @@ class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):
                         control cost.
                     * reward_ctrl (float): The reward for acting i.e. the
                         control cost (always negative).
-                    * task (dict):
-                        * direction (float): 1.0 for forwards, -1.0 for
-                            backwards.
+                    * task_dir (float): Target direction. 1.0 for forwards,
+                        -1.0 for backwards.
 
         """
         xposbefore = self.sim.data.qpos[0]
@@ -72,8 +70,8 @@ class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):
         done = False
         infos = dict(reward_forward=forward_reward,
                      reward_ctrl=-ctrl_cost,
-                     task=self._task)
-        return (observation, reward, done, infos)
+                     task_dir=self._goal_dir)
+        return observation, reward, done, infos
 
     def sample_tasks(self, num_tasks):
         """Sample a list of `num_tasks` tasks.
@@ -100,5 +98,4 @@ class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):
                 key, "direction", mapping to -1 or 1).
 
         """
-        self._task = task
         self._goal_dir = task['direction']

--- a/src/garage/envs/half_cheetah_vel_env.py
+++ b/src/garage/envs/half_cheetah_vel_env.py
@@ -31,7 +31,6 @@ class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):
 
     def __init__(self, task=None):
         task = task or {'velocity': 0.}
-        self._task = task
         self._goal_vel = task['velocity']
         super().__init__()
 
@@ -54,9 +53,8 @@ class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):
                         control cost.
                     * reward_ctrl (float): The reward for acting i.e. the
                         control cost (always negative).
-                    * task (dict):
-                        * velocity (float): Target velocity. Usually between 0
-                            and 2.
+                    * task_vel (float): Target velocity.
+                        Usually between 0 and 2.
 
         """
         xposbefore = self.sim.data.qpos[0]
@@ -72,8 +70,8 @@ class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):
         done = False
         infos = dict(reward_forward=forward_reward,
                      reward_ctrl=-ctrl_cost,
-                     task=self._task)
-        return (observation, reward, done, infos)
+                     task_vel=self._goal_vel)
+        return observation, reward, done, infos
 
     def sample_tasks(self, num_tasks):
         """Sample a list of `num_tasks` tasks.
@@ -99,5 +97,4 @@ class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):
                 key, "velocity", usually between 0 and 2).
 
         """
-        self._task = task
         self._goal_vel = task['velocity']


### PR DESCRIPTION
This PR flattens `env_info` of `HalfCheetahVel` and `HalfCheetahDir` to be a dict of only float. Previously, `env_info['task']` is a dict, but `env_info` should not have a value of dict type because it is not compatible with `TrajectoryBatch.concatenate()`.

Another option is to change `TrajectoryBatch` to make them compatible with each other. But since `env_info` already has flatten fields regarding reward (i.e. `reward_ctrl` and `reward_forward`) I think changing `HalfCheetah*` makes more sense. 