### PR TITLE
Use a GH token in the CI to retrieve packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
     - name: "Large tests"
       env: JOB_RUN_CMD="make ci-job-large"
     - if: type != pull_request OR head_repo = "rlworkgroup/garage"
-      name: "Mujoco based tests"
+      name: "MuJoCo-based tests"
       env:
         - JOB_RUN_CMD="make ci-job-mujoco"
     - name: "Verify conda and pipenv installations"

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ run-ci:
 		-e TRAVIS_COMMIT_RANGE \
 		-e TRAVIS \
 		-e MJKEY \
+		-e GARAGE_GH_TOKEN \
 		--memory 7500m \
 		--memory-swap 7500m \
 		${RUN_ARGS} \

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ EXTRAS['dm_control'] = [
     # command again and the install succeeds because absl-py has been
     # installed. This is stupid, but harmless.
     'dm_control @ https://{}@api.github.com/repos/deepmind/dm_control/tarball/7a36377879c57777e5d5b4da5aae2cd2a29b607a'.format(GARAGE_GH_TOKEN),  # noqa: E501
-]
+]  # yapf: disable
 
 EXTRAS['all'] = list(set(sum(EXTRAS.values(), [])))
 
@@ -83,7 +83,7 @@ EXTRAS['dev'] = [
     'sphinx',
     'sphinx_rtd_theme',
     'yapf==0.28.0',
-]
+]  # yapf: disable
 
 with open('README.md') as f:
     README = f.read()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 """setuptools based setup module."""
+import os
+
 from setuptools import find_packages
 from setuptools import setup
 
+GARAGE_GH_TOKEN = os.environ.get('GARAGE_GH_TOKEN') or 'git'
 TF_VERSION = '<1.16,>=1.15.0'
 GYM_VERSION = '==0.15.4'
 
@@ -46,7 +49,7 @@ EXTRAS['dm_control'] = [
     # find a build dependency (absl-py). Later pip executes the `install`
     # command again and the install succeeds because absl-py has been
     # installed. This is stupid, but harmless.
-    'dm_control @ https://api.github.com/repos/deepmind/dm_control/tarball/7a36377879c57777e5d5b4da5aae2cd2a29b607a',  # noqa: E501
+    'dm_control @ https://{}@api.github.com/repos/deepmind/dm_control/tarball/7a36377879c57777e5d5b4da5aae2cd2a29b607a'.format(GARAGE_GH_TOKEN),  # noqa: E501
 ]
 
 EXTRAS['all'] = list(set(sum(EXTRAS.values(), [])))
@@ -57,13 +60,13 @@ EXTRAS['gpu'] = ['tensorflow-gpu' + TF_VERSION]
 # Development dependencies (*not* included in 'all')
 EXTRAS['dev'] = [
     # Please keep alphabetized
-    'baselines @ https://api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3',  # noqa: E501
+    'baselines @ https://{}@api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'flake8',
     'flake8-docstrings>=1.5.0',
     'flake8-import-order',
     'gtimer',
     'matplotlib',
-    'metaworld @ git+https://github.com/rlworkgroup/metaworld.git@dfdbc7cf495678ee96b360d1e6e199acc141b36c',  # noqa: E501
+    'metaworld @ https://{}@api.github.com/repos/rlworkgroup/metaworld/tarball/dfdbc7cf495678ee96b360d1e6e199acc141b36c'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'pandas',
     'pep8-naming==0.7.0',
     'pre-commit',
@@ -75,7 +78,7 @@ EXTRAS['dev'] = [
     'pytest-timeout',
     'pytest-xdist',
     'recommonmark',
-    'rlkit @ git+https://github.com/vitchyr/rlkit/@1d469a509b797ca04a39b8734c1816ca7d108fc8',  # noqa: E501
+    'rlkit @ https://{}@api.github.com/repos/vitchyr/rlkit/tarball/1d469a509b797ca04a39b8734c1816ca7d108fc8'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'seaborn',
     'sphinx',
     'sphinx_rtd_theme',


### PR DESCRIPTION
Recently the CI has been crippled by rate-limiting from GitHub, which
limits API requests from unauthenticated IP addresses to 60/hour. This
has broken our ability to retrieve source tarballs for non-PyPI
packages from Travis, which can schedule many jobs onto the same IP
address. We have never hit this rate limit in the past, and the root
cause of the behavior change is unclear (e.g. it could be recent Travis
incidents causing many jobs to repeatedly requests resources as part of
restart or recovery, a policy change by GitHub, or a change in Travis
scheduling strategies, etc.).

This PR allows setup.py to use an optional GitHub Personal Access token
to authenticate downloads. This is only active if the environment
variable `GARAGE_GH_TOKEN` is present, and otherwise uses the token
`'git'`, which signifies an unauthenicated request when using the GitHub
API.