### PR TITLE
Remove superfluous manual example tests

### DIFF
--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -20,7 +20,6 @@ LONG_RUNNING_EXAMPLES = [
     EXAMPLES_ROOT_DIR / 'tf/ppo_memorize_digits.py',
     EXAMPLES_ROOT_DIR / 'tf/dqn_pong.py',
     EXAMPLES_ROOT_DIR / 'tf/trpo_cubecrash.py',
-    EXAMPLES_ROOT_DIR / 'tf/trpo_swimmer_ray_sampler.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_ppo_half_cheetah_dir.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_trpo_half_cheetah_dir.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_vpg_half_cheetah_dir.py',
@@ -30,9 +29,6 @@ LONG_RUNNING_EXAMPLES = [
     EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_ml10.py',
     EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_ml10_meta_test.py',
     EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_ml45.py',
-    EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_halfcheetah.py',
-    EXAMPLES_ROOT_DIR / 'tf/rl2_trpo_halfcheetah.py',
-    EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_halfcheetah_meta_test.py'
 ]
 # yapf: enable
 
@@ -222,42 +218,6 @@ def test_maml_vpg():
     assert subprocess.run([
         EXAMPLES_ROOT_DIR / 'torch/maml_vpg_half_cheetah_dir.py', '--epochs',
         '1', '--rollouts_per_task', '1', '--meta_batch_size', '1'
-    ],
-                          check=False).returncode == 0
-
-
-@pytest.mark.mujoco
-@pytest.mark.no_cover
-@pytest.mark.timeout(40)
-def test_rl2_ppo_halfcheetah():
-    """Test rl2_ppo_halfcheetah.py."""
-    assert subprocess.run([
-        EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_halfcheetah.py', '--n_epochs', '1',
-        '--episode_per_task', '4', '--meta_batch_size', '10'
-    ],
-                          check=False).returncode == 0
-
-
-@pytest.mark.mujoco
-@pytest.mark.no_cover
-@pytest.mark.timeout(40)
-def test_rl2_trpo_halfcheetah():
-    """Test rl2_trpo_halfcheetah.py."""
-    assert subprocess.run([
-        EXAMPLES_ROOT_DIR / 'tf/rl2_trpo_halfcheetah.py', '--n_epochs', '1',
-        '--episode_per_task', '4', '--meta_batch_size', '10'
-    ],
-                          check=False).returncode == 0
-
-
-@pytest.mark.mujoco
-@pytest.mark.no_cover
-@pytest.mark.timeout(80)
-def test_rl2_ppo_halfcheetah_meta_test():
-    """Test rl2_ppo_halfcheetah_meta_test.py."""
-    assert subprocess.run([
-        EXAMPLES_ROOT_DIR / 'tf/rl2_ppo_halfcheetah_meta_test.py',
-        '--n_epochs', '1', '--episode_per_task', '4', '--meta_batch_size', '10'
     ],
                           check=False).returncode == 0
 


### PR DESCRIPTION
These tests can be easily covered by test_algo_examples test within its defined timeout