### PR TITLE
Check if mujoco key exists before removing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,14 @@ ci-job-precommit: assert-docker docs
 	scripts/travisci/check_precommit.sh
 
 ci-job-normal: assert-docker
-	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
-	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
+	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak
 	pytest --cov=garage -v -m \
 	    'not nightly and not huge and not benchmark and not flaky and not large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
 ci-job-large: assert-docker
-	mv $(MJKEY_PATH) $(MJKEY_PATH).bak
-	echo "Warning: Removing $(MJKEY_PATH) and backing it up at $(MJKEY_PATH).bak"
+	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak
 	pytest --cov=garage -v -m 'large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
In case of external PRs, the docker container doesn't have
a mujoco key file and thus errors at removing mjkey.txt.
This commit adds a check for existence of file before
removing.