### PR TITLE
Downgrade sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,5 +18,5 @@ tensorflow-probability<0.6.0,>=0.5.0
 # dev dependencies
 matplotlib
 recommonmark
-sphinx
+sphinx==2.4.4
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ EXTRAS['dev'] = [
     'recommonmark',
     'rlkit @ https://{}@api.github.com/repos/vitchyr/rlkit/tarball/1d469a509b797ca04a39b8734c1816ca7d108fc8'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'seaborn',
-    'sphinx',
+    'sphinx==2.4.4',
     'sphinx_rtd_theme',
     'yapf==0.28.0',
 ]  # yapf: disable


### PR DESCRIPTION
Two days ago, sphinx doc released a new version, 3.0.0.
Unfortunately, there's an issue with it that causes building docs for
garage to crash.

Until [that issue](https://github.com/sphinx-doc/sphinx/issues/7422) is
closed, we need to avoid updating for the CI to work.