### PR TITLE
Fix off-policy algos tabular record not working

### DIFF
--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -148,6 +148,9 @@ class LocalRunner:
         self.step_itr = None
         self.step_path = None
 
+        # only used for off-policy algorithms
+        self.enable_logging = True
+
         self._n_workers = None
         self._worker_class = None
         self._worker_args = None
@@ -496,9 +499,11 @@ class LocalRunner:
                 self._stats.total_itr = self.step_itr
 
                 self.save(epoch)
-                self.log_diagnostics(self._train_args.pause_for_plot)
-                logger.dump_all(self.step_itr)
-                tabular.clear()
+
+                if self.enable_logging:
+                    self.log_diagnostics(self._train_args.pause_for_plot)
+                    logger.dump_all(self.step_itr)
+                    tabular.clear()
 
     def resume(self,
                n_epochs=None,

--- a/src/garage/np/algos/off_policy_rl_algorithm.py
+++ b/src/garage/np/algos/off_policy_rl_algorithm.py
@@ -85,6 +85,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
 
         """
         last_return = None
+        runner.enable_logging = False
 
         for _ in runner.step_epochs():
             for cycle in range(self.steps_per_epoch):
@@ -94,6 +95,7 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
                 last_return = self.train_once(runner.step_itr,
                                               runner.step_path)
                 if cycle == 0 and self._buffer_prefilled:
+                    runner.enable_logging = True
                     log_performance(runner.step_itr,
                                     self._obtain_evaluation_samples(
                                         runner.get_env_copy()),


### PR DESCRIPTION
The off-policy algorithms are failing to use dower to record.

By default, `LocalRunner` [dumps](https://github.com/rlworkgroup/garage/blob/254a1d0946bd61f9418e17cba625ca283ea0840e/src/garage/experiment/local_runner.py#L500) all records per epoch. However when it comes to off-policy algorithms, buffer must be [pre-filled](https://github.com/rlworkgroup/garage/blob/254a1d0946bd61f9418e17cba625ca283ea0840e/src/garage/np/algos/off_policy_rl_algorithm.py#L96) before we log any performance, because `dower` relies on the first-time dumping attributes. If we keep this way to implement it, this PR provides a quick fix: If `LocalRunner` is where dumping occurs, then it should know whether buffer is pre-filled.

However, if we think more, this may include a larger refactoring. It is worth considering whether `log_performance()` should be fully responsible for recording and dumping. In other words, all current `log_diagnostics()` functions (like the one in `LocalRunner`) should avoid recording anything. Checking the codebase, I conclude doing so would affect many lines of code and we should discuss if it's a good step to move forward.



