### PR TITLE
Use tf rnn for recurrent networks

### DIFF
--- a/src/garage/tf/models/gru.py
+++ b/src/garage/tf/models/gru.py
@@ -21,7 +21,7 @@ def gru(name,
         step_input_var (tf.Tensor): Place holder for step inputs, with shape
             :math:`(N, S^*)`.
         step_hidden_var (tf.Tensor): Place holder for step hidden state, with
-            shape :math:`(N, hidden_dim)`.
+            shape :math:`(N, H)`.
         output_nonlinearity_layer (callable): Activation function for output
             dense layer. It should return a tf.Tensor. Set it to None to
             maintain a linear activation.
@@ -33,8 +33,8 @@ def gru(name,
     Return:
         tf.Tensor: Entire time-series outputs, with shape :math:`(N, T, S^*)`.
         tf.Tensor: Step output, with shape :math:`(N, S^*)`.
-        tf.Tensor: Step hidden state, with shape :math:`(N, hidden_dim)`
-        tf.Tensor: Initial hidden state, with shape :math:`(hidden_dim, )`
+        tf.Tensor: Step hidden state, with shape :math:`(N, H)`
+        tf.Tensor: Initial hidden state, with shape :math:`(H, )`
 
     """
     with tf.compat.v1.variable_scope(name):

--- a/src/garage/tf/models/gru.py
+++ b/src/garage/tf/models/gru.py
@@ -10,15 +10,18 @@ def gru(name,
         output_nonlinearity_layer,
         hidden_state_init=tf.zeros_initializer(),
         hidden_state_init_trainable=False):
-    """Gated Recurrent Unit (GRU).
+    r"""Gated Recurrent Unit (GRU).
 
     Args:
         name (str): Name of the variable scope.
         gru_cell (tf.keras.layers.Layer): GRU cell used to generate
             outputs.
-        all_input_var (tf.Tensor): Place holder for entire time-series inputs.
-        step_input_var (tf.Tensor): Place holder for step inputs.
-        step_hidden_var (tf.Tensor): Place holder for step hidden state.
+        all_input_var (tf.Tensor): Place holder for entire time-series inputs,
+            with shape :math:`(N, T, S^*)`.
+        step_input_var (tf.Tensor): Place holder for step inputs, with shape
+            :math:`(N, S^*)`.
+        step_hidden_var (tf.Tensor): Place holder for step hidden state, with
+            shape :math:`(N, hidden_dim)`.
         output_nonlinearity_layer (callable): Activation function for output
             dense layer. It should return a tf.Tensor. Set it to None to
             maintain a linear activation.
@@ -30,8 +33,8 @@ def gru(name,
     Return:
         tf.Tensor: Entire time-series outputs, with shape :math:`(N, T, S^*)`.
         tf.Tensor: Step output, with shape :math:`(N, S^*)`.
-        tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`
-        tf.Tensor: Initial hidden state, with shape :math:`(H, )`
+        tf.Tensor: Step hidden state, with shape :math:`(N, hidden_dim)`
+        tf.Tensor: Initial hidden state, with shape :math:`(hidden_dim, )`
 
     """
     with tf.compat.v1.variable_scope(name):

--- a/src/garage/tf/models/gru.py
+++ b/src/garage/tf/models/gru.py
@@ -28,10 +28,10 @@ def gru(name,
             hidden state is trainable.
 
     Return:
-        outputs (tf.Tensor): Entire time-series outputs.
-        output (tf.Tensor): Step output.
-        hidden (tf.Tensor): Step hidden state.
-        hidden_init_var (tf.Tensor): Initial hidden state.
+        tf.Tensor: Entire time-series outputs.
+        tf.Tensor: Step output.
+        tf.Tensor: Step hidden state.
+        tf.Tensor: Initial hidden state.
 
     """
     with tf.compat.v1.variable_scope(name):
@@ -49,13 +49,9 @@ def gru(name,
         hidden_init_var_b = tf.broadcast_to(
             hidden_init_var, shape=[tf.shape(all_input_var)[0], hidden_dim])
 
-        def step(hprev, x):
-            _, [h] = gru_cell(x, states=[hprev])
-            return h
+        rnn = tf.keras.layers.RNN(gru_cell, return_sequences=True)
 
-        shuffled_input = tf.transpose(all_input_var, (1, 0, 2))
-        hs = tf.scan(step, elems=shuffled_input, initializer=hidden_init_var_b)
-        hs = tf.transpose(hs, (1, 0, 2))
+        hs = rnn(all_input_var, initial_state=hidden_init_var_b)
         outputs = output_nonlinearity_layer(hs)
 
     return outputs, output, hidden, hidden_init_var

--- a/src/garage/tf/models/gru.py
+++ b/src/garage/tf/models/gru.py
@@ -28,10 +28,10 @@ def gru(name,
             hidden state is trainable.
 
     Return:
-        tf.Tensor: Entire time-series outputs.
-        tf.Tensor: Step output.
-        tf.Tensor: Step hidden state.
-        tf.Tensor: Initial hidden state.
+        tf.Tensor: Entire time-series outputs, with shape :math:`(N, T, S^*)`.
+        tf.Tensor: Step output, with shape :math:`(N, S^*)`.
+        tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`
+        tf.Tensor: Initial hidden state, with shape :math:`(H, )`
 
     """
     with tf.compat.v1.variable_scope(name):

--- a/src/garage/tf/models/lstm.py
+++ b/src/garage/tf/models/lstm.py
@@ -24,9 +24,9 @@ def lstm(name,
         step_input_var (tf.Tensor): Place holder for step inputs, with shape
             :math:`(N, S^*)`.
         step_hidden_var (tf.Tensor): Place holder for step hidden state, with
-            shape :math:`(N, hidden_dim)`.
+            shape :math:`(N, H)`.
         step_cell_var (tf.Tensor): Place holder for cell state, with shape
-            :math:`(N, hidden_dim)`.
+            :math:`(N, H)`.
         output_nonlinearity_layer (callable): Activation function for output
             dense layer. It should return a tf.Tensor. Set it to None to
             maintain a linear activation.
@@ -42,10 +42,10 @@ def lstm(name,
     Return:
         tf.Tensor: Entire time-seried outputs, with shape :math:`(N, T, S^*)`.
         tf.Tensor: Step output, with shape :math:`(N, S^*)`.
-        tf.Tensor: Step hidden state, with shape :math:`(N, hidden_dim)`.
-        tf.Tensor: Step cell state, with shape :math:`(N, hidden_dim)`.
-        tf.Tensor: Initial hidden state, with shape :math:`(hidden_dim, )`.
-        tf.Tensor: Initial cell state, with shape :math:`(hidden_dim, )`.
+        tf.Tensor: Step hidden state, with shape :math:`(N, H)`.
+        tf.Tensor: Step cell state, with shape :math:`(N, H)`.
+        tf.Tensor: Initial hidden state, with shape :math:`(H, )`.
+        tf.Tensor: Initial cell state, with shape :math:`(H, )`.
 
     """
     with tf.compat.v1.variable_scope(name):

--- a/src/garage/tf/models/lstm.py
+++ b/src/garage/tf/models/lstm.py
@@ -36,12 +36,12 @@ def lstm(name,
             cell state is trainable.
 
     Return:
-        tf.Tensor: Entire time-seried outputs.
-        tf.Tensor: Step output.
-        tf.Tensor: Step hidden state.
-        tf.Tensor: Step cell state.
-        tf.Tensor: Initial hidden state.
-        tf.Tensor: Initial cell state.
+        tf.Tensor: Entire time-seried outputs, with shape :math:`(N, T, S^*)`.
+        tf.Tensor: Step output, with shape :math:`(N, S^*)`.
+        tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`.
+        tf.Tensor: Step cell state, with shape :math:`(N, S^*)`.
+        tf.Tensor: Initial hidden state, with shape :math:`(H, )`.
+        tf.Tensor: Initial cell state, with shape :math:`(H, )`.
 
     """
     with tf.compat.v1.variable_scope(name):

--- a/src/garage/tf/models/lstm.py
+++ b/src/garage/tf/models/lstm.py
@@ -13,16 +13,20 @@ def lstm(name,
          hidden_state_init_trainable=False,
          cell_state_init=tf.zeros_initializer(),
          cell_state_init_trainable=False):
-    """Long Short-Term Memory (LSTM).
+    r"""Long Short-Term Memory (LSTM).
 
     Args:
         name (str): Name of the variable scope.
         lstm_cell (tf.keras.layers.Layer): LSTM cell used to generate
             outputs.
-        all_input_var (tf.Tensor): Place holder for entire time-seried inputs.
-        step_input_var (tf.Tensor): Place holder for step inputs.
-        step_hidden_var (tf.Tensor): Place holder for step hidden state.
-        step_cell_var (tf.Tensor): Place holder for cell state.
+        all_input_var (tf.Tensor): Place holder for entire time-seried inputs,
+            with shape :math:`(N, T, S^*)`.
+        step_input_var (tf.Tensor): Place holder for step inputs, with shape
+            :math:`(N, S^*)`.
+        step_hidden_var (tf.Tensor): Place holder for step hidden state, with
+            shape :math:`(N, hidden_dim)`.
+        step_cell_var (tf.Tensor): Place holder for cell state, with shape
+            :math:`(N, hidden_dim)`.
         output_nonlinearity_layer (callable): Activation function for output
             dense layer. It should return a tf.Tensor. Set it to None to
             maintain a linear activation.
@@ -38,10 +42,10 @@ def lstm(name,
     Return:
         tf.Tensor: Entire time-seried outputs, with shape :math:`(N, T, S^*)`.
         tf.Tensor: Step output, with shape :math:`(N, S^*)`.
-        tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`.
-        tf.Tensor: Step cell state, with shape :math:`(N, S^*)`.
-        tf.Tensor: Initial hidden state, with shape :math:`(H, )`.
-        tf.Tensor: Initial cell state, with shape :math:`(H, )`.
+        tf.Tensor: Step hidden state, with shape :math:`(N, hidden_dim)`.
+        tf.Tensor: Step cell state, with shape :math:`(N, hidden_dim)`.
+        tf.Tensor: Initial hidden state, with shape :math:`(hidden_dim, )`.
+        tf.Tensor: Initial cell state, with shape :math:`(hidden_dim, )`.
 
     """
     with tf.compat.v1.variable_scope(name):


### PR DESCRIPTION
Use tf.keras.layers.RNN for feedforwarding the entire time-series input on recurrent networks.