### PR TITLE
Fix PEARL.adapt_policy

### DIFF
--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -592,7 +592,12 @@ class PEARL(MetaRLAlgorithm):
                 exploration_trajectories.
 
         """
-        context = self._sample_context(self._task_idx)
+        total_steps = sum(exploration_trajectories.lengths)
+        o = exploration_trajectories.observations
+        a = exploration_trajectories.actions
+        r = exploration_trajectories.rewards.reshape(total_steps, 1)
+        ctxt = np.hstack((o, a, r)).reshape(1, total_steps, -1)
+        context = torch.as_tensor(ctxt, device=tu.global_device()).float()
         self._policy.infer_posterior(context)
 
         return self._policy


### PR DESCRIPTION
Before it was using samples from the replay buffer to create the
context. Now it uses the exploration samples (as it should).

This fixes the behavior of PEARL on HalfCheetahDirEnv (and probably most
other meta-learning environments).