### PR TITLE
Add empty mjkey.txt to non-MuJoCo test jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,14 @@ ci-job-precommit: assert-docker docs
 	scripts/travisci/check_precommit.sh
 
 ci-job-normal: assert-docker
-	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak
+	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak && touch $(MJKEY_PATH)
 	pytest --cov=garage -v -m \
 	    'not nightly and not huge and not benchmark and not flaky and not large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)
 
 ci-job-large: assert-docker
-	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak
+	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak && touch $(MJKEY_PATH)
 	pytest --cov=garage -v -m 'large and not mujoco' --durations=0
 	coverage xml
 	bash <(curl -s https://codecov.io/bash)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ extend-ignore =
     F841  # Unused variables are checked by pylint
 
 [tool:pytest]
-addopts = -n auto -rfEs -s --strict-markers
+addopts = -rfEs -s --strict-markers
 testpaths = tests
 markers =
     nightly


### PR DESCRIPTION
This should silence warnings during test collection.