### PR TITLE
Fix categorical primitives distribution argument

### DIFF
--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -60,7 +60,7 @@ class CategoricalGRUModel(GRUModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -116,6 +116,5 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
-        outputs = outputs / tf.math.reduce_sum(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -60,7 +60,7 @@ class CategoricalGRUModel(GRUModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -75,12 +75,13 @@ class CategoricalGRUModel(GRUModel):
             hidden_b_init=hidden_b_init,
             recurrent_nonlinearity=recurrent_nonlinearity,
             recurrent_w_init=recurrent_w_init,
-            output_nonlinearity=output_nonlinearity,
+            output_nonlinearity=tf.nn.softmax,
             output_w_init=output_w_init,
             output_b_init=output_b_init,
             hidden_state_init=hidden_state_init,
             hidden_state_init_trainable=hidden_state_init_trainable,
             layer_normalization=layer_normalization)
+        self._output_nonlinearity = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -116,5 +117,6 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
+        outputs = self._output_nonlinearity(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -116,5 +116,5 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
-        dist = tfp.distributions.OneHotCategorical(outputs)
+        dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -81,7 +81,7 @@ class CategoricalGRUModel(GRUModel):
             hidden_state_init=hidden_state_init,
             hidden_state_init_trainable=hidden_state_init_trainable,
             layer_normalization=layer_normalization)
-        self._output_nonlinearity = output_nonlinearity
+        self._output_normalization_fn = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -117,7 +117,7 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
-        if self._output_nonlinearity:
-            outputs = self._output_nonlinearity(outputs)
+        if self._output_normalization_fn:
+            outputs = self._output_normalization_fn(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -116,5 +116,6 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
+        outputs = outputs / tf.math.reduce_sum(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -117,6 +117,7 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
-        outputs = self._output_nonlinearity(outputs)
+        if self._output_nonlinearity:
+            outputs = self._output_nonlinearity(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -67,7 +67,7 @@ class CategoricalLSTMModel(LSTMModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -146,7 +146,6 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
-        outputs = outputs / tf.math.reduce_sum(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -146,6 +146,6 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
-        dist = tfp.distributions.OneHotCategorical(outputs)
+        dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -94,7 +94,7 @@ class CategoricalLSTMModel(LSTMModel):
             cell_state_init_trainable=cell_state_init_trainable,
             forget_bias=forget_bias,
             layer_normalization=layer_normalization)
-        self._output_nonlinearity = output_nonlinearity
+        self._output_normalization_fn = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -147,8 +147,8 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
-        if self._output_nonlinearity:
-            outputs = self._output_nonlinearity(outputs)
+        if self._output_normalization_fn:
+            outputs = self._output_normalization_fn(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -147,7 +147,8 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
-        outputs = self._output_nonlinearity(outputs)
+        if self._output_nonlinearity:
+            outputs = self._output_nonlinearity(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -146,6 +146,7 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
+        outputs = outputs / tf.math.reduce_sum(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -67,7 +67,7 @@ class CategoricalLSTMModel(LSTMModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -85,7 +85,7 @@ class CategoricalLSTMModel(LSTMModel):
             hidden_b_init=hidden_b_init,
             recurrent_nonlinearity=recurrent_nonlinearity,
             recurrent_w_init=recurrent_w_init,
-            output_nonlinearity=output_nonlinearity,
+            output_nonlinearity=tf.nn.softmax,
             output_w_init=output_w_init,
             output_b_init=output_b_init,
             hidden_state_init=hidden_state_init,
@@ -94,6 +94,7 @@ class CategoricalLSTMModel(LSTMModel):
             cell_state_init_trainable=cell_state_init_trainable,
             forget_bias=forget_bias,
             layer_normalization=layer_normalization)
+        self._output_nonlinearity = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -146,6 +147,7 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
+        outputs = self._output_nonlinearity(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -72,4 +72,5 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
+        prob = prob / tf.math.reduce_sum(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -57,7 +57,7 @@ class CategoricalMLPModel(MLPModel):
         super().__init__(output_dim, name, hidden_sizes, hidden_nonlinearity,
                          hidden_w_init, hidden_b_init, tf.nn.softmax,
                          output_w_init, output_b_init, layer_normalization)
-        self._output_nonlinearity = output_nonlinearity
+        self._output_normalization_fn = output_nonlinearity
 
     def _build(self, state_input, name=None):
         """Build model.
@@ -73,6 +73,6 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
-        if self._output_nonlinearity:
-            prob = self._output_nonlinearity(prob)
+        if self._output_normalization_fn:
+            prob = self._output_normalization_fn(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -50,13 +50,14 @@ class CategoricalMLPModel(MLPModel):
                  hidden_nonlinearity=tf.nn.tanh,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):
         super().__init__(output_dim, name, hidden_sizes, hidden_nonlinearity,
-                         hidden_w_init, hidden_b_init, output_nonlinearity,
+                         hidden_w_init, hidden_b_init, tf.nn.softmax,
                          output_w_init, output_b_init, layer_normalization)
+        self._output_nonlinearity = output_nonlinearity
 
     def _build(self, state_input, name=None):
         """Build model.
@@ -72,4 +73,5 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
+        prob = self._output_nonlinearity(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -72,4 +72,4 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
-        return tfp.distributions.OneHotCategorical(prob)
+        return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -73,5 +73,6 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
-        prob = self._output_nonlinearity(prob)
+        if self._output_nonlinearity:
+            prob = self._output_nonlinearity(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -47,10 +47,10 @@ class CategoricalMLPModel(MLPModel):
                  output_dim,
                  name=None,
                  hidden_sizes=(32, 32),
-                 hidden_nonlinearity=tf.nn.relu,
+                 hidden_nonlinearity=tf.nn.tanh,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):
@@ -72,5 +72,4 @@ class CategoricalMLPModel(MLPModel):
 
         """
         prob = super()._build(state_input, name=name)
-        prob = prob / tf.math.reduce_sum(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/policies/categorical_cnn_policy2.py
+++ b/src/garage/tf/policies/categorical_cnn_policy2.py
@@ -125,7 +125,7 @@ class CategoricalCNNPolicy2(StochasticPolicy2):
             self._dist = self.model.build(state_input, name=name)
 
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
-                [tf.argmax(self._dist.sample(), -1), self._dist.logits],
+                [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])
 
     @property

--- a/src/garage/tf/policies/categorical_gru_policy2.py
+++ b/src/garage/tf/policies/categorical_gru_policy2.py
@@ -67,7 +67,7 @@ class CategoricalGRUPolicy2(StochasticPolicy2):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),

--- a/src/garage/tf/policies/categorical_lstm_policy2.py
+++ b/src/garage/tf/policies/categorical_lstm_policy2.py
@@ -74,7 +74,7 @@ class CategoricalLSTMPolicy2(StochasticPolicy2):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),

--- a/src/garage/tf/policies/categorical_mlp_policy2.py
+++ b/src/garage/tf/policies/categorical_mlp_policy2.py
@@ -101,7 +101,7 @@ class CategoricalMLPPolicy2(StochasticPolicy2):
             self._dist = self.model.build(state_input, name=name)
 
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
-                [tf.argmax(self._dist.sample(), -1), self._dist.logits],
+                [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])
 
     @property

--- a/src/garage/tf/policies/categorical_mlp_policy2.py
+++ b/src/garage/tf/policies/categorical_mlp_policy2.py
@@ -53,7 +53,7 @@ class CategoricalMLPPolicy2(StochasticPolicy2):
                  hidden_nonlinearity=tf.nn.tanh,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=tf.nn.softmax,
+                 output_nonlinearity=None,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):

--- a/tests/garage/tf/models/test_categorical_cnn_model.py
+++ b/tests/garage/tf/models/test_categorical_cnn_model.py
@@ -46,7 +46,6 @@ class TestCategoricalMLPModel(TfGraphTestCase):
     @pytest.mark.parametrize(
         'output_dim, filter_dims, num_filters, strides,'
         'padding, hidden_sizes', [
-            (1, (1, ), (1, ), (1, ), 'VALID', (0, )),
             (1, (1, ), (1, ), (1, ), 'SAME', (1, )),
             (1, (3, ), (3, ), (2, ), 'VALID', (2, )),
             (1, (3, ), (3, ), (2, ), 'SAME', (3, )),
@@ -75,7 +74,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
         bias.load(tf.ones_like(bias).eval())
         cnn_bias.load(tf.ones_like(cnn_bias).eval())
 
-        output1 = self.sess.run(dist.logits,
+        output1 = self.sess.run(dist.probs,
                                 feed_dict={self._input_ph: self._obs_input})
 
         h = pickle.dumps(model)
@@ -85,7 +84,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                                  self._input_shape)
             model_pickled = pickle.loads(h)
             dist2 = model_pickled.build(input_var)
-            output2 = sess.run(dist2.logits,
+            output2 = sess.run(dist2.probs,
                                feed_dict={input_var: self._obs_input})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -53,7 +53,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
 
         hidden = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].dist.logits,
+        outputs1 = self.sess.run(model.networks['default'].dist.probs,
                                  feed_dict={self.input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
@@ -83,7 +83,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
                                                        dtype=tf.float32)
 
             model_pickled.build(input_var, step_input_var, step_hidden_var)
-            outputs2 = sess.run(model_pickled.networks['default'].dist.logits,
+            outputs2 = sess.run(model_pickled.networks['default'].dist.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -1,6 +1,7 @@
 import pickle
 
 import numpy as np
+import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
 
@@ -36,6 +37,21 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         model.build(self.input_var, self.step_input_var, step_hidden_var)
         assert isinstance(model.networks['default'].dist,
                           tfp.distributions.OneHotCategorical)
+
+    @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
+    def test_output_normalized(self, output_dim):
+        model = CategoricalGRUModel(output_dim=output_dim, hidden_dim=4)
+        obs_ph = tf.compat.v1.placeholder(tf.float32,
+                                          shape=(None, None, output_dim))
+        step_obs_ph = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, output_dim))
+        step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
+        obs = np.ones((1, 1, output_dim))
+        dist, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph)
+        probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
+            dist.probs),
+                                                       feed_dict={obs_ph: obs})
+        assert probs == 1.0
 
     def test_is_pickleable(self):
         model = CategoricalGRUModel(output_dim=1, hidden_dim=1)

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -51,7 +51,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
-        assert probs == 1.0
+        assert np.isclose(probs, 1.0)
 
     def test_is_pickleable(self):
         model = CategoricalGRUModel(output_dim=1, hidden_dim=1)

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -38,6 +38,19 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         assert isinstance(model.networks['default'].dist,
                           tfp.distributions.OneHotCategorical)
 
+    def test_output_nonlinearity(self):
+        model = CategoricalGRUModel(output_dim=1,
+                                    hidden_dim=4,
+                                    output_nonlinearity=lambda x: x / 2)
+        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 1))
+        step_obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
+        step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
+        obs = np.ones((1, 1, 1))
+        dist, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph)
+        probs = tf.compat.v1.get_default_session().run(dist.probs,
+                                                       feed_dict={obs_ph: obs})
+        assert probs == [0.5]
+
     @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
     def test_output_normalized(self, output_dim):
         model = CategoricalGRUModel(output_dim=output_dim, hidden_dim=4)

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -62,7 +62,7 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         hidden = np.zeros((self.batch_size, 1))
         cell = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].dist.logits,
+        outputs1 = self.sess.run(model.networks['default'].dist.probs,
                                  feed_dict={self._input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
@@ -97,7 +97,7 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
 
             model_pickled.build(input_var, step_input_var, step_hidden_var,
                                 step_cell_var)
-            outputs2 = sess.run(model_pickled.networks['default'].dist.logits,
+            outputs2 = sess.run(model_pickled.networks['default'].dist.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -42,6 +42,21 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         assert isinstance(model.networks['default'].dist,
                           tfp.distributions.OneHotCategorical)
 
+    def test_output_nonlinearity(self):
+        model = CategoricalLSTMModel(output_dim=1,
+                                     hidden_dim=4,
+                                     output_nonlinearity=lambda x: x / 2)
+        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 1))
+        step_obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
+        step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
+        step_cell_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
+        obs = np.ones((1, 1, 1))
+        dist, _, _, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph,
+                                          step_cell_ph)
+        probs = tf.compat.v1.get_default_session().run(dist.probs,
+                                                       feed_dict={obs_ph: obs})
+        assert probs == [0.5]
+
     @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
     def test_output_normalized(self, output_dim):
         model = CategoricalLSTMModel(output_dim=output_dim, hidden_dim=4)

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -57,7 +57,7 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
-        assert probs == 1.0
+        assert np.isclose(probs, 1.0)
 
     def test_is_pickleable(self):
         model = CategoricalLSTMModel(output_dim=1, hidden_dim=1)

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -32,6 +32,16 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                                        feed_dict={obs_ph: obs})
         assert np.isclose(probs, 1.0)
 
+    def test_output_nonlinearity(self):
+        model = CategoricalMLPModel(output_dim=1,
+                                    output_nonlinearity=lambda x: x / 2)
+        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
+        obs = np.ones((1, 1))
+        dist = model.build(obs_ph)
+        probs = tf.compat.v1.get_default_session().run(dist.probs,
+                                                       feed_dict={obs_ph: obs})
+        assert probs == [0.5]
+
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_sizes', [
         (1, (1, )),

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -21,6 +21,17 @@ class TestCategoricalMLPModel(TfGraphTestCase):
         dist = model.build(self.input_var)
         assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
+    @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
+    def test_output_normalized(self, output_dim):
+        model = CategoricalMLPModel(output_dim=output_dim)
+        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, output_dim))
+        obs = np.ones((1, output_dim))
+        dist = model.build(obs_ph)
+        probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
+            dist.probs),
+                                                       feed_dict={obs_ph: obs})
+        assert probs == 1.0
+
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_sizes', [
         (1, (1, )),

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -23,7 +23,6 @@ class TestCategoricalMLPModel(TfGraphTestCase):
 
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_sizes', [
-        (1, (0, )),
         (1, (1, )),
         (1, (2, )),
         (2, (3, )),
@@ -45,7 +44,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
 
         bias.load(tf.ones_like(bias).eval())
 
-        output1 = self.sess.run(dist.logits,
+        output1 = self.sess.run(dist.probs,
                                 feed_dict={self.input_var: self.obs})
 
         h = pickle.dumps(model)
@@ -53,6 +52,6 @@ class TestCategoricalMLPModel(TfGraphTestCase):
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
             dist2 = model_pickled.build(input_var)
-            output2 = sess.run(dist2.logits, feed_dict={input_var: self.obs})
+            output2 = sess.run(dist2.probs, feed_dict={input_var: self.obs})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -30,7 +30,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
-        assert probs == 1.0
+        assert np.isclose(probs, 1.0)
 
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_sizes', [

--- a/tests/garage/tf/policies/test_categorical_cnn_policy2.py
+++ b/tests/garage/tf/policies/test_categorical_cnn_policy2.py
@@ -72,7 +72,7 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         cnn_bias.load(tf.ones_like(cnn_bias).eval())
         bias.load(tf.ones_like(bias).eval())
 
-        output1 = self.sess.run(policy.distribution.logits,
+        output1 = self.sess.run(policy.distribution.probs,
                                 feed_dict={policy.model.input: [obs]})
         p = pickle.dumps(policy)
 
@@ -83,7 +83,7 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
                                                env.observation_space.shape,
                                                name='obs')
             policy_pickled.build(obs_var)
-            output2 = sess.run(policy_pickled.distribution.logits,
+            output2 = sess.run(policy_pickled.distribution.probs,
                                feed_dict={policy_pickled.model.input: [obs]})
             assert np.array_equal(output1, output2)
 

--- a/tests/garage/tf/policies/test_categorical_gru_policy2.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy2.py
@@ -86,7 +86,7 @@ class TestCategoricalGRUPolicy2(TfGraphTestCase):
             tf.ones_like(policy.model._gru_cell.weights[0]).eval())
 
         output1 = self.sess.run(
-            [policy.distribution.logits],
+            [policy.distribution.probs],
             feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
 
         p = pickle.dumps(policy)
@@ -100,7 +100,7 @@ class TestCategoricalGRUPolicy2(TfGraphTestCase):
             policy_pickled.build(obs_var)
             # yapf: disable
             output2 = sess.run(
-                [policy_pickled.distribution.logits],
+                [policy_pickled.distribution.probs],
                 feed_dict={
                     policy_pickled.model.input: [[obs.flatten()],
                                                  [obs.flatten()]]

--- a/tests/garage/tf/policies/test_categorical_lstm_policy2.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy2.py
@@ -90,7 +90,7 @@ class TestCategoricalLSTMPolicy2(TfGraphTestCase):
             tf.ones_like(policy.model._lstm_cell.weights[0]).eval())
 
         output1 = self.sess.run(
-            [policy.distribution.logits],
+            [policy.distribution.probs],
             feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
 
         p = pickle.dumps(policy)
@@ -102,7 +102,7 @@ class TestCategoricalLSTMPolicy2(TfGraphTestCase):
                 shape=[None, None, env.observation_space.flat_dim],
                 name='obs')
             policy_pickled.build(obs_var)
-            output2 = sess.run([policy_pickled.distribution.logits],
+            output2 = sess.run([policy_pickled.distribution.probs],
                                feed_dict={
                                    policy_pickled.model.input:
                                    [[obs.flatten()], [obs.flatten()]]

--- a/tests/garage/tf/policies/test_categorical_mlp_policy2.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy2.py
@@ -67,7 +67,7 @@ class TestCategoricalMLPPolicy2(TfGraphTestCase):
         # assign it to all one
         bias.load(tf.ones_like(bias).eval())
         output1 = self.sess.run(
-            [policy.distribution.logits],
+            [policy.distribution.probs],
             feed_dict={policy.model.input: [obs.flatten()]})
 
         p = pickle.dumps(policy)
@@ -80,7 +80,7 @@ class TestCategoricalMLPPolicy2(TfGraphTestCase):
                 name='obs')
             policy_pickled.build(obs_var)
             output2 = sess.run(
-                [policy_pickled.distribution.logits],
+                [policy_pickled.distribution.probs],
                 feed_dict={policy_pickled.model.input: [obs.flatten()]})
             assert np.array_equal(output1, output2)
 


### PR DESCRIPTION
Without providing the function argument `probs`, the default argument is `logits`
which is not the vanilla probability values.