### PR TITLE
Relax timeout limit on MAML ML10

### DIFF
--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -228,7 +228,7 @@ def test_pearl_ml45():
 
 @pytest.mark.nightly
 @pytest.mark.no_cover
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(200)
 def test_maml_ml10():
     """Test maml_trpo_ml10.py."""
     assert subprocess.run([


### PR DESCRIPTION
After replacing baseline with MLP value function, MAML runs slower and the ML10 example is failing in nightly test.