### PR TITLE
Fix policy gradient algorithm constructor arguments

### DIFF
--- a/examples/tf/rl2_ppo_halfcheetah.py
+++ b/examples/tf/rl2_ppo_halfcheetah.py
@@ -60,7 +60,6 @@ def rl2_ppo_halfcheetah(ctxt, seed, max_path_length, meta_batch_size, n_epochs,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
-                      pg_loss='surrogate_clip',
                       optimizer_args=dict(
                           batch_size=32,
                           max_epochs=10,

--- a/examples/tf/rl2_ppo_halfcheetah_meta_test.py
+++ b/examples/tf/rl2_ppo_halfcheetah_meta_test.py
@@ -67,7 +67,6 @@ def rl2_ppo_halfcheetah_meta_test(ctxt, seed, max_path_length, meta_batch_size,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
-                      pg_loss='surrogate_clip',
                       optimizer_args=dict(
                           batch_size=32,
                           max_epochs=10,

--- a/examples/tf/rl2_ppo_ml10.py
+++ b/examples/tf/rl2_ppo_ml10.py
@@ -64,7 +64,6 @@ def rl2_ppo_ml10(ctxt, seed, max_path_length, meta_batch_size, n_epochs,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
-                      pg_loss='surrogate_clip',
                       optimizer_args=dict(
                           batch_size=32,
                           max_epochs=10,

--- a/examples/tf/rl2_ppo_ml10_meta_test.py
+++ b/examples/tf/rl2_ppo_ml10_meta_test.py
@@ -77,7 +77,6 @@ def rl2_ppo_ml10_meta_test(ctxt, seed, max_path_length, meta_batch_size,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
-                      pg_loss='surrogate_clip',
                       optimizer_args=dict(
                           batch_size=32,
                           max_epochs=10,

--- a/examples/tf/rl2_ppo_ml45.py
+++ b/examples/tf/rl2_ppo_ml45.py
@@ -66,7 +66,6 @@ def rl2_ppo_ml45(ctxt, seed, max_path_length, meta_batch_size, n_epochs,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
-                      pg_loss='surrogate_clip',
                       optimizer_args=dict(
                           batch_size=32,
                           max_epochs=10,

--- a/src/garage/tf/algos/erwr.py
+++ b/src/garage/tf/algos/erwr.py
@@ -1,3 +1,4 @@
+"""Episodic Reward Weighted Regression."""
 from garage.tf.algos.vpg import VPG
 from garage.tf.optimizers import LbfgsOptimizer
 
@@ -37,8 +38,6 @@ class ERWR(VPG):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -59,7 +58,11 @@ class ERWR(VPG):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -73,7 +76,6 @@ class ERWR(VPG):
                  center_adv=True,
                  positive_adv=True,
                  fixed_horizon=False,
-                 pg_loss='vanilla',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -83,30 +85,30 @@ class ERWR(VPG):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
                  name='ERWR'):
         if optimizer is None:
             optimizer = LbfgsOptimizer
             if optimizer_args is None:
                 optimizer_args = dict()
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         name=name)

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -27,8 +27,6 @@ class PPO(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -53,6 +51,7 @@ class PPO(NPO):
             dimension. If True, for example, an observation with shape (2, 4)
             will be flattened to 8.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -66,7 +65,6 @@ class PPO(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='surrogate_clip',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -92,7 +90,7 @@ class PPO(NPO):
                          center_adv=center_adv,
                          positive_adv=positive_adv,
                          fixed_horizon=fixed_horizon,
-                         pg_loss=pg_loss,
+                         pg_loss='surrogate_clip',
                          lr_clip_range=lr_clip_range,
                          max_kl_step=max_kl_step,
                          optimizer=optimizer,

--- a/src/garage/tf/algos/rl2ppo.py
+++ b/src/garage/tf/algos/rl2ppo.py
@@ -32,8 +32,6 @@ class RL2PPO(RL2):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -77,7 +75,6 @@ class RL2PPO(RL2):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='surrogate_clip',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer_args=None,
@@ -105,7 +102,7 @@ class RL2PPO(RL2):
                          center_adv=center_adv,
                          positive_adv=positive_adv,
                          fixed_horizon=fixed_horizon,
-                         pg_loss=pg_loss,
+                         pg_loss='surrogate_clip',
                          lr_clip_range=lr_clip_range,
                          max_kl_step=max_kl_step,
                          optimizer=FirstOrderOptimizer,

--- a/src/garage/tf/algos/rl2trpo.py
+++ b/src/garage/tf/algos/rl2trpo.py
@@ -33,8 +33,6 @@ class RL2TRPO(RL2):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -81,7 +79,6 @@ class RL2TRPO(RL2):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='surrogate',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -120,7 +117,7 @@ class RL2TRPO(RL2):
                          center_adv=center_adv,
                          positive_adv=positive_adv,
                          fixed_horizon=fixed_horizon,
-                         pg_loss=pg_loss,
+                         pg_loss='surrogate',
                          lr_clip_range=lr_clip_range,
                          max_kl_step=max_kl_step,
                          optimizer=optimizer,

--- a/src/garage/tf/algos/tnpg.py
+++ b/src/garage/tf/algos/tnpg.py
@@ -1,3 +1,4 @@
+"""Truncated Natural Policy Gradient."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import ConjugateGradientOptimizer
 
@@ -26,8 +27,6 @@ class TNPG(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -48,7 +47,11 @@ class TNPG(NPO):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -62,7 +65,6 @@ class TNPG(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='surrogate',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -72,6 +74,7 @@ class TNPG(NPO):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
                  name='TNPG'):
         if optimizer is None:
             optimizer = ConjugateGradientOptimizer
@@ -80,25 +83,25 @@ class TNPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss='surrogate',
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         flatten_input=flatten_input,
+                         name=name)

--- a/src/garage/tf/algos/trpo.py
+++ b/src/garage/tf/algos/trpo.py
@@ -28,8 +28,6 @@ class TRPO(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -45,12 +43,17 @@ class TRPO(NPO):
         use_neg_logli_entropy (bool): Whether to estimate the entropy as the
             negative log likelihood of the action.
         stop_entropy_gradient (bool): Whether to stop the entropy gradient.
+        kl_constraint (str): KL constraint, either 'hard' or 'soft'.
         entropy_method (str): A string from: 'max', 'regularized',
             'no_entropy'. The type of entropy method to use. 'max' adds the
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -64,7 +67,6 @@ class TRPO(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='surrogate',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -98,7 +100,7 @@ class TRPO(NPO):
                          center_adv=center_adv,
                          positive_adv=positive_adv,
                          fixed_horizon=fixed_horizon,
-                         pg_loss=pg_loss,
+                         pg_loss='surrogate',
                          lr_clip_range=lr_clip_range,
                          max_kl_step=max_kl_step,
                          optimizer=optimizer,

--- a/src/garage/tf/algos/vpg.py
+++ b/src/garage/tf/algos/vpg.py
@@ -1,3 +1,4 @@
+"""Vanilla Policy Gradient."""
 from garage.tf.algos.npo import NPO
 from garage.tf.optimizers import FirstOrderOptimizer
 
@@ -24,8 +25,6 @@ class VPG(NPO):
             conjunction with center_adv the advantages will be
             standardized before shifting.
         fixed_horizon (bool): Whether to fix horizon.
-        pg_loss (str): A string from: 'vanilla', 'surrogate',
-            'surrogate_clip'. The type of loss functions to use.
         lr_clip_range (float): The limit on the likelihood ratio between
             policies, as in PPO.
         max_kl_step (float): The maximum KL divergence between old and new
@@ -46,7 +45,11 @@ class VPG(NPO):
             dense entropy to the reward for each time step. 'regularized' adds
             the mean entropy to the surrogate objective. See
             https://arxiv.org/abs/1805.00909 for more details.
+        flatten_input (bool): Whether to flatten input along the observation
+            dimension. If True, for example, an observation with shape (2, 4)
+            will be flattened to 8.
         name (str): The name of the algorithm.
+
     """
 
     def __init__(self,
@@ -60,7 +63,6 @@ class VPG(NPO):
                  center_adv=True,
                  positive_adv=False,
                  fixed_horizon=False,
-                 pg_loss='vanilla',
                  lr_clip_range=0.01,
                  max_kl_step=0.01,
                  optimizer=None,
@@ -70,6 +72,7 @@ class VPG(NPO):
                  use_neg_logli_entropy=False,
                  stop_entropy_gradient=False,
                  entropy_method='no_entropy',
+                 flatten_input=True,
                  name='VPG'):
         if optimizer is None:
             default_args = dict(
@@ -81,25 +84,24 @@ class VPG(NPO):
                 optimizer_args = default_args
             else:
                 optimizer_args = dict(default_args, **optimizer_args)
-        super().__init__(
-            env_spec=env_spec,
-            policy=policy,
-            baseline=baseline,
-            scope=scope,
-            max_path_length=max_path_length,
-            discount=discount,
-            gae_lambda=gae_lambda,
-            center_adv=center_adv,
-            positive_adv=positive_adv,
-            fixed_horizon=fixed_horizon,
-            pg_loss=pg_loss,
-            lr_clip_range=lr_clip_range,
-            max_kl_step=max_kl_step,
-            optimizer=optimizer,
-            optimizer_args=optimizer_args,
-            policy_ent_coeff=policy_ent_coeff,
-            use_softplus_entropy=use_softplus_entropy,
-            use_neg_logli_entropy=use_neg_logli_entropy,
-            stop_entropy_gradient=stop_entropy_gradient,
-            entropy_method=entropy_method,
-            name=name)
+        super().__init__(env_spec=env_spec,
+                         policy=policy,
+                         baseline=baseline,
+                         scope=scope,
+                         max_path_length=max_path_length,
+                         discount=discount,
+                         gae_lambda=gae_lambda,
+                         center_adv=center_adv,
+                         positive_adv=positive_adv,
+                         fixed_horizon=fixed_horizon,
+                         pg_loss='vanilla',
+                         lr_clip_range=lr_clip_range,
+                         max_kl_step=max_kl_step,
+                         optimizer=optimizer,
+                         optimizer_args=optimizer_args,
+                         policy_ent_coeff=policy_ent_coeff,
+                         use_softplus_entropy=use_softplus_entropy,
+                         use_neg_logli_entropy=use_neg_logli_entropy,
+                         stop_entropy_gradient=stop_entropy_gradient,
+                         entropy_method=entropy_method,
+                         name=name)

--- a/tests/garage/tf/algos/test_rl2ppo.py
+++ b/tests/garage/tf/algos/test_rl2ppo.py
@@ -57,7 +57,6 @@ class TestRL2PPO(TfGraphTestCase):
                           discount=0.99,
                           gae_lambda=0.95,
                           lr_clip_range=0.2,
-                          pg_loss='surrogate_clip',
                           stop_entropy_gradient=True,
                           entropy_method='max',
                           policy_ent_coeff=0.02,
@@ -105,7 +104,6 @@ class TestRL2PPO(TfGraphTestCase):
                           discount=0.99,
                           gae_lambda=0.95,
                           lr_clip_range=0.2,
-                          pg_loss='surrogate_clip',
                           stop_entropy_gradient=True,
                           entropy_method='max',
                           policy_ent_coeff=0.02,
@@ -143,7 +141,6 @@ class TestRL2PPO(TfGraphTestCase):
                           discount=0.99,
                           gae_lambda=0.95,
                           lr_clip_range=0.2,
-                          pg_loss='surrogate_clip',
                           optimizer_args=dict(
                               batch_size=32,
                               max_epochs=10,
@@ -180,7 +177,6 @@ class TestRL2PPO(TfGraphTestCase):
                           discount=0.99,
                           gae_lambda=0.95,
                           lr_clip_range=0.2,
-                          pg_loss='surrogate_clip',
                           optimizer_args=dict(
                               batch_size=32,
                               max_epochs=10,
@@ -209,7 +205,6 @@ class TestRL2PPO(TfGraphTestCase):
                           discount=0.99,
                           gae_lambda=0.95,
                           lr_clip_range=0.2,
-                          pg_loss='surrogate_clip',
                           optimizer_args=dict(
                               batch_size=32,
                               max_epochs=10,
@@ -243,7 +238,6 @@ class TestRL2PPO(TfGraphTestCase):
                               discount=0.99,
                               gae_lambda=0.95,
                               lr_clip_range=0.2,
-                              pg_loss='surrogate_clip',
                               optimizer_args=dict(
                                   batch_size=32,
                                   max_epochs=10,


### PR DESCRIPTION
This PR adds missing docstring and arguments to all policy gradient algorithms, and also remove unnecessary `pg_loss` option in most algorithms.