### PR TITLE
Fix TRPO, PPO benchmark

### DIFF
--- a/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
+++ b/tests/benchmarks/garage/tf/algos/test_benchmark_ppo.py
@@ -125,7 +125,7 @@ class TestBenchmarkPPO:
                 plt_file=plt_file,
                 env_id=env_id,
                 x_label='Iteration',
-                y_label='Evaluation/AverageReturn',
+                y_label='AverageReturn',
                 names=['baseline', 'garage-TensorFlow', 'garage-PyTorch'],
             )
 
@@ -134,7 +134,8 @@ class TestBenchmarkPPO:
                 seeds=seeds,
                 trials=hyper_parameters['n_trials'],
                 xs=[
-                    'nupdates', 'Evaluation/Iteration', 'Evaluation/Iteration'
+                    'misc/nupdates', 'Evaluation/Iteration',
+                    'Evaluation/Iteration'
                 ],
                 ys=[
                     'eprewmean', 'Evaluation/AverageReturn',


### PR DESCRIPTION
Change parameters for trpo_mpi to match new openai.baseline version.

There is no `nupdate` column in the progress.csv file from openai.baseline.trpo_mpi
so I append `Evaluation/Iteration` column. Also I change column name from `EpRewMean` (from openai.baseline trpo_mpi) to `Evaluation/AverageReturn`