### PR TITLE
Add max_eval_path_length to off-policy algorithms

### DIFF
--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -30,6 +30,8 @@ class DDPG(OffPolicyRLAlgorithm):
         n_train_steps (int): Training steps.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
+        max_eval_path_length (int or None): Maximum length of paths used for
+            off-policy evaluation. If None, defaults to `max_path_length`.
         buffer_batch_size (int): Batch size of replay buffer.
         min_buffer_size (int): The minimum buffer size for replay buffer.
         rollout_batch_size (int): Roll out batch size.
@@ -57,32 +59,35 @@ class DDPG(OffPolicyRLAlgorithm):
 
     """
 
-    def __init__(self,
-                 env_spec,
-                 policy,
-                 qf,
-                 replay_buffer,
-                 steps_per_epoch=20,
-                 n_train_steps=50,
-                 max_path_length=None,
-                 buffer_batch_size=64,
-                 min_buffer_size=int(1e4),
-                 rollout_batch_size=1,
-                 exploration_strategy=None,
-                 target_update_tau=0.01,
-                 policy_lr=1e-4,
-                 qf_lr=1e-3,
-                 discount=0.99,
-                 policy_weight_decay=0,
-                 qf_weight_decay=0,
-                 policy_optimizer=tf.compat.v1.train.AdamOptimizer,
-                 qf_optimizer=tf.compat.v1.train.AdamOptimizer,
-                 clip_pos_returns=False,
-                 clip_return=np.inf,
-                 max_action=None,
-                 reward_scale=1.,
-                 smooth_return=True,
-                 name='DDPG'):
+    def __init__(
+            self,
+            env_spec,
+            policy,
+            qf,
+            replay_buffer,
+            *,  # Everything after this is numbers.
+            steps_per_epoch=20,
+            n_train_steps=50,
+            max_path_length=None,
+            max_eval_path_length=None,
+            buffer_batch_size=64,
+            min_buffer_size=int(1e4),
+            rollout_batch_size=1,
+            exploration_strategy=None,
+            target_update_tau=0.01,
+            policy_lr=1e-4,
+            qf_lr=1e-3,
+            discount=0.99,
+            policy_weight_decay=0,
+            qf_weight_decay=0,
+            policy_optimizer=tf.compat.v1.train.AdamOptimizer,
+            qf_optimizer=tf.compat.v1.train.AdamOptimizer,
+            clip_pos_returns=False,
+            clip_return=np.inf,
+            max_action=None,
+            reward_scale=1.,
+            smooth_return=True,
+            name='DDPG'):
         action_bound = env_spec.action_space.high
         self.max_action = action_bound if max_action is None else max_action
         self.tau = target_update_tau
@@ -112,6 +117,7 @@ class DDPG(OffPolicyRLAlgorithm):
                                    n_train_steps=n_train_steps,
                                    steps_per_epoch=steps_per_epoch,
                                    max_path_length=max_path_length,
+                                   max_eval_path_length=max_eval_path_length,
                                    buffer_batch_size=buffer_batch_size,
                                    min_buffer_size=min_buffer_size,
                                    rollout_batch_size=rollout_batch_size,

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -46,6 +46,8 @@ class TD3(DDPG):
         name (str): Name of the algorithm shown in computation graph.
         steps_per_epoch (int): Number of batches of samples in each epoch.
         max_path_length (int): Maximum length of a path.
+        max_eval_path_length (int or None): Maximum length of paths used for
+            off-policy evaluation. If None, defaults to `max_path_length`.
         n_train_steps (int): Number of optimizations in each epoch cycle.
         buffer_batch_size (int): Size of replay buffer.
         min_buffer_size (int):
@@ -63,36 +65,39 @@ class TD3(DDPG):
 
     """
 
-    def __init__(self,
-                 env_spec,
-                 policy,
-                 qf,
-                 qf2,
-                 replay_buffer,
-                 target_update_tau=0.01,
-                 policy_lr=1e-4,
-                 qf_lr=1e-3,
-                 policy_weight_decay=0,
-                 qf_weight_decay=0,
-                 policy_optimizer=tf.compat.v1.train.AdamOptimizer,
-                 qf_optimizer=tf.compat.v1.train.AdamOptimizer,
-                 clip_pos_returns=False,
-                 clip_return=np.inf,
-                 discount=0.99,
-                 max_action=None,
-                 name='TD3',
-                 steps_per_epoch=20,
-                 max_path_length=None,
-                 n_train_steps=50,
-                 buffer_batch_size=64,
-                 min_buffer_size=1e4,
-                 rollout_batch_size=1,
-                 reward_scale=1.,
-                 action_noise_sigma=0.2,
-                 actor_update_period=2,
-                 action_noise_clip=0.5,
-                 smooth_return=True,
-                 exploration_strategy=None):
+    def __init__(
+            self,
+            env_spec,
+            policy,
+            qf,
+            qf2,
+            replay_buffer,
+            *,  # Everything after this is numbers.
+            target_update_tau=0.01,
+            policy_lr=1e-4,
+            qf_lr=1e-3,
+            policy_weight_decay=0,
+            qf_weight_decay=0,
+            policy_optimizer=tf.compat.v1.train.AdamOptimizer,
+            qf_optimizer=tf.compat.v1.train.AdamOptimizer,
+            clip_pos_returns=False,
+            clip_return=np.inf,
+            discount=0.99,
+            max_action=None,
+            name='TD3',
+            steps_per_epoch=20,
+            max_path_length=None,
+            max_eval_path_length=None,
+            n_train_steps=50,
+            buffer_batch_size=64,
+            min_buffer_size=1e4,
+            rollout_batch_size=1,
+            reward_scale=1.,
+            action_noise_sigma=0.2,
+            actor_update_period=2,
+            action_noise_clip=0.5,
+            smooth_return=True,
+            exploration_strategy=None):
         self.qf2 = qf2
         self._action_noise_sigma = action_noise_sigma
         self._action_noise_clip = action_noise_clip
@@ -119,6 +124,7 @@ class TD3(DDPG):
                                   name=name,
                                   steps_per_epoch=steps_per_epoch,
                                   max_path_length=max_path_length,
+                                  max_eval_path_length=max_eval_path_length,
                                   n_train_steps=n_train_steps,
                                   buffer_batch_size=buffer_batch_size,
                                   min_buffer_size=min_buffer_size,

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -29,6 +29,8 @@ class DDPG(OffPolicyRLAlgorithm):
         n_train_steps (int): Training steps.
         max_path_length (int): Maximum path length. The episode will
             terminate when length of trajectory reaches max_path_length.
+        max_eval_path_length (int or None): Maximum length of paths used for
+            off-policy evaluation. If None, defaults to `max_path_length`.
         buffer_batch_size (int): Batch size of replay buffer.
         min_buffer_size (int): The minimum buffer size for replay buffer.
         rollout_batch_size (int): Roll out batch size.
@@ -62,31 +64,34 @@ class DDPG(OffPolicyRLAlgorithm):
 
     """
 
-    def __init__(self,
-                 env_spec,
-                 policy,
-                 qf,
-                 replay_buffer,
-                 steps_per_epoch=20,
-                 n_train_steps=50,
-                 max_path_length=None,
-                 buffer_batch_size=64,
-                 min_buffer_size=int(1e4),
-                 rollout_batch_size=1,
-                 exploration_strategy=None,
-                 target_update_tau=0.01,
-                 discount=0.99,
-                 policy_weight_decay=0,
-                 qf_weight_decay=0,
-                 policy_optimizer=torch.optim.Adam,
-                 qf_optimizer=torch.optim.Adam,
-                 policy_lr=_Default(1e-4),
-                 qf_lr=_Default(1e-3),
-                 clip_pos_returns=False,
-                 clip_return=np.inf,
-                 max_action=None,
-                 reward_scale=1.,
-                 smooth_return=True):
+    def __init__(
+            self,
+            env_spec,
+            policy,
+            qf,
+            replay_buffer,
+            *,  # Everything after this is numbers.
+            steps_per_epoch=20,
+            n_train_steps=50,
+            max_path_length=None,
+            max_eval_path_length=None,
+            buffer_batch_size=64,
+            min_buffer_size=int(1e4),
+            rollout_batch_size=1,
+            exploration_strategy=None,
+            target_update_tau=0.01,
+            discount=0.99,
+            policy_weight_decay=0,
+            qf_weight_decay=0,
+            policy_optimizer=torch.optim.Adam,
+            qf_optimizer=torch.optim.Adam,
+            policy_lr=_Default(1e-4),
+            qf_lr=_Default(1e-3),
+            clip_pos_returns=False,
+            clip_return=np.inf,
+            max_action=None,
+            reward_scale=1.,
+            smooth_return=True):
         action_bound = env_spec.action_space.high
         self._tau = target_update_tau
         self._policy_weight_decay = policy_weight_decay
@@ -108,6 +113,7 @@ class DDPG(OffPolicyRLAlgorithm):
                          n_train_steps=n_train_steps,
                          steps_per_epoch=steps_per_epoch,
                          max_path_length=max_path_length,
+                         max_eval_path_length=max_eval_path_length,
                          buffer_batch_size=buffer_batch_size,
                          min_buffer_size=min_buffer_size,
                          rollout_batch_size=rollout_batch_size,

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -43,7 +43,11 @@ class SAC(OffPolicyRLAlgorithm):
             environment that the agent is being trained in. Usually accessable
             by calling env.spec.
         max_path_length (int): Max path length of the algorithm.
+        max_eval_path_length (int or None): Maximum length of paths used for
+            off-policy evaluation. If None, defaults to `max_path_length`.
         gradient_steps_per_itr (int): Number of optimization steps that should
+        max_path_length(int): Max path length of the environment.
+        gradient_steps_per_itr(int): Number of optimization steps that should
             occur before the training step is over and a new batch of
             transitions is collected by the sampler.
         fixed_alpha (float): The entropy/temperature to be used if temperature
@@ -81,12 +85,14 @@ class SAC(OffPolicyRLAlgorithm):
 
     def __init__(
             self,
+            env_spec,
             policy,
             qf1,
             qf2,
             replay_buffer,
-            env_spec,
+            *,  # Everything after this is numbers.
             max_path_length,
+            max_eval_path_length=None,
             gradient_steps_per_itr,
             fixed_alpha=None,
             target_entropy=None,
@@ -122,6 +128,7 @@ class SAC(OffPolicyRLAlgorithm):
                          qf=qf1,
                          n_train_steps=self._gradient_steps,
                          max_path_length=max_path_length,
+                         max_eval_path_length=max_eval_path_length,
                          buffer_batch_size=buffer_batch_size,
                          min_buffer_size=min_buffer_size,
                          replay_buffer=replay_buffer,


### PR DESCRIPTION
Note that the default in this change is `max_path_length`, but maybe it should be 1000.