### PR TITLE
Add run script for benchmarking

### DIFF
--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -17,4 +17,9 @@ REQUIRED = [
 setup(name='garage_benchmarks',
       packages=find_packages(where='src'),
       package_dir={'': 'src'},
-      install_requires=REQUIRED)
+      install_requires=REQUIRED,
+      include_package_data=True,
+      entry_points='''
+              [console_scripts]
+              garage_benchmark=garage_benchmarks.run_benchmarks:cli
+          ''')

--- a/benchmarks/src/garage_benchmarks/benchmark_auto.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_auto.py
@@ -1,0 +1,48 @@
+"""Automatic benchmarking."""
+from garage_benchmarks.experiments.algos import ddpg_garage_tf
+from garage_benchmarks.experiments.algos import ppo_garage_pytorch
+from garage_benchmarks.experiments.algos import ppo_garage_tf
+from garage_benchmarks.experiments.algos import td3_garage_tf
+from garage_benchmarks.experiments.algos import trpo_garage_pytorch
+from garage_benchmarks.experiments.algos import trpo_garage_tf
+from garage_benchmarks.experiments.algos import vpg_garage_pytorch
+from garage_benchmarks.experiments.algos import vpg_garage_tf
+from garage_benchmarks.helper import benchmark, iterate_experiments
+from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
+
+
+@benchmark(plot=False, auto=True)
+def auto_ddpg_benchmarks():
+    """Run experiments for DDPG benchmarking."""
+    iterate_experiments(ddpg_garage_tf, MuJoCo1M_ENV_SET)
+
+
+@benchmark(plot=False, auto=True)
+def auto_ppo_benchmarks():
+    """Run experiments for PPO benchmarking."""
+    iterate_experiments(ppo_garage_pytorch, MuJoCo1M_ENV_SET)
+    iterate_experiments(ppo_garage_tf, MuJoCo1M_ENV_SET)
+
+
+@benchmark(plot=False, auto=True)
+def auto_td3_benchmarks():
+    """Run experiments for TD3 benchmarking."""
+    td3_env_ids = [
+        env_id for env_id in MuJoCo1M_ENV_SET if env_id != 'Reacher-v2'
+    ]
+
+    iterate_experiments(td3_garage_tf, td3_env_ids)
+
+
+@benchmark(plot=False, auto=True)
+def auto_trpo_benchmarks():
+    """Run experiments for TRPO benchmarking."""
+    iterate_experiments(trpo_garage_pytorch, MuJoCo1M_ENV_SET)
+    iterate_experiments(trpo_garage_tf, MuJoCo1M_ENV_SET)
+
+
+@benchmark(plot=False, auto=True)
+def auto_vpg_benchmarks():
+    """Run experiments for VPG benchmarking."""
+    iterate_experiments(vpg_garage_pytorch, MuJoCo1M_ENV_SET)
+    iterate_experiments(vpg_garage_tf, MuJoCo1M_ENV_SET)

--- a/benchmarks/src/garage_benchmarks/run_benchmarks.py
+++ b/benchmarks/src/garage_benchmarks/run_benchmarks.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""Script for running benchmarking.
+
+Examples:
+    # List all benchmark options
+    benchmark show
+
+    # Run selected benchmarks
+    benchmark run b_1 b_2 ...
+
+"""
+import inspect
+
+import click
+from garage_benchmarks import benchmark_algos
+from garage_benchmarks import benchmark_auto
+from garage_benchmarks import benchmark_baselines
+from garage_benchmarks import benchmark_policies
+from garage_benchmarks import benchmark_q_functions
+
+
+@click.group()
+def cli():
+    """The main command group."""
+
+
+@click.command()
+def list():  # pylint: disable=redefined-builtin
+    """List all benchmarks."""
+    _echo_run_names('Algorithms', _get_runs_dict(benchmark_algos))
+    _echo_run_names('Policies', _get_runs_dict(benchmark_policies))
+    _echo_run_names('Baselines', _get_runs_dict(benchmark_baselines))
+    _echo_run_names('Q Functions', _get_runs_dict(benchmark_q_functions))
+    _echo_run_names('Automatic benchmarking', _get_runs_dict(benchmark_auto))
+
+
+@click.command()
+@click.argument('names', nargs=-1)
+def run(names):
+    """Run selected benchmarks.
+
+    Args:
+        names (tuple): Benchmark names.
+
+    Raises:
+        BadParameter: if any run name is invalid or duplicated.
+
+    """
+    if not names:
+        raise click.BadParameter('Empty names!')
+
+    if len(names) != len(set(names)):
+        raise click.BadParameter('Duplicate names!')
+
+    options = _get_all_options()
+
+    for name in names:
+        if name not in options:
+            raise click.BadParameter(
+                'Invalid run name! Make sure every name can be found in '
+                '`garage_benchmark list`!')
+
+    for name in names:
+        options[name]()
+
+
+cli.add_command(list)
+cli.add_command(run)
+
+
+def _get_all_options():
+    """Return a dict containing all benchmark options.
+
+    Dict of (str: obj) representing benchmark name and its function object.
+
+    Returns:
+        dict: Benchmark options.
+
+    """
+    d = {}
+    d.update(_get_runs_dict(benchmark_algos))
+    d.update(_get_runs_dict(benchmark_policies))
+    d.update(_get_runs_dict(benchmark_baselines))
+    d.update(_get_runs_dict(benchmark_q_functions))
+    d.update(_get_runs_dict(benchmark_auto))
+    return d
+
+
+def _get_runs_dict(module):
+    """Return a dict containing benchmark options of the module.
+
+    Dict of (str: obj) representing benchmark name and its function object.
+
+    Args:
+        module (object): Module object.
+
+    Returns:
+        dict: Benchmark options of the module.
+
+    """
+    d = {}
+    for name, obj in inspect.getmembers(module):
+        if inspect.isfunction(obj) and name.endswith('benchmarks'):
+            d[name] = obj
+    return d
+
+
+def _echo_run_names(header, d):
+    """Echo run names to the command line.
+
+    Args:
+        header (str): The header name.
+        d (dict): The dict containing benchmark options.
+
+    """
+    click.echo('-----' + header + '-----')
+    for name in d:
+        click.echo(name)
+    click.echo()


### PR DESCRIPTION
This PR adds a script to trigger automatic benchmarking.

Install: `cd benchmarks && pip install -e . `

List available benchmarks: `garage_benchmark list`
```
-----Algorithms-----
ddpg_benchmarks
her_benchmarks
ppo_benchmarks
td3_benchmarks
trpo_benchmarks
vpg_benchmarks

-----Policies-----
categorical_cnn_policy_tf_ppo_benchmarks
categorical_gru_policy_tf_ppo_benchmarks
categorical_lstm_policy_tf_ppo_benchmarks
categorical_mlp_policy_tf_ppo_benchmarks
continuous_mlp_policy_tf_ddpg_benchmarks
gaussian_gru_policy_tf_ppo_benchmarks
gaussian_lstm_policy_tf_ppo_benchmarks
gaussian_mlp_policy_tf_ppo_benchmarks

-----Baselines-----
continuous_mlp_baseline_tf_ppo_benchmarks
gaussian_cnn_baseline_tf_ppo_benchmarks
gaussian_mlp_baseline_tf_ppo_benchmarks

-----Q Functions-----
continuous_mlp_q_function_tf_ddpg_benchmarks

-----Automatic benchmarking-----
auto_ddpg_benchmarks
auto_ppo_benchmarks
auto_td3_benchmarks
auto_trpo_benchmarks
auto_vpg_benchmarks
```
Run benchmark(s): `garage_benchmark run ppo_benchmarks trpo_benchmarks`