### PR TITLE
Make runner._sampler optional

### DIFF
--- a/src/garage/tf/experiment/local_tf_runner.py
+++ b/src/garage/tf/experiment/local_tf_runner.py
@@ -183,7 +183,7 @@ class LocalTFRunner(LocalRunner):
         if self._plot:
             # pylint: disable=import-outside-toplevel
             from garage.tf.plotter import Plotter
-            self._plotter = Plotter(self.get_env_copy(), self._policy)
+            self._plotter = Plotter(self.get_env_copy(), self._algo.policy)
             self._plotter.start()
 
     def initialize_tf_vars(self):

--- a/tests/garage/experiment/test_local_runner.py
+++ b/tests/garage/experiment/test_local_runner.py
@@ -6,6 +6,7 @@ from garage.envs import normalize
 from garage.envs.base import GarageEnv
 from garage.experiment import deterministic, LocalRunner
 from garage.plotter import Plotter
+from garage.sampler import LocalSampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -49,3 +50,59 @@ class TestLocalRunner:
         assert isinstance(
             runner._plotter,
             Plotter), ('self.plotter in LocalRunner should be set to Plotter.')
+
+
+def test_setup_no_sampler():
+    runner = LocalRunner(snapshot_config)
+
+    class SupervisedAlgo:
+
+        def train(self, runner):
+            # pylint: disable=undefined-loop-variable
+            for epoch in runner.step_epochs():
+                pass
+            assert epoch == 4
+
+    runner.setup(SupervisedAlgo(), None)
+    runner.train(n_epochs=5)
+
+
+class CrashingAlgo:
+
+    def train(self, runner):
+        # pylint: disable=undefined-loop-variable
+        for epoch in runner.step_epochs():
+            runner.obtain_samples(epoch)
+
+
+def test_setup_no_sampler_cls():
+    runner = LocalRunner(snapshot_config)
+    algo = CrashingAlgo()
+    algo.max_path_length = 100
+    runner.setup(algo, None)
+    with pytest.raises(ValueError, match='sampler_cls'):
+        runner.train(n_epochs=5)
+
+
+def test_setup_no_policy():
+    runner = LocalRunner(snapshot_config)
+    with pytest.raises(ValueError, match='policy'):
+        runner.setup(CrashingAlgo(), None, sampler_cls=LocalSampler)
+
+
+def test_setup_no_max_path_length():
+    runner = LocalRunner(snapshot_config)
+    algo = CrashingAlgo()
+    algo.policy = None
+    with pytest.raises(ValueError, match='max_path_length'):
+        runner.setup(algo, None, sampler_cls=LocalSampler)
+
+
+def test_setup_no_batch_size():
+    runner = LocalRunner(snapshot_config)
+    algo = CrashingAlgo()
+    algo.max_path_length = 100
+    algo.policy = None
+    runner.setup(algo, None, sampler_cls=LocalSampler)
+    with pytest.raises(ValueError, match='batch_size'):
+        runner.train(n_epochs=5)

--- a/tests/garage/experiment/test_resume.py
+++ b/tests/garage/experiment/test_resume.py
@@ -30,7 +30,7 @@ class TestResume(TfGraphTestCase):
         with LocalTFRunner(self.snapshot_config, sess) as runner:
             args = runner.restore(self.temp_dir.name)
             assert np.equal(
-                runner._policy.get_param_values(),
+                runner._algo.policy.get_param_values(),
                 self.policy_params).all(), 'Policy parameters should persist'
             assert args.n_epochs == 5, (
                 'Snapshot should save training parameters')


### PR DESCRIPTION
This makes the garage runner much more usable for writing algorithms
that don't need the sampler (e.g. fully off-policy algorithms, pure
behavioral cloning, and supervised learning).