### PR TITLE
Revert "Downgrade sphinx version (#1284)"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,5 +18,5 @@ tensorflow-probability<0.6.0,>=0.5.0
 # dev dependencies
 matplotlib
 recommonmark
-sphinx==2.4.4
+sphinx
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ EXTRAS['dev'] = [
     'recommonmark',
     'rlkit @ https://{}@api.github.com/repos/vitchyr/rlkit/tarball/1d469a509b797ca04a39b8734c1816ca7d108fc8'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'seaborn',
-    'sphinx==2.4.4',
+    'sphinx',
     'sphinx_rtd_theme',
     'yapf==0.28.0',
 ]  # yapf: disable


### PR DESCRIPTION
This reverts commit aabfe20e63e253adb322dda8423e318c53a87a01.

The [underlying issue](https://github.com/sphinx-doc/sphinx/issues/7422) was fixed in sphinx 3.0.1