### PR TITLE
Fix experiment 'name' scope

### DIFF
--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -388,11 +388,11 @@ class ExperimentTemplate:
         if args:
             raise ValueError('garage.experiment currently only supports '
                              'keyword arguments')
+        name = self.name
+        if name is None:
+            name = self.function.__name__
         log_dir = self.log_dir
         if log_dir is None:
-            name = self.name
-            if name is None:
-                name = self.function.__name__
             log_dir = ('{data}/local/{prefix}/{name}'.format(
                 data=os.path.join(os.getcwd(), 'data'),
                 prefix=self.prefix,


### PR DESCRIPTION
Fix leaves `name` in scope for use [here](https://github.com/rlworkgroup/garage/blob/52049c330995b442ab3efaf312cbc789071a1990/src/garage/experiment/experiment.py#L419)

@zhanpenghe @krzentner  