### PR TITLE
Restrict test discovery to tests directory

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ extend-ignore =
 
 [tool:pytest]
 addopts = -n auto -rfE -s --strict-markers
+testpaths = tests
 markers =
     nightly
     huge


### PR DESCRIPTION
Currently pytest starts test discovery in root directory
of garage. This was also causing it to pickup an example
ending with `_meta_test` as a test. While it is possible to
tell pytest to pick only function of name pattern `test_*` and
not `*_test`, restricting the directory is more solid and
avoids unneccasry work.