### PR TITLE
Add Multitask metaworld benchmark support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ EXTRAS['dev'] = [
     'flake8-import-order',
     'gtimer',
     'matplotlib',
-    'metaworld @ https://{}@api.github.com/repos/rlworkgroup/metaworld/tarball/b556580204bf704dabcd0b5e558850db7a4335c4'.format(GARAGE_GH_TOKEN),  # noqa: E501
+    'metaworld @ https://{}@api.github.com/repos/rlworkgroup/metaworld/tarball/9a3ce2be718196447119e8f5445565d1c7f94770'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'pandas',
     'pep8-naming==0.7.0',
     'pre-commit',

--- a/src/garage/envs/__init__.py
+++ b/src/garage/envs/__init__.py
@@ -4,11 +4,18 @@ from garage.envs.base import GarageEnv
 from garage.envs.base import Step
 from garage.envs.env_spec import EnvSpec
 from garage.envs.grid_world_env import GridWorldEnv
+from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.envs.normalized_env import normalize
 from garage.envs.point_env import PointEnv
 from garage.envs.task_onehot_wrapper import TaskOnehotWrapper
 
 __all__ = [
-    'GarageEnv', 'Step', 'EnvSpec', 'GridWorldEnv', 'normalize', 'PointEnv',
-    'TaskOnehotWrapper'
+    'GarageEnv',
+    'Step',
+    'EnvSpec',
+    'GridWorldEnv',
+    'MultiEnvWrapper',
+    'normalize',
+    'PointEnv',
+    'TaskOnehotWrapper',
 ]

--- a/src/garage/envs/multi_env_wrapper.py
+++ b/src/garage/envs/multi_env_wrapper.py
@@ -53,7 +53,9 @@ class MultiEnvWrapper(gym.Wrapper):
         sample_strategy (function(int, int)):
             Sample strategy to be used when sampling a new task.
         metaworld_mt (bool): Set if the envs that are passed Metaworld
-            environments from Multitask Benchmark Environments.
+            environments from Multitask Benchmark Environments. Primarily
+            disables wrapper from augmenting observations with task one-hot
+            ids.
     """
 
     def __init__(self,
@@ -193,6 +195,7 @@ class MultiEnvWrapper(gym.Wrapper):
         if not self._metaworld_mt:
             obs = self._obs_with_one_hot(obs)
         info['task_id'] = self._active_task_index
+        info['task_name'] = self.active_task_name
         return obs, reward, done, info
 
     def close(self):
@@ -212,3 +215,18 @@ class MultiEnvWrapper(gym.Wrapper):
         """
         oh_obs = np.concatenate([self.active_task_one_hot, obs])
         return oh_obs
+
+    @property
+    def active_task_name(self):
+        """Return the name of the active task.
+
+        Returns:
+            str: The name of the task. If wrapping metaworld benchmark,
+                environments, this will be the name of the environment,
+                given by metaworld. Otherwise, the name is the unwrapped
+                environment's class name.
+
+        """
+        if self._metaworld_mt:
+            return self.env.all_task_names[0]
+        return str(self.env.unwrapped)

--- a/tests/garage/envs/test_multi_env_wrapper.py
+++ b/tests/garage/envs/test_multi_env_wrapper.py
@@ -143,3 +143,47 @@ class TestMultiEnvWrapper:
         """
         task_envs = [TfEnv(env_name=name) for name in env_names]
         return MultiEnvWrapper(task_envs, sample_strategy=sample_strategy)
+
+
+@pytest.mark.mujoco
+class TestMetaWorldMultiEnvWrapper:
+    """Tests for garage.envs.multi_env_wrapper using Metaworld Envs"""
+
+    def setup_class(self):
+        """Init Wrapper with MT10."""
+        # pylint: disable=import-outside-toplevel
+        from metaworld.benchmarks import MT10
+        tasks = MT10.get_train_tasks().all_task_names
+        envs = []
+        for task in tasks:
+            envs.append(MT10.from_task(task))
+        self.env = MultiEnvWrapper(envs,
+                                   sample_strategy=round_robin_strategy,
+                                   metaworld_mt=True)
+
+    def teardown_class(self):
+        """Close the MTMetaWorldWrapper."""
+        self.env.close()
+
+    def test_num_tasks(self):
+        """Assert num tasks returns 10, because MT10 is being tested."""
+        assert self.env.num_tasks == 10
+
+    def test_step(self):
+        """Test that env_infos includes extra infos and obs has onehot."""
+        self.env.reset()
+        action = self.env.spec.action_space.sample()
+        obs, _, _, info = self.env.step(action)
+        assert info['task_id'] == self.env.active_task_index
+        assert (self.env.active_task_one_hot == obs[9:]).all()
+
+    def test_reset(self):
+        """Test round robin switching of environments during call to reset."""
+        self.env.reset()
+        active_task_id = self.env.active_task_index
+        for _ in range(self.env.num_tasks):
+            self.env.reset()
+            action = self.env.spec.action_space.sample()
+            _, _, _, info = self.env.step(action)
+            assert not info['task_id'] == active_task_id
+            active_task_id = self.env.active_task_index

--- a/tests/garage/envs/test_multi_env_wrapper.py
+++ b/tests/garage/envs/test_multi_env_wrapper.py
@@ -129,6 +129,14 @@ class TestMultiEnvWrapper:
         obs = mt_env.step(1)[0]
         assert (obs[:2] == np.array([0., 1.])).all()
 
+    def test_active_task_name(self):
+        """Check if the task name of the active task corresponds to its """
+        envs = ['CartPole-v0', 'CartPole-v1']
+        mt_env = self._init_multi_env_wrapper(envs)
+        for _ in range(mt_env.num_tasks):
+            assert mt_env.active_task_name == str(mt_env.env.unwrapped)
+            mt_env.reset()
+
     def _init_multi_env_wrapper(self,
                                 env_names,
                                 sample_strategy=uniform_random_strategy):
@@ -187,3 +195,9 @@ class TestMetaWorldMultiEnvWrapper:
             _, _, _, info = self.env.step(action)
             assert not info['task_id'] == active_task_id
             active_task_id = self.env.active_task_index
+
+    def test_active_task_name(self):
+        """Assert the task name of the active task corresponds to its metaworld name."""  # noqa: E501
+        for _ in range(self.env.num_tasks):
+            self.env.reset()
+            assert self.env.active_task_name == self.env.env.all_task_names[0]

--- a/tests/garage/experiment/test_task_sampler.py
+++ b/tests/garage/experiment/test_task_sampler.py
@@ -24,15 +24,10 @@ def test_env_pool_sampler():
     # Import, construct environments here to avoid using up too much
     # resources if this test isn't run.
     # pylint: disable=import-outside-toplevel
-    from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_ARGS_KWARGS
-    from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_CLS_DICT
-    ML10_ARGS = MEDIUM_MODE_ARGS_KWARGS
-    ML10_ENVS = MEDIUM_MODE_CLS_DICT
-
+    from metaworld.benchmarks import ML10
+    train_tasks = ML10.get_train_tasks().all_task_names
     ML10_train_envs = [
-        env(*ML10_ARGS['train'][task]['args'],
-            **ML10_ARGS['train'][task]['kwargs'])
-        for (task, env) in ML10_ENVS['train'].items()
+        ML10.from_task(train_task) for train_task in train_tasks
     ]
     tasks = task_sampler.EnvPoolSampler(ML10_train_envs)
     assert tasks.n_tasks == 10
@@ -50,15 +45,11 @@ def test_env_pool_sampler():
 @pytest.mark.mujoco
 def test_construct_envs_sampler_ml10():
     # pylint: disable=import-outside-toplevel
-    from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_ARGS_KWARGS
-    from metaworld.envs.mujoco.env_dict import MEDIUM_MODE_CLS_DICT
-    ML10_ARGS = MEDIUM_MODE_ARGS_KWARGS
-    ML10_ENVS = MEDIUM_MODE_CLS_DICT
-
+    from metaworld.benchmarks import ML10
+    train_tasks = ML10.get_train_tasks().all_task_names
     ML10_constructors = [
-        functools.partial(env, *ML10_ARGS['train'][task]['args'],
-                          **ML10_ARGS['train'][task]['kwargs'])
-        for (task, env) in ML10_ENVS['train'].items()
+        functools.partial(ML10.from_task, train_task)
+        for train_task in train_tasks
     ]
     tasks = task_sampler.ConstructEnvsSampler(ML10_constructors)
     assert tasks.n_tasks == 10


### PR DESCRIPTION
- Add option to MultiEnvWrapper to account for task_one_hot
  that is already appended to metaworld multi task benchmark
  environments

- tests that initialize metaworld benchmark environments now
  use the metaworld from_task api

opened this separate pr from #1303  to potentially resolve mujoco key issues