### PR TITLE
Pin torchvision properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIRED = [
     'tensorflow',
     'tensorflow-probability',
     'torch>=1.0.0,<1.5.0',
-    'torchvision>=0.2.1',
+    'torchvision>=0.2.1,<0.6.0',
 ]
 
 # Dependencies for optional features


### PR DESCRIPTION
#1335 pinned torch, but not torchvision. virtualenv doesn't properly
resolve compatible torchvision versions, printing an error. This appears
scary, but is harmless.