### PR TITLE
Normalize images in CategoricalCNNPolicy

### DIFF
--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -51,7 +51,7 @@ def run_task(snapshot_config, variant_data, *_):
         env = ClipReward(env)
         env = StackFrames(env, 4)
 
-        env = TfEnv(env)
+        env = TfEnv(env, is_image=True)
 
         replay_buffer = SimpleReplayBuffer(
             env_spec=env.spec,

--- a/examples/tf/ppo_memorize_digits.py
+++ b/examples/tf/ppo_memorize_digits.py
@@ -28,7 +28,7 @@ def run_task(snapshot_config, variant_data, *_):
 
     """
     with LocalTFRunner(snapshot_config=snapshot_config) as runner:
-        env = TfEnv(normalize(gym.make('MemorizeDigits-v0')))
+        env = TfEnv(normalize(gym.make('MemorizeDigits-v0')), is_image=True)
         policy = CategoricalCNNPolicy(env_spec=env.spec,
                                       conv_filters=(32, 64, 64),
                                       conv_filter_sizes=(5, 3, 2),

--- a/src/garage/envs/base.py
+++ b/src/garage/envs/base.py
@@ -41,10 +41,13 @@ class GarageEnv(gym.Wrapper):
         env_name (str): If the env_name is speficied, a gym environment
             with that name will be created. If such an environment does not
             exist, a `gym.error` is thrown.
+        is_image (bool): True if observations contain pixel values,
+            false otherwise. Setting this to true converts a gym.Spaces.Box
+            obs space to an akro.Image and normalizes pixel values.
 
     """
 
-    def __init__(self, env=None, env_name=''):
+    def __init__(self, env=None, env_name='', is_image=False):
         # Needed for deserialization
         self._env_name = env_name
         self._env = env
@@ -55,7 +58,8 @@ class GarageEnv(gym.Wrapper):
             super().__init__(env)
 
         self.action_space = akro.from_gym(self.env.action_space)
-        self.observation_space = akro.from_gym(self.env.observation_space)
+        self.observation_space = akro.from_gym(self.env.observation_space,
+                                               is_image=is_image)
         self.__spec = EnvSpec(action_space=self.action_space,
                               observation_space=self.observation_space)
 

--- a/src/garage/misc/tensor_utils.py
+++ b/src/garage/misc/tensor_utils.py
@@ -1,5 +1,4 @@
 """Utiliy functions for tensors."""
-import gym.spaces
 import numpy as np
 import scipy.signal
 
@@ -275,27 +274,21 @@ def truncate_tensor_dict(tensor_dict, truncated_len):
     return ret
 
 
-def normalize_pixel_batch(env_spec, observations):
+def normalize_pixel_batch(observations):
     """Normalize the observations (images).
 
-    If the observations appear to be flattened, attempts to unflatten them.
-
-    If the input are images, it normalized into range [0, 1].
+    Normalize pixel values to be between [0, 1].
 
     Args:
-        env_spec (garage.envs.EnvSpec): Environment specification.
         observations (numpy.ndarray): Observations from environment.
+            obses should be unflattened and should contain pixel
+            values.
 
     Returns:
         numpy.ndarray: Normalized observations.
 
     """
-    if isinstance(env_spec.observation_space, gym.spaces.Box):
-        if len(observations.shape) == 2:
-            observations = env_spec.observation_space.unflatten_n(observations)
-        if len(env_spec.observation_space.shape) == 3:
-            return [obs.astype(np.float32) / 255.0 for obs in observations]
-    return observations
+    return [obs.astype(np.float32) / 255.0 for obs in observations]
 
 
 def slice_nested_dict(dict_or_array, start, stop):

--- a/src/garage/sampler/off_policy_vectorized_sampler.py
+++ b/src/garage/sampler/off_policy_vectorized_sampler.py
@@ -7,6 +7,7 @@ It diffs from OnPolicyVectorizedSampler in two parts:
  from replay buffer, which only has buffer_batch_size.
  - It needs to add transitions to replay buffer throughout the rollout.
 """
+
 import itertools
 import pickle
 
@@ -93,15 +94,15 @@ class OffPolicyVectorizedSampler(BatchSampler):
 
         while n_samples < batch_size:
             policy.reset(completes)
-            input_obses = self.algo.env_spec.observation_space.flatten_n(obses)
-            obs_normalized = tensor_utils.normalize_pixel_batch(
-                self._env_spec, input_obses)
+            obs_space = self.algo.env_spec.observation_space
+            input_obses = obs_space.flatten_n(obses)
+
             if self.algo.es:
                 actions, agent_infos = self.algo.es.get_actions(
-                    itr, obs_normalized, self.algo.policy)
+                    itr, input_obses, self.algo.policy)
             else:
                 actions, agent_infos = self.algo.policy.get_actions(
-                    obs_normalized)
+                    input_obses)
 
             next_obses, rewards, dones, env_infos = \
                 self._vec_env.step(actions)

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -1,9 +1,9 @@
 """Deep Q-Learning Network algorithm."""
+import akro
 from dowel import tabular
 import numpy as np
 import tensorflow as tf
 
-from garage.misc.tensor_utils import normalize_pixel_batch
 from garage.np.algos.off_policy_rl_algorithm import OffPolicyRLAlgorithm
 from garage.tf.misc import tensor_utils
 
@@ -234,12 +234,13 @@ class DQN(OffPolicyRLAlgorithm):
         next_observations = transitions['next_observation']
         dones = transitions['terminal']
 
-        # normalize pixel to range [0, 1] since the samples stored in the
-        # replay buffer are of type uint8 and not normalized, for memory
-        # optimization
-        observations = normalize_pixel_batch(self.env_spec, observations)
-        next_observations = normalize_pixel_batch(self.env_spec,
-                                                  next_observations)
+        if isinstance(self.env_spec.observation_space, akro.Image):
+            if len(self.env_spec.observation_space.shape) < 3:
+                observations = self.env_spec.observation_space.unflatten_n(
+                    observations)
+                next_observations = self.env_spec.observation_space.\
+                    unflatten_n(next_observations)
+
         loss, _ = self._train_qf(observations, actions, rewards, dones,
                                  next_observations)
 

--- a/src/garage/tf/envs/base.py
+++ b/src/garage/tf/envs/base.py
@@ -7,24 +7,29 @@ from garage.envs import GarageEnv
 
 
 class TfEnv(GarageEnv):
-    """
-    Returns a TensorFlow wrapper class for gym.Env.
+    """Returns a TensorFlow wrapper class for gym.Env.
 
     Args:
         env (gym.Env): the env that will be wrapped
+        env_name (string): If the env_name is speficied, a gym environment
+            with that name will be created. If such an environment does not
+            exist, a `gym.error` is thrown.
+        is_image (bool): True if observations contain pixel values,
+            false otherwise. Setting this to true converts a gym.Spaces.Box
+            obs space to an akro.Image and normalizes pixel values.
     """
 
-    def __init__(self, env=None, env_name=''):
-        super().__init__(env, env_name)
+    def __init__(self, env=None, env_name='', is_image=False):
+        super().__init__(env, env_name, is_image=is_image)
         self.action_space = akro.from_gym(self.env.action_space)
-        self.observation_space = akro.from_gym(self.env.observation_space)
+        self.observation_space = akro.from_gym(self.env.observation_space,
+                                               is_image=is_image)
 
     @cached_property
     def max_episode_steps(self):
         """Return gym.Env's max episode steps.
 
         Returns:
-            max_episode_steps (int)
-
+            int: Max episode steps.
         """
         return self.env.spec.max_episode_steps

--- a/src/garage/tf/misc/tensor_utils.py
+++ b/src/garage/tf/misc/tensor_utils.py
@@ -1,11 +1,27 @@
-from collections import Iterable
+"""Tensor utility functions for tensorflow."""
 from collections import namedtuple
+from collections.abc import Iterable
 
 import numpy as np
 import tensorflow as tf
 
 
+# pylint: disable=unused-argument
+# yapf: disable
+# pylint: disable=missing-return-doc, missing-return-type-doc
 def compile_function(inputs, outputs, log_name=None):
+    """Compiles a tensorflow function using the current session.
+
+    Args:
+        inputs (list[tf.Tensor]): Inputs to the function. Can be a list of
+            inputs or just one.
+        outputs (list[tf.Tensor]): Outputs of the function. Can be a list of
+            outputs or just one.
+        log_name (string): Name of the function. This is None by default.
+
+    Returns:
+        function: Compiled tensorflow function.
+    """
 
     def run(*input_vals):
         sess = tf.compat.v1.get_default_session()
@@ -14,9 +30,13 @@ def compile_function(inputs, outputs, log_name=None):
     return run
 
 
+# yapf: enable
+# pylint: enable=missing-return-doc, missing-return-type-doc
+# pylint: enable=unused-argument
+
+
 def get_target_ops(variables, target_variables, tau=None):
-    """
-    Get target variables update operations.
+    """Get target variables update operations.
 
     In RL algorithms we often update target network every n
     steps. This function returns the tf.Operation for updating
@@ -27,10 +47,13 @@ def get_target_ops(variables, target_variables, tau=None):
 
     Args:
         variables (list[tf.Variable]): Soure variables for update.
-        target_variable (list[tf.Variable]): Target variables to
+        target_variables (list[tf.Variable]): Target variables to
             be updated.
         tau (float): Fraction to update. Set it to be None for
             hard-update.
+
+    Returns:
+        tf.Operation: Operation for updating the target variables.
     """
     update_ops = []
     init_ops = []
@@ -49,16 +72,46 @@ def get_target_ops(variables, target_variables, tau=None):
 
 
 def flatten_batch(t, name='flatten_batch'):
+    """Flatten a batch of observations.
+
+    Reshape a tensor of size (X, Y, Z) into (X*Y, Z)
+
+    Args:
+        t (tf.Tensor): Tensor to flatten.
+        name (string): Name of the operation.
+
+    Returns:
+        tf.Tensor: Flattened tensor.
+    """
     return tf.reshape(t, [-1] + list(t.shape[2:]), name=name)
 
 
 def flatten_batch_dict(d, name='flatten_batch_dict'):
+    """Flatten a batch of observations represented as a dict.
+
+    Args:
+        d (dict[tf.Tensor]): A dict of Tensors to flatten.
+        name (string): The name of the operation (None by default).
+
+    Returns:
+        dict[tf.Tensor]: A dict with flattened tensors.
+    """
     with tf.name_scope(name):
         return {k: flatten_batch(v) for k, v in d.items()}
 
 
 def filter_valids(t, valid, name='filter_valids'):
-    # 'valid' is either 0 or 1 with dtype of tf.float32
+    """Filter out tensor using valid array.
+
+    Args:
+        t (tf.Tensor): The tensor to filter.
+        valid (list[float]): Array of length of the valid values (either
+            0 or 1).
+        name (string): Name of the operation.
+
+    Returns:
+        tf.Tensor: Filtered Tensor.
+    """
     # Must round before cast to prevent floating-error
     return tf.dynamic_partition(t,
                                 tf.cast(tf.round(valid), tf.int32),
@@ -67,17 +120,50 @@ def filter_valids(t, valid, name='filter_valids'):
 
 
 def filter_valids_dict(d, valid, name='filter_valids_dict'):
+    """Filter valid values on a dict.
+
+    Args:
+        d (dict[tf.Tensor]): Dict of tensors to be filtered.
+        valid (list[float]): Array of length of the valid values (elements
+        can be either 0 or 1).
+        name (string): Name of the operation. None by default.
+
+    Returns:
+        dict[tf.Tensor]: Dict with filtered tensors.
+    """
     with tf.name_scope(name):
         return {k: filter_valids(v, valid) for k, v in d.items()}
 
 
 def graph_inputs(name, **kwargs):
+    """Creates a namedtuple of the given keys and values.
+
+    Args:
+        name (string): Name of the tuple.
+        kwargs (tf.Tensor): One or more tensor(s) to add to the
+            namedtuple's values. The parameter names are used as keys
+            in the namedtuple. Ex. obs1=tensor1, obs2=tensor2.
+
+    Returns:
+        namedtuple: Namedtuple containing the collection of variables
+            passed.
+    """
     Singleton = namedtuple(name, kwargs.keys())
     return Singleton(**kwargs)
 
 
+# yapf: disable
+# pylint: disable=missing-yield-doc
+# pylint: disable=missing-yield-type-doc
 def flatten_inputs(deep):
+    """Flattens an Iterable recursively.
 
+    Args:
+        deep (Iterable): An Iterable to flatten.
+
+    Returns:
+        List: The flattened result.
+    """
     def flatten(deep):
         for d in deep:
             if isinstance(d, Iterable) and not isinstance(
@@ -88,40 +174,81 @@ def flatten_inputs(deep):
 
     return list(flatten(deep))
 
+# pylint: enable=missing-yield-doc
+# pylint: enable=missing-yield-type-doc
+# yapf: enable
+
 
 def flatten_tensor_variables(ts):
+    """Flattens a list of tensors into a single, 1-dimensional tensor.
+
+    Args:
+        ts (Iterable): Iterable containing either tf.Tensors or arrays.
+
+    Returns:
+        tf.Tensor: Flattened Tensor.
+    """
     return tf.concat(axis=0,
                      values=[tf.reshape(x, [-1]) for x in ts],
                      name='flatten_tensor_variables')
 
 
-def unflatten_tensor_variables(flatarr, shapes, symb_arrs):
-    arrs = []
-    n = 0
-    for (shape, symb_arr) in zip(shapes, symb_arrs):
-        size = np.prod(list(shape))
-        arr = tf.reshape(flatarr[n:n + size], shape)
-        arrs.append(arr)
-        n += size
-    return arrs
-
-
 def new_tensor(name, ndim, dtype):
+    """Creates a placeholder tf.Tensor with the specified arguments.
+
+    Args:
+        name (string): Name of the tf.Tensor.
+        ndim (int): Number of dimensions of the tf.Tensor.
+        dtype (type): Data type of the tf.Tensor's contents.
+
+    Returns:
+        tf.Tensor: Placeholder tensor.
+    """
     return tf.compat.v1.placeholder(dtype=dtype,
                                     shape=[None] * ndim,
                                     name=name)
 
 
 def new_tensor_like(name, arr_like):
+    """Creates a new placeholder tf.Tensor similar to arr_like.
+
+    The new tf.Tensor has the same number of dimensions and
+    dtype as arr_like.
+
+    Args:
+        name (string): Name of the new tf.Tensor.
+        arr_like (tf.Tensor): Tensor to copy attributes from.
+
+    Returns:
+        tf.Tensor: New placeholder tensor.
+    """
     return new_tensor(name,
                       arr_like.get_shape().ndims, arr_like.dtype.base_dtype)
 
 
 def concat_tensor_list(tensor_list):
+    """Concatenates a list of tensors into one tensor.
+
+    Args:
+        tensor_list (list[ndarray]): list of tensors.
+
+    Return:
+        ndarray: Concatenated tensor.
+    """
     return np.concatenate(tensor_list, axis=0)
 
 
 def concat_tensor_dict_list(tensor_dict_list):
+    """Concatenates a dict of tensors lists.
+
+    Each list of tensors gets concatenated into one tensor.
+
+    Args:
+        tensor_dict_list (dict[list[ndarray]]): Dict with lists of tensors.
+
+    Returns:
+        dict[ndarray]: A dict with the concatenated tensors.
+    """
     keys = list(tensor_dict_list[0].keys())
     ret = dict()
     for k in keys:
@@ -134,20 +261,16 @@ def concat_tensor_dict_list(tensor_dict_list):
     return ret
 
 
-def stack_tensor_list(tensor_list):
-    return np.array(tensor_list)
-    # tensor_shape = np.array(tensor_list[0]).shape
-    # if tensor_shape is tuple():
-    #     return np.array(tensor_list)
-    # return np.vstack(tensor_list)
-
-
 def stack_tensor_dict_list(tensor_dict_list):
-    """
-    Stack a list of dictionaries of {tensors or dictionary of tensors}.
-    :param tensor_dict_list: a list of dictionaries of {tensors or dictionary
-     of tensors}.
-    :return: a dictionary of {stacked tensors or dictionary of stacked tensors}
+    """Stack a list of dictionaries of {tensors or dictionary of tensors}.
+
+    Args:
+        tensor_dict_list (dict): a list of dictionaries of {tensors or
+            dictionary of tensors}.
+
+    Returns:
+        dict: a dictionary of {stacked tensors or dictionary of stacked
+            tensors}.
     """
     keys = list(tensor_dict_list[0].keys())
     ret = dict()
@@ -156,12 +279,21 @@ def stack_tensor_dict_list(tensor_dict_list):
         if isinstance(example, dict):
             v = stack_tensor_dict_list([x[k] for x in tensor_dict_list])
         else:
-            v = stack_tensor_list([x[k] for x in tensor_dict_list])
+            v = np.array([x[k] for x in tensor_dict_list])
         ret[k] = v
     return ret
 
 
 def split_tensor_dict_list(tensor_dict):
+    """Split a list of dictionaries of {tensors or dictionary of tensors}.
+
+    Args:
+        tensor_dict (dict): a list of dictionaries of {tensors or
+        dictionary of tensors}.
+
+    Returns:
+        dict: a dictionary of {split tensors or dictionary of split tensors}.
+    """
     keys = list(tensor_dict.keys())
     ret = None
     for k in keys:
@@ -177,6 +309,15 @@ def split_tensor_dict_list(tensor_dict):
 
 
 def pad_tensor(x, max_len):
+    """Pad tensors with zeros.
+
+    Args:
+        x (numpy.ndarray): Tensors to be padded.
+        max_len (int): Maximum length.
+
+    Returns:
+        numpy.ndarray: Padded tensor.
+    """
     return np.concatenate([
         x,
         np.tile(np.zeros_like(x[0]),
@@ -185,6 +326,15 @@ def pad_tensor(x, max_len):
 
 
 def pad_tensor_n(xs, max_len):
+    """Pad array of tensors.
+
+    Args:
+        xs (numpy.ndarray): Tensors to be padded.
+        max_len (int): Maximum length.
+
+    Returns:
+        numpy.ndarray: Padded tensor.
+    """
     ret = np.zeros((len(xs), max_len) + xs[0].shape[1:], dtype=xs[0].dtype)
     for idx, x in enumerate(xs):
         ret[idx][:len(x)] = x
@@ -192,6 +342,15 @@ def pad_tensor_n(xs, max_len):
 
 
 def pad_tensor_dict(tensor_dict, max_len):
+    """Pad dictionary of tensors with zeros.
+
+    Args:
+        tensor_dict (dict[numpy.ndarray]): Tensors to be padded.
+        max_len (int): Maximum length.
+
+    Returns:
+        dict[numpy.ndarray]: Padded tensor.
+    """
     keys = list(tensor_dict.keys())
     ret = dict()
     for k in keys:
@@ -208,33 +367,54 @@ def compute_advantages(discount,
                        baselines,
                        rewards,
                        name='compute_advantages'):
+    """Calculate advantages.
+
+    Advantages are a discounted cumulative sum.
+
+    The discount cumulative sum can be represented as an IIR
+    filter ob the reversed input vectors, i.e.
+
+    y[t] - discount*y[t+1] = x[t], or
+    rev(y)[t] - discount*rev(y)[t-1] = rev(x)[t]
+
+    Given the time-domain IIR filter step response, we can
+    calculate the filter response to our signal by convolving the
+    signal with the filter response function. The time-domain IIR
+    step response is calculated below as discount_filter:
+
+    discount_filter = [1, discount, discount^2, ..., discount^N-1]
+    where the epsiode length is N.
+
+    We convolve discount_filter with the reversed time-domain
+    signal deltas to calculate the reversed advantages:
+
+    rev(advantages) = discount_filter (X) rev(deltas)
+
+    TensorFlow's tf.nn.conv1d op is not a true convolution, but
+    actually a cross-correlation, so its input and output are
+    already implicitly reversed for us.
+
+    advantages = discount_filter (tf.nn.conv1d) deltas
+
+    Args:
+        discount (float): Discount factor.
+        gae_lambda (float): Lambda, as used for Generalized Advantage
+            Estimation (GAE).
+        max_len (int): Maximum length of a single rollout.
+        baselines (tf.Tensor): A 2D vector of value function estimates with
+            shape (N, T), where N is the batch dimension (number of episodes)
+            and T is the maximum path length experienced by the agent.
+        rewards (tf.Tensor): A 2D vector of per-step rewards with shape
+            (N, T), where N is the batch dimension (number of episodes) and T
+            is the maximum path length experienced by the agent.
+        name (string): Name of the operation.
+
+    Returns:
+        tf.Tensor: A 2D vector of calculated advantage values with shape
+            (N, T), where N is the batch dimension (number of episodes) and T
+            is the maximum path length experienced by the agent.
+    """
     with tf.name_scope(name):
-        # Calculate advantages
-        #
-        # Advantages are a discounted cumulative sum.
-        #
-        # The discount cumulative sum can be represented as an IIR
-        # filter ob the reversed input vectors, i.e.
-        #    y[t] - discount*y[t+1] = x[t]
-        #        or
-        #    rev(y)[t] - discount*rev(y)[t-1] = rev(x)[t]
-        #
-        # Given the time-domain IIR filter step response, we can
-        # calculate the filter response to our signal by convolving the
-        # signal with the filter response function. The time-domain IIR
-        # step response is calculated below as discount_filter:
-        #     discount_filter =
-        #         [1, discount, discount^2, ..., discount^N-1]
-        #         where the epsiode length is N.
-        #
-        # We convolve discount_filter with the reversed time-domain
-        # signal deltas to calculate the reversed advantages:
-        #     rev(advantages) = discount_filter (X) rev(deltas)
-        #
-        # TensorFlow's tf.nn.conv1d op is not a true convolution, but
-        # actually a cross-correlation, so its input and output are
-        # already implicitly reversed for us.
-        #    advantages = discount_filter (tf.nn.conv1d) deltas
 
         # Prepare convolutional IIR filter to calculate advantages
         gamma_lambda = tf.constant(float(discount) * float(gae_lambda),
@@ -246,6 +426,7 @@ def compute_advantages(discount,
         pad = tf.zeros_like(baselines[:, :1])
         baseline_shift = tf.concat([baselines[:, 1:], pad], 1)
         deltas = rewards + discount * baseline_shift - baselines
+
         # Convolve deltas with the discount filter to get advantages
         deltas_pad = tf.expand_dims(tf.concat(
             [deltas, tf.zeros_like(deltas[:, :-1])], axis=1),
@@ -259,7 +440,24 @@ def compute_advantages(discount,
 
 
 def center_advs(advs, axes, eps, offset=0, scale=1, name='center_adv'):
-    """ Normalize the advs tensor """
+    """Normalize the advs tensor.
+
+    This calculates the mean and variance using the axes specified
+    and normalizes the tensor using those values.
+
+    Args:
+        advs (tf.Tensor): Tensor to normalize.
+        axes (array[int]): Axes along which to compute the mean and variance.
+        eps (float): Small number to avoid dividing by zero.
+        offset (tf.Tensor): Offset added to the normalized tensor.
+            This is zero by default.
+        scale (tf.Tensor): Scale to apply to the normalized tensor. This is
+            1 by default but can also be None.
+        name (string): Name of the operation. None by default.
+
+    Returns:
+        tf.Tensor: Normalized, scaled and offset tensor.
+    """
     with tf.name_scope(name):
         mean, var = tf.nn.moments(advs, axes=axes)
         advs = tf.nn.batch_normalization(advs, mean, var, offset, scale, eps)
@@ -267,7 +465,19 @@ def center_advs(advs, axes, eps, offset=0, scale=1, name='center_adv'):
 
 
 def positive_advs(advs, eps, name='positive_adv'):
-    """ Make all the values in the advs tensor positive """
+    """Make all the values in the advs tensor positive.
+
+    Offsets all values in advs by the minimum value in
+    the tensor, plus an epsilon value to avoid dividing by zero.
+
+    Args:
+        advs (tf.Tensor): The tensor to offset.
+        eps (tf.float32): A small value to avoid by-zero division.
+        name (string): Name of the operation.
+
+    Returns:
+        tf.Tensor: Tensor with modified (postiive) values.
+    """
     with tf.name_scope(name):
         m = tf.reduce_min(advs)
         advs = (advs - m) + eps
@@ -275,6 +485,19 @@ def positive_advs(advs, eps, name='positive_adv'):
 
 
 def discounted_returns(discount, max_len, rewards, name='discounted_returns'):
+    """Calculate discounted returns.
+
+    Args:
+        discount (float): Discount factor.
+        max_len (int): Maximum length of a single rollout.
+        rewards (tf.Tensor): A 2D vector of per-step rewards with shape
+            (N, T), where N is the batch dimension (number of episodes) and T
+            is the maximum path length experienced by the agent.
+        name (string): Name of the operation. None by default.
+
+    Returns:
+        tf.Tensor: Tensor of discounted returns.
+    """
     with tf.name_scope(name):
         gamma = tf.constant(float(discount),
                             dtype=tf.float32,

--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -55,6 +55,11 @@ class DiscreteQfDerivedPolicy(Policy):
                 dict since there is no parameterization.
 
         """
+        if isinstance(self.env_spec.observation_space, akro.Image) and \
+                len(observation.shape) < \
+                len(self.env_spec.observation_space.shape):
+            observation = self.env_spec.observation_space.unflatten(
+                observation)
         q_vals = self._f_qval([observation])
         opt_action = np.argmax(q_vals)
 
@@ -72,6 +77,11 @@ class DiscreteQfDerivedPolicy(Policy):
                 dict since there is no parameterization.
 
         """
+        if isinstance(self.env_spec.observation_space, akro.Image) and \
+                len(observations[0].shape) < \
+                len(self.env_spec.observation_space.shape):
+            observations = self.env_spec.observation_space.unflatten_n(
+                observations)
         q_vals = self._f_qval(observations)
         opt_actions = np.argmax(q_vals, axis=1)
 

--- a/tests/garage/misc/test_tensor_utils.py
+++ b/tests/garage/misc/test_tensor_utils.py
@@ -11,7 +11,6 @@ from garage.misc.tensor_utils import pad_tensor
 from garage.misc.tensor_utils import stack_and_pad_tensor_dict_list
 from garage.misc.tensor_utils import stack_tensor_dict_list
 from garage.tf.envs import TfEnv
-from tests.fixtures.envs.dummy import DummyBoxEnv
 from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
@@ -35,18 +34,12 @@ class TestTensorUtil:
         self.max_len = 10
         self.tensor = [1, 1, 1]
 
-    def test_normalize_pixel_patch(self):
-        env = TfEnv(DummyDiscretePixelEnv())
+    def test_normalize_pixel_batch(self):
+        env = TfEnv(DummyDiscretePixelEnv(), is_image=True)
         obs = env.reset()
-        obs_normalized = normalize_pixel_batch(env, obs)
+        obs_normalized = normalize_pixel_batch(obs)
         expected = [ob / 255.0 for ob in obs]
         assert np.allclose(obs_normalized, expected)
-
-    def test_normalize_pixel_patch_not_trigger(self):
-        env = TfEnv(DummyBoxEnv())
-        obs = env.reset()
-        obs_normalized = normalize_pixel_batch(env, obs)
-        assert np.array_equal(obs, obs_normalized)
 
     def test_concat_tensor_dict_list(self):
         results = concat_tensor_dict_list(self.data)

--- a/tests/garage/tf/misc/test_tensor_utils.py
+++ b/tests/garage/tf/misc/test_tensor_utils.py
@@ -10,15 +10,18 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestTensorUtil(TfGraphTestCase):
+
     def test_compute_advantages(self):
         """Tests compute_advantages function in utils."""
         discount = 1
         gae_lambda = 1
         max_len = 1
-        rewards = tf.compat.v1.placeholder(
-            dtype=tf.float32, name='reward', shape=[None, None])
-        baselines = tf.compat.v1.placeholder(
-            dtype=tf.float32, name='baseline', shape=[None, None])
+        rewards = tf.compat.v1.placeholder(dtype=tf.float32,
+                                           name='reward',
+                                           shape=[None, None])
+        baselines = tf.compat.v1.placeholder(dtype=tf.float32,
+                                             name='baseline',
+                                             shape=[None, None])
         adv = compute_advantages(discount, gae_lambda, max_len, baselines,
                                  rewards)
 
@@ -27,17 +30,17 @@ class TestTensorUtil(TfGraphTestCase):
         baselines_val = np.zeros(shape=[2, 1])
         desired_val = np.array([1., 1.])
 
-        adv = self.sess.run(
-            adv, feed_dict={
-                rewards: rewards_val,
-                baselines: baselines_val,
-            })
+        adv = self.sess.run(adv,
+                            feed_dict={
+                                rewards: rewards_val,
+                                baselines: baselines_val,
+                            })
 
         assert np.array_equal(adv, desired_val)
 
     def test_get_target_ops(self):
-        var = tf.compat.v1.get_variable(
-            'var', [1], initializer=tf.constant_initializer(1))
+        var = tf.compat.v1.get_variable('var', [1],
+                                        initializer=tf.constant_initializer(1))
         target_var = tf.compat.v1.get_variable(
             'target_var', [1], initializer=tf.constant_initializer(2))
         self.sess.run(tf.compat.v1.global_variables_initializer())
@@ -47,8 +50,8 @@ class TestTensorUtil(TfGraphTestCase):
         assert target_var.eval() == 1
 
     def test_get_target_ops_tau(self):
-        var = tf.compat.v1.get_variable(
-            'var', [1], initializer=tf.constant_initializer(1))
+        var = tf.compat.v1.get_variable('var', [1],
+                                        initializer=tf.constant_initializer(1))
         target_var = tf.compat.v1.get_variable(
             'target_var', [1], initializer=tf.constant_initializer(2))
         self.sess.run(tf.compat.v1.global_variables_initializer())

--- a/tests/garage/tf/q_functions/test_discrete_cnn_q_function.py
+++ b/tests/garage/tf/q_functions/test_discrete_cnn_q_function.py
@@ -6,8 +6,10 @@ import pytest
 import tensorflow as tf
 
 from garage.tf.envs import TfEnv
+from garage.tf.models import CNNModel
 from garage.tf.q_functions import DiscreteCNNQFunction
 from tests.fixtures import TfGraphTestCase
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
 from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 from tests.fixtures.models import SimpleCNNModel
 from tests.fixtures.models import SimpleCNNModelWithMaxPooling
@@ -15,6 +17,7 @@ from tests.fixtures.models import SimpleMLPModel
 
 
 class TestDiscreteCNNQFunction(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.env = TfEnv(DummyDiscretePixelEnv())
@@ -34,12 +37,11 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    dueling=False)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          dueling=False)
 
         action_dim = self.env.action_space.n
         expected_output = np.full(action_dim, 0.5)
@@ -49,6 +51,88 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             qf.q_vals, feed_dict={qf.input: [self.obs, self.obs, self.obs]})
         for output in outputs:
             assert np.array_equal(output, expected_output)
+
+    @pytest.mark.parametrize('obs_dim', [[1], [2], [1, 1, 1, 1], [2, 2, 2, 2]])
+    def test_invalid_obs_shape(self, obs_dim):
+        boxEnv = TfEnv(DummyDiscreteEnv(obs_dim=obs_dim))
+        with pytest.raises(ValueError):
+            DiscreteCNNQFunction(env_spec=boxEnv.spec,
+                                 filter_dims=(3, ),
+                                 num_filters=(5, ),
+                                 strides=(2, ),
+                                 dueling=False)
+
+    def test_obs_is_image(self):
+        image_env = TfEnv(DummyDiscretePixelEnv(), is_image=True)
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_cnn_policy.CNNModel._build'),
+                        autospec=True,
+                        side_effect=CNNModel._build) as build:
+
+            qf = DiscreteCNNQFunction(env_spec=image_env.spec,
+                                      filter_dims=(3, ),
+                                      num_filters=(5, ),
+                                      strides=(2, ),
+                                      dueling=False)
+            normalized_obs = build.call_args_list[0][0][1]
+
+            input_ph = tf.compat.v1.get_default_graph().get_tensor_by_name(
+                'obs:0')
+
+            fake_obs = [np.full(image_env.spec.observation_space.shape, 255)]
+            assert (self.sess.run(normalized_obs,
+                                  feed_dict={input_ph: fake_obs}) == 1.).all()
+
+            obs_dim = image_env.spec.observation_space.shape
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, ) + obs_dim)
+
+            qf.get_qval_sym(state_input, name='another')
+            normalized_obs = build.call_args_list[1][0][1]
+
+            input_ph = tf.compat.v1.get_default_graph().get_tensor_by_name(
+                'Placeholder:0')
+
+            fake_obs = [np.full(image_env.spec.observation_space.shape, 255)]
+            assert (self.sess.run(normalized_obs,
+                                  feed_dict={input_ph: fake_obs}) == 1.).all()
+
+    def test_obs_not_image(self):
+        env = self.env
+        with mock.patch(('garage.tf.policies.'
+                         'categorical_cnn_policy.CNNModel._build'),
+                        autospec=True,
+                        side_effect=CNNModel._build) as build:
+
+            qf = DiscreteCNNQFunction(env_spec=env.spec,
+                                      filter_dims=(3, ),
+                                      num_filters=(5, ),
+                                      strides=(2, ),
+                                      dueling=False)
+            normalized_obs = build.call_args_list[0][0][1]
+
+            input_ph = tf.compat.v1.get_default_graph().get_tensor_by_name(
+                'obs:0')
+
+            fake_obs = [np.full(env.spec.observation_space.shape, 255)]
+            assert (self.sess.run(normalized_obs,
+                                  feed_dict={input_ph:
+                                             fake_obs}) == 255.).all()
+
+            obs_dim = env.spec.observation_space.shape
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, ) + obs_dim)
+
+            qf.get_qval_sym(state_input, name='another')
+            normalized_obs = build.call_args_list[1][0][1]
+
+            input_ph = tf.compat.v1.get_default_graph().get_tensor_by_name(
+                'Placeholder:0')
+
+            fake_obs = [np.full(env.spec.observation_space.shape, 255)]
+            assert (self.sess.run(normalized_obs,
+                                  feed_dict={input_ph:
+                                             fake_obs}) == 255).all()
 
     # yapf: disable
     @pytest.mark.parametrize('filter_dims, num_filters, strides', [
@@ -64,12 +148,11 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPDuelingModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    dueling=True)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          dueling=True)
 
         action_dim = self.env.action_space.n
         expected_output = np.full(action_dim, 0.5)
@@ -97,15 +180,14 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    max_pooling=True,
-                    pool_strides=pool_strides,
-                    pool_shapes=pool_shapes,
-                    dueling=False)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          max_pooling=True,
+                                          pool_strides=pool_strides,
+                                          pool_shapes=pool_shapes,
+                                          dueling=False)
 
         action_dim = self.env.action_space.n
         expected_output = np.full(action_dim, 0.5)
@@ -130,19 +212,18 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    dueling=False)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          dueling=False)
         output1 = self.sess.run(qf.q_vals, feed_dict={qf.input: [self.obs]})
 
         obs_dim = self.env.observation_space.shape
         action_dim = self.env.action_space.n
 
-        input_var = tf.compat.v1.placeholder(
-            tf.float32, shape=(None, ) + obs_dim)
+        input_var = tf.compat.v1.placeholder(tf.float32,
+                                             shape=(None, ) + obs_dim)
         q_vals = qf.get_qval_sym(input_var, 'another')
         output2 = self.sess.run(q_vals, feed_dict={input_var: [self.obs]})
 
@@ -165,12 +246,11 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    dueling=False)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          dueling=False)
         with tf.compat.v1.variable_scope(
                 'DiscreteCNNQFunction/Sequential/SimpleMLPModel', reuse=True):
             return_var = tf.compat.v1.get_variable('return_var')
@@ -182,8 +262,8 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
         h_data = pickle.dumps(qf)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             qf_pickled = pickle.loads(h_data)
-            output2 = sess.run(
-                qf_pickled.q_vals, feed_dict={qf_pickled.input: [self.obs]})
+            output2 = sess.run(qf_pickled.q_vals,
+                               feed_dict={qf_pickled.input: [self.obs]})
 
         assert np.array_equal(output1, output2)
 
@@ -201,12 +281,11 @@ class TestDiscreteCNNQFunction(TfGraphTestCase):
             with mock.patch(('garage.tf.q_functions.'
                              'discrete_cnn_q_function.MLPModel'),
                             new=SimpleMLPModel):
-                qf = DiscreteCNNQFunction(
-                    env_spec=self.env.spec,
-                    filter_dims=filter_dims,
-                    num_filters=num_filters,
-                    strides=strides,
-                    dueling=False)
+                qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                          filter_dims=filter_dims,
+                                          num_filters=num_filters,
+                                          strides=strides,
+                                          dueling=False)
         qf_clone = qf.clone('another_qf')
         assert qf_clone._filter_dims == qf._filter_dims
         assert qf_clone._num_filters == qf._num_filters


### PR DESCRIPTION
Normalizes pixel values and accepts uint8 inputs (addresses [#734](https://github.com/rlworkgroup/garage/issues/734))