### PR TITLE
Re-enable after_n_builds in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,4 @@ coverage:
 codecov:
     notify:
         wait_for_ci: yes
+        after_n_builds: 3


### PR DESCRIPTION
Its reports still seem to be flagging.