### PR TITLE
Fix flake8 config in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,14 +2,19 @@
 import-order-style = google
 application-import-names = tests, garage, examples
 per-file-ignores =
-    # interferes with idiomatic `from torch.nn import functional as F`
-    ./src/garage/torch/*:N812
-    ./tests/garage/torch/*:N812
-    ./examples/torch/*:N812
+    # NOTE: Please keep this sorted alphabetically, then from
+    # shallowest-to-deepest application. Deeper rules must repeat also-matching
+    # shallower rules, due to a quirk in flake8.
+    # See https://gitlab.com/pycqa/flake8/-/issues/494
+    #
     # errors on valid property docstrings
-    ./src/garage/*:D403
-    # tests don't need docstrings
-    ./tests/*:D
+    src/garage/*:D403
+    # unit tests don't need docstrings
+    tests/garage/*:D
+    # interferes with idiomatic `from torch.nn import functional as F`
+    examples/torch/*:N812
+    src/garage/torch/*:N812,D403
+    tests/garage/torch/*:N812,D
 
 # Docstring style checks
 docstring-convention = google


### PR DESCRIPTION
Due to a quirk in flake8's per-file-ignores feature (which makes the
order of per-file-ignores rules matter), several of our flake8 rules and
exclusions have improperly applied. This PR re-organizes the
per-file-ignores section of setup.cfg to apply our rules properly, and
leaves a warning for future changes.

See https://gitlab.com/pycqa/flake8/-/issues/494 for more information.