### PR TITLE
Fix TF plotter

### DIFF
--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -446,7 +446,10 @@ class LocalRunner:
 
         self._plot = plot
 
-        return self._algo.train(self)
+        average_return = self._algo.train(self)
+        self._shutdown_worker()
+
+        return average_return
 
     def step_epochs(self):
         """Step through each epoch.

--- a/src/garage/tf/models/base.py
+++ b/src/garage/tf/models/base.py
@@ -43,7 +43,7 @@ class BaseModel(abc.ABC):
             name (str): Name of the model.
 
         Return:
-            object: Output(s) of the model.
+            list[tf.Tensor]: Output(s) of the model.
 
         """
 
@@ -60,7 +60,7 @@ class BaseModel(abc.ABC):
         function model.
 
         Returns:
-            list[object]: Parameters.
+            list[tf.Tensor]: Parameters.
 
         """
 
@@ -69,7 +69,7 @@ class BaseModel(abc.ABC):
         """Set parameters of the Model.
 
         Args:
-            parameters (list[object]): Parameters.
+            parameters (list[tf.Tensor]): Parameters.
 
         """
 

--- a/src/garage/tf/models/base.py
+++ b/src/garage/tf/models/base.py
@@ -7,8 +7,7 @@ import tensorflow as tf
 
 
 class BaseModel(abc.ABC):
-    """
-    Interface-only abstract class for models.
+    """Interface-only abstract class for models.
 
     A Model contains the structure/configuration of a set of computation
     graphs, or can be understood as a set of networks. Using a model
@@ -32,47 +31,51 @@ class BaseModel(abc.ABC):
 
     """
 
-    def build(self, *inputs):
-        """
-        Output of model with the given input placeholder(s).
+    def build(self, *inputs, name=None):
+        """Output of model with the given input placeholder(s).
 
         This function is implemented by subclasses to create their computation
         graphs, which will be managed by Model. Generally, subclasses should
         implement `build()` directly.
 
         Args:
-            inputs: Tensor input(s) for the model.
+            inputs (object): Input(s) for the model.
+            name (str): Name of the model.
 
         Return:
-            output: Tensor output(s) of the model.
+            object: Output(s) of the model.
+
         """
-        pass
 
     @property
     def name(self):
         """Name for this Model."""
-        pass
 
     @property
     def parameters(self):
-        """
-        Parameters of the Model.
+        """Parameters of the Model.
 
         The output of a model is determined by its parameter. It could be
         the weights of a neural network model or parameters of a loss
         function model.
+
+        Returns:
+            list[object]: Parameters.
+
         """
-        pass
 
     @parameters.setter
     def parameters(self, parameters):
-        """Set parameters of the Model."""
-        pass
+        """Set parameters of the Model.
+
+        Args:
+            parameters (list[object]): Parameters.
+
+        """
 
 
 class Network:
-    """
-    Network class For TensorFlow.
+    """Network class For TensorFlow.
 
     A Network contains connectivity information by inputs/outputs.
     When a Network is built, it appears as a subgraph in the computation
@@ -80,30 +83,53 @@ class Network:
     model share the same parameters, i.e same inputs yield to same outputs.
     """
 
+    def __init__(self):
+        self._inputs = None
+        self._outputs = None
+
     @property
     def input(self):
-        """Tensor input of the Network."""
+        """Tensor input of the Network.
+
+        Returns:
+            tf.Tensor: Input.
+
+        """
         return self._inputs[0]
 
     @property
     def inputs(self):
-        """Tensor inputs of the Network."""
+        """Tensor inputs of the Network.
+
+        Returns:
+            list[tf.Tensor]: Inputs.
+
+        """
         return self._inputs
 
     @property
     def output(self):
-        """Tensor output of the Network."""
+        """Tensor output of the Network.
+
+        Returns:
+            tf.Tensor: Output.
+
+        """
         return self._outputs[0]
 
     @property
     def outputs(self):
-        """Tensor outputs of the Network."""
+        """Tensor outputs of the Network.
+
+        Returns:
+            list[tf.Tensor]: Outputs.
+
+        """
         return self._outputs
 
 
 class Model(BaseModel):
-    r"""
-    Model class for TensorFlow.
+    r"""Model class for TensorFlow.
 
     A TfModel only contains the structure/configuration of the underlying
     computation graphs. Connectivity information are all in Network class.
@@ -148,7 +174,8 @@ class Model(BaseModel):
 
     Args:
       name (str): Name of the model. It will also become the variable scope
-      of the model. Every model should have a unique name.
+          of the model. Every model should have a unique name.
+
     """
 
     def __init__(self, name):
@@ -158,9 +185,9 @@ class Model(BaseModel):
         self._default_parameters = None
         self._variable_scope = None
 
+    # pylint: disable=protected-access, assignment-from-no-return
     def build(self, *inputs, name=None):
-        """
-        Build a Network with the given input(s).
+        """Build a Network with the given input(s).
 
         ***
         Do not call tf.global_variable_initializers() after building a model
@@ -172,18 +199,18 @@ class Model(BaseModel):
         parameter sharing. Different Networks must have an unique name.
 
         Args:
-          inputs (list[tf.Tensor]) : Tensor input(s), recommended to be
-            positional arguments, for example,
-            def build(self, state_input, action_input, name=None).
-          name (str): Name of the model, which is also the name scope of the
-            model.
+            inputs (list[tf.Tensor]) : Tensor input(s), recommended to be
+                positional arguments, for example,
+                def build(self, state_input, action_input, name=None).
+            name (str): Name of the model, which is also the name scope of the
+                model.
 
         Raises:
-          ValueError when a Network with the same name is already built.
+            ValueError: When a Network with the same name is already built.
 
         Returns:
-          outputs (list[tf.Tensor]): Output tensors of the model with the given
-            inputs.
+            list[tf.Tensor]: Output tensors of the model with the given
+                inputs.
 
         """
         network_name = name or 'default'
@@ -205,9 +232,9 @@ class Model(BaseModel):
             if network_name in self._networks:
                 raise ValueError(
                     'Network {} already exists!'.format(network_name))
-            with tf.compat.v1.variable_scope(
-                    self._variable_scope, reuse=True,
-                    auxiliary_name_scope=False):
+            with tf.compat.v1.variable_scope(self._variable_scope,
+                                             reuse=True,
+                                             auxiliary_name_scope=False):
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
@@ -236,51 +263,62 @@ class Model(BaseModel):
         return network.outputs
 
     def _build(self, *inputs, name=None):
-        """
-        Output of the model given input placeholder(s).
+        """Output of the model given input placeholder(s).
 
         User should implement _build() inside their subclassed model,
         and construct the computation graphs in this function.
 
         Args:
             inputs: Tensor input(s), recommended to be position arguments, e.g.
-              def _build(self, state_input, action_input, name=None).
-              It would be usually same as the inputs in build().
+                def _build(self, state_input, action_input, name=None).
+                It would be usually same as the inputs in build().
             name (str): Inner model name, also the variable scope of the
                 inner model, if exist. One example is
                 garage.tf.models.Sequential.
 
         Return:
-            output: Tensor output(s) of the model.
-        """
-        pass
+            list[tf.Tensor]: Tensor output(s) of the model.
 
-    def network_input_spec(self):
         """
-        Network input spec.
+
+    # pylint: disable=no-self-use
+    def network_input_spec(self):
+        """Network input spec.
 
         Return:
-            *inputs (list[str]): List of key(str) for the network inputs.
+            list[str]: List of key(str) for the network inputs.
+
         """
         return []
 
+    # pylint: disable=no-self-use
     def network_output_spec(self):
-        """
-        Network output spec.
+        """Network output spec.
 
         Return:
-            *inputs (list[str]): List of key(str) for the network outputs.
+            list[str]: List of key(str) for the network outputs.
+
         """
         return []
 
     @property
     def networks(self):
-        """Networks of the model."""
+        """Networks of the model.
+
+        Returns:
+            dict[str: Network]: Networks.
+
+        """
         return self._networks
 
     @property
     def parameters(self):
-        """Parameters of the model."""
+        """Parameters of the model.
+
+        Returns:
+            np.ndarray: Parameters
+
+        """
         _variables = self._get_variables()
         if _variables:
             return tf.compat.v1.get_default_session().run(_variables)
@@ -289,7 +327,12 @@ class Model(BaseModel):
 
     @parameters.setter
     def parameters(self, parameters):
-        """Set model parameters."""
+        """Set model parameters.
+
+        Args:
+            parameters (tf.Tensor): Parameters.
+
+        """
         variables = self._get_variables()
         for name, var in variables.items():
             if name in parameters:
@@ -299,71 +342,102 @@ class Model(BaseModel):
 
     @property
     def name(self):
-        """
-        Name (str) of the model.
+        """Name (str) of the model.
 
         This is also the variable scope of the model.
+
+        Returns:
+            str: Name of the model.
+
         """
         return self._name
 
     @property
     def input(self):
-        """
-        Default input (tf.Tensor) of the model.
+        """Default input of the model.
 
         When the model is built the first time, by default it
         creates the 'default' network. This property creates
         a reference to the input of the network.
+
+        Returns:
+            tf.Tensor: Default input of the model.
+
         """
         return self.networks['default'].input
 
     @property
     def output(self):
-        """
-        Default output (tf.Tensor) of the model.
+        """Default output of the model.
 
         When the model is built the first time, by default it
         creates the 'default' network. This property creates
         a reference to the output of the network.
+
+        Returns:
+            tf.Tensor: Default output of the model.
+
         """
         return self.networks['default'].output
 
     @property
     def inputs(self):
-        """
-        Default inputs (tf.Tensor) of the model.
+        """Default inputs of the model.
 
         When the model is built the first time, by default it
         creates the 'default' network. This property creates
         a reference to the inputs of the network.
+
+        Returns:
+            list[tf.Tensor]: Default inputs of the model.
+
         """
         return self.networks['default'].inputs
 
     @property
     def outputs(self):
-        """
-        Default outputs (tf.Tensor) of the model.
+        """Default outputs of the model.
 
         When the model is built the first time, by default it
         creates the 'default' network. This property creates
         a reference to the outputs of the network.
+
+        Returns:
+            list[tf.Tensor]: Default outputs of the model.
+
         """
         return self.networks['default'].outputs
 
     def _get_variables(self):
+        """Get variables of this model.
+
+        Returns:
+            dict[str: tf.Tensor]: Variables of this model.
+
+        """
         if self._variable_scope:
             return {v.name: v for v in self._variable_scope.global_variables()}
         else:
             return dict()
 
     def __getstate__(self):
-        """Object.__getstate__."""
+        """Get the pickle state.
+
+        Returns:
+            dict: The pickled state.
+
+        """
         new_dict = self.__dict__.copy()
         del new_dict['_networks']
         new_dict['_default_parameters'] = self.parameters
         return new_dict
 
     def __setstate__(self, state):
-        """Object.__setstate__."""
+        """Object.__setstate__.
+
+        Args:
+            state (dict): unpickled state.
+
+        """
         self.__dict__.update(state)
         self._networks = {}

--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -56,7 +56,7 @@ class Plotter:
         self.sess = tf.compat.v1.Session() if sess is None else sess
         self.graph = tf.compat.v1.get_default_graph(
         ) if graph is None else graph
-        with self.sess.as_default(), self.sess.graph.as_default():
+        with self.sess.as_default(), self.graph.as_default():
             self._policy = policy.clone('plotter_policy')
         self.rollout = rollout
         self.worker_thread = Thread(target=self._start_worker, daemon=True)

--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -53,11 +53,11 @@ class Plotter:
                  rollout=default_rollout):
         Plotter.__plotters.append(self)
         self._env = env
-        self._policy = policy
         self.sess = tf.compat.v1.Session() if sess is None else sess
-
         self.graph = tf.compat.v1.get_default_graph(
         ) if graph is None else graph
+        with self.sess.as_default(), self.sess.graph.as_default():
+            self._policy = policy.clone('plotter_policy')
         self.rollout = rollout
         self.worker_thread = Thread(target=self._start_worker, daemon=True)
         self.queue = Queue()

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -9,7 +9,7 @@ from garage.tf.policies import StochasticPolicy
 
 
 class CategoricalLSTMPolicy(StochasticPolicy):
-    """CategoricalLSTMPolicy
+    """Estimate action distribution with Categorical parameterized by a LSTM.
 
     A policy that contains a LSTM to make prediction based on
     a categorical distribution.
@@ -59,6 +59,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             at initialization. It's used to reduce the scale of forgetting at
             the beginning of the training.
         layer_normalization (bool): Bool for using layer normalization or not.
+
     """
 
     def __init__(self,
@@ -88,12 +89,21 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         self._obs_dim = env_spec.observation_space.flat_dim
         self._action_dim = env_spec.action_space.n
         self._hidden_dim = hidden_dim
+        self._hidden_nonlinearity = hidden_nonlinearity
+        self._hidden_w_init = hidden_w_init
+        self._hidden_b_init = hidden_b_init
+        self._recurrent_nonlinearity = recurrent_nonlinearity
+        self._recurrent_w_init = recurrent_w_init
         self._state_include_action = state_include_action
         self._output_nonlinearity = output_nonlinearity
         self._output_w_init = output_w_init
         self._output_b_init = output_b_init
         self._hidden_state_init = hidden_state_init
+        self._hidden_state_init_trainable = hidden_state_init_trainable
         self._cell_state_init = cell_state_init
+        self._cell_stat_init_trainable = cell_state_init_trainable
+        self._forget_bias = forget_bias
+        self._layere_normalization = layer_normalization
 
         if state_include_action:
             self._input_dim = self._obs_dim + self._action_dim
@@ -155,11 +165,28 @@ class CategoricalLSTMPolicy(StochasticPolicy):
 
     @property
     def vectorized(self):
-        """Vectorized or not."""
+        """Vectorized or not.
+
+        Returns:
+            Bool: True if primitive supports vectorized operations.
+
+        """
         return True
 
     def dist_info_sym(self, obs_var, state_info_vars, name=None):
-        """Symbolic graph of the distribution."""
+        """Build a symbolic graph of the distribution parameters.
+
+        Args:
+            obs_var (tf.Tensor): Tensor input for symbolic graph.
+            state_info_vars (dict): Extra state information, e.g.
+                previous action.
+            name (str): Name for symbolic graph.
+
+        Returns:
+            dict[tf.Tensor]: Outputs of the symbolic graph of distribution
+                parameters.
+
+        """
         if self._state_include_action:
             prev_action_var = state_info_vars['prev_action']
             prev_action_var = tf.cast(prev_action_var, tf.float32)
@@ -179,7 +206,17 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         return dict(prob=outputs)
 
     def reset(self, dones=None):
-        """Reset the policy."""
+        """Reset the policy.
+
+        Note:
+            If `dones` is None, it will be by default `np.array([True])` which
+            implies the policy will not be "vectorized", i.e. number of
+            parallel environments for training data sampling = 1.
+
+        Args:
+            dones (numpy.ndarray): Bool that indicates terminal state(s).
+
+        """
         if dones is None:
             dones = [True]
         dones = np.asarray(dones)
@@ -196,12 +233,30 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             'default'].init_cell.eval()
 
     def get_action(self, observation):
-        """Return a single action."""
+        """Get single action from this policy for the input observation.
+
+        Args:
+            observation (numpy.ndarray): Observation from environment.
+
+        Returns:
+            numpy.ndarray: Predicted action.
+            dict: Empty dict since this policy does not model a distribution.
+
+        """
         actions, agent_infos = self.get_actions([observation])
         return actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
-        """Return multiple actions."""
+        """Get multiple actions from this policy for the input observations.
+
+        Args:
+            observations (numpy.ndarray): Observations from environment.
+
+        Returns:
+            numpy.ndarray: Predicted actions.
+            dict: Empty dict since this policy does not model a distribution.
+
+        """
         flat_obs = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
@@ -224,17 +279,32 @@ class CategoricalLSTMPolicy(StochasticPolicy):
 
     @property
     def recurrent(self):
-        """Recurrent or not."""
+        """Recurrent or not.
+
+        Returns:
+            Bool: True if policy is recurrent.
+
+        """
         return True
 
     @property
     def distribution(self):
-        """Policy distribution."""
+        """Policy distribution.
+
+        Returns:
+            garage.tf.distributions.DiagonalGaussian: Policy distribution.
+
+        """
         return RecurrentCategorical(self._action_dim)
 
     @property
     def state_info_specs(self):
-        """State info specification."""
+        """State info specification.
+
+        Returns:
+            list[tuple]: State info specification.
+
+        """
         if self._state_include_action:
             return [
                 ('prev_action', (self._action_dim, )),
@@ -242,13 +312,56 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         else:
             return []
 
+    def clone(self, name):
+        """Return a clone of the policy.
+
+        It only copies the configuration of the Q-function,
+        not the parameters.
+
+        Args:
+            name (str): Name of the newly created policy.
+
+        Returns:
+            garage.tf.policies.ContinuousMLPPolicy: Clone of this object
+
+        """
+        return self.__class__(
+            name=name,
+            env_spec=self._env_spec,
+            hidden_dim=self._hidden_dim,
+            hidden_nonlinearity=self._hidden_nonlinearity,
+            hidden_w_init=self._hidden_w_init,
+            hidden_b_init=self._hidden_b_init,
+            recurrent_nonlinearity=self._recurrent_nonlinearity,
+            recurrent_w_init=self._recurrent_w_init,
+            output_nonlinearity=self._output_nonlinearity,
+            output_w_init=self._output_w_init,
+            output_b_init=self._output_b_init,
+            hidden_state_init=self._hidden_state_init,
+            hidden_state_init_trainable=self._hidden_state_init_trainable,
+            cell_state_init=self._cell_state_init,
+            cell_state_init_trainable=self._cell_stat_init_trainable,
+            state_include_action=self._state_include_action,
+            forget_bias=self._forget_bias,
+            layer_normalization=self._layere_normalization)
+
     def __getstate__(self):
-        """Object.__getstate__."""
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
         new_dict = super().__getstate__()
         del new_dict['_f_step_prob']
         return new_dict
 
     def __setstate__(self, state):
-        """Object.__setstate__."""
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
         super().__setstate__(state)
         self._initialize()

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -103,7 +103,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         self._cell_state_init = cell_state_init
         self._cell_stat_init_trainable = cell_state_init_trainable
         self._forget_bias = forget_bias
-        self._layere_normalization = layer_normalization
+        self._layer_normalization = layer_normalization
 
         if state_include_action:
             self._input_dim = self._obs_dim + self._action_dim
@@ -168,7 +168,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         """Vectorized or not.
 
         Returns:
-            Bool: True if primitive supports vectorized operations.
+            bool: True if primitive supports vectorized operations.
 
         """
         return True
@@ -178,7 +178,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
 
         Args:
             obs_var (tf.Tensor): Tensor input for symbolic graph.
-            state_info_vars (dict): Extra state information, e.g.
+            state_info_vars (dict[np.ndarray]): Extra state information, e.g.
                 previous action.
             name (str): Name for symbolic graph.
 
@@ -240,7 +240,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
 
         Returns:
             numpy.ndarray: Predicted action.
-            dict: Empty dict since this policy does not model a distribution.
+            dict[str: np.ndarray]: Action distribution.
 
         """
         actions, agent_infos = self.get_actions([observation])
@@ -254,7 +254,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
 
         Returns:
             numpy.ndarray: Predicted actions.
-            dict: Empty dict since this policy does not model a distribution.
+            dict[str: np.ndarray]: Action distributions.
 
         """
         flat_obs = self.observation_space.flatten_n(observations)
@@ -282,7 +282,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         """Recurrent or not.
 
         Returns:
-            Bool: True if policy is recurrent.
+            bool: True if policy is recurrent.
 
         """
         return True
@@ -322,7 +322,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             name (str): Name of the newly created policy.
 
         Returns:
-            garage.tf.policies.ContinuousMLPPolicy: Clone of this object
+            garage.tf.policies.CategoricalLSTMPolicy: Clone of this object
 
         """
         return self.__class__(
@@ -343,7 +343,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             cell_state_init_trainable=self._cell_stat_init_trainable,
             state_include_action=self._state_include_action,
             forget_bias=self._forget_bias,
-            layer_normalization=self._layere_normalization)
+            layer_normalization=self._layer_normalization)
 
     def __getstate__(self):
         """Object.__getstate__.

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -8,7 +8,7 @@ from garage.tf.policies import StochasticPolicy
 
 
 class CategoricalMLPPolicy(StochasticPolicy):
-    """CategoricalMLPPolicy
+    """Estimate action distribution with Categorical parameterized by a MLP.
 
     A policy that contains a MLP to make prediction based on
     a categorical distribution.
@@ -58,10 +58,18 @@ class CategoricalMLPPolicy(StochasticPolicy):
             'CategoricalMLPPolicy only works with akro.Discrete action '
             'space.')
         super().__init__(name, env_spec)
-        self.obs_dim = env_spec.observation_space.flat_dim
-        self.action_dim = env_spec.action_space.n
+        self._obs_dim = env_spec.observation_space.flat_dim
+        self._action_dim = env_spec.action_space.n
+        self._hidden_sizes = hidden_sizes
+        self._hidden_nonlinearity = hidden_nonlinearity
+        self._hidden_w_init = hidden_w_init
+        self._hidden_b_init = hidden_b_init
+        self._output_nonlinearity = output_nonlinearity
+        self._output_w_init = output_w_init
+        self._output_b_init = output_b_init
+        self._layer_normalization = layer_normalization
 
-        self.model = MLPModel(output_dim=self.action_dim,
+        self.model = MLPModel(output_dim=self._action_dim,
                               hidden_sizes=hidden_sizes,
                               hidden_nonlinearity=hidden_nonlinearity,
                               hidden_w_init=hidden_w_init,
@@ -76,7 +84,7 @@ class CategoricalMLPPolicy(StochasticPolicy):
 
     def _initialize(self):
         state_input = tf.compat.v1.placeholder(tf.float32,
-                                               shape=(None, self.obs_dim))
+                                               shape=(None, self._obs_dim))
 
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
@@ -88,36 +96,87 @@ class CategoricalMLPPolicy(StochasticPolicy):
 
     @property
     def vectorized(self):
-        """Vectorized or not."""
+        """Vectorized or not.
+
+        Returns:
+            bool: True if primitive supports vectorized operations.
+
+        """
         return True
 
     def dist_info_sym(self, obs_var, state_info_vars=None, name=None):
-        """Symbolic graph of the distribution."""
+        """Build a symbolic graph of the distribution parameters.
+
+        Args:
+            obs_var (tf.Tensor): Tensor input for symbolic graph.
+            state_info_vars (dict[tf.Tensor]): Extra state information, e.g.
+                previous action.
+            name (str): Name for symbolic graph.
+
+        Returns:
+            dict[tf.Tensor]: Outputs of the symbolic graph of distribution
+                parameters.
+
+        """
         with tf.compat.v1.variable_scope(self._variable_scope):
             prob = self.model.build(obs_var, name=name)
         return dict(prob=prob)
 
     def dist_info(self, obs, state_infos=None):
-        """Distribution info."""
+        """Build a symbolic graph of the distribution parameters.
+
+        Args:
+            obs (np.ndarray): Input for symbolic graph.
+            state_infos (dict[np.ndarray]): Extra state information, e.g.
+                previous action.
+
+        Returns:
+            dict[np.ndarray]: Outputs of the symbolic graph of distribution
+                parameters.
+
+        """
         prob = self._f_prob(obs)
         return dict(prob=prob)
 
     def get_action(self, observation):
-        """Return a single action."""
+        """Get single action from this policy for the input observation.
+
+        Args:
+            observation (numpy.ndarray): Observation from environment.
+
+        Returns:
+            numpy.ndarray: Predicted action.
+            dict[str: np.ndarray]: Action distribution.
+
+        """
         flat_obs = self.observation_space.flatten(observation)
         prob = self._f_prob([flat_obs])[0]
         action = self.action_space.weighted_sample(prob)
         return action, dict(prob=prob)
 
     def get_actions(self, observations):
-        """Return multiple actions."""
+        """Get multiple actions from this policy for the input observations.
+
+        Args:
+            observations (numpy.ndarray): Observations from environment.
+
+        Returns:
+            numpy.ndarray: Predicted actions.
+            dict[str: np.ndarray]: Action distributions.
+
+        """
         flat_obs = self.observation_space.flatten_n(observations)
         probs = self._f_prob(flat_obs)
         actions = list(map(self.action_space.weighted_sample, probs))
         return actions, dict(prob=probs)
 
     def get_regularizable_vars(self):
-        """Get regularizable weight variables under the Policy scope."""
+        """Get regularizable weight variables under the Policy scope.
+
+        Returns:
+            list(tf.Variable): List of regularizable variables.
+
+        """
         trainable = self.get_trainable_vars()
         return [
             var for var in trainable
@@ -126,16 +185,55 @@ class CategoricalMLPPolicy(StochasticPolicy):
 
     @property
     def distribution(self):
-        """Policy distribution."""
-        return Categorical(self.action_dim)
+        """Policy distribution.
+
+        Returns:
+            garage.tf.distributions.Categorical: Policy distribution.
+
+        """
+        return Categorical(self._action_dim)
+
+    def clone(self, name):
+        """Return a clone of the policy.
+
+        It only copies the configuration of the Q-function,
+        not the parameters.
+
+        Args:
+            name (str): Name of the newly created policy.
+
+        Returns:
+            garage.tf.policies.CategoricalMLPPolicy: Clone of this object
+
+        """
+        return self.__class__(name=name,
+                              env_spec=self._env_spec,
+                              hidden_sizes=self._hidden_sizes,
+                              hidden_nonlinearity=self._hidden_nonlinearity,
+                              hidden_w_init=self._hidden_w_init,
+                              hidden_b_init=self._hidden_b_init,
+                              output_nonlinearity=self._output_nonlinearity,
+                              output_w_init=self._output_w_init,
+                              output_b_init=self._output_b_init,
+                              layer_normalization=self._layer_normalization)
 
     def __getstate__(self):
-        """Object.__getstate__."""
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
         new_dict = super().__getstate__()
         del new_dict['_f_prob']
         return new_dict
 
     def __setstate__(self, state):
-        """Object.__setstate__."""
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
         super().__setstate__(state)
         self._initialize()

--- a/src/garage/tf/samplers/worker.py
+++ b/src/garage/tf/samplers/worker.py
@@ -45,6 +45,7 @@ class TFWorkerWrapper(Worker):
         # pylint: disable=super-init-not-called
         self._inner_worker = None
         self._sess = None
+        self._sess_entered = None
         self.worker_init()
 
     def worker_init(self):
@@ -55,12 +56,14 @@ class TFWorkerWrapper(Worker):
             # sampler worker processes in
             # order to execute the policy.
             self._sess = tf.compat.v1.Session()
+            self._sess_entered = True
             self._sess.__enter__()
 
     def shutdown(self):
         """Perform shutdown processes for TF."""
         self._inner_worker.shutdown()
-        if tf.get_default_session():
+        if tf.get_default_session() and self._sess_entered:
+            self._sess_entered = False
             self._sess.__exit__(None, None, None)
 
     @property

--- a/tests/garage/tf/samplers/test_tf_worker.py
+++ b/tests/garage/tf/samplers/test_tf_worker.py
@@ -1,0 +1,32 @@
+import tensorflow as tf
+
+from garage.sampler import DefaultWorker
+from garage.tf.experiment import LocalTFRunner
+from garage.tf.samplers import TFWorkerWrapper
+from tests.fixtures import snapshot_config
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+class TestTFWorker:
+
+    def test_tf_worker_with_default_session(self):
+        with LocalTFRunner(snapshot_config):
+            tf_worker = TFWorkerWrapper()
+            worker = DefaultWorker(seed=1,
+                                   max_path_length=100,
+                                   worker_number=1)
+            worker.update_env(DummyBoxEnv())
+            tf_worker._inner_worker = worker
+            tf_worker.worker_init()
+            assert tf_worker._sess == tf.compat.v1.get_default_session()
+        assert tf_worker._sess._closed
+
+    def test_tf_worker_without_default_session(self):
+        tf_worker = TFWorkerWrapper()
+        worker = DefaultWorker(seed=1, max_path_length=100, worker_number=1)
+        worker.update_env(DummyBoxEnv())
+        tf_worker._inner_worker = worker
+        tf_worker.worker_init()
+        assert tf_worker._sess == tf.compat.v1.get_default_session()
+        tf_worker.shutdown()
+        assert tf_worker._sess._closed


### PR DESCRIPTION
Currently, the main thread and plotter thread share the same policy object, which might break
because of shape mismatch, e.g. in most cases main thread performs vectorized sampling
while plotter thread samples from a single environment. This PR basically clone the policy
for the plotter to avoid the mentioned issue.