### PR TITLE
Update baselines and remove input_include_goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ ci-job-verify-envs-conda:
 	$(CONDA) info -a
 	$(CONDA) create -n garage-ci python=3.5 pip -y
 	$(GARAGE_BIN)/pip install --upgrade pip
+	$(GARAGE_BIN)/pip install dist/garage.tar.gz[all]
 	$(GARAGE_BIN)/pip install dist/garage.tar.gz[all,dev]
 	# pylint will verify all imports work
 	$(GARAGE_BIN)/pylint --disable=all --enable=import-error garage
@@ -85,6 +86,7 @@ ci-job-verify-envs-pipenv:
 	touch $(MJKEY_PATH)
 	pip3 install --upgrade pipenv setuptools
 	pipenv --three
+	pipenv install dist/garage.tar.gz[all]
 	pipenv install dist/garage.tar.gz[all,dev]
 	pipenv graph
 	# pylint will verify all imports work

--- a/docker/Dockerfile.base.16.04
+++ b/docker/Dockerfile.base.16.04
@@ -101,6 +101,7 @@ RUN pip install --upgrade pip
 # In this step only the presence of the file mjkey.txt is required, so we only
 # create an empty file
 RUN touch /root/.mujoco/mjkey.txt && \
+  pip install .[all] && \
   pip install .[all,dev] && \
   rm -r /root/.cache/pip && \
   rm /root/.mujoco/mjkey.txt

--- a/docker/Dockerfile.base.18.04
+++ b/docker/Dockerfile.base.18.04
@@ -91,6 +91,7 @@ RUN pip install --upgrade pip
 # In this step only the presence of the file mjkey.txt is required, so we only
 # create an empty file
 RUN touch /root/.mujoco/mjkey.txt && \
+  pip install .[all] && \
   pip install .[all,dev] && \
   rm -r /root/.cache/pip && \
   rm /root/.mujoco/mjkey.txt

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -40,7 +40,6 @@ def run_task(snapshot_config, *_):
             hidden_sizes=[256, 256, 256],
             hidden_nonlinearity=tf.nn.relu,
             output_nonlinearity=tf.nn.tanh,
-            input_include_goal=True,
         )
 
         qf = ContinuousMLPQFunction(
@@ -48,7 +47,6 @@ def run_task(snapshot_config, *_):
             name='QFunction',
             hidden_sizes=[256, 256, 256],
             hidden_nonlinearity=tf.nn.relu,
-            input_include_goal=True,
         )
 
         replay_buffer = HerReplayBuffer(env_spec=env.spec,
@@ -73,7 +71,6 @@ def run_task(snapshot_config, *_):
             policy_optimizer=tf.train.AdamOptimizer,
             qf_optimizer=tf.train.AdamOptimizer,
             buffer_batch_size=256,
-            input_include_goal=True,
         )
 
         runner.setup(algo=ddpg, env=env)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTRAS['gpu'] = ['tensorflow-gpu' + TF_VERSION]
 # Development dependencies (*not* included in 'all')
 EXTRAS['dev'] = [
     # Please keep alphabetized
-    'baselines @ https://{}@api.github.com/repos/openai/baselines/tarball/f2729693253c0ef4d4086231d36e0a4307ec1cb3'.format(GARAGE_GH_TOKEN),  # noqa: E501
+    'baselines @ https://{}@api.github.com/repos/openai/baselines/tarball/ea25b9e8b234e6ee1bca43083f8f3cf974143998'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'flake8',
     'flake8-docstrings>=1.5.0',
     'flake8-import-order',

--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -105,7 +105,7 @@ class TrajectoryBatch(
             # Discrete actions can be either in the space normally, or one-hot
             # encoded.
             if isinstance(env_spec.observation_space,
-                          (akro.Box, akro.Discrete)):
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.observation_space.flat_dim != np.prod(
                         first_observation.shape):
                     raise ValueError('observations should have the same '
@@ -131,7 +131,7 @@ class TrajectoryBatch(
             # Discrete actions can be either in the space normally, or one-hot
             # encoded.
             if isinstance(env_spec.observation_space,
-                          (akro.Box, akro.Discrete)):
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.observation_space.flat_dim != np.prod(
                         last_observations[0].shape):
                     raise ValueError('last_observations should have the same '
@@ -156,7 +156,8 @@ class TrajectoryBatch(
         if not env_spec.action_space.contains(first_action):
             # Discrete actions can be either in the space normally, or one-hot
             # encoded.
-            if isinstance(env_spec.action_space, (akro.Box, akro.Discrete)):
+            if isinstance(env_spec.action_space,
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.action_space.flat_dim != np.prod(
                         first_action.shape):
                     raise ValueError('actions should have the same '
@@ -455,7 +456,7 @@ class TimeStep(
         # observation
         if not env_spec.observation_space.contains(observation):
             if isinstance(env_spec.observation_space,
-                          (akro.Box, akro.Discrete)):
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.observation_space.flat_dim != np.prod(
                         observation.shape):
                     raise ValueError('observation should have the same '
@@ -472,7 +473,7 @@ class TimeStep(
 
         if not env_spec.observation_space.contains(next_observation):
             if isinstance(env_spec.observation_space,
-                          (akro.Box, akro.Discrete)):
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.observation_space.flat_dim != np.prod(
                         next_observation.shape):
                     raise ValueError('next_observation should have the same '
@@ -489,7 +490,8 @@ class TimeStep(
 
         # action
         if not env_spec.action_space.contains(action):
-            if isinstance(env_spec.action_space, (akro.Box, akro.Discrete)):
+            if isinstance(env_spec.action_space,
+                          (akro.Box, akro.Discrete, akro.Dict)):
                 if env_spec.action_space.flat_dim != np.prod(action.shape):
                     raise ValueError('action should have the same '
                                      'dimensionality as the action_space '

--- a/src/garage/misc/tensor_utils.py
+++ b/src/garage/misc/tensor_utils.py
@@ -278,6 +278,8 @@ def truncate_tensor_dict(tensor_dict, truncated_len):
 def normalize_pixel_batch(env_spec, observations):
     """Normalize the observations (images).
 
+    If the observations appear to be flattened, attempts to unflatten them.
+
     If the input are images, it normalized into range [0, 1].
 
     Args:
@@ -289,6 +291,8 @@ def normalize_pixel_batch(env_spec, observations):
 
     """
     if isinstance(env_spec.observation_space, gym.spaces.Box):
+        if len(observations.shape) == 2:
+            observations = env_spec.observation_space.unflatten_n(observations)
         if len(env_spec.observation_space.shape) == 3:
             return [obs.astype(np.float32) / 255.0 for obs in observations]
     return observations

--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -30,7 +30,7 @@ def rollout(env,
 
     Returns:
         dict[str, np.ndarray or dict]: Dictionary, with keys:
-            * observations(np.array): Non-flattened array of observations.
+            * observations(np.array): Flattened array of observations.
                 There should be one more of these than actions. Note that
                 observations[i] (for i < len(observations) - 1) was used by the
                 agent to choose actions[i]. Should have shape (T + 1, S^*) (the
@@ -59,6 +59,7 @@ def rollout(env,
     if animated:
         env.render()
     while path_length < (max_path_length or np.inf):
+        o = env.observation_space.flatten(o)
         a, agent_info = agent.get_action(o)
         if deterministic and 'mean' in agent_infos:
             a = agent_info['mean']

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -43,7 +43,6 @@ class DQN(OffPolicyRLAlgorithm):
             docstring for tf.clip_by_norm.
         double_q (bool): Bool for using double q-network.
         reward_scale (float): Reward scale.
-        input_include_goal (bool): Whether input includes goal.
         smooth_return (bool): Whether to smooth the return.
         name (str): Name of the algorithm.
 
@@ -68,7 +67,6 @@ class DQN(OffPolicyRLAlgorithm):
                  grad_norm_clipping=None,
                  double_q=False,
                  reward_scale=1.,
-                 input_include_goal=False,
                  smooth_return=True,
                  name='DQN'):
         self.qf_lr = qf_lr
@@ -94,7 +92,6 @@ class DQN(OffPolicyRLAlgorithm):
                                   max_path_length=max_path_length,
                                   discount=discount,
                                   reward_scale=reward_scale,
-                                  input_include_goal=input_include_goal,
                                   smooth_return=smooth_return)
 
     def init_opt(self):

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -40,7 +40,6 @@ class ContinuousMLPPolicy(Policy):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             tf.Tensor.
-        input_include_goal (bool): Include goal in the observation or not.
         layer_normalization (bool): Bool for using layer normalization or not.
 
     """
@@ -55,7 +54,6 @@ class ContinuousMLPPolicy(Policy):
                  output_nonlinearity=tf.nn.tanh,
                  output_w_init=tf.glorot_uniform_initializer(),
                  output_b_init=tf.zeros_initializer(),
-                 input_include_goal=False,
                  layer_normalization=False):
         super().__init__(name, env_spec)
         action_dim = env_spec.action_space.flat_dim
@@ -66,13 +64,8 @@ class ContinuousMLPPolicy(Policy):
         self._output_nonlinearity = output_nonlinearity
         self._output_w_init = output_w_init
         self._output_b_init = output_b_init
-        self._input_include_goal = input_include_goal
         self._layer_normalization = layer_normalization
-        if self._input_include_goal:
-            self.obs_dim = env_spec.observation_space.flat_dim_with_keys(
-                ['observation', 'desired_goal'])
-        else:
-            self.obs_dim = env_spec.observation_space.flat_dim
+        self.obs_dim = env_spec.observation_space.flat_dim
 
         self.model = MLPModel(output_dim=action_dim,
                               name='MLPModel',
@@ -188,7 +181,6 @@ class ContinuousMLPPolicy(Policy):
                               output_nonlinearity=self._output_nonlinearity,
                               output_w_init=self._output_w_init,
                               output_b_init=self._output_b_init,
-                              input_include_goal=self._input_include_goal,
                               layer_normalization=self._layer_normalization)
 
     def __getstate__(self):

--- a/src/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/src/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -41,7 +41,6 @@ class ContinuousMLPQFunction(QFunction):
         output_b_init (callable): Initializer function for the bias
             of output dense layer(s). The function should return a
             tf.Tensor.
-        input_include_goal (bool): Whether input includes goal.
         layer_normalization (bool): Bool for using layer normalization.
 
     """
@@ -57,7 +56,6 @@ class ContinuousMLPQFunction(QFunction):
                  output_nonlinearity=None,
                  output_w_init=tf.glorot_uniform_initializer(),
                  output_b_init=tf.zeros_initializer(),
-                 input_include_goal=False,
                  layer_normalization=False):
         super().__init__(name)
 
@@ -70,14 +68,9 @@ class ContinuousMLPQFunction(QFunction):
         self._output_nonlinearity = output_nonlinearity
         self._output_w_init = output_w_init
         self._output_b_init = output_b_init
-        self._input_include_goal = input_include_goal
         self._layer_normalization = layer_normalization
 
-        if self._input_include_goal:
-            self._obs_dim = env_spec.observation_space.flat_dim_with_keys(
-                ['observation', 'desired_goal'])
-        else:
-            self._obs_dim = env_spec.observation_space.flat_dim
+        self._obs_dim = env_spec.observation_space.flat_dim
         self._action_dim = env_spec.action_space.flat_dim
 
         self.model = MLPMergeModel(output_dim=1,
@@ -171,8 +164,7 @@ class ContinuousMLPQFunction(QFunction):
                               output_nonlinearity=self._output_nonlinearity,
                               output_w_init=self._output_w_init,
                               output_b_init=self._output_b_init,
-                              layer_normalization=self._layer_normalization,
-                              input_include_goal=self._input_include_goal)
+                              layer_normalization=self._layer_normalization)
 
     def __getstate__(self):
         """Object.__getstate__.

--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
@@ -12,7 +12,6 @@ from baselines.common import set_global_seeds
 from baselines.common.vec_env.dummy_vec_env import DummyVecEnv
 from baselines.logger import configure
 from baselines.ppo2 import ppo2
-from baselines.ppo2.policies import MlpPolicy
 import dowel
 from dowel import logger as dowel_logger
 import gym
@@ -296,9 +295,7 @@ def run_baselines(env, seed, log_dir):
     ])
 
     set_global_seeds(seed)
-    policy = MlpPolicy
-
-    ppo2.learn(policy=policy,
+    ppo2.learn(network='mlp',
                env=env,
                nsteps=hyper_parameters['batch_size'],
                nminibatches=32,

--- a/tests/fixtures/envs/dummy/dummy_dict_env.py
+++ b/tests/fixtures/envs/dummy/dummy_dict_env.py
@@ -1,5 +1,5 @@
-"""Dummy gym.spaces.Dict environment for testing purpose."""
-import gym
+"""Dummy akro.Dict environment for testing purpose."""
+import akro
 import numpy as np
 
 from garage.envs import EnvSpec
@@ -7,7 +7,7 @@ from tests.fixtures.envs.dummy import DummyEnv
 
 
 class DummyDictEnv(DummyEnv):
-    """A dummy gym.spaces.Dict environment with predefined inner spaces.
+    """A dummy akro.Dict environment with predefined inner spaces.
 
     Args:
         random (bool): If observations are randomly generated or not.
@@ -24,22 +24,17 @@ class DummyDictEnv(DummyEnv):
         """Return the observation space.
 
         Returns:
-            gym.spaces.Dict: Observation space.
+            akro.Dict: Observation space.
 
         """
 
-        return gym.spaces.Dict({
+        return akro.Dict({
             'achieved_goal':
-            gym.spaces.Box(low=-200., high=200., shape=(3, ),
-                           dtype=np.float32),
+            akro.Box(low=-200., high=200., shape=(3, ), dtype=np.float32),
             'desired_goal':
-            gym.spaces.Box(low=-200., high=200., shape=(3, ),
-                           dtype=np.float32),
+            akro.Box(low=-200., high=200., shape=(3, ), dtype=np.float32),
             'observation':
-            gym.spaces.Box(low=-200.,
-                           high=200.,
-                           shape=(25, ),
-                           dtype=np.float32)
+            akro.Box(low=-200., high=200., shape=(25, ), dtype=np.float32)
         })
 
     @property
@@ -47,13 +42,10 @@ class DummyDictEnv(DummyEnv):
         """Return the action space.
 
         Returns:
-            gym.spaces.Box: Action space.
+            akro.Box: Action space.
 
         """
-        return gym.spaces.Box(low=-5.0,
-                              high=5.0,
-                              shape=(1, ),
-                              dtype=np.float32)
+        return akro.Box(low=-5.0, high=5.0, shape=(1, ), dtype=np.float32)
 
     def reset(self):
         """Reset the environment.

--- a/tests/garage/sampler/test_off_policy_vectorized_sampler_integration.py
+++ b/tests/garage/sampler/test_off_policy_vectorized_sampler_integration.py
@@ -98,8 +98,7 @@ class TestOffPolicyVectorizedSampler(TfGraphTestCase):
                                   qf=None,
                                   replay_buffer=replay_buffer,
                                   policy=policy,
-                                  exploration_strategy=None,
-                                  input_include_goal=True)
+                                  exploration_strategy=None)
 
         sampler = OffPolicyVectorizedSampler(algo, env, 1, no_reset=True)
         sampler.start_worker()

--- a/tests/garage/sampler/test_utils.py
+++ b/tests/garage/sampler/test_utils.py
@@ -27,9 +27,9 @@ class TestRollout:
         # dummy is the env_info_key
         assert path['env_infos']['dummy'].shape[0] == 3
 
-    def test_does_not_flatten(self):
+    def test_does_flatten(self):
         path = utils.rollout(self.env, self.policy, max_path_length=5)
-        assert path['observations'][0].shape == (4, 4)
+        assert path['observations'][0].shape == (16, )
         assert path['actions'][0].shape == (2, 2)
 
 

--- a/tests/garage/tf/q_functions/test_continuous_mlp_q_function.py
+++ b/tests/garage/tf/q_functions/test_continuous_mlp_q_function.py
@@ -32,7 +32,6 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         act = np.full(action_dim, 0.5).flatten()
 
         expected_output = np.full((1, ), 0.5)
-        obs_ph, act_ph = qf.inputs
 
         outputs = qf.get_qval([obs], [act])
         assert np.array_equal(outputs[0], expected_output)
@@ -42,21 +41,20 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         for output in outputs:
             assert np.array_equal(output, expected_output)
 
-    def test_q_vals_input_include_goal(self):
+    def test_q_vals_goal_conditioned(self):
         env = TfEnv(DummyDictEnv())
         with mock.patch(('garage.tf.q_functions.'
                          'continuous_mlp_q_function.MLPMergeModel'),
                         new=SimpleMLPMergeModel):
-            qf = ContinuousMLPQFunction(env_spec=env.spec,
-                                        input_include_goal=True)
+            qf = ContinuousMLPQFunction(env_spec=env.spec)
         env.reset()
         obs, _, _, _ = env.step(1)
-        obs = np.concatenate((obs['observation'], obs['desired_goal']),
-                             axis=-1)
+        obs = np.concatenate(
+            (obs['observation'], obs['desired_goal'], obs['achieved_goal']),
+            axis=-1)
         act = np.full((1, ), 0.5).flatten()
 
         expected_output = np.full((1, ), 0.5)
-        obs_ph, act_ph = qf.inputs
 
         outputs = qf.get_qval([obs], [act])
         assert np.array_equal(outputs[0], expected_output)
@@ -81,7 +79,6 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
         obs = obs.flatten()
         act = np.full(action_dim, 0.5).flatten()
-        obs_ph, act_ph = qf.inputs
 
         outputs = qf.get_qval([obs], [act])
 
@@ -103,7 +100,6 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
         obs = obs.flatten()
         act = np.full(action_dim, 0.5).flatten()
-        obs_ph, act_ph = qf.inputs
 
         output1 = qf.get_qval([obs], [act])
 
@@ -139,7 +135,6 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         obs, _, _, _ = env.step(1)
         obs = obs.flatten()
         act = np.full(action_dim, 0.5).flatten()
-        obs_ph, act_ph = qf.inputs
 
         with tf.compat.v1.variable_scope(
                 'ContinuousMLPQFunction/SimpleMLPMergeModel', reuse=True):
@@ -152,7 +147,6 @@ class TestContinuousMLPQFunction(TfGraphTestCase):
         h_data = pickle.dumps(qf)
         with tf.compat.v1.Session(graph=tf.Graph()):
             qf_pickled = pickle.loads(h_data)
-            obs_ph_pickled, act_ph_pickled = qf_pickled.inputs
             output2 = qf_pickled.get_qval([obs], [act])
 
         assert np.array_equal(output1, output2)


### PR DESCRIPTION
This change should be an alternative to #1233.

Because HER was already broken on master, and one of the three uses of baselines is `test_benchmark_her.py`, I've fixed HER by removing the `input_include_goal` flag (it's no longer needed, garage can now handle dictionary observations directly for off-policy algorithms).