### PR TITLE
Fix setting model parameters

### DIFF
--- a/src/garage/tf/models/base.py
+++ b/src/garage/tf/models/base.py
@@ -339,9 +339,15 @@ class Model(BaseModel):
         """
         variables = self._get_variables()
         for name, var in variables.items():
-            if name in parameters:
-                var.load(parameters[name])
-            else:
+            found = False
+            # param name without model name
+            param_name = name[name.find(self.name) + len(self.name) + 1:]
+            for k, v in parameters.items():
+                if param_name in k:
+                    var.load(v)
+                    found = True
+                    continue
+            if not found:
                 warnings.warn('No value provided for variable {}'.format(name))
 
     @property


### PR DESCRIPTION
Currently, when setting model parameters, the parameter name has to be an exact
match. This would not work when assigning a model's parameters with a model with
a different name. This PR fixes the bug by only matching the part of the parameter
name without the model name.