### PR TITLE
Remove MuJoCo key for normal and large test jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL := /bin/bash
 
 .PHONY: help test check docs ci-job-normal ci-job-large ci-job-nightly \
-	ci-job-verify-envs ci-verify-conda ci-verify-pipenv build-ci \
-	build-headless build-nvidia run-ci run-headless run-nvidia
+	ci-job-verify-envs ci-verify-envs-conda ci-verify-envs-pipenv build-ci \
+	build-headless build-nvidia run-ci run-headless run-nvidia assert-docker
 
 .DEFAULT_GOAL := help
 
@@ -22,10 +22,10 @@ docs:  ## Build HTML documentation
 docs:
 	@pushd docs && make html && popd
 
-ci-job-precommit: docs
+ci-job-precommit: assert-docker docs
 	scripts/travisci/check_precommit.sh
 
-ci-job-normal:
+ci-job-normal: assert-docker
 	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
 	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
 	pytest --cov=garage -v -m \
@@ -33,28 +33,29 @@ ci-job-normal:
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
-ci-job-large:
+ci-job-large: assert-docker
 	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
 	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
 	pytest --cov=garage -v -m 'large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
-ci-job-mujoco:
-	pytest --cov=garage -v -m mujoco --durations=0
+ci-job-mujoco: assert-docker
+	pytest --cov=garage -v -m 'mujoco and not flaky' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
-ci-job-nightly:
+ci-job-nightly: assert-docker
 	pytest -v -m nightly
 
-# ci-job-verify-envs: ci-verify-conda ci-verify-pipenv
-ci-job-verify-envs: ci-verify-pipenv
+# ci-job-verify-envs: assert-docker ci-verify-envs-conda ci-verify-envs-pipenv
+ci-job-verify-envs: assert-docker ci-verify-envs-pipenv
 
-ci-verify-conda: CONDA_ROOT := $$HOME/miniconda
-ci-verify-conda: CONDA := $(CONDA_ROOT)/bin/conda
-ci-verify-conda: GARAGE_BIN = $(CONDA_ROOT)/envs/garage-ci/bin
-ci-verify-conda:
+ci-job-verify-envs-conda: assert-docker
+ci-job-verify-envs-conda: CONDA_ROOT := $$HOME/miniconda
+ci-job-verify-envs-conda: CONDA := $(CONDA_ROOT)/bin/conda
+ci-job-verify-envs-conda: GARAGE_BIN = $(CONDA_ROOT)/envs/garage-ci/bin
+ci-job-verify-envs-conda:
 	touch $(MJKEY_PATH)
 	wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 	bash miniconda.sh -b -p $(CONDA_ROOT)
@@ -77,9 +78,10 @@ ci-verify-conda:
 
 # The following two lines remove the Dockerfile's built-in virtualenv from the
 # path, so we can test with pipenv directly
-ci-verify-pipenv: export PATH=$(shell echo $$PATH | awk -v RS=: -v ORS=: '/venv/ {next} {print}')
-ci-verify-pipenv: export VIRTUAL_ENV=
-ci-verify-pipenv:
+ci-job-verify-envs-pipenv: assert-docker
+ci-job-verify-envs-pipenv: export PATH=$(shell echo $$PATH | awk -v RS=: -v ORS=: '/venv/ {next} {print}')
+ci-job-verify-envs-pipenv: export VIRTUAL_ENV=
+ci-job-verify-envs-pipenv:
 	touch $(MJKEY_PATH)
 	pip3 install --upgrade pipenv setuptools
 	pipenv --three
@@ -88,7 +90,7 @@ ci-verify-pipenv:
 	# pylint will verify all imports work
 	pipenv run pylint --disable=all --enable=import-error garage
 
-ci-deploy-docker:
+ci-deploy-docker: assert-travis
 	echo "${DOCKER_API_KEY}" | docker login -u "${DOCKER_USERNAME}" \
 		--password-stdin
 	docker tag "${TAG}" rlworkgroup/garage-ci:latest
@@ -161,6 +163,18 @@ run-nvidia: build-nvidia
 		--name $(CONTAINER_NAME) \
 		${RUN_ARGS} \
 		rlworkgroup/garage-nvidia ${RUN_CMD}
+
+# Checks that we are in a docker container
+assert-docker:
+	@test -f /proc/1/cgroup && /bin/grep -qa docker /proc/1/cgroup \
+		|| (echo 'This recipe is only to be run inside Docker.' && exit 1)
+
+# Checks that we are in a docker container
+assert-travis:
+ifndef TRAVIS
+	@echo 'This recipe is only to be run from TravisCI'
+	@exit 1
+endif
 
 # Help target
 # See https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,16 @@ ci-job-precommit: docs
 	scripts/travisci/check_precommit.sh
 
 ci-job-normal:
+	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
+	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
 	pytest --cov=garage -v -m \
 	    'not nightly and not huge and not flaky and not large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
 ci-job-large:
+	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
+	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
 	pytest --cov=garage -v -m 'large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ extend-ignore =
     F841  # Unused variables are checked by pylint
 
 [tool:pytest]
-addopts = -n auto -rfE -s --strict-markers
+addopts = -n auto -rfEs -s --strict-markers
 testpaths = tests
 markers =
     nightly

--- a/tests/garage/envs/test_half_cheetah_meta_envs.py
+++ b/tests/garage/envs/test_half_cheetah_meta_envs.py
@@ -15,6 +15,7 @@ from garage.envs.mujoco.half_cheetah_dir_env import HalfCheetahDirEnv
 from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 
 
+@pytest.mark.mujoco
 class TestMetaHalfCheetahEnvs:
 
     @pytest.mark.parametrize('env_type',

--- a/tests/garage/experiment/test_task_sampler.py
+++ b/tests/garage/experiment/test_task_sampler.py
@@ -19,7 +19,7 @@ from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 from garage.experiment import task_sampler
 
 
-@pytest.mark.large
+@pytest.mark.mujoco
 def test_env_pool_sampler():
     # Import, construct environments here to avoid using up too much
     # resources if this test isn't run.
@@ -47,7 +47,7 @@ def test_env_pool_sampler():
     tasks.sample(20)
 
 
-@pytest.mark.large
+@pytest.mark.mujoco
 def test_construct_envs_sampler_ml10():
     # pylint: disable=import-outside-toplevel
     from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_ARGS_KWARGS
@@ -73,7 +73,7 @@ def test_construct_envs_sampler_ml10():
     env.close.assert_called()
 
 
-@pytest.mark.large
+@pytest.mark.mujoco
 def test_set_task_task_sampler_ml10():
     # pylint: disable=import-outside-toplevel
     from metaworld.benchmarks import ML10
@@ -90,6 +90,7 @@ def test_set_task_task_sampler_ml10():
     env.close.assert_not_called()
 
 
+@pytest.mark.mujoco
 def test_set_task_task_sampler_half_cheetah_vel_env():
     tasks = task_sampler.SetTaskSampler(HalfCheetahVelEnv)
     assert tasks.n_tasks is None

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -19,7 +19,6 @@ from tests.fixtures import snapshot_config, TfGraphTestCase
 class TestDDPG(TfGraphTestCase):
     """Tests for DDPG algorithm."""
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_ddpg_double_pendulum(self):
         """Test DDPG with Pendulum environment."""
@@ -56,7 +55,6 @@ class TestDDPG(TfGraphTestCase):
 
             env.close()
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_ddpg_pendulum(self):
         """Test DDPG with Pendulum environment.
@@ -97,7 +95,6 @@ class TestDDPG(TfGraphTestCase):
             env.close()
 
     @pytest.mark.mujoco
-    @pytest.mark.large
     def test_ddpg_pendulum_with_decayed_weights(self):
         """Test DDPG with Pendulum environment and decayed weights.
 

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -31,7 +31,6 @@ class TestNPO(TfGraphTestCase):
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_npo_pendulum(self):
         """Test NPO with Pendulum environment."""

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -39,8 +39,6 @@ class TestPPO(TfGraphTestCase):
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
 
-    # large marker removed to balance test jobs
-    # @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_pendulum(self):
         """Test PPO with Pendulum environment."""
@@ -56,8 +54,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 35
 
-    # large marker removed to balance test jobs
-    # @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_with_maximum_entropy(self):
         """Test PPO with maxium entropy method."""
@@ -77,8 +73,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 35
 
-    # large marker removed to balance test jobs
-    # @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_with_neg_log_likeli_entropy_estimation_and_max(self):
         """
@@ -102,8 +96,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 35
 
-    # large marker removed to balance test jobs
-    # @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_with_neg_log_likeli_entropy_estimation_and_regularized(self):
         """
@@ -127,8 +119,6 @@ class TestPPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 35
 
-    # large marker removed to balance test jobs
-    # @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_with_regularized_entropy(self):
         """Test PPO with regularized entropy method."""
@@ -185,7 +175,6 @@ class TestPPO(TfGraphTestCase):
 class TestPPOContinuousBaseline(TfGraphTestCase):
 
     @pytest.mark.huge
-    @pytest.mark.mujoco
     def test_ppo_pendulum_continuous_baseline(self):
         """Test PPO with Pendulum environment."""
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
@@ -223,7 +212,6 @@ class TestPPOContinuousBaseline(TfGraphTestCase):
 
             env.close()
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_pendulum_recurrent_continuous_baseline(self):
         """Test PPO with Pendulum environment and recurrent policy."""
@@ -260,7 +248,6 @@ class TestPPOContinuousBaseline(TfGraphTestCase):
 
 class TestPPOPendulumLSTM(TfGraphTestCase):
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_pendulum_lstm(self):
         """Test PPO with Pendulum environment and recurrent policy."""
@@ -295,7 +282,6 @@ class TestPPOPendulumLSTM(TfGraphTestCase):
 
 class TestPPOPendulumGRU(TfGraphTestCase):
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_ppo_pendulum_gru(self):
         """Test PPO with Pendulum environment and recurrent policy."""

--- a/tests/garage/tf/algos/test_rl2ppo.py
+++ b/tests/garage/tf/algos/test_rl2ppo.py
@@ -28,6 +28,7 @@ from garage.tf.policies import GaussianGRUPolicy
 from tests.fixtures import snapshot_config, TfGraphTestCase
 
 
+@pytest.mark.mujoco
 class TestRL2PPO(TfGraphTestCase):
 
     def setup_method(self):

--- a/tests/garage/tf/algos/test_rl2trpo.py
+++ b/tests/garage/tf/algos/test_rl2trpo.py
@@ -31,6 +31,7 @@ from garage.tf.policies import GaussianGRUPolicy
 from tests.fixtures import snapshot_config, TfGraphTestCase
 
 
+@pytest.mark.mujoco
 class TestRL2TRPO(TfGraphTestCase):
 
     def setup_method(self):

--- a/tests/garage/tf/algos/test_tnpg.py
+++ b/tests/garage/tf/algos/test_tnpg.py
@@ -12,7 +12,6 @@ from tests.fixtures import snapshot_config, TfGraphTestCase
 
 class TestTNPG(TfGraphTestCase):
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_tnpg_inverted_pendulum(self):
         """Test TNPG with InvertedPendulum-v2 environment."""

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -39,7 +39,6 @@ class TestTRPO(TfGraphTestCase):
             regressor_args=dict(hidden_sizes=(32, 32)),
         )
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
@@ -70,7 +69,6 @@ class TestTRPO(TfGraphTestCase):
                 kl_constraint='random kl_constraint',
             )
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_trpo_soft_kl_constraint(self):
         """Test TRPO with unkown KL constraints."""
@@ -87,7 +85,6 @@ class TestTRPO(TfGraphTestCase):
             last_avg_ret = runner.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 45
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_trpo_lstm_cartpole(self):
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
@@ -113,7 +110,6 @@ class TestTRPO(TfGraphTestCase):
 
             env.close()
 
-    @pytest.mark.large
     @pytest.mark.mujoco
     def test_trpo_gru_cartpole(self):
         deterministic.set_seed(2)

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -19,7 +19,6 @@ class TestDDPG:
     """Test class for DDPG."""
 
     @pytest.mark.mujoco
-    @pytest.mark.large
     def test_ddpg_double_pendulum(self):
         """Test DDPG with Pendulum environment."""
         deterministic.set_seed(0)
@@ -58,7 +57,6 @@ class TestDDPG:
         env.close()
 
     @pytest.mark.mujoco
-    @pytest.mark.large
     def test_ddpg_pendulum(self):
         """Test DDPG with Pendulum environment.
 

--- a/tests/garage/torch/algos/test_maml.py
+++ b/tests/garage/torch/algos/test_maml.py
@@ -2,6 +2,17 @@
 from functools import partial
 
 import pytest
+try:
+    # pylint: disable=unused-import
+    import mujoco_py  # noqa: F401
+except ImportError:
+    pytest.skip('To use mujoco-based features, please install garage[mujoco].',
+                allow_module_level=True)
+except Exception:  # pylint: disable=broad-except
+    pytest.skip(
+        'Skipping tests, failed to import mujoco. Do you have a '
+        'valid mujoco key installed?',
+        allow_module_level=True)
 import torch
 
 from garage.envs import normalize
@@ -13,6 +24,7 @@ from garage.torch.algos import MAMLPPO
 from garage.torch.policies import GaussianMLPPolicy
 
 
+@pytest.mark.mujoco
 class TestMAML:
     """Test class for MAML."""
 

--- a/tests/garage/torch/algos/test_maml_ppo.py
+++ b/tests/garage/torch/algos/test_maml_ppo.py
@@ -23,6 +23,7 @@ from garage.torch.policies import GaussianMLPPolicy
 from tests.fixtures import snapshot_config
 
 
+@pytest.mark.mujoco
 class TestMAMLPPO:
     """Test class for MAML-PPO."""
 

--- a/tests/garage/torch/algos/test_maml_trpo.py
+++ b/tests/garage/torch/algos/test_maml_trpo.py
@@ -24,6 +24,7 @@ from tests.fixtures import snapshot_config
 from tests.fixtures.envs.dummy import DummyMultiTaskBoxEnv
 
 
+@pytest.mark.mujoco
 def test_maml_trpo_pendulum():
     """Test PPO with Pendulum environment."""
     env = GarageEnv(normalize(HalfCheetahDirEnv(), expected_action_scale=10.))

--- a/tests/garage/torch/algos/test_maml_vpg.py
+++ b/tests/garage/torch/algos/test_maml_vpg.py
@@ -24,6 +24,7 @@ from garage.torch.policies import GaussianMLPPolicy
 from tests.fixtures import snapshot_config
 
 
+@pytest.mark.mujoco
 class TestMAMLVPG:
     """Test class for MAML-VPG."""
 

--- a/tests/garage/torch/algos/test_pearl.py
+++ b/tests/garage/torch/algos/test_pearl.py
@@ -28,6 +28,7 @@ import garage.torch.utils as tu
 from tests.fixtures import snapshot_config
 
 
+@pytest.mark.mujoco
 class TestPEARL:
     """Test class for PEARL."""
 

--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -135,7 +135,7 @@ def test_maml_halfcheetah():
                           check=False).returncode == 0
 
 
-@pytest.mark.large
+@pytest.mark.mujoco
 @pytest.mark.no_cover
 @pytest.mark.timeout(120)
 def test_pearl_ml1_push():
@@ -164,6 +164,7 @@ def test_maml_ml10():
                           check=False).returncode == 0
 
 
+@pytest.mark.mujoco
 @pytest.mark.no_cover
 @pytest.mark.timeout(30)
 def test_maml_trpo():
@@ -175,6 +176,7 @@ def test_maml_trpo():
                           check=False).returncode == 0
 
 
+@pytest.mark.mujoco
 @pytest.mark.no_cover
 @pytest.mark.timeout(30)
 def test_maml_ppo():
@@ -186,6 +188,7 @@ def test_maml_ppo():
                           check=False).returncode == 0
 
 
+@pytest.mark.mujoco
 @pytest.mark.no_cover
 @pytest.mark.timeout(30)
 def test_maml_vpg():


### PR DESCRIPTION
to make sure that no mujoco based tests slip into
either normal or large test jobs, since both of
these jobs are run for external PRs where mujoco
key is not present.

* Exclude flaky tests from MuJoCo test job