### PR TITLE
Update all examples to not use run_experiment

### DIFF
--- a/examples/jupyter/custom_env.ipynb
+++ b/examples/jupyter/custom_env.ipynb
@@ -1,934 +1,941 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "custom_env.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true,
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/custom_env.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Za0nLGHy5jyP"
+   },
+   "source": [
+    "Demonstrate usage of a custom openai/gym environment with rlworkgroup/garage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "acXH8kwHsAYT"
+   },
+   "source": [
+    "Demonstrate usage of [garage](https://github.com/rlworkgroup/garage) with a custom `openai/gym` environment in a jupyter notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "GmPLYXrXH7A5"
+   },
+   "source": [
+    "## Install pre-requisites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 901
+    },
+    "colab_type": "code",
+    "id": "Aj3bL9HaG5HL",
+    "outputId": "21508810-1b19-4f63-c1da-fdde3cb17e88"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/custom_env.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fatal: destination path 'garage' already exists and is not an empty directory.\n",
+      "start of setup_colab.sh\n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "Cloning into '/tmp/tmp.4slNT9c4V6/glfw'...\n",
+      "remote: Enumerating objects: 23479, done.\u001b[K\n",
+      "remote: Total 23479 (delta 0), reused 0 (delta 0), pack-reused 23479\u001b[K\n",
+      "Receiving objects: 100% (23479/23479), 11.64 MiB | 22.78 MiB/s, done.\n",
+      "Resolving deltas: 100% (16458/16458), done.\n",
+      "Note: checking out '0be4f3f75aebd9d24583ee86590a38e741db0904'.\n",
+      "\n",
+      "You are in 'detached HEAD' state. You can look around, make experimental\n",
+      "changes and commit them, and you can discard any commits you make in this\n",
+      "state without impacting any branches by performing another checkout.\n",
+      "\n",
+      "If you want to create a new branch to retain commits you create, you may\n",
+      "do so (now or later) by using -b with the checkout command again. Example:\n",
+      "\n",
+      "  git checkout -b <new-branch-name>\n",
+      "\n",
+      "HEAD is now at 0be4f3f7 Add GLFW_FOCUS_ON_SHOW window hint and attribute\n",
+      "Cloning into '/tmp/tmp.Xq2ekFYVDa/mujoco_150'...\n",
+      "remote: Enumerating objects: 200, done.\u001b[K\n",
+      "remote: Counting objects: 100% (200/200), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (192/192), done.\u001b[K\n",
+      "remote: Total 200 (delta 7), reused 166 (delta 3), pack-reused 0\u001b[K\n",
+      "Receiving objects: 100% (200/200), 2.98 MiB | 23.15 MiB/s, done.\n",
+      "Resolving deltas: 100% (7/7), done.\n",
+      "Note: checking out '3ba83940a957a0e2236aaa739fc6a8e8f5b7c421'.\n",
+      "\n",
+      "You are in 'detached HEAD' state. You can look around, make experimental\n",
+      "changes and commit them, and you can discard any commits you make in this\n",
+      "state without impacting any branches by performing another checkout.\n",
+      "\n",
+      "If you want to create a new branch to retain commits you create, you may\n",
+      "do so (now or later) by using -b with the checkout command again. Example:\n",
+      "\n",
+      "  git checkout -b <new-branch-name>\n",
+      "\n",
+      "end of setup_colab.sh\n"
+     ]
     },
     {
-      "metadata": {
-        "id": "Za0nLGHy5jyP",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Demonstrate usage of a custom openai/gym environment with rlworkgroup/garage"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "acXH8kwHsAYT",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "Demonstrate usage of [garage](https://github.com/rlworkgroup/garage) with a custom `openai/gym` environment in a jupyter notebook."
-      ]
-    },
-    {
-      "metadata": {
-        "id": "GmPLYXrXH7A5",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Install pre-requisites"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Aj3bL9HaG5HL",
-        "colab_type": "code",
-        "outputId": "21508810-1b19-4f63-c1da-fdde3cb17e88",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 901
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "%%shell\n",
-        "\n",
-        "echo \"abcd\" > mujoco_fake_key\n",
-        "\n",
-        "\n",
-        "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
-        "\n",
-        "cd garage\n",
-        "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"
-      ],
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "fatal: destination path 'garage' already exists and is not an empty directory.\n",
-            "start of setup_colab.sh\n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "Cloning into '/tmp/tmp.4slNT9c4V6/glfw'...\n",
-            "remote: Enumerating objects: 23479, done.\u001b[K\n",
-            "remote: Total 23479 (delta 0), reused 0 (delta 0), pack-reused 23479\u001b[K\n",
-            "Receiving objects: 100% (23479/23479), 11.64 MiB | 22.78 MiB/s, done.\n",
-            "Resolving deltas: 100% (16458/16458), done.\n",
-            "Note: checking out '0be4f3f75aebd9d24583ee86590a38e741db0904'.\n",
-            "\n",
-            "You are in 'detached HEAD' state. You can look around, make experimental\n",
-            "changes and commit them, and you can discard any commits you make in this\n",
-            "state without impacting any branches by performing another checkout.\n",
-            "\n",
-            "If you want to create a new branch to retain commits you create, you may\n",
-            "do so (now or later) by using -b with the checkout command again. Example:\n",
-            "\n",
-            "  git checkout -b <new-branch-name>\n",
-            "\n",
-            "HEAD is now at 0be4f3f7 Add GLFW_FOCUS_ON_SHOW window hint and attribute\n",
-            "Cloning into '/tmp/tmp.Xq2ekFYVDa/mujoco_150'...\n",
-            "remote: Enumerating objects: 200, done.\u001b[K\n",
-            "remote: Counting objects: 100% (200/200), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (192/192), done.\u001b[K\n",
-            "remote: Total 200 (delta 7), reused 166 (delta 3), pack-reused 0\u001b[K\n",
-            "Receiving objects: 100% (200/200), 2.98 MiB | 23.15 MiB/s, done.\n",
-            "Resolving deltas: 100% (7/7), done.\n",
-            "Note: checking out '3ba83940a957a0e2236aaa739fc6a8e8f5b7c421'.\n",
-            "\n",
-            "You are in 'detached HEAD' state. You can look around, make experimental\n",
-            "changes and commit them, and you can discard any commits you make in this\n",
-            "state without impacting any branches by performing another checkout.\n",
-            "\n",
-            "If you want to create a new branch to retain commits you create, you may\n",
-            "do so (now or later) by using -b with the checkout command again. Example:\n",
-            "\n",
-            "  git checkout -b <new-branch-name>\n",
-            "\n",
-            "end of setup_colab.sh\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              ""
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 3
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "_FWFcZWCgjrm",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "raise Exception(\"Please restart your runtime so that the installed dependencies for 'garage' can be loaded, and then resume running the notebook\")"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "wCuJ9d-Jgk1Y",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "\n",
-        "---\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "34oLOKVb5t8l",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# custom gym environment"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "oBv4mojWRT6v",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Create a gym env that simulates the current water treatment plant\n",
-        "# Based on https://github.com/openai/gym/blob/master/gym/envs/toy_text/nchain.py\n",
-        "\n",
-        "import gym\n",
-        "from gym import spaces\n",
-        "import numpy as np\n",
-        "import random\n",
-        "\n",
-        "\n",
-        "\n",
-        "# Gym env\n",
-        "class MyEnv(gym.Env):\n",
-        "    \"\"\"Custom gym environment\n",
-        "    \n",
-        "    Observation: Coin flip (Discrete binary: 0/1)\n",
-        "      \n",
-        "    Actions: Guess of coin flip outcome (Discrete binary: 0/1)\n",
-        "      \n",
-        "    Reward: Guess the coin flip correctly\n",
-        "      \n",
-        "    Episode termination: Make 5 correct guesses within 20 attempts\n",
-        "    \"\"\"\n",
-        "    def __init__(self):\n",
-        "        # set action/observation spaces\n",
-        "        self.action_space = spaces.Discrete(2)\n",
-        "        self.observation_space = spaces.Discrete(2)\n",
-        "        self.reset()\n",
-        "\n",
-        "    def step(self, action):\n",
-        "        assert self.action_space.contains(action), \"action not in action space!\"\n",
-        "        \n",
-        "        # flip a coin\n",
-        "        self.state = np.random.rand() < 0.5\n",
-        "\n",
-        "        # increment number of attempts\n",
-        "        self.attempt += 1\n",
-        "        \n",
-        "        # calculate reward of this element\n",
-        "        reward = (action == self.state)\n",
-        "        self.score += reward\n",
-        "          \n",
-        "        # allow a maximum number of attempts or reach max score\n",
-        "        done = (self.attempt >= 20) | (self.score >= 5)\n",
-        "          \n",
-        "        return self.state, reward, done, {}\n",
-        "      \n",
-        "    def reset(self):\n",
-        "      # accumulate score\n",
-        "      self.score = 0\n",
-        "      # count number of attempts\n",
-        "      self.attempt = 0\n",
-        "      \n",
-        "      return 0"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Xi3SwHSJO3xm",
-        "colab_type": "code",
-        "outputId": "d8557925-1e7c-4173-d2f2-ce035e5811be",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 272
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# some smoke testing\n",
-        "env_test = MyEnv()\n",
-        "observation = env_test.reset()\n",
-        "\n",
-        "for step in range(40):\n",
-        "  action = np.random.rand() < 0.5\n",
-        "  observation, reward, done, _ = env_test.step(action)\n",
-        "  print(\"step %i: action=%i, observation=%i => reward = %i, done = %s\" % (step, action, observation, reward, done))\n",
-        "  if done: break"
-      ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "step 0: action=0, observation=1 => reward = 0, done = False\n",
-            "step 1: action=1, observation=0 => reward = 0, done = False\n",
-            "step 2: action=0, observation=1 => reward = 0, done = False\n",
-            "step 3: action=0, observation=0 => reward = 1, done = False\n",
-            "step 4: action=1, observation=0 => reward = 0, done = False\n",
-            "step 5: action=1, observation=0 => reward = 0, done = False\n",
-            "step 6: action=1, observation=0 => reward = 0, done = False\n",
-            "step 7: action=0, observation=1 => reward = 0, done = False\n",
-            "step 8: action=0, observation=1 => reward = 0, done = False\n",
-            "step 9: action=1, observation=1 => reward = 1, done = False\n",
-            "step 10: action=1, observation=1 => reward = 1, done = False\n",
-            "step 11: action=1, observation=0 => reward = 0, done = False\n",
-            "step 12: action=0, observation=0 => reward = 1, done = False\n",
-            "step 13: action=1, observation=1 => reward = 1, done = True\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Nd-RbAhH6Kx8",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "# Prepare training"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "9j8M1L9S6rvU",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# The contents of this cell are mostly copied from garage/examples/...\n",
-        "\n",
-        "from garage.np.baselines import LinearFeatureBaseline # <<<<<< requires restarting the runtime in colab after the 1st dependency installation above\n",
-        "from garage.envs import normalize\n",
-        "#from garage.envs.box2d import CartpoleEnv # no need since will use WtpDesignerEnv_v0 defined above\n",
-        "from garage.experiment import run_experiment\n",
-        "from garage.tf.algos import TRPO\n",
-        "from garage.tf.envs import TfEnv\n",
-        "#from garage.tf.policies import GaussianMLPPolicy\n",
-        "from garage.tf.policies import CategoricalMLPPolicy\n",
-        "\n",
-        "import gym # already imported before\n",
-        "\n",
-        "\n",
-        "from garage.experiment import LocalRunner\n",
-        "from garage.logger import logger, StdOutput"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "UNoyVv0tA23n",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# register the env with gym\n",
-        "# https://github.com/openai/gym/tree/master/gym/envs#how-to-create-new-environments-for-gym\n",
-        "from gym.envs.registration import register\n",
-        "\n",
-        "register(\n",
-        "    id='MyEnv-v0',\n",
-        "    entry_point=MyEnv,\n",
-        ")\n",
-        "\n",
-        "# test registration was successful\n",
-        "env = gym.make(\"MyEnv-v0\")\n",
-        "# env = TfEnv(normalize(gym.make(\"MyEnv-v0\")))\n",
-        "# env = TfEnv(env_name='MyEnv-v0') "
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "tx8_cmOe63QK",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# Wrap the environment to convert the observation to numpy array\n",
-        "# Not sure why this is necessary ATM\n",
-        "# Based on https://github.com/openai/gym/blob/5404b39d06f72012f562ec41f60734bd4b5ceb4b/gym/wrappers/dict.py\n",
-        "\n",
-        "      \n",
-        "# from gym import wrappers\n",
-        "\n",
-        "class NpWrapper(gym.ObservationWrapper):\n",
-        "    def observation(self, observation):\n",
-        "        obs = np.array(observation).astype('int')\n",
-        "        return obs\n",
-        "      \n",
-        "      \n",
-        "env = NpWrapper(env)\n",
-        "env = TfEnv(normalize(env))"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "mpc-sCTvnlH7",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "policy = CategoricalMLPPolicy(\n",
-        "    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
-        "\n",
-        "baseline = LinearFeatureBaseline(env_spec=env.spec)\n",
-        "\n",
-        "\n",
-        "algo = TRPO(\n",
-        "    env_spec=env.spec,\n",
-        "    policy=policy,\n",
-        "    baseline=baseline,\n",
-        "    max_path_length=50,\n",
-        "    n_itr=50,\n",
-        "    discount=0.99,\n",
-        "    max_kl_step=0.01\n",
-        ")\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "hFgHLyD7oRaH",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Start training"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "v7LQO4zBp8h4",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# log to stdout\n",
-        "logger.add_output(StdOutput())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "eBk8B2h36pMw",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# start a tensorflow session so that we can keep it open after training and use the trained network to see it performing\n",
-        "import tensorflow as tf\n",
-        "sess = tf.InteractiveSession()\n",
-        "\n",
-        "# no need to initialize\n",
-        "sess.run(tf.compat.v1.global_variables_initializer())\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "mu0Vg3j8iK-q",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 5209
-        },
-        "outputId": "dc07d5fb-1ddc-4ede-982c-096f872964c7"
-      },
-      "cell_type": "code",
-      "source": [
-        "# Train the policy (neural network) on the environment\n",
-        "runner = LocalRunner()\n",
-        "\n",
-        "runner.setup(algo=algo, env=env)\n",
-        "\n",
-        "# use n_epochs = 2 for quick demo\n",
-        "runner.train(n_epochs=2, batch_size=10000, plot=False)"
-      ],
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 06:42:42 | epoch #0 | Obtaining samples...\n",
-            "2019-04-01 06:42:42 | epoch #0 | Obtaining samples for iteration 0...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "/content/garage/garage/experiment/local_tf_runner.py:129: LoggerWarning: \u001b[33mLog data of type Graph was not accepted by any output\u001b[0m\n",
-            "  logger.log(self.sess.graph)\n",
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 06:42:49 | epoch #0 | Logging diagnostics...\n",
-            "2019-04-01 06:42:49 | epoch #0 | Optimizing policy...\n",
-            "2019-04-01 06:42:49 | epoch #0 | Computing loss before\n",
-            "2019-04-01 06:42:49 | epoch #0 | Computing KL before\n",
-            "2019-04-01 06:42:49 | epoch #0 | Optimizing\n",
-            "2019-04-01 06:42:49 | epoch #0 | Start CG optimization: #parameters: 1218, #inputs: 1013, #subsample_inputs: 1013\n",
-            "2019-04-01 06:42:49 | epoch #0 | computing loss before\n",
-            "2019-04-01 06:42:49 | epoch #0 | performing update\n",
-            "2019-04-01 06:42:49 | epoch #0 | computing gradient\n",
-            "2019-04-01 06:42:49 | epoch #0 | gradient computed\n",
-            "2019-04-01 06:42:49 | epoch #0 | computing descent direction\n",
-            "2019-04-01 06:42:50 | epoch #0 | descent direction computed\n",
-            "2019-04-01 06:42:50 | epoch #0 | backtrack iters: 0\n",
-            "2019-04-01 06:42:50 | epoch #0 | computing loss after\n",
-            "2019-04-01 06:42:50 | epoch #0 | optimization finished\n",
-            "2019-04-01 06:42:50 | epoch #0 | Computing KL after\n",
-            "2019-04-01 06:42:50 | epoch #0 | Computing loss after\n",
-            "2019-04-01 06:42:50 | epoch #0 | Fitting baseline...\n",
-            "2019-04-01 06:42:50 | epoch #0 | Saving snapshot...\n",
-            "2019-04-01 06:42:50 | epoch #0 | Saved\n",
-            "2019-04-01 06:42:50 | epoch #0 | Time 8.01 s\n",
-            "2019-04-01 06:42:50 | epoch #0 | EpochTime 8.01 s\n",
-            "---------------------------------------  --------------\n",
-            "AverageDiscountedReturn                     4.75304\n",
-            "AverageReturn                               4.9921\n",
-            "Entropy                                     0.688329\n",
-            "EnvExecTime                                 0.847786\n",
-            "Extras/EpisodeRewardMean                    5\n",
-            "Iteration                                   0\n",
-            "LinearFeatureBaseline/ExplainedVariance    -2.87756e-08\n",
-            "MaxReturn                                   5\n",
-            "MinReturn                                   4\n",
-            "NumTrajs                                 1013\n",
-            "Perplexity                                  1.99039\n",
-            "PolicyExecTime                              5.25753\n",
-            "ProcessExecTime                             0.239677\n",
-            "StdReturn                                   0.0885153\n",
-            "policy/Entropy                              0.691807\n",
-            "policy/KL                                   0.00989275\n",
-            "policy/KLBefore                             1.52696e-08\n",
-            "policy/LossAfter                           -0.000533063\n",
-            "policy/LossBefore                          -1.73125e-06\n",
-            "policy/dLoss                                0.000531331\n",
-            "---------------------------------------  --------------\n",
-            "2019-04-01 06:42:50 | epoch #1 | Obtaining samples...\n",
-            "2019-04-01 06:42:50 | epoch #1 | Obtaining samples for iteration 1...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:07\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 06:42:57 | epoch #1 | Logging diagnostics...\n",
-            "2019-04-01 06:42:57 | epoch #1 | Optimizing policy...\n",
-            "2019-04-01 06:42:57 | epoch #1 | Computing loss before\n",
-            "2019-04-01 06:42:57 | epoch #1 | Computing KL before\n",
-            "2019-04-01 06:42:57 | epoch #1 | Optimizing\n",
-            "2019-04-01 06:42:57 | epoch #1 | Start CG optimization: #parameters: 1218, #inputs: 1018, #subsample_inputs: 1018\n",
-            "2019-04-01 06:42:57 | epoch #1 | computing loss before\n",
-            "2019-04-01 06:42:57 | epoch #1 | performing update\n",
-            "2019-04-01 06:42:57 | epoch #1 | computing gradient\n",
-            "2019-04-01 06:42:57 | epoch #1 | gradient computed\n",
-            "2019-04-01 06:42:57 | epoch #1 | computing descent direction\n",
-            "2019-04-01 06:42:58 | epoch #1 | descent direction computed\n",
-            "2019-04-01 06:42:58 | epoch #1 | backtrack iters: 0\n",
-            "2019-04-01 06:42:58 | epoch #1 | computing loss after\n",
-            "2019-04-01 06:42:58 | epoch #1 | optimization finished\n",
-            "2019-04-01 06:42:58 | epoch #1 | Computing KL after\n",
-            "2019-04-01 06:42:58 | epoch #1 | Computing loss after\n",
-            "2019-04-01 06:42:58 | epoch #1 | Fitting baseline...\n",
-            "2019-04-01 06:42:58 | epoch #1 | Saving snapshot...\n",
-            "2019-04-01 06:42:58 | epoch #1 | Saved\n",
-            "2019-04-01 06:42:58 | epoch #1 | Time 16.23 s\n",
-            "2019-04-01 06:42:58 | epoch #1 | EpochTime 8.20 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                     4.7542\n",
-            "AverageReturn                               4.99018\n",
-            "Entropy                                     0.691801\n",
-            "EnvExecTime                                 0.916491\n",
-            "Extras/EpisodeRewardMean                    4.98\n",
-            "Iteration                                   1\n",
-            "LinearFeatureBaseline/ExplainedVariance     0.660687\n",
-            "MaxReturn                                   5\n",
-            "MinReturn                                   3\n",
-            "NumTrajs                                 1018\n",
-            "Perplexity                                  1.99731\n",
-            "PolicyExecTime                              5.84212\n",
-            "ProcessExecTime                             0.261647\n",
-            "StdReturn                                   0.116859\n",
-            "policy/Entropy                              0.675743\n",
-            "policy/KL                                   0.00992123\n",
-            "policy/KLBefore                             0\n",
-            "policy/LossAfter                           -0.00114127\n",
-            "policy/LossBefore                           3.3767e-08\n",
-            "policy/dLoss                                0.0011413\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 06:42:58 | epoch #2 | Obtaining samples...\n",
-            "2019-04-01 06:42:58 | epoch #2 | Obtaining samples for iteration 2...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:07\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 06:43:05 | epoch #2 | Logging diagnostics...\n",
-            "2019-04-01 06:43:05 | epoch #2 | Optimizing policy...\n",
-            "2019-04-01 06:43:05 | epoch #2 | Computing loss before\n",
-            "2019-04-01 06:43:05 | epoch #2 | Computing KL before\n",
-            "2019-04-01 06:43:05 | epoch #2 | Optimizing\n",
-            "2019-04-01 06:43:05 | epoch #2 | Start CG optimization: #parameters: 1218, #inputs: 1000, #subsample_inputs: 1000\n",
-            "2019-04-01 06:43:05 | epoch #2 | computing loss before\n",
-            "2019-04-01 06:43:05 | epoch #2 | performing update\n",
-            "2019-04-01 06:43:05 | epoch #2 | computing gradient\n",
-            "2019-04-01 06:43:05 | epoch #2 | gradient computed\n",
-            "2019-04-01 06:43:05 | epoch #2 | computing descent direction\n",
-            "2019-04-01 06:43:06 | epoch #2 | descent direction computed\n",
-            "2019-04-01 06:43:06 | epoch #2 | backtrack iters: 0\n",
-            "2019-04-01 06:43:06 | epoch #2 | computing loss after\n",
-            "2019-04-01 06:43:06 | epoch #2 | optimization finished\n",
-            "2019-04-01 06:43:06 | epoch #2 | Computing KL after\n",
-            "2019-04-01 06:43:06 | epoch #2 | Computing loss after\n",
-            "2019-04-01 06:43:06 | epoch #2 | Fitting baseline...\n",
-            "2019-04-01 06:43:06 | epoch #2 | Saving snapshot...\n",
-            "2019-04-01 06:43:06 | epoch #2 | Saved\n",
-            "2019-04-01 06:43:06 | epoch #2 | Time 24.15 s\n",
-            "2019-04-01 06:43:06 | epoch #2 | EpochTime 7.92 s\n",
-            "---------------------------------------  --------------\n",
-            "AverageDiscountedReturn                     4.75373\n",
-            "AverageReturn                               4.996\n",
-            "Entropy                                     0.676001\n",
-            "EnvExecTime                                 0.902346\n",
-            "Extras/EpisodeRewardMean                    5\n",
-            "Iteration                                   2\n",
-            "LinearFeatureBaseline/ExplainedVariance     0.675589\n",
-            "MaxReturn                                   5\n",
-            "MinReturn                                   3\n",
-            "NumTrajs                                 1000\n",
-            "Perplexity                                  1.966\n",
-            "PolicyExecTime                              5.62656\n",
-            "ProcessExecTime                             0.25995\n",
-            "StdReturn                                   0.0773563\n",
-            "policy/Entropy                              0.647502\n",
-            "policy/KL                                   0.00991697\n",
-            "policy/KLBefore                            -1.3626e-08\n",
-            "policy/LossAfter                           -0.000339933\n",
-            "policy/LossBefore                          -2.14577e-09\n",
-            "policy/dLoss                                0.000339931\n",
-            "---------------------------------------  --------------\n",
-            "2019-04-01 06:43:06 | epoch #3 | Obtaining samples...\n",
-            "2019-04-01 06:43:06 | epoch #3 | Obtaining samples for iteration 3...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 06:43:13 | epoch #3 | Logging diagnostics...\n",
-            "2019-04-01 06:43:13 | epoch #3 | Optimizing policy...\n",
-            "2019-04-01 06:43:13 | epoch #3 | Computing loss before\n",
-            "2019-04-01 06:43:13 | epoch #3 | Computing KL before\n",
-            "2019-04-01 06:43:13 | epoch #3 | Optimizing\n",
-            "2019-04-01 06:43:13 | epoch #3 | Start CG optimization: #parameters: 1218, #inputs: 1006, #subsample_inputs: 1006\n",
-            "2019-04-01 06:43:13 | epoch #3 | computing loss before\n",
-            "2019-04-01 06:43:13 | epoch #3 | performing update\n",
-            "2019-04-01 06:43:13 | epoch #3 | computing gradient\n",
-            "2019-04-01 06:43:13 | epoch #3 | gradient computed\n",
-            "2019-04-01 06:43:13 | epoch #3 | computing descent direction\n",
-            "2019-04-01 06:43:13 | epoch #3 | descent direction computed\n",
-            "2019-04-01 06:43:13 | epoch #3 | backtrack iters: 1\n",
-            "2019-04-01 06:43:13 | epoch #3 | computing loss after\n",
-            "2019-04-01 06:43:13 | epoch #3 | optimization finished\n",
-            "2019-04-01 06:43:13 | epoch #3 | Computing KL after\n",
-            "2019-04-01 06:43:13 | epoch #3 | Computing loss after\n",
-            "2019-04-01 06:43:13 | epoch #3 | Fitting baseline...\n",
-            "2019-04-01 06:43:13 | epoch #3 | Saving snapshot...\n",
-            "2019-04-01 06:43:13 | epoch #3 | Saved\n",
-            "2019-04-01 06:43:13 | epoch #3 | Time 31.58 s\n",
-            "2019-04-01 06:43:13 | epoch #3 | EpochTime 7.42 s\n",
-            "---------------------------------------  --------------\n",
-            "AverageDiscountedReturn                     4.75649\n",
-            "AverageReturn                               4.99801\n",
-            "Entropy                                     0.647744\n",
-            "EnvExecTime                                 0.851849\n",
-            "Extras/EpisodeRewardMean                    5\n",
-            "Iteration                                   3\n",
-            "LinearFeatureBaseline/ExplainedVariance     0.671654\n",
-            "MaxReturn                                   5\n",
-            "MinReturn                                   4\n",
-            "NumTrajs                                 1006\n",
-            "Perplexity                                  1.91122\n",
-            "PolicyExecTime                              5.17552\n",
-            "ProcessExecTime                             0.244249\n",
-            "StdReturn                                   0.0445435\n",
-            "policy/Entropy                              0.67191\n",
-            "policy/KL                                   0.00653902\n",
-            "policy/KLBefore                            -1.18269e-08\n",
-            "policy/LossAfter                           -0.00187737\n",
-            "policy/LossBefore                           3.88273e-09\n",
-            "policy/dLoss                                0.00187737\n",
-            "---------------------------------------  --------------\n",
-            "2019-04-01 06:43:13 | epoch #4 | Obtaining samples...\n",
-            "2019-04-01 06:43:13 | epoch #4 | Obtaining samples for iteration 4...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [######                        ] 100% | ETA: 00:00:05"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "error",
-          "ename": "KeyboardInterrupt",
-          "evalue": "ignored",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-9-09af41d54102>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# use n_epochs = 100 for practical example, n_epochs = 10 for quick demo, n_epochs = 1 for smoke testing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mrunner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_epochs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m10000\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mplot\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;32m/content/garage/garage/experiment/local_tf_runner.py\u001b[0m in \u001b[0;36mtrain\u001b[0;34m(self, n_epochs, n_epoch_cycles, batch_size, plot, store_paths, pause_for_plot)\u001b[0m\n\u001b[1;32m    251\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprefix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'epoch #%d | '\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mepoch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    252\u001b[0m                 \u001b[0;32mfor\u001b[0m \u001b[0mcycle\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_epoch_cycles\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 253\u001b[0;31m                     \u001b[0mpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobtain_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    254\u001b[0m                     \u001b[0mpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprocess_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    255\u001b[0m                     \u001b[0mlast_return\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malgo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain_once\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/content/garage/garage/experiment/local_tf_runner.py\u001b[0m in \u001b[0;36mobtain_samples\u001b[0;34m(self, itr, batch_size)\u001b[0m\n\u001b[1;32m    171\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mn_epoch_cycles\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    172\u001b[0m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Obtaining samples...'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 173\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobtain_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    174\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msave_snapshot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/content/garage/garage/tf/samplers/on_policy_vectorized_sampler.py\u001b[0m in \u001b[0;36mobtain_samples\u001b[0;34m(self, itr, batch_size, whole_paths)\u001b[0m\n\u001b[1;32m     55\u001b[0m             \u001b[0mpolicy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdones\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 57\u001b[0;31m             \u001b[0mactions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0magent_infos\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpolicy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobses\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     58\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     59\u001b[0m             \u001b[0mpolicy_time\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/content/garage/garage/tf/policies/categorical_mlp_policy.py\u001b[0m in \u001b[0;36mget_actions\u001b[0;34m(self, observations)\u001b[0m\n\u001b[1;32m     89\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobservations\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m         \u001b[0mflat_obs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobservation_space\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflatten_n\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobservations\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 91\u001b[0;31m         \u001b[0mprobs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_f_prob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflat_obs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     92\u001b[0m         \u001b[0mactions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maction_space\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mweighted_sample\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     93\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mactions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprob\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprobs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/content/garage/garage/tf/misc/tensor_utils.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(*input_vals)\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0minput_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m         \u001b[0msess\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_default_session\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msess\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minput_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mrun\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, fetches, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m    927\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    928\u001b[0m       result = self._run(None, fetches, feed_dict, options_ptr,\n\u001b[0;32m--> 929\u001b[0;31m                          run_metadata_ptr)\n\u001b[0m\u001b[1;32m    930\u001b[0m       \u001b[0;32mif\u001b[0m \u001b[0mrun_metadata\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    931\u001b[0m         \u001b[0mproto_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf_session\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTF_GetBuffer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrun_metadata_ptr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_run\u001b[0;34m(self, handle, fetches, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m   1150\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mfinal_fetches\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mfinal_targets\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mhandle\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfeed_dict_tensor\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1151\u001b[0m       results = self._do_run(handle, final_targets, final_fetches,\n\u001b[0;32m-> 1152\u001b[0;31m                              feed_dict_tensor, options, run_metadata)\n\u001b[0m\u001b[1;32m   1153\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1154\u001b[0m       \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_do_run\u001b[0;34m(self, handle, target_list, fetch_list, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m   1326\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mhandle\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1327\u001b[0m       return self._do_call(_run_fn, feeds, fetches, targets, options,\n\u001b[0;32m-> 1328\u001b[0;31m                            run_metadata)\n\u001b[0m\u001b[1;32m   1329\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1330\u001b[0m       \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_prun_fn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeeds\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetches\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_do_call\u001b[0;34m(self, fn, *args)\u001b[0m\n\u001b[1;32m   1332\u001b[0m   \u001b[0;32mdef\u001b[0m \u001b[0m_do_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1333\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1334\u001b[0;31m       \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1335\u001b[0m     \u001b[0;32mexcept\u001b[0m \u001b[0merrors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOpError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1336\u001b[0m       \u001b[0mmessage\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcompat\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mas_text\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_run_fn\u001b[0;34m(feed_dict, fetch_list, target_list, options, run_metadata)\u001b[0m\n\u001b[1;32m   1317\u001b[0m       \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_extend_graph\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1318\u001b[0m       return self._call_tf_sessionrun(\n\u001b[0;32m-> 1319\u001b[0;31m           options, feed_dict, fetch_list, target_list, run_metadata)\n\u001b[0m\u001b[1;32m   1320\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1321\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_prun_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_call_tf_sessionrun\u001b[0;34m(self, options, feed_dict, fetch_list, target_list, run_metadata)\u001b[0m\n\u001b[1;32m   1405\u001b[0m     return tf_session.TF_SessionRun_wrapper(\n\u001b[1;32m   1406\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_session\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget_list\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1407\u001b[0;31m         run_metadata)\n\u001b[0m\u001b[1;32m   1408\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1409\u001b[0m   \u001b[0;32mdef\u001b[0m \u001b[0m_call_tf_sessionprun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-            "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
-          ]
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "LfG7tMG4LbtF",
-        "colab_type": "code",
-        "outputId": "c6356fd6-0e95-46dd-e335-8021bd9df25e",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 378
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# test results\n",
-        "n_experiments = 10\n",
-        "row_all = []\n",
-        "\n",
-        "for i in range(n_experiments):\n",
-        "  #print(\"experiment \", i+1)\n",
-        "\n",
-        "  # reset\n",
-        "  obs_initial = env.reset()\n",
-        "\n",
-        "  # start\n",
-        "  done = False\n",
-        "  obs_i = obs_initial\n",
-        "  while not done:\n",
-        "    row_i = {}\n",
-        "    row_i['exp'] = i + 1\n",
-        "    row_i['obs'] = obs_i\n",
-        "    act_i, _ = policy.get_action(obs_i)\n",
-        "    row_i['act'] = act_i\n",
-        "    obs_i, rew_i, done, _ = env.step(act_i)\n",
-        "    row_i['obs'] = obs_i\n",
-        "    row_i['rew'] = rew_i\n",
-        "    row_all.append(row_i)\n",
-        "    \n",
-        "    if done: break\n",
-        "    \n",
-        "#env.close()\n",
-        "\n",
-        "import pandas as pd\n",
-        "df = pd.DataFrame(row_all)\n",
-        "pd.DataFrame({\n",
-        "    'score': df.groupby('exp')['rew'].sum(),\n",
-        "    'nstep': df.groupby('exp')['rew'].count()\n",
-        "})"
-      ],
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>nstep</th>\n",
-              "      <th>score</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>exp</th>\n",
-              "      <th></th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>7</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>8</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>7</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>13</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>5</th>\n",
-              "      <td>8</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>6</th>\n",
-              "      <td>7</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>7</th>\n",
-              "      <td>8</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>10</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>9</th>\n",
-              "      <td>7</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>10</th>\n",
-              "      <td>10</td>\n",
-              "      <td>5.0</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "     nstep  score\n",
-              "exp              \n",
-              "1        7    5.0\n",
-              "2        8    5.0\n",
-              "3        7    5.0\n",
-              "4       13    5.0\n",
-              "5        8    5.0\n",
-              "6        7    5.0\n",
-              "7        8    5.0\n",
-              "8       10    5.0\n",
-              "9        7    5.0\n",
-              "10      10    5.0"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 20
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "nBxUpmnto1Qi",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 3,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
     }
-  ]
+   ],
+   "source": [
+    "%%shell\n",
+    "\n",
+    "echo \"abcd\" > mujoco_fake_key\n",
+    "\n",
+    "\n",
+    "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
+    "\n",
+    "cd garage\n",
+    "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "_FWFcZWCgjrm"
+   },
+   "outputs": [],
+   "source": [
+    "raise Exception(\"Please restart your runtime so that the installed dependencies for 'garage' can be loaded, and then resume running the notebook\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "wCuJ9d-Jgk1Y"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "34oLOKVb5t8l"
+   },
+   "source": [
+    "# custom gym environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "oBv4mojWRT6v"
+   },
+   "outputs": [],
+   "source": [
+    "# Create a gym env that simulates the current water treatment plant\n",
+    "# Based on https://github.com/openai/gym/blob/master/gym/envs/toy_text/nchain.py\n",
+    "\n",
+    "import gym\n",
+    "from gym import spaces\n",
+    "import numpy as np\n",
+    "import random\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Gym env\n",
+    "class MyEnv(gym.Env):\n",
+    "    \"\"\"Custom gym environment\n",
+    "    \n",
+    "    Observation: Coin flip (Discrete binary: 0/1)\n",
+    "      \n",
+    "    Actions: Guess of coin flip outcome (Discrete binary: 0/1)\n",
+    "      \n",
+    "    Reward: Guess the coin flip correctly\n",
+    "      \n",
+    "    Episode termination: Make 5 correct guesses within 20 attempts\n",
+    "    \"\"\"\n",
+    "    def __init__(self):\n",
+    "        # set action/observation spaces\n",
+    "        self.action_space = spaces.Discrete(2)\n",
+    "        self.observation_space = spaces.Discrete(2)\n",
+    "        self.reset()\n",
+    "\n",
+    "    def step(self, action):\n",
+    "        assert self.action_space.contains(action), \"action not in action space!\"\n",
+    "        \n",
+    "        # flip a coin\n",
+    "        self.state = np.random.rand() < 0.5\n",
+    "\n",
+    "        # increment number of attempts\n",
+    "        self.attempt += 1\n",
+    "        \n",
+    "        # calculate reward of this element\n",
+    "        reward = (action == self.state)\n",
+    "        self.score += reward\n",
+    "          \n",
+    "        # allow a maximum number of attempts or reach max score\n",
+    "        done = (self.attempt >= 20) | (self.score >= 5)\n",
+    "          \n",
+    "        return self.state, reward, done, {}\n",
+    "      \n",
+    "    def reset(self):\n",
+    "      # accumulate score\n",
+    "      self.score = 0\n",
+    "      # count number of attempts\n",
+    "      self.attempt = 0\n",
+    "      \n",
+    "      return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 272
+    },
+    "colab_type": "code",
+    "id": "Xi3SwHSJO3xm",
+    "outputId": "d8557925-1e7c-4173-d2f2-ce035e5811be"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "step 0: action=0, observation=1 => reward = 0, done = False\n",
+      "step 1: action=1, observation=0 => reward = 0, done = False\n",
+      "step 2: action=0, observation=1 => reward = 0, done = False\n",
+      "step 3: action=0, observation=0 => reward = 1, done = False\n",
+      "step 4: action=1, observation=0 => reward = 0, done = False\n",
+      "step 5: action=1, observation=0 => reward = 0, done = False\n",
+      "step 6: action=1, observation=0 => reward = 0, done = False\n",
+      "step 7: action=0, observation=1 => reward = 0, done = False\n",
+      "step 8: action=0, observation=1 => reward = 0, done = False\n",
+      "step 9: action=1, observation=1 => reward = 1, done = False\n",
+      "step 10: action=1, observation=1 => reward = 1, done = False\n",
+      "step 11: action=1, observation=0 => reward = 0, done = False\n",
+      "step 12: action=0, observation=0 => reward = 1, done = False\n",
+      "step 13: action=1, observation=1 => reward = 1, done = True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# some smoke testing\n",
+    "env_test = MyEnv()\n",
+    "observation = env_test.reset()\n",
+    "\n",
+    "for step in range(40):\n",
+    "  action = np.random.rand() < 0.5\n",
+    "  observation, reward, done, _ = env_test.step(action)\n",
+    "  print(\"step %i: action=%i, observation=%i => reward = %i, done = %s\" % (step, action, observation, reward, done))\n",
+    "  if done: break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Nd-RbAhH6Kx8"
+   },
+   "source": [
+    "# Prepare training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "9j8M1L9S6rvU"
+   },
+   "outputs": [],
+   "source": [
+    "# The contents of this cell are mostly copied from garage/examples/...\n",
+    "\n",
+    "from garage.np.baselines import LinearFeatureBaseline # <<<<<< requires restarting the runtime in colab after the 1st dependency installation above\n",
+    "from garage.envs import normalize\n",
+    "from garage.tf.algos import TRPO\n",
+    "from garage.tf.envs import TfEnv\n",
+    "#from garage.tf.policies import GaussianMLPPolicy\n",
+    "from garage.tf.policies import CategoricalMLPPolicy\n",
+    "\n",
+    "import gym # already imported before\n",
+    "\n",
+    "\n",
+    "from garage.experiment import LocalRunner\n",
+    "from garage.logger import logger, StdOutput"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "UNoyVv0tA23n"
+   },
+   "outputs": [],
+   "source": [
+    "# register the env with gym\n",
+    "# https://github.com/openai/gym/tree/master/gym/envs#how-to-create-new-environments-for-gym\n",
+    "from gym.envs.registration import register\n",
+    "\n",
+    "register(\n",
+    "    id='MyEnv-v0',\n",
+    "    entry_point=MyEnv,\n",
+    ")\n",
+    "\n",
+    "# test registration was successful\n",
+    "env = gym.make(\"MyEnv-v0\")\n",
+    "# env = TfEnv(normalize(gym.make(\"MyEnv-v0\")))\n",
+    "# env = TfEnv(env_name='MyEnv-v0') "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "tx8_cmOe63QK"
+   },
+   "outputs": [],
+   "source": [
+    "# Wrap the environment to convert the observation to numpy array\n",
+    "# Not sure why this is necessary ATM\n",
+    "# Based on https://github.com/openai/gym/blob/5404b39d06f72012f562ec41f60734bd4b5ceb4b/gym/wrappers/dict.py\n",
+    "\n",
+    "      \n",
+    "# from gym import wrappers\n",
+    "\n",
+    "class NpWrapper(gym.ObservationWrapper):\n",
+    "    def observation(self, observation):\n",
+    "        obs = np.array(observation).astype('int')\n",
+    "        return obs\n",
+    "      \n",
+    "      \n",
+    "env = NpWrapper(env)\n",
+    "env = TfEnv(normalize(env))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "mpc-sCTvnlH7"
+   },
+   "outputs": [],
+   "source": [
+    "policy = CategoricalMLPPolicy(\n",
+    "    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
+    "\n",
+    "baseline = LinearFeatureBaseline(env_spec=env.spec)\n",
+    "\n",
+    "\n",
+    "algo = TRPO(\n",
+    "    env_spec=env.spec,\n",
+    "    policy=policy,\n",
+    "    baseline=baseline,\n",
+    "    max_path_length=50,\n",
+    "    n_itr=50,\n",
+    "    discount=0.99,\n",
+    "    max_kl_step=0.01\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "hFgHLyD7oRaH"
+   },
+   "source": [
+    "## Start training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "v7LQO4zBp8h4"
+   },
+   "outputs": [],
+   "source": [
+    "# log to stdout\n",
+    "logger.add_output(StdOutput())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "eBk8B2h36pMw"
+   },
+   "outputs": [],
+   "source": [
+    "# start a tensorflow session so that we can keep it open after training and use the trained network to see it performing\n",
+    "import tensorflow as tf\n",
+    "sess = tf.InteractiveSession()\n",
+    "\n",
+    "# no need to initialize\n",
+    "sess.run(tf.compat.v1.global_variables_initializer())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 5209
+    },
+    "colab_type": "code",
+    "id": "mu0Vg3j8iK-q",
+    "outputId": "dc07d5fb-1ddc-4ede-982c-096f872964c7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 06:42:42 | epoch #0 | Obtaining samples...\n",
+      "2019-04-01 06:42:42 | epoch #0 | Obtaining samples for iteration 0...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/content/garage/garage/experiment/local_tf_runner.py:129: LoggerWarning: \u001b[33mLog data of type Graph was not accepted by any output\u001b[0m\n",
+      "  logger.log(self.sess.graph)\n",
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 06:42:49 | epoch #0 | Logging diagnostics...\n",
+      "2019-04-01 06:42:49 | epoch #0 | Optimizing policy...\n",
+      "2019-04-01 06:42:49 | epoch #0 | Computing loss before\n",
+      "2019-04-01 06:42:49 | epoch #0 | Computing KL before\n",
+      "2019-04-01 06:42:49 | epoch #0 | Optimizing\n",
+      "2019-04-01 06:42:49 | epoch #0 | Start CG optimization: #parameters: 1218, #inputs: 1013, #subsample_inputs: 1013\n",
+      "2019-04-01 06:42:49 | epoch #0 | computing loss before\n",
+      "2019-04-01 06:42:49 | epoch #0 | performing update\n",
+      "2019-04-01 06:42:49 | epoch #0 | computing gradient\n",
+      "2019-04-01 06:42:49 | epoch #0 | gradient computed\n",
+      "2019-04-01 06:42:49 | epoch #0 | computing descent direction\n",
+      "2019-04-01 06:42:50 | epoch #0 | descent direction computed\n",
+      "2019-04-01 06:42:50 | epoch #0 | backtrack iters: 0\n",
+      "2019-04-01 06:42:50 | epoch #0 | computing loss after\n",
+      "2019-04-01 06:42:50 | epoch #0 | optimization finished\n",
+      "2019-04-01 06:42:50 | epoch #0 | Computing KL after\n",
+      "2019-04-01 06:42:50 | epoch #0 | Computing loss after\n",
+      "2019-04-01 06:42:50 | epoch #0 | Fitting baseline...\n",
+      "2019-04-01 06:42:50 | epoch #0 | Saving snapshot...\n",
+      "2019-04-01 06:42:50 | epoch #0 | Saved\n",
+      "2019-04-01 06:42:50 | epoch #0 | Time 8.01 s\n",
+      "2019-04-01 06:42:50 | epoch #0 | EpochTime 8.01 s\n",
+      "---------------------------------------  --------------\n",
+      "AverageDiscountedReturn                     4.75304\n",
+      "AverageReturn                               4.9921\n",
+      "Entropy                                     0.688329\n",
+      "EnvExecTime                                 0.847786\n",
+      "Extras/EpisodeRewardMean                    5\n",
+      "Iteration                                   0\n",
+      "LinearFeatureBaseline/ExplainedVariance    -2.87756e-08\n",
+      "MaxReturn                                   5\n",
+      "MinReturn                                   4\n",
+      "NumTrajs                                 1013\n",
+      "Perplexity                                  1.99039\n",
+      "PolicyExecTime                              5.25753\n",
+      "ProcessExecTime                             0.239677\n",
+      "StdReturn                                   0.0885153\n",
+      "policy/Entropy                              0.691807\n",
+      "policy/KL                                   0.00989275\n",
+      "policy/KLBefore                             1.52696e-08\n",
+      "policy/LossAfter                           -0.000533063\n",
+      "policy/LossBefore                          -1.73125e-06\n",
+      "policy/dLoss                                0.000531331\n",
+      "---------------------------------------  --------------\n",
+      "2019-04-01 06:42:50 | epoch #1 | Obtaining samples...\n",
+      "2019-04-01 06:42:50 | epoch #1 | Obtaining samples for iteration 1...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:07\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 06:42:57 | epoch #1 | Logging diagnostics...\n",
+      "2019-04-01 06:42:57 | epoch #1 | Optimizing policy...\n",
+      "2019-04-01 06:42:57 | epoch #1 | Computing loss before\n",
+      "2019-04-01 06:42:57 | epoch #1 | Computing KL before\n",
+      "2019-04-01 06:42:57 | epoch #1 | Optimizing\n",
+      "2019-04-01 06:42:57 | epoch #1 | Start CG optimization: #parameters: 1218, #inputs: 1018, #subsample_inputs: 1018\n",
+      "2019-04-01 06:42:57 | epoch #1 | computing loss before\n",
+      "2019-04-01 06:42:57 | epoch #1 | performing update\n",
+      "2019-04-01 06:42:57 | epoch #1 | computing gradient\n",
+      "2019-04-01 06:42:57 | epoch #1 | gradient computed\n",
+      "2019-04-01 06:42:57 | epoch #1 | computing descent direction\n",
+      "2019-04-01 06:42:58 | epoch #1 | descent direction computed\n",
+      "2019-04-01 06:42:58 | epoch #1 | backtrack iters: 0\n",
+      "2019-04-01 06:42:58 | epoch #1 | computing loss after\n",
+      "2019-04-01 06:42:58 | epoch #1 | optimization finished\n",
+      "2019-04-01 06:42:58 | epoch #1 | Computing KL after\n",
+      "2019-04-01 06:42:58 | epoch #1 | Computing loss after\n",
+      "2019-04-01 06:42:58 | epoch #1 | Fitting baseline...\n",
+      "2019-04-01 06:42:58 | epoch #1 | Saving snapshot...\n",
+      "2019-04-01 06:42:58 | epoch #1 | Saved\n",
+      "2019-04-01 06:42:58 | epoch #1 | Time 16.23 s\n",
+      "2019-04-01 06:42:58 | epoch #1 | EpochTime 8.20 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                     4.7542\n",
+      "AverageReturn                               4.99018\n",
+      "Entropy                                     0.691801\n",
+      "EnvExecTime                                 0.916491\n",
+      "Extras/EpisodeRewardMean                    4.98\n",
+      "Iteration                                   1\n",
+      "LinearFeatureBaseline/ExplainedVariance     0.660687\n",
+      "MaxReturn                                   5\n",
+      "MinReturn                                   3\n",
+      "NumTrajs                                 1018\n",
+      "Perplexity                                  1.99731\n",
+      "PolicyExecTime                              5.84212\n",
+      "ProcessExecTime                             0.261647\n",
+      "StdReturn                                   0.116859\n",
+      "policy/Entropy                              0.675743\n",
+      "policy/KL                                   0.00992123\n",
+      "policy/KLBefore                             0\n",
+      "policy/LossAfter                           -0.00114127\n",
+      "policy/LossBefore                           3.3767e-08\n",
+      "policy/dLoss                                0.0011413\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 06:42:58 | epoch #2 | Obtaining samples...\n",
+      "2019-04-01 06:42:58 | epoch #2 | Obtaining samples for iteration 2...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:07\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 06:43:05 | epoch #2 | Logging diagnostics...\n",
+      "2019-04-01 06:43:05 | epoch #2 | Optimizing policy...\n",
+      "2019-04-01 06:43:05 | epoch #2 | Computing loss before\n",
+      "2019-04-01 06:43:05 | epoch #2 | Computing KL before\n",
+      "2019-04-01 06:43:05 | epoch #2 | Optimizing\n",
+      "2019-04-01 06:43:05 | epoch #2 | Start CG optimization: #parameters: 1218, #inputs: 1000, #subsample_inputs: 1000\n",
+      "2019-04-01 06:43:05 | epoch #2 | computing loss before\n",
+      "2019-04-01 06:43:05 | epoch #2 | performing update\n",
+      "2019-04-01 06:43:05 | epoch #2 | computing gradient\n",
+      "2019-04-01 06:43:05 | epoch #2 | gradient computed\n",
+      "2019-04-01 06:43:05 | epoch #2 | computing descent direction\n",
+      "2019-04-01 06:43:06 | epoch #2 | descent direction computed\n",
+      "2019-04-01 06:43:06 | epoch #2 | backtrack iters: 0\n",
+      "2019-04-01 06:43:06 | epoch #2 | computing loss after\n",
+      "2019-04-01 06:43:06 | epoch #2 | optimization finished\n",
+      "2019-04-01 06:43:06 | epoch #2 | Computing KL after\n",
+      "2019-04-01 06:43:06 | epoch #2 | Computing loss after\n",
+      "2019-04-01 06:43:06 | epoch #2 | Fitting baseline...\n",
+      "2019-04-01 06:43:06 | epoch #2 | Saving snapshot...\n",
+      "2019-04-01 06:43:06 | epoch #2 | Saved\n",
+      "2019-04-01 06:43:06 | epoch #2 | Time 24.15 s\n",
+      "2019-04-01 06:43:06 | epoch #2 | EpochTime 7.92 s\n",
+      "---------------------------------------  --------------\n",
+      "AverageDiscountedReturn                     4.75373\n",
+      "AverageReturn                               4.996\n",
+      "Entropy                                     0.676001\n",
+      "EnvExecTime                                 0.902346\n",
+      "Extras/EpisodeRewardMean                    5\n",
+      "Iteration                                   2\n",
+      "LinearFeatureBaseline/ExplainedVariance     0.675589\n",
+      "MaxReturn                                   5\n",
+      "MinReturn                                   3\n",
+      "NumTrajs                                 1000\n",
+      "Perplexity                                  1.966\n",
+      "PolicyExecTime                              5.62656\n",
+      "ProcessExecTime                             0.25995\n",
+      "StdReturn                                   0.0773563\n",
+      "policy/Entropy                              0.647502\n",
+      "policy/KL                                   0.00991697\n",
+      "policy/KLBefore                            -1.3626e-08\n",
+      "policy/LossAfter                           -0.000339933\n",
+      "policy/LossBefore                          -2.14577e-09\n",
+      "policy/dLoss                                0.000339931\n",
+      "---------------------------------------  --------------\n",
+      "2019-04-01 06:43:06 | epoch #3 | Obtaining samples...\n",
+      "2019-04-01 06:43:06 | epoch #3 | Obtaining samples for iteration 3...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 06:43:13 | epoch #3 | Logging diagnostics...\n",
+      "2019-04-01 06:43:13 | epoch #3 | Optimizing policy...\n",
+      "2019-04-01 06:43:13 | epoch #3 | Computing loss before\n",
+      "2019-04-01 06:43:13 | epoch #3 | Computing KL before\n",
+      "2019-04-01 06:43:13 | epoch #3 | Optimizing\n",
+      "2019-04-01 06:43:13 | epoch #3 | Start CG optimization: #parameters: 1218, #inputs: 1006, #subsample_inputs: 1006\n",
+      "2019-04-01 06:43:13 | epoch #3 | computing loss before\n",
+      "2019-04-01 06:43:13 | epoch #3 | performing update\n",
+      "2019-04-01 06:43:13 | epoch #3 | computing gradient\n",
+      "2019-04-01 06:43:13 | epoch #3 | gradient computed\n",
+      "2019-04-01 06:43:13 | epoch #3 | computing descent direction\n",
+      "2019-04-01 06:43:13 | epoch #3 | descent direction computed\n",
+      "2019-04-01 06:43:13 | epoch #3 | backtrack iters: 1\n",
+      "2019-04-01 06:43:13 | epoch #3 | computing loss after\n",
+      "2019-04-01 06:43:13 | epoch #3 | optimization finished\n",
+      "2019-04-01 06:43:13 | epoch #3 | Computing KL after\n",
+      "2019-04-01 06:43:13 | epoch #3 | Computing loss after\n",
+      "2019-04-01 06:43:13 | epoch #3 | Fitting baseline...\n",
+      "2019-04-01 06:43:13 | epoch #3 | Saving snapshot...\n",
+      "2019-04-01 06:43:13 | epoch #3 | Saved\n",
+      "2019-04-01 06:43:13 | epoch #3 | Time 31.58 s\n",
+      "2019-04-01 06:43:13 | epoch #3 | EpochTime 7.42 s\n",
+      "---------------------------------------  --------------\n",
+      "AverageDiscountedReturn                     4.75649\n",
+      "AverageReturn                               4.99801\n",
+      "Entropy                                     0.647744\n",
+      "EnvExecTime                                 0.851849\n",
+      "Extras/EpisodeRewardMean                    5\n",
+      "Iteration                                   3\n",
+      "LinearFeatureBaseline/ExplainedVariance     0.671654\n",
+      "MaxReturn                                   5\n",
+      "MinReturn                                   4\n",
+      "NumTrajs                                 1006\n",
+      "Perplexity                                  1.91122\n",
+      "PolicyExecTime                              5.17552\n",
+      "ProcessExecTime                             0.244249\n",
+      "StdReturn                                   0.0445435\n",
+      "policy/Entropy                              0.67191\n",
+      "policy/KL                                   0.00653902\n",
+      "policy/KLBefore                            -1.18269e-08\n",
+      "policy/LossAfter                           -0.00187737\n",
+      "policy/LossBefore                           3.88273e-09\n",
+      "policy/dLoss                                0.00187737\n",
+      "---------------------------------------  --------------\n",
+      "2019-04-01 06:43:13 | epoch #4 | Obtaining samples...\n",
+      "2019-04-01 06:43:13 | epoch #4 | Obtaining samples for iteration 4...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [######                        ] 100% | ETA: 00:00:05"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "ignored",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-9-09af41d54102>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# use n_epochs = 100 for practical example, n_epochs = 10 for quick demo, n_epochs = 1 for smoke testing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 6\u001b[0;31m \u001b[0mrunner\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_epochs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m10000\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mplot\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/content/garage/garage/experiment/local_tf_runner.py\u001b[0m in \u001b[0;36mtrain\u001b[0;34m(self, n_epochs, n_epoch_cycles, batch_size, plot, store_paths, pause_for_plot)\u001b[0m\n\u001b[1;32m    251\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprefix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'epoch #%d | '\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mepoch\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    252\u001b[0m                 \u001b[0;32mfor\u001b[0m \u001b[0mcycle\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_epoch_cycles\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 253\u001b[0;31m                     \u001b[0mpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobtain_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    254\u001b[0m                     \u001b[0mpaths\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprocess_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    255\u001b[0m                     \u001b[0mlast_return\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0malgo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtrain_once\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/content/garage/garage/experiment/local_tf_runner.py\u001b[0m in \u001b[0;36mobtain_samples\u001b[0;34m(self, itr, batch_size)\u001b[0m\n\u001b[1;32m    171\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mn_epoch_cycles\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    172\u001b[0m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Obtaining samples...'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 173\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msampler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobtain_samples\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbatch_size\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    174\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    175\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msave_snapshot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mitr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpaths\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/content/garage/garage/tf/samplers/on_policy_vectorized_sampler.py\u001b[0m in \u001b[0;36mobtain_samples\u001b[0;34m(self, itr, batch_size, whole_paths)\u001b[0m\n\u001b[1;32m     55\u001b[0m             \u001b[0mpolicy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdones\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     56\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 57\u001b[0;31m             \u001b[0mactions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0magent_infos\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpolicy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobses\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     58\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     59\u001b[0m             \u001b[0mpolicy_time\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/content/garage/garage/tf/policies/categorical_mlp_policy.py\u001b[0m in \u001b[0;36mget_actions\u001b[0;34m(self, observations)\u001b[0m\n\u001b[1;32m     89\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobservations\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     90\u001b[0m         \u001b[0mflat_obs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobservation_space\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflatten_n\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobservations\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 91\u001b[0;31m         \u001b[0mprobs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_f_prob\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflat_obs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     92\u001b[0m         \u001b[0mactions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmap\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maction_space\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mweighted_sample\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mprobs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     93\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mactions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mprob\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mprobs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/content/garage/garage/tf/misc/tensor_utils.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(*input_vals)\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0minput_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m         \u001b[0msess\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_default_session\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msess\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moutputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mzip\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minput_vals\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     12\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mrun\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, fetches, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m    927\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    928\u001b[0m       result = self._run(None, fetches, feed_dict, options_ptr,\n\u001b[0;32m--> 929\u001b[0;31m                          run_metadata_ptr)\n\u001b[0m\u001b[1;32m    930\u001b[0m       \u001b[0;32mif\u001b[0m \u001b[0mrun_metadata\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    931\u001b[0m         \u001b[0mproto_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtf_session\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTF_GetBuffer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrun_metadata_ptr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_run\u001b[0;34m(self, handle, fetches, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m   1150\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mfinal_fetches\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mfinal_targets\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mhandle\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mfeed_dict_tensor\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1151\u001b[0m       results = self._do_run(handle, final_targets, final_fetches,\n\u001b[0;32m-> 1152\u001b[0;31m                              feed_dict_tensor, options, run_metadata)\n\u001b[0m\u001b[1;32m   1153\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1154\u001b[0m       \u001b[0mresults\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_do_run\u001b[0;34m(self, handle, target_list, fetch_list, feed_dict, options, run_metadata)\u001b[0m\n\u001b[1;32m   1326\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mhandle\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1327\u001b[0m       return self._do_call(_run_fn, feeds, fetches, targets, options,\n\u001b[0;32m-> 1328\u001b[0;31m                            run_metadata)\n\u001b[0m\u001b[1;32m   1329\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1330\u001b[0m       \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_prun_fn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeeds\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetches\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_do_call\u001b[0;34m(self, fn, *args)\u001b[0m\n\u001b[1;32m   1332\u001b[0m   \u001b[0;32mdef\u001b[0m \u001b[0m_do_call\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1333\u001b[0m     \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1334\u001b[0;31m       \u001b[0;32mreturn\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1335\u001b[0m     \u001b[0;32mexcept\u001b[0m \u001b[0merrors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mOpError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1336\u001b[0m       \u001b[0mmessage\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcompat\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mas_text\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_run_fn\u001b[0;34m(feed_dict, fetch_list, target_list, options, run_metadata)\u001b[0m\n\u001b[1;32m   1317\u001b[0m       \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_extend_graph\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1318\u001b[0m       return self._call_tf_sessionrun(\n\u001b[0;32m-> 1319\u001b[0;31m           options, feed_dict, fetch_list, target_list, run_metadata)\n\u001b[0m\u001b[1;32m   1320\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1321\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_prun_fn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/tensorflow/python/client/session.py\u001b[0m in \u001b[0;36m_call_tf_sessionrun\u001b[0;34m(self, options, feed_dict, fetch_list, target_list, run_metadata)\u001b[0m\n\u001b[1;32m   1405\u001b[0m     return tf_session.TF_SessionRun_wrapper(\n\u001b[1;32m   1406\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_session\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moptions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtarget_list\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1407\u001b[0;31m         run_metadata)\n\u001b[0m\u001b[1;32m   1408\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1409\u001b[0m   \u001b[0;32mdef\u001b[0m \u001b[0m_call_tf_sessionprun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhandle\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfeed_dict\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfetch_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "# Train the policy (neural network) on the environment\n",
+    "runner = LocalRunner()\n",
+    "\n",
+    "runner.setup(algo=algo, env=env)\n",
+    "\n",
+    "# use n_epochs = 2 for quick demo\n",
+    "runner.train(n_epochs=2, batch_size=10000, plot=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 378
+    },
+    "colab_type": "code",
+    "id": "LfG7tMG4LbtF",
+    "outputId": "c6356fd6-0e95-46dd-e335-8021bd9df25e"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>nstep</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>exp</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>8</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>13</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>8</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>10</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>7</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>10</td>\n",
+       "      <td>5.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     nstep  score\n",
+       "exp              \n",
+       "1        7    5.0\n",
+       "2        8    5.0\n",
+       "3        7    5.0\n",
+       "4       13    5.0\n",
+       "5        8    5.0\n",
+       "6        7    5.0\n",
+       "7        8    5.0\n",
+       "8       10    5.0\n",
+       "9        7    5.0\n",
+       "10      10    5.0"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test results\n",
+    "n_experiments = 10\n",
+    "row_all = []\n",
+    "\n",
+    "for i in range(n_experiments):\n",
+    "  #print(\"experiment \", i+1)\n",
+    "\n",
+    "  # reset\n",
+    "  obs_initial = env.reset()\n",
+    "\n",
+    "  # start\n",
+    "  done = False\n",
+    "  obs_i = obs_initial\n",
+    "  while not done:\n",
+    "    row_i = {}\n",
+    "    row_i['exp'] = i + 1\n",
+    "    row_i['obs'] = obs_i\n",
+    "    act_i, _ = policy.get_action(obs_i)\n",
+    "    row_i['act'] = act_i\n",
+    "    obs_i, rew_i, done, _ = env.step(act_i)\n",
+    "    row_i['obs'] = obs_i\n",
+    "    row_i['rew'] = rew_i\n",
+    "    row_all.append(row_i)\n",
+    "    \n",
+    "    if done: break\n",
+    "    \n",
+    "#env.close()\n",
+    "\n",
+    "import pandas as pd\n",
+    "df = pd.DataFrame(row_all)\n",
+    "pd.DataFrame({\n",
+    "    'score': df.groupby('exp')['rew'].sum(),\n",
+    "    'nstep': df.groupby('exp')['rew'].count()\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "nBxUpmnto1Qi"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "custom_env.ipynb",
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/jupyter/trpo_gym_tf_cartpole.ipynb
+++ b/examples/jupyter/trpo_gym_tf_cartpole.ipynb
@@ -1,1257 +1,1362 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "trpo_gym_tf_cartpole.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true,
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/trpo_gym_tf_cartpole.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "acXH8kwHsAYT"
+   },
+   "source": [
+    "This is a jupyter notebook demonstrating usage of [garage](https://github.com/rlworkgroup/garage) in a jupyter notebook.\n",
+    "\n",
+    "In particular, it demonstrates the example `trpo_gym_tf_cartpole.py` file already available in [garage/examples/tf/](https://github.com/rlworkgroup/garage/blob/master/examples/tf/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "GmPLYXrXH7A5"
+   },
+   "source": [
+    "## Install pre-requisites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1655
+    },
+    "colab_type": "code",
+    "id": "Aj3bL9HaG5HL",
+    "outputId": "6d152547-07e8-4f32-9cf0-882fc97620ed"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
-      "source": [
-        "<a href=\"https://colab.research.google.com/github/rlworkgroup/garage/blob/master/examples/jupyter/trpo_gym_tf_cartpole.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cloning into 'garage'...\n",
+      "remote: Enumerating objects: 416, done.\u001b[K\n",
+      "remote: Counting objects: 100% (416/416), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (381/381), done.\u001b[K\n",
+      "remote: Total 416 (delta 68), reused 148 (delta 25), pack-reused 0\u001b[K\n",
+      "Receiving objects: 100% (416/416), 568.43 KiB | 11.37 MiB/s, done.\n",
+      "Resolving deltas: 100% (68/68), done.\n",
+      "start of setup_colab.sh\n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "debconf: unable to initialize frontend: Dialog\n",
+      "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 68.)\n",
+      "debconf: falling back to frontend: Readline\n",
+      "debconf: unable to initialize frontend: Readline\n",
+      "debconf: (This frontend requires a controlling tty.)\n",
+      "debconf: falling back to frontend: Teletype\n",
+      "dpkg-preconfigure: unable to re-open stdin: \n",
+      "\n",
+      "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
+      "\n",
+      "Cloning into '/tmp/tmp.iA4POZSkg1/glfw'...\n",
+      "remote: Enumerating objects: 23479, done.\u001b[K\n",
+      "remote: Total 23479 (delta 0), reused 0 (delta 0), pack-reused 23479\u001b[K\n",
+      "Receiving objects: 100% (23479/23479), 11.64 MiB | 22.44 MiB/s, done.\n",
+      "Resolving deltas: 100% (16458/16458), done.\n",
+      "Note: checking out '0be4f3f75aebd9d24583ee86590a38e741db0904'.\n",
+      "\n",
+      "You are in 'detached HEAD' state. You can look around, make experimental\n",
+      "changes and commit them, and you can discard any commits you make in this\n",
+      "state without impacting any branches by performing another checkout.\n",
+      "\n",
+      "If you want to create a new branch to retain commits you create, you may\n",
+      "do so (now or later) by using -b with the checkout command again. Example:\n",
+      "\n",
+      "  git checkout -b <new-branch-name>\n",
+      "\n",
+      "HEAD is now at 0be4f3f7 Add GLFW_FOCUS_ON_SHOW window hint and attribute\n",
+      "--2019-04-01 05:43:53--  https://www.roboti.us/download/mjpro150_linux.zip\n",
+      "Resolving www.roboti.us (www.roboti.us)... 104.40.85.93\n",
+      "Connecting to www.roboti.us (www.roboti.us)|104.40.85.93|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 1950775 (1.9M) [application/zip]\n",
+      "Saving to: ‘/tmp/tmp.TkeoytbyBl/mujoco.zip’\n",
+      "\n",
+      "/tmp/tmp.TkeoytbyBl 100%[===================>]   1.86M  2.80MB/s    in 0.7s    \n",
+      "\n",
+      "2019-04-01 05:43:54 (2.80 MB/s) - ‘/tmp/tmp.TkeoytbyBl/mujoco.zip’ saved [1950775/1950775]\n",
+      "\n",
+      "--2019-04-01 05:43:54--  https://www.roboti.us/download/mujoco200_linux.zip\n",
+      "Resolving www.roboti.us (www.roboti.us)... 104.40.85.93\n",
+      "Connecting to www.roboti.us (www.roboti.us)|104.40.85.93|:443... connected.\n",
+      "HTTP request sent, awaiting response... 200 OK\n",
+      "Length: 4427362 (4.2M) [application/zip]\n",
+      "Saving to: ‘/tmp/tmp.EWUV4iDzKO/mujoco.zip’\n",
+      "\n",
+      "/tmp/tmp.EWUV4iDzKO 100%[===================>]   4.22M  4.85MB/s    in 0.9s    \n",
+      "\n",
+      "2019-04-01 05:43:55 (4.85 MB/s) - ‘/tmp/tmp.EWUV4iDzKO/mujoco.zip’ saved [4427362/4427362]\n",
+      "\n",
+      "Cloning into 'mujoco-py'...\n",
+      "remote: Enumerating objects: 200, done.\u001b[K\n",
+      "remote: Counting objects: 100% (200/200), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (192/192), done.\u001b[K\n",
+      "remote: Total 200 (delta 7), reused 166 (delta 3), pack-reused 0\u001b[K\n",
+      "Receiving objects: 100% (200/200), 2.98 MiB | 25.68 MiB/s, done.\n",
+      "Resolving deltas: 100% (7/7), done.\n",
+      "Note: checking out '3ba83940a957a0e2236aaa739fc6a8e8f5b7c421'.\n",
+      "\n",
+      "You are in 'detached HEAD' state. You can look around, make experimental\n",
+      "changes and commit them, and you can discard any commits you make in this\n",
+      "state without impacting any branches by performing another checkout.\n",
+      "\n",
+      "If you want to create a new branch to retain commits you create, you may\n",
+      "do so (now or later) by using -b with the checkout command again. Example:\n",
+      "\n",
+      "  git checkout -b <new-branch-name>\n",
+      "\n",
+      "\u001b[31mspacy 2.0.18 has requirement numpy>=1.15.0, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
+      "\u001b[31mimgaug 0.2.8 has requirement numpy>=1.15.0, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
+      "\u001b[31mfeaturetools 0.4.1 has requirement pandas>=0.23.0, but you'll have pandas 0.22.0 which is incompatible.\u001b[0m\n",
+      "\u001b[31mfastai 1.0.50.post1 has requirement numpy>=1.15, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
+      "\u001b[31mdatascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible.\u001b[0m\n",
+      "\u001b[31malbumentations 0.1.12 has requirement imgaug<0.2.7,>=0.2.5, but you'll have imgaug 0.2.8 which is incompatible.\u001b[0m\n",
+      "\u001b[31mnose2 0.9.0 has requirement coverage>=4.4.1, but you'll have coverage 3.7.1 which is incompatible.\u001b[0m\n",
+      "end of setup_colab.sh\n"
+     ]
     },
     {
-      "metadata": {
-        "id": "acXH8kwHsAYT",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "This is a jupyter notebook demonstrating usage of [garage](https://github.com/rlworkgroup/garage) in a jupyter notebook.\n",
-        "\n",
-        "In particular, it demonstrates the example `trpo_gym_tf_cartpole.py` file already available in [garage/examples/tf/](https://github.com/rlworkgroup/garage/blob/master/examples/tf/)"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "GmPLYXrXH7A5",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Install pre-requisites"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Aj3bL9HaG5HL",
-        "colab_type": "code",
-        "outputId": "6d152547-07e8-4f32-9cf0-882fc97620ed",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 1655
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "%%shell\n",
-        "\n",
-        "echo \"abcd\" > mujoco_fake_key\n",
-        "\n",
-        "\n",
-        "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
-        "\n",
-        "cd garage\n",
-        "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Cloning into 'garage'...\n",
-            "remote: Enumerating objects: 416, done.\u001b[K\n",
-            "remote: Counting objects: 100% (416/416), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (381/381), done.\u001b[K\n",
-            "remote: Total 416 (delta 68), reused 148 (delta 25), pack-reused 0\u001b[K\n",
-            "Receiving objects: 100% (416/416), 568.43 KiB | 11.37 MiB/s, done.\n",
-            "Resolving deltas: 100% (68/68), done.\n",
-            "start of setup_colab.sh\n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "debconf: unable to initialize frontend: Dialog\n",
-            "debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 68.)\n",
-            "debconf: falling back to frontend: Readline\n",
-            "debconf: unable to initialize frontend: Readline\n",
-            "debconf: (This frontend requires a controlling tty.)\n",
-            "debconf: falling back to frontend: Teletype\n",
-            "dpkg-preconfigure: unable to re-open stdin: \n",
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "Cloning into '/tmp/tmp.iA4POZSkg1/glfw'...\n",
-            "remote: Enumerating objects: 23479, done.\u001b[K\n",
-            "remote: Total 23479 (delta 0), reused 0 (delta 0), pack-reused 23479\u001b[K\n",
-            "Receiving objects: 100% (23479/23479), 11.64 MiB | 22.44 MiB/s, done.\n",
-            "Resolving deltas: 100% (16458/16458), done.\n",
-            "Note: checking out '0be4f3f75aebd9d24583ee86590a38e741db0904'.\n",
-            "\n",
-            "You are in 'detached HEAD' state. You can look around, make experimental\n",
-            "changes and commit them, and you can discard any commits you make in this\n",
-            "state without impacting any branches by performing another checkout.\n",
-            "\n",
-            "If you want to create a new branch to retain commits you create, you may\n",
-            "do so (now or later) by using -b with the checkout command again. Example:\n",
-            "\n",
-            "  git checkout -b <new-branch-name>\n",
-            "\n",
-            "HEAD is now at 0be4f3f7 Add GLFW_FOCUS_ON_SHOW window hint and attribute\n",
-            "--2019-04-01 05:43:53--  https://www.roboti.us/download/mjpro150_linux.zip\n",
-            "Resolving www.roboti.us (www.roboti.us)... 104.40.85.93\n",
-            "Connecting to www.roboti.us (www.roboti.us)|104.40.85.93|:443... connected.\n",
-            "HTTP request sent, awaiting response... 200 OK\n",
-            "Length: 1950775 (1.9M) [application/zip]\n",
-            "Saving to: ‘/tmp/tmp.TkeoytbyBl/mujoco.zip’\n",
-            "\n",
-            "/tmp/tmp.TkeoytbyBl 100%[===================>]   1.86M  2.80MB/s    in 0.7s    \n",
-            "\n",
-            "2019-04-01 05:43:54 (2.80 MB/s) - ‘/tmp/tmp.TkeoytbyBl/mujoco.zip’ saved [1950775/1950775]\n",
-            "\n",
-            "--2019-04-01 05:43:54--  https://www.roboti.us/download/mujoco200_linux.zip\n",
-            "Resolving www.roboti.us (www.roboti.us)... 104.40.85.93\n",
-            "Connecting to www.roboti.us (www.roboti.us)|104.40.85.93|:443... connected.\n",
-            "HTTP request sent, awaiting response... 200 OK\n",
-            "Length: 4427362 (4.2M) [application/zip]\n",
-            "Saving to: ‘/tmp/tmp.EWUV4iDzKO/mujoco.zip’\n",
-            "\n",
-            "/tmp/tmp.EWUV4iDzKO 100%[===================>]   4.22M  4.85MB/s    in 0.9s    \n",
-            "\n",
-            "2019-04-01 05:43:55 (4.85 MB/s) - ‘/tmp/tmp.EWUV4iDzKO/mujoco.zip’ saved [4427362/4427362]\n",
-            "\n",
-            "Cloning into 'mujoco-py'...\n",
-            "remote: Enumerating objects: 200, done.\u001b[K\n",
-            "remote: Counting objects: 100% (200/200), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (192/192), done.\u001b[K\n",
-            "remote: Total 200 (delta 7), reused 166 (delta 3), pack-reused 0\u001b[K\n",
-            "Receiving objects: 100% (200/200), 2.98 MiB | 25.68 MiB/s, done.\n",
-            "Resolving deltas: 100% (7/7), done.\n",
-            "Note: checking out '3ba83940a957a0e2236aaa739fc6a8e8f5b7c421'.\n",
-            "\n",
-            "You are in 'detached HEAD' state. You can look around, make experimental\n",
-            "changes and commit them, and you can discard any commits you make in this\n",
-            "state without impacting any branches by performing another checkout.\n",
-            "\n",
-            "If you want to create a new branch to retain commits you create, you may\n",
-            "do so (now or later) by using -b with the checkout command again. Example:\n",
-            "\n",
-            "  git checkout -b <new-branch-name>\n",
-            "\n",
-            "\u001b[31mspacy 2.0.18 has requirement numpy>=1.15.0, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
-            "\u001b[31mimgaug 0.2.8 has requirement numpy>=1.15.0, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
-            "\u001b[31mfeaturetools 0.4.1 has requirement pandas>=0.23.0, but you'll have pandas 0.22.0 which is incompatible.\u001b[0m\n",
-            "\u001b[31mfastai 1.0.50.post1 has requirement numpy>=1.15, but you'll have numpy 1.14.5 which is incompatible.\u001b[0m\n",
-            "\u001b[31mdatascience 0.10.6 has requirement folium==0.2.1, but you'll have folium 0.8.3 which is incompatible.\u001b[0m\n",
-            "\u001b[31malbumentations 0.1.12 has requirement imgaug<0.2.7,>=0.2.5, but you'll have imgaug 0.2.8 which is incompatible.\u001b[0m\n",
-            "\u001b[31mnose2 0.9.0 has requirement coverage>=4.4.1, but you'll have coverage 3.7.1 which is incompatible.\u001b[0m\n",
-            "end of setup_colab.sh\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              ""
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 1
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "6dGO3j0txY_l",
-        "colab_type": "code",
-        "outputId": "43ea0b65-bb1b-4977-acd0-53c8d761dd27",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 169
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "raise Exception(\"Please restart your runtime so that the installed dependencies for 'garage' can be loaded, and then resume running the notebook\")"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "Exception",
-          "evalue": "ignored",
-          "traceback": [
-            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-            "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-            "\u001b[0;32m<ipython-input-8-ca63a73504b0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Please restart your runtime so that the added installations can be loaded, and then resume running the notebook\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-            "\u001b[0;31mException\u001b[0m: Please restart your runtime so that the added installations can be loaded, and then resume running the notebook"
-          ]
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "pGyQDPC2Vs9O",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "\n",
-        "---\n",
-        "\n"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "G3KbL5sQH9m1",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Prepare for the training"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "IPmbM_77tk3S",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# The contents of this cell and the one after are mostly copied from garage/examples/...\n",
-        "# Note that these need to be run twice if for the first time on a colab.research.google.com instance\n",
-        "# 1st time is to create the \"personal config from template\"\n",
-        "# 2nd time is the charm\n",
-        "\n",
-        "from garage.np.baselines import LinearFeatureBaseline\n",
-        "from garage.envs import normalize\n",
-        "# from garage.envs.box2d import CartpoleEnv\n",
-        "from garage.experiment import run_experiment\n",
-        "from garage.tf.algos import TRPO\n",
-        "from garage.tf.envs import TfEnv\n",
-        "#from garage.tf.policies import GaussianMLPPolicy\n",
-        "from garage.tf.policies import CategoricalMLPPolicy\n",
-        "\n",
-        "import gym\n",
-        "\n",
-        "from garage.experiment import LocalRunner\n",
-        "from garage.logger import logger, StdOutput\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "Zu0ce9h3IEF9",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# garage version of CartPole environment, has Discrete action space instead of Box\n",
-        "#env = TfEnv(normalize(CartpoleEnv()))\n",
-        "#policy = GaussianMLPPolicy(\n",
-        "#    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
-        "\n",
-        "# gym version of CartPole. Check note above\n",
-        "# env = TfEnv(normalize(gym.make(\"CartPole-v0\")))\n",
-        "\n",
-        "# garage updated method of getting env\n",
-        "env = TfEnv(env_name='CartPole-v1')\n",
-        "policy = CategoricalMLPPolicy(\n",
-        "    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
-        "\n",
-        "# create baseline\n",
-        "baseline = LinearFeatureBaseline(env_spec=env.spec)\n",
-        "\n",
-        "# specify an algorithm\n",
-        "algo = TRPO(\n",
-        "    env_spec=env.spec,\n",
-        "    policy=policy,\n",
-        "    baseline=baseline,\n",
-        "    \n",
-        "    # Use these settings for garage version of env\n",
-        "    # max_path_length=100,\n",
-        "    # n_itr=100,\n",
-        "    \n",
-        "    # Use these for gym version\n",
-        "    max_path_length=200,\n",
-        "    n_itr=20,\n",
-        "\n",
-        "    discount=0.99,\n",
-        "    max_kl_step=0.01\n",
-        "    )\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "rjkcy1nUIFYX",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Train the algorithm"
-      ]
-    },
-    {
-      "metadata": {
-        "id": "eWxt4JcxEMUC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# start a tensorflow session so that we can keep it open after training and use the trained network to see it performing\n",
-        "import tensorflow as tf\n",
-        "sess = tf.InteractiveSession()\n"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "or9eQFb3EVgv",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# initialize\n",
-        "sess.run(tf.compat.v1.global_variables_initializer())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "aEyXIDZPP9QP",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# log to stdout\n",
-        "logger.add_output(StdOutput())"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "ozn95FIDJEdC",
-        "colab_type": "code",
-        "outputId": "99127151-e1a8-4bd1-f266-e60dc3139f4f",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 8799
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# train the algo\n",
-        "\n",
-        "runner = LocalRunner()\n",
-        "\n",
-        "runner.setup(algo=algo, env=env)\n",
-        "\n",
-        "# use n_epochs = 100 for practical example, n_epochs = 10 for quick demo, n_epochs = 1 for smoke testing\n",
-        "runner.train(n_epochs=10, batch_size=10000, plot=False)"
-      ],
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:46:28 | epoch #0 | Obtaining samples...\n",
-            "2019-04-01 05:46:28 | epoch #0 | Obtaining samples for iteration 0...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "/content/garage/garage/experiment/local_tf_runner.py:129: LoggerWarning: \u001b[33mLog data of type Graph was not accepted by any output\u001b[0m\n",
-            "  logger.log(self.sess.graph)\n",
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:46:34 | epoch #0 | Logging diagnostics...\n",
-            "2019-04-01 05:46:34 | epoch #0 | Optimizing policy...\n",
-            "2019-04-01 05:46:34 | epoch #0 | Computing loss before\n",
-            "2019-04-01 05:46:34 | epoch #0 | Computing KL before\n",
-            "2019-04-01 05:46:35 | epoch #0 | Optimizing\n",
-            "2019-04-01 05:46:35 | epoch #0 | Start CG optimization: #parameters: 1282, #inputs: 721, #subsample_inputs: 721\n",
-            "2019-04-01 05:46:35 | epoch #0 | computing loss before\n",
-            "2019-04-01 05:46:35 | epoch #0 | performing update\n",
-            "2019-04-01 05:46:35 | epoch #0 | computing gradient\n",
-            "2019-04-01 05:46:35 | epoch #0 | gradient computed\n",
-            "2019-04-01 05:46:35 | epoch #0 | computing descent direction\n",
-            "2019-04-01 05:46:39 | epoch #0 | descent direction computed\n",
-            "2019-04-01 05:46:40 | epoch #0 | backtrack iters: 3\n",
-            "2019-04-01 05:46:40 | epoch #0 | computing loss after\n",
-            "2019-04-01 05:46:40 | epoch #0 | optimization finished\n",
-            "2019-04-01 05:46:40 | epoch #0 | Computing KL after\n",
-            "2019-04-01 05:46:40 | epoch #0 | Computing loss after\n",
-            "2019-04-01 05:46:41 | epoch #0 | Fitting baseline...\n",
-            "2019-04-01 05:46:41 | epoch #0 | Saving snapshot...\n",
-            "2019-04-01 05:46:41 | epoch #0 | Saved\n",
-            "2019-04-01 05:46:41 | epoch #0 | Time 12.91 s\n",
-            "2019-04-01 05:46:41 | epoch #0 | EpochTime 12.91 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   12.9191\n",
-            "AverageReturn                             13.889\n",
-            "Entropy                                    0.586143\n",
-            "EnvExecTime                                0.712197\n",
-            "Extras/EpisodeRewardMean                  13.71\n",
-            "Iteration                                  0\n",
-            "LinearFeatureBaseline/ExplainedVariance   -1.55761e-08\n",
-            "MaxReturn                                 42\n",
-            "MinReturn                                  8\n",
-            "NumTrajs                                 721\n",
-            "Perplexity                                 1.79704\n",
-            "PolicyExecTime                             5.32993\n",
-            "ProcessExecTime                            0.232649\n",
-            "StdReturn                                  5.07081\n",
-            "policy/Entropy                             0.632138\n",
-            "policy/KL                                  0.00875508\n",
-            "policy/KLBefore                           -1.23854e-10\n",
-            "policy/LossAfter                          -0.0242026\n",
-            "policy/LossBefore                          4.10478e-06\n",
-            "policy/dLoss                               0.0242067\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:46:41 | epoch #1 | Obtaining samples...\n",
-            "2019-04-01 05:46:41 | epoch #1 | Obtaining samples for iteration 1...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:46:48 | epoch #1 | Logging diagnostics...\n",
-            "2019-04-01 05:46:48 | epoch #1 | Optimizing policy...\n",
-            "2019-04-01 05:46:48 | epoch #1 | Computing loss before\n",
-            "2019-04-01 05:46:48 | epoch #1 | Computing KL before\n",
-            "2019-04-01 05:46:48 | epoch #1 | Optimizing\n",
-            "2019-04-01 05:46:48 | epoch #1 | Start CG optimization: #parameters: 1282, #inputs: 599, #subsample_inputs: 599\n",
-            "2019-04-01 05:46:48 | epoch #1 | computing loss before\n",
-            "2019-04-01 05:46:48 | epoch #1 | performing update\n",
-            "2019-04-01 05:46:48 | epoch #1 | computing gradient\n",
-            "2019-04-01 05:46:48 | epoch #1 | gradient computed\n",
-            "2019-04-01 05:46:48 | epoch #1 | computing descent direction\n",
-            "2019-04-01 05:46:51 | epoch #1 | descent direction computed\n",
-            "2019-04-01 05:46:52 | epoch #1 | backtrack iters: 2\n",
-            "2019-04-01 05:46:52 | epoch #1 | computing loss after\n",
-            "2019-04-01 05:46:52 | epoch #1 | optimization finished\n",
-            "2019-04-01 05:46:52 | epoch #1 | Computing KL after\n",
-            "2019-04-01 05:46:52 | epoch #1 | Computing loss after\n",
-            "2019-04-01 05:46:52 | epoch #1 | Fitting baseline...\n",
-            "2019-04-01 05:46:52 | epoch #1 | Saving snapshot...\n",
-            "2019-04-01 05:46:52 | epoch #1 | Saved\n",
-            "2019-04-01 05:46:52 | epoch #1 | Time 24.61 s\n",
-            "2019-04-01 05:46:52 | epoch #1 | EpochTime 11.69 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   15.246\n",
-            "AverageReturn                             16.7129\n",
-            "Entropy                                    0.643499\n",
-            "EnvExecTime                                0.758384\n",
-            "Extras/EpisodeRewardMean                  17.94\n",
-            "Iteration                                  1\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.356434\n",
-            "MaxReturn                                 60\n",
-            "MinReturn                                  8\n",
-            "NumTrajs                                 599\n",
-            "Perplexity                                 1.90313\n",
-            "PolicyExecTime                             5.6485\n",
-            "ProcessExecTime                            0.242136\n",
-            "StdReturn                                  7.24996\n",
-            "policy/Entropy                             0.660685\n",
-            "policy/KL                                  0.00689534\n",
-            "policy/KLBefore                           -6.77591e-11\n",
-            "policy/LossAfter                          -0.032553\n",
-            "policy/LossBefore                         -6.93512e-08\n",
-            "policy/dLoss                               0.032553\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:46:52 | epoch #2 | Obtaining samples...\n",
-            "2019-04-01 05:46:52 | epoch #2 | Obtaining samples for iteration 2...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:46:59 | epoch #2 | Logging diagnostics...\n",
-            "2019-04-01 05:46:59 | epoch #2 | Optimizing policy...\n",
-            "2019-04-01 05:46:59 | epoch #2 | Computing loss before\n",
-            "2019-04-01 05:46:59 | epoch #2 | Computing KL before\n",
-            "2019-04-01 05:46:59 | epoch #2 | Optimizing\n",
-            "2019-04-01 05:46:59 | epoch #2 | Start CG optimization: #parameters: 1282, #inputs: 494, #subsample_inputs: 494\n",
-            "2019-04-01 05:46:59 | epoch #2 | computing loss before\n",
-            "2019-04-01 05:46:59 | epoch #2 | performing update\n",
-            "2019-04-01 05:46:59 | epoch #2 | computing gradient\n",
-            "2019-04-01 05:46:59 | epoch #2 | gradient computed\n",
-            "2019-04-01 05:46:59 | epoch #2 | computing descent direction\n",
-            "2019-04-01 05:47:02 | epoch #2 | descent direction computed\n",
-            "2019-04-01 05:47:02 | epoch #2 | backtrack iters: 1\n",
-            "2019-04-01 05:47:02 | epoch #2 | computing loss after\n",
-            "2019-04-01 05:47:02 | epoch #2 | optimization finished\n",
-            "2019-04-01 05:47:02 | epoch #2 | Computing KL after\n",
-            "2019-04-01 05:47:02 | epoch #2 | Computing loss after\n",
-            "2019-04-01 05:47:03 | epoch #2 | Fitting baseline...\n",
-            "2019-04-01 05:47:03 | epoch #2 | Saving snapshot...\n",
-            "2019-04-01 05:47:03 | epoch #2 | Saved\n",
-            "2019-04-01 05:47:03 | epoch #2 | Time 34.87 s\n",
-            "2019-04-01 05:47:03 | epoch #2 | EpochTime 10.26 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   17.871\n",
-            "AverageReturn                             20.2672\n",
-            "Entropy                                    0.666088\n",
-            "EnvExecTime                                0.721046\n",
-            "Extras/EpisodeRewardMean                  21.24\n",
-            "Iteration                                  2\n",
-            "LinearFeatureBaseline/ExplainedVariance   -0.0455278\n",
-            "MaxReturn                                 96\n",
-            "MinReturn                                  8\n",
-            "NumTrajs                                 494\n",
-            "Perplexity                                 1.94661\n",
-            "PolicyExecTime                             5.27265\n",
-            "ProcessExecTime                            0.228765\n",
-            "StdReturn                                 12.1072\n",
-            "policy/Entropy                             0.661384\n",
-            "policy/KL                                  0.00825417\n",
-            "policy/KLBefore                           -2.21965e-10\n",
-            "policy/LossAfter                          -0.0213919\n",
-            "policy/LossBefore                         -7.00825e-08\n",
-            "policy/dLoss                               0.0213919\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:03 | epoch #3 | Obtaining samples...\n",
-            "2019-04-01 05:47:03 | epoch #3 | Obtaining samples for iteration 3...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:09 | epoch #3 | Logging diagnostics...\n",
-            "2019-04-01 05:47:09 | epoch #3 | Optimizing policy...\n",
-            "2019-04-01 05:47:09 | epoch #3 | Computing loss before\n",
-            "2019-04-01 05:47:09 | epoch #3 | Computing KL before\n",
-            "2019-04-01 05:47:09 | epoch #3 | Optimizing\n",
-            "2019-04-01 05:47:09 | epoch #3 | Start CG optimization: #parameters: 1282, #inputs: 393, #subsample_inputs: 393\n",
-            "2019-04-01 05:47:09 | epoch #3 | computing loss before\n",
-            "2019-04-01 05:47:09 | epoch #3 | performing update\n",
-            "2019-04-01 05:47:09 | epoch #3 | computing gradient\n",
-            "2019-04-01 05:47:09 | epoch #3 | gradient computed\n",
-            "2019-04-01 05:47:09 | epoch #3 | computing descent direction\n",
-            "2019-04-01 05:47:12 | epoch #3 | descent direction computed\n",
-            "2019-04-01 05:47:12 | epoch #3 | backtrack iters: 1\n",
-            "2019-04-01 05:47:12 | epoch #3 | computing loss after\n",
-            "2019-04-01 05:47:12 | epoch #3 | optimization finished\n",
-            "2019-04-01 05:47:12 | epoch #3 | Computing KL after\n",
-            "2019-04-01 05:47:12 | epoch #3 | Computing loss after\n",
-            "2019-04-01 05:47:12 | epoch #3 | Fitting baseline...\n",
-            "2019-04-01 05:47:12 | epoch #3 | Saving snapshot...\n",
-            "2019-04-01 05:47:12 | epoch #3 | Saved\n",
-            "2019-04-01 05:47:12 | epoch #3 | Time 44.31 s\n",
-            "2019-04-01 05:47:12 | epoch #3 | EpochTime 9.43 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   21.7521\n",
-            "AverageReturn                             25.5013\n",
-            "Entropy                                    0.666487\n",
-            "EnvExecTime                                0.725008\n",
-            "Extras/EpisodeRewardMean                  24.77\n",
-            "Iteration                                  3\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.246326\n",
-            "MaxReturn                                 90\n",
-            "MinReturn                                  9\n",
-            "NumTrajs                                 393\n",
-            "Perplexity                                 1.94738\n",
-            "PolicyExecTime                             5.23944\n",
-            "ProcessExecTime                            0.225307\n",
-            "StdReturn                                 15.351\n",
-            "policy/Entropy                             0.662219\n",
-            "policy/KL                                  0.00899243\n",
-            "policy/KLBefore                            5.38312e-10\n",
-            "policy/LossAfter                          -0.0293233\n",
-            "policy/LossBefore                          1.24752e-07\n",
-            "policy/dLoss                               0.0293234\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:12 | epoch #4 | Obtaining samples...\n",
-            "2019-04-01 05:47:12 | epoch #4 | Obtaining samples for iteration 4...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:18 | epoch #4 | Logging diagnostics...\n",
-            "2019-04-01 05:47:18 | epoch #4 | Optimizing policy...\n",
-            "2019-04-01 05:47:18 | epoch #4 | Computing loss before\n",
-            "2019-04-01 05:47:18 | epoch #4 | Computing KL before\n",
-            "2019-04-01 05:47:19 | epoch #4 | Optimizing\n",
-            "2019-04-01 05:47:19 | epoch #4 | Start CG optimization: #parameters: 1282, #inputs: 254, #subsample_inputs: 254\n",
-            "2019-04-01 05:47:19 | epoch #4 | computing loss before\n",
-            "2019-04-01 05:47:19 | epoch #4 | performing update\n",
-            "2019-04-01 05:47:19 | epoch #4 | computing gradient\n",
-            "2019-04-01 05:47:19 | epoch #4 | gradient computed\n",
-            "2019-04-01 05:47:19 | epoch #4 | computing descent direction\n",
-            "2019-04-01 05:47:20 | epoch #4 | descent direction computed\n",
-            "2019-04-01 05:47:20 | epoch #4 | backtrack iters: 1\n",
-            "2019-04-01 05:47:20 | epoch #4 | computing loss after\n",
-            "2019-04-01 05:47:20 | epoch #4 | optimization finished\n",
-            "2019-04-01 05:47:20 | epoch #4 | Computing KL after\n",
-            "2019-04-01 05:47:20 | epoch #4 | Computing loss after\n",
-            "2019-04-01 05:47:20 | epoch #4 | Fitting baseline...\n",
-            "2019-04-01 05:47:20 | epoch #4 | Saving snapshot...\n",
-            "2019-04-01 05:47:20 | epoch #4 | Saved\n",
-            "2019-04-01 05:47:20 | epoch #4 | Time 52.72 s\n",
-            "2019-04-01 05:47:20 | epoch #4 | EpochTime 8.40 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   30.5253\n",
-            "AverageReturn                             39.5118\n",
-            "Entropy                                    0.661557\n",
-            "EnvExecTime                                0.713541\n",
-            "Extras/EpisodeRewardMean                  40.15\n",
-            "Iteration                                  4\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.0373423\n",
-            "MaxReturn                                148\n",
-            "MinReturn                                  8\n",
-            "NumTrajs                                 254\n",
-            "Perplexity                                 1.93781\n",
-            "PolicyExecTime                             5.25705\n",
-            "ProcessExecTime                            0.215813\n",
-            "StdReturn                                 27.0103\n",
-            "policy/Entropy                             0.640965\n",
-            "policy/KL                                  0.0082276\n",
-            "policy/KLBefore                           -2.02467e-10\n",
-            "policy/LossAfter                          -0.0239729\n",
-            "policy/LossBefore                          1.02532e-07\n",
-            "policy/dLoss                               0.023973\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:20 | epoch #5 | Obtaining samples...\n",
-            "2019-04-01 05:47:20 | epoch #5 | Obtaining samples for iteration 5...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:27 | epoch #5 | Logging diagnostics...\n",
-            "2019-04-01 05:47:27 | epoch #5 | Optimizing policy...\n",
-            "2019-04-01 05:47:27 | epoch #5 | Computing loss before\n",
-            "2019-04-01 05:47:27 | epoch #5 | Computing KL before\n",
-            "2019-04-01 05:47:27 | epoch #5 | Optimizing\n",
-            "2019-04-01 05:47:27 | epoch #5 | Start CG optimization: #parameters: 1282, #inputs: 162, #subsample_inputs: 162\n",
-            "2019-04-01 05:47:27 | epoch #5 | computing loss before\n",
-            "2019-04-01 05:47:27 | epoch #5 | performing update\n",
-            "2019-04-01 05:47:27 | epoch #5 | computing gradient\n",
-            "2019-04-01 05:47:27 | epoch #5 | gradient computed\n",
-            "2019-04-01 05:47:27 | epoch #5 | computing descent direction\n",
-            "2019-04-01 05:47:28 | epoch #5 | descent direction computed\n",
-            "2019-04-01 05:47:28 | epoch #5 | backtrack iters: 1\n",
-            "2019-04-01 05:47:28 | epoch #5 | computing loss after\n",
-            "2019-04-01 05:47:28 | epoch #5 | optimization finished\n",
-            "2019-04-01 05:47:28 | epoch #5 | Computing KL after\n",
-            "2019-04-01 05:47:28 | epoch #5 | Computing loss after\n",
-            "2019-04-01 05:47:28 | epoch #5 | Fitting baseline...\n",
-            "2019-04-01 05:47:28 | epoch #5 | Saving snapshot...\n",
-            "2019-04-01 05:47:28 | epoch #5 | Saved\n",
-            "2019-04-01 05:47:28 | epoch #5 | Time 60.39 s\n",
-            "2019-04-01 05:47:28 | epoch #5 | EpochTime 7.67 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   42.0991\n",
-            "AverageReturn                             61.7407\n",
-            "Entropy                                    0.645176\n",
-            "EnvExecTime                                0.716291\n",
-            "Extras/EpisodeRewardMean                  63.42\n",
-            "Iteration                                  5\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.187122\n",
-            "MaxReturn                                200\n",
-            "MinReturn                                  8\n",
-            "NumTrajs                                 162\n",
-            "Perplexity                                 1.90632\n",
-            "PolicyExecTime                             5.22226\n",
-            "ProcessExecTime                            0.208991\n",
-            "StdReturn                                 40.7597\n",
-            "policy/Entropy                             0.618815\n",
-            "policy/KL                                  0.00801669\n",
-            "policy/KLBefore                            6.41567e-11\n",
-            "policy/LossAfter                          -0.0200282\n",
-            "policy/LossBefore                         -1.79112e-07\n",
-            "policy/dLoss                               0.020028\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:28 | epoch #6 | Obtaining samples...\n",
-            "2019-04-01 05:47:28 | epoch #6 | Obtaining samples for iteration 6...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:35 | epoch #6 | Logging diagnostics...\n",
-            "2019-04-01 05:47:35 | epoch #6 | Optimizing policy...\n",
-            "2019-04-01 05:47:35 | epoch #6 | Computing loss before\n",
-            "2019-04-01 05:47:35 | epoch #6 | Computing KL before\n",
-            "2019-04-01 05:47:35 | epoch #6 | Optimizing\n",
-            "2019-04-01 05:47:35 | epoch #6 | Start CG optimization: #parameters: 1282, #inputs: 96, #subsample_inputs: 96\n",
-            "2019-04-01 05:47:35 | epoch #6 | computing loss before\n",
-            "2019-04-01 05:47:35 | epoch #6 | performing update\n",
-            "2019-04-01 05:47:35 | epoch #6 | computing gradient\n",
-            "2019-04-01 05:47:35 | epoch #6 | gradient computed\n",
-            "2019-04-01 05:47:35 | epoch #6 | computing descent direction\n",
-            "2019-04-01 05:47:35 | epoch #6 | descent direction computed\n",
-            "2019-04-01 05:47:35 | epoch #6 | backtrack iters: 1\n",
-            "2019-04-01 05:47:35 | epoch #6 | computing loss after\n",
-            "2019-04-01 05:47:35 | epoch #6 | optimization finished\n",
-            "2019-04-01 05:47:35 | epoch #6 | Computing KL after\n",
-            "2019-04-01 05:47:35 | epoch #6 | Computing loss after\n",
-            "2019-04-01 05:47:35 | epoch #6 | Fitting baseline...\n",
-            "2019-04-01 05:47:35 | epoch #6 | Saving snapshot...\n",
-            "2019-04-01 05:47:35 | epoch #6 | Saved\n",
-            "2019-04-01 05:47:35 | epoch #6 | Time 67.72 s\n",
-            "2019-04-01 05:47:35 | epoch #6 | EpochTime 7.32 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   59.7166\n",
-            "AverageReturn                            106.208\n",
-            "Entropy                                    0.620143\n",
-            "EnvExecTime                                0.726109\n",
-            "Extras/EpisodeRewardMean                 103.3\n",
-            "Iteration                                  6\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.312894\n",
-            "MaxReturn                                200\n",
-            "MinReturn                                 12\n",
-            "NumTrajs                                  96\n",
-            "Perplexity                                 1.85919\n",
-            "PolicyExecTime                             5.31482\n",
-            "ProcessExecTime                            0.212881\n",
-            "StdReturn                                 57.622\n",
-            "policy/Entropy                             0.585054\n",
-            "policy/KL                                  0.00674056\n",
-            "policy/KLBefore                            2.19351e-10\n",
-            "policy/LossAfter                          -0.0151696\n",
-            "policy/LossBefore                          5.10229e-08\n",
-            "policy/dLoss                               0.0151696\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:35 | epoch #7 | Obtaining samples...\n",
-            "2019-04-01 05:47:35 | epoch #7 | Obtaining samples for iteration 7...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:42 | epoch #7 | Logging diagnostics...\n",
-            "2019-04-01 05:47:42 | epoch #7 | Optimizing policy...\n",
-            "2019-04-01 05:47:42 | epoch #7 | Computing loss before\n",
-            "2019-04-01 05:47:42 | epoch #7 | Computing KL before\n",
-            "2019-04-01 05:47:42 | epoch #7 | Optimizing\n",
-            "2019-04-01 05:47:42 | epoch #7 | Start CG optimization: #parameters: 1282, #inputs: 63, #subsample_inputs: 63\n",
-            "2019-04-01 05:47:42 | epoch #7 | computing loss before\n",
-            "2019-04-01 05:47:42 | epoch #7 | performing update\n",
-            "2019-04-01 05:47:42 | epoch #7 | computing gradient\n",
-            "2019-04-01 05:47:42 | epoch #7 | gradient computed\n",
-            "2019-04-01 05:47:42 | epoch #7 | computing descent direction\n",
-            "2019-04-01 05:47:42 | epoch #7 | descent direction computed\n",
-            "2019-04-01 05:47:42 | epoch #7 | backtrack iters: 0\n",
-            "2019-04-01 05:47:42 | epoch #7 | computing loss after\n",
-            "2019-04-01 05:47:42 | epoch #7 | optimization finished\n",
-            "2019-04-01 05:47:42 | epoch #7 | Computing KL after\n",
-            "2019-04-01 05:47:42 | epoch #7 | Computing loss after\n",
-            "2019-04-01 05:47:42 | epoch #7 | Fitting baseline...\n",
-            "2019-04-01 05:47:42 | epoch #7 | Saving snapshot...\n",
-            "2019-04-01 05:47:42 | epoch #7 | Saved\n",
-            "2019-04-01 05:47:42 | epoch #7 | Time 74.69 s\n",
-            "2019-04-01 05:47:42 | epoch #7 | EpochTime 6.97 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   77.7217\n",
-            "AverageReturn                            160.968\n",
-            "Entropy                                    0.602291\n",
-            "EnvExecTime                                0.714021\n",
-            "Extras/EpisodeRewardMean                 141.18\n",
-            "Iteration                                  7\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.579558\n",
-            "MaxReturn                                200\n",
-            "MinReturn                                 37\n",
-            "NumTrajs                                  63\n",
-            "Perplexity                                 1.8263\n",
-            "PolicyExecTime                             5.26534\n",
-            "ProcessExecTime                            0.209869\n",
-            "StdReturn                                 45.2979\n",
-            "policy/Entropy                             0.576159\n",
-            "policy/KL                                  0.0089821\n",
-            "policy/KLBefore                            6.54432e-10\n",
-            "policy/LossAfter                          -0.014546\n",
-            "policy/LossBefore                          6.15971e-09\n",
-            "policy/dLoss                               0.014546\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:42 | epoch #8 | Obtaining samples...\n",
-            "2019-04-01 05:47:42 | epoch #8 | Obtaining samples for iteration 8...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:49 | epoch #8 | Logging diagnostics...\n",
-            "2019-04-01 05:47:49 | epoch #8 | Optimizing policy...\n",
-            "2019-04-01 05:47:49 | epoch #8 | Computing loss before\n",
-            "2019-04-01 05:47:49 | epoch #8 | Computing KL before\n",
-            "2019-04-01 05:47:49 | epoch #8 | Optimizing\n",
-            "2019-04-01 05:47:49 | epoch #8 | Start CG optimization: #parameters: 1282, #inputs: 53, #subsample_inputs: 53\n",
-            "2019-04-01 05:47:49 | epoch #8 | computing loss before\n",
-            "2019-04-01 05:47:49 | epoch #8 | performing update\n",
-            "2019-04-01 05:47:49 | epoch #8 | computing gradient\n",
-            "2019-04-01 05:47:49 | epoch #8 | gradient computed\n",
-            "2019-04-01 05:47:49 | epoch #8 | computing descent direction\n",
-            "2019-04-01 05:47:49 | epoch #8 | descent direction computed\n",
-            "2019-04-01 05:47:49 | epoch #8 | backtrack iters: 1\n",
-            "2019-04-01 05:47:49 | epoch #8 | computing loss after\n",
-            "2019-04-01 05:47:49 | epoch #8 | optimization finished\n",
-            "2019-04-01 05:47:49 | epoch #8 | Computing KL after\n",
-            "2019-04-01 05:47:49 | epoch #8 | Computing loss after\n",
-            "2019-04-01 05:47:49 | epoch #8 | Fitting baseline...\n",
-            "2019-04-01 05:47:49 | epoch #8 | Saving snapshot...\n",
-            "2019-04-01 05:47:49 | epoch #8 | Saved\n",
-            "2019-04-01 05:47:49 | epoch #8 | Time 81.60 s\n",
-            "2019-04-01 05:47:49 | epoch #8 | EpochTime 6.91 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   84.1507\n",
-            "AverageReturn                            189.415\n",
-            "Entropy                                    0.586332\n",
-            "EnvExecTime                                0.718586\n",
-            "Extras/EpisodeRewardMean                 178.3\n",
-            "Iteration                                  8\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.874438\n",
-            "MaxReturn                                200\n",
-            "MinReturn                                 45\n",
-            "NumTrajs                                  53\n",
-            "Perplexity                                 1.79738\n",
-            "PolicyExecTime                             5.25259\n",
-            "ProcessExecTime                            0.202226\n",
-            "StdReturn                                 28.9544\n",
-            "policy/Entropy                             0.562766\n",
-            "policy/KL                                  0.00847467\n",
-            "policy/KLBefore                            3.99525e-10\n",
-            "policy/LossAfter                          -0.00608158\n",
-            "policy/LossBefore                         -2.09041e-07\n",
-            "policy/dLoss                               0.00608137\n",
-            "---------------------------------------  -------------\n",
-            "2019-04-01 05:47:49 | epoch #9 | Obtaining samples...\n",
-            "2019-04-01 05:47:49 | epoch #9 | Obtaining samples for iteration 9...\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "0% [##############################] 100% | ETA: 00:00:00\n",
-            "Total time elapsed: 00:00:06\n"
-          ],
-          "name": "stderr"
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "2019-04-01 05:47:56 | epoch #9 | Logging diagnostics...\n",
-            "2019-04-01 05:47:56 | epoch #9 | Optimizing policy...\n",
-            "2019-04-01 05:47:56 | epoch #9 | Computing loss before\n",
-            "2019-04-01 05:47:56 | epoch #9 | Computing KL before\n",
-            "2019-04-01 05:47:56 | epoch #9 | Optimizing\n",
-            "2019-04-01 05:47:56 | epoch #9 | Start CG optimization: #parameters: 1282, #inputs: 51, #subsample_inputs: 51\n",
-            "2019-04-01 05:47:56 | epoch #9 | computing loss before\n",
-            "2019-04-01 05:47:56 | epoch #9 | performing update\n",
-            "2019-04-01 05:47:56 | epoch #9 | computing gradient\n",
-            "2019-04-01 05:47:56 | epoch #9 | gradient computed\n",
-            "2019-04-01 05:47:56 | epoch #9 | computing descent direction\n",
-            "2019-04-01 05:47:56 | epoch #9 | descent direction computed\n",
-            "2019-04-01 05:47:56 | epoch #9 | backtrack iters: 0\n",
-            "2019-04-01 05:47:56 | epoch #9 | computing loss after\n",
-            "2019-04-01 05:47:56 | epoch #9 | optimization finished\n",
-            "2019-04-01 05:47:56 | epoch #9 | Computing KL after\n",
-            "2019-04-01 05:47:56 | epoch #9 | Computing loss after\n",
-            "2019-04-01 05:47:56 | epoch #9 | Fitting baseline...\n",
-            "2019-04-01 05:47:56 | epoch #9 | Saving snapshot...\n",
-            "2019-04-01 05:47:56 | epoch #9 | Saved\n",
-            "2019-04-01 05:47:56 | epoch #9 | Time 88.54 s\n",
-            "2019-04-01 05:47:56 | epoch #9 | EpochTime 6.94 s\n",
-            "---------------------------------------  -------------\n",
-            "AverageDiscountedReturn                   86.2569\n",
-            "AverageReturn                            198.196\n",
-            "Entropy                                    0.578476\n",
-            "EnvExecTime                                0.717167\n",
-            "Extras/EpisodeRewardMean                 193.47\n",
-            "Iteration                                  9\n",
-            "LinearFeatureBaseline/ExplainedVariance    0.95866\n",
-            "MaxReturn                                200\n",
-            "MinReturn                                124\n",
-            "NumTrajs                                  51\n",
-            "Perplexity                                 1.78332\n",
-            "PolicyExecTime                             5.29\n",
-            "ProcessExecTime                            0.203098\n",
-            "StdReturn                                 10.6071\n",
-            "policy/Entropy                             0.574217\n",
-            "policy/KL                                  0.00468092\n",
-            "policy/KLBefore                            3.1718e-10\n",
-            "policy/LossAfter                          -0.00568248\n",
-            "policy/LossBefore                          1.99641e-07\n",
-            "policy/dLoss                               0.00568268\n",
-            "---------------------------------------  -------------\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "198.19607843137254"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 6
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "Q1PsTMwAH1Jr",
-        "colab_type": "text"
-      },
-      "cell_type": "markdown",
-      "source": [
-        "## Visualize a video of the algorithm playing "
-      ]
-    },
-    {
-      "metadata": {
-        "id": "OQHSMjkYQoPq",
-        "colab_type": "code",
-        "outputId": "68193720-6fb2-4998-bdba-dae9019a3277",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 795
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "%%shell\n",
-        "\n",
-        "# Prepare display for seeing a video of the policy in action in the jupyter notebook\n",
-        "# Note that this doesn't require a runtime restart\n",
-        "# https://stackoverflow.com/a/51183488/4126114\n",
-        "\n",
-        "apt-get install python-opengl ffmpeg xvfb\n",
-        "pip install pyvirtualdisplay"
-      ],
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "\rReading package lists... 0%\r\rReading package lists... 0%\r\rReading package lists... 0%\r\rReading package lists... 8%\r\rReading package lists... 8%\r\rReading package lists... 8%\r\rReading package lists... 8%\r\rReading package lists... 73%\r\rReading package lists... 75%\r\rReading package lists... 75%\r\rReading package lists... 76%\r\rReading package lists... 76%\r\rReading package lists... 81%\r\rReading package lists... 81%\r\rReading package lists... 81%\r\rReading package lists... 81%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 89%\r\rReading package lists... 92%\r\rReading package lists... 92%\r\rReading package lists... 92%\r\rReading package lists... 92%\r\rReading package lists... 93%\r\rReading package lists... 93%\r\rReading package lists... 93%\r\rReading package lists... 93%\r\rReading package lists... 93%\r\rReading package lists... 93%\r\rReading package lists... 94%\r\rReading package lists... 94%\r\rReading package lists... 94%\r\rReading package lists... 94%\r\rReading package lists... 98%\r\rReading package lists... 98%\r\rReading package lists... 98%\r\rReading package lists... 98%\r\rReading package lists... Done\r\n",
-            "\rBuilding dependency tree... 0%\r\rBuilding dependency tree... 0%\r\rBuilding dependency tree... 50%\r\rBuilding dependency tree... 50%\r\rBuilding dependency tree       \r\n",
-            "\rReading state information... 0%\r\rReading state information... 0%\r\rReading state information... Done\r\n",
-            "ffmpeg is already the newest version (7:3.4.4-0ubuntu0.18.04.1).\n",
-            "The following package was automatically installed and is no longer required:\n",
-            "  libnvidia-common-410\n",
-            "Use 'apt autoremove' to remove it.\n",
-            "Suggested packages:\n",
-            "  libgle3\n",
-            "The following NEW packages will be installed:\n",
-            "  python-opengl xvfb\n",
-            "0 upgraded, 2 newly installed, 0 to remove and 8 not upgraded.\n",
-            "Need to get 1,280 kB of archives.\n",
-            "After this operation, 7,682 kB of additional disk space will be used.\n",
-            "Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-opengl all 3.1.0+dfsg-1 [496 kB]\n",
-            "Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 xvfb amd64 2:1.19.6-1ubuntu4.2 [783 kB]\n",
-            "Fetched 1,280 kB in 1s (1,495 kB/s)\n",
-            "Selecting previously unselected package python-opengl.\n",
-            "(Reading database ... 133568 files and directories currently installed.)\n",
-            "Preparing to unpack .../python-opengl_3.1.0+dfsg-1_all.deb ...\n",
-            "Unpacking python-opengl (3.1.0+dfsg-1) ...\n",
-            "Selecting previously unselected package xvfb.\n",
-            "Preparing to unpack .../xvfb_2%3a1.19.6-1ubuntu4.2_amd64.deb ...\n",
-            "Unpacking xvfb (2:1.19.6-1ubuntu4.2) ...\n",
-            "Setting up python-opengl (3.1.0+dfsg-1) ...\n",
-            "Setting up xvfb (2:1.19.6-1ubuntu4.2) ...\n",
-            "Processing triggers for man-db (2.8.3-2ubuntu0.1) ...\n",
-            "Collecting pyvirtualdisplay\n",
-            "  Downloading https://files.pythonhosted.org/packages/39/37/f285403a09cc261c56b6574baace1bdcf4b8c7428c8a7239cbba137bc0eb/PyVirtualDisplay-0.2.1.tar.gz\n",
-            "Collecting EasyProcess (from pyvirtualdisplay)\n",
-            "  Downloading https://files.pythonhosted.org/packages/45/3a/4eecc0c7995a13a64739bbedc0d3691fc574245b7e79cff81905aa0c2b38/EasyProcess-0.2.5.tar.gz\n",
-            "Building wheels for collected packages: pyvirtualdisplay, EasyProcess\n",
-            "  Building wheel for pyvirtualdisplay (setup.py) ... \u001b[?25ldone\n",
-            "\u001b[?25h  Stored in directory: /root/.cache/pip/wheels/d1/8c/16/1c64227974ae29c687e4cc30fd691d5c0fd40f54446dde99da\n",
-            "  Building wheel for EasyProcess (setup.py) ... \u001b[?25ldone\n",
-            "\u001b[?25h  Stored in directory: /root/.cache/pip/wheels/41/22/19/af15ef6264c58b625a82641ed7483ad05e258fbd8925505227\n",
-            "Successfully built pyvirtualdisplay EasyProcess\n",
-            "Installing collected packages: EasyProcess, pyvirtualdisplay\n",
-            "Successfully installed EasyProcess-0.2.5 pyvirtualdisplay-0.2.1\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              ""
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 7
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "i4kwHJFkGB9R",
-        "colab_type": "code",
-        "outputId": "ffaf04a7-fb30-4daa-9776-b9501cce7250",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 62
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# Virtual display\n",
-        "from pyvirtualdisplay import Display\n",
-        "\n",
-        "virtual_display = Display(visible=0, size=(1400, 900))\n",
-        "virtual_display.start()"
-      ],
-      "execution_count": 8,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<Display cmd_param=['Xvfb', '-br', '-nolisten', 'tcp', '-screen', '0', '1400x900x24', ':1001'] cmd=['Xvfb', '-br', '-nolisten', 'tcp', '-screen', '0', '1400x900x24', ':1001'] oserror=None return_code=None stdout=\"None\" stderr=\"None\" timeout_happened=False>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 8
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "uOrLZ_UGrdgO",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        "# bugfix?\n",
-        "# Set an \"id\" field since missing for some reason (uncovered in monitor wrapper below)\n",
-        "env.spec.id = 1"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "metadata": {
-        "id": "GntG175cY8m0",
-        "colab_type": "code",
-        "outputId": "d75c47d4-7ad5-414e-a18b-edcb83b9d6ed",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 35
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# wrap the gym environment for recording a video of the policy performance\n",
-        "# https://kyso.io/eoin/openai-gym-jupyter?utm_campaign=News&utm_medium=Community&utm_source=DataCamp.com\n",
-        "import gym\n",
-        "from gym import wrappers\n",
-        "\n",
-        "env = wrappers.Monitor(env, \"./gym-results\", force=True)\n",
-        "obs = env.reset()\n",
-        "for i in range(1000):\n",
-        "    #action = env.action_space.sample()\n",
-        "    action, _ = policy.get_action(obs)\n",
-        "    obs, reward, done, info = env.step(action)\n",
-        "    if done: break\n",
-        "\n",
-        "print(\"done at step %i\"%i)\n",
-        "env.close()"
-      ],
-      "execution_count": 10,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "done at step 174\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "HKAAXIuaZQo-",
-        "colab_type": "code",
-        "outputId": "e72c4b26-7385-4315-ed87-473098e19e09",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 201
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        "# Display the video in the jupyter notebook\n",
-        "# Click the play button below to watch the video\n",
-        "import io\n",
-        "import base64\n",
-        "from IPython.display import HTML\n",
-        "\n",
-        "video = io.open('./gym-results/openaigym.video.%s.video000000.mp4' % env.file_infix, 'r+b').read()\n",
-        "encoded = base64.b64encode(video)\n",
-        "\n",
-        "vid_ascii = encoded.decode('ascii')\n",
-        "HTML(data='''\n",
-        "    <video width=\"360\" height=\"auto\" alt=\"test\" controls><source src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\" /></video>'''\n",
-        ".format(vid_ascii))"
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/html": [
-              "\n",
-              "    <video width=\"360\" height=\"auto\" alt=\"test\" controls><source src=\"data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAPXttZGF0AAACrgYF//+q3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE1MiByMjg1NCBlOWE1OTAzIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAxNyAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTMgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTQwIGludHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4wMACAAAACMWWIhAAz//727L4FNf2f0JcRLMXaSnA+KqSAgHc0wAAAAwAAAwAAFgn0I7DkqgN3QAAAHGAFBCwCPCVC2EhH2OkN/wer9sgDkZbGwFqFpQ9m7i+AI+L2+8Q56Dx6GFpxTeq4BlWDPtDxl7pW1XUMGhn9Zes6LJntDH3/XTe34HRwj/N2p8+ef0YPO6lBUWdiiPJXqg+2oJ3/Ze61G+QHlVNHgkRxcgirvUGEoBrZ1CMSQk1nBRkk8Zw4UrFt8rtMHH8lbtM3foy97e/sm50lAwUNKdAy1o32OBRDdBawfwoHcNHuI6oC3OzApKFAtovvL9HGy3w/SLzXSeAIeJwLlmhrI17zB21AmJz8mXbb0IjB6mTuAGTodKOS6nyvusJJ5BKpOMXpz7IA11JJN5iQUVvppJO8CoWSbxNVXEc/ixZLXfnLMNfyjfMktrkZdBkfr/0BbAAhNmqejJdUXM25lG8NPpJBlhQmosIZp4aqllCgAm5vVnccMvCMz4Wc38w6mjdSeVnNtdVW3rXNBbzsO3RCqI1RF547sCQV6Oddy+gfQhJbdqL/NWTjyvUgTath0dYU8BYjz0zFu/ZxhgGQg0qhT0lsm05G5YakP4wqFAAOzItV1VPAf4sz+3RrC8dmeV96dyQIfUl/q15sU+grhAdqrdMhq4ZurleNdMbibHoFd8uyuy+6LTpinlaTqwSFIe6sTXriDULnUrvtpNo36vWAi1QIODPVwAAAAwAAAwAFhQAAANZBmiRsQz/+nhAAAEVLF3gAWHOIteliSAxt/Na3NIzY/6HuF+oDb0Pe7usGSyhv13HDjsUuI/+XDsC1jlf0VrEIcPhQrIcFefezna2dbHZdg8ybO3hsEs88eHalR36PBnjn0fsNj3QUZ8h2hfSLociVAikbLFn7BRPZUUzwEkGe0WPrEctNN2SzqlbMkQIFhVydRQNtxQ1p2I/ovrkWaI2PKkw2tIaqYP79KvM/Ncpt3srym6Yev43vsJ3nIg4c5bIVLeBoABwNZgVulfvsZ4hdNCV6Zt6AAAAAa0GeQniEfwAAFrOkBgAthPJwo949r1zImXzDdDVZjF40iplIG5Q9hpv4m+dA1C6U/F1IfLbjCsduB5p0s4JJ7h3SKgrsB67Hzx0JGYxU8/9K5NnHtCoR6ERbI5n51jAAAAMACOZfSqcoywFtAAAAQgGeYXRH/wAAI7f/DorfMWLB8BmP5VnuvA2qoENDcjyD1AFDcWA94ZF5D3qwAnSxeYlJsqm0jEAAAAMAADHBZEBJwAAAADMBnmNqR/8AACKyLvu4hgq5kPV0JrZ+QOL7am/8YuZMysRkCoOfGcBRm6oABLHgjPLAWcEAAABtQZpoSahBaJlMCGf//p4QAABFRVLUAEWuP4+FFUKr0HGjTtKGDZ8xiwxteSTANK7wA0ztOmnS83ZZab8pN6Jmv02uUPtwJorsGj8Z9sryBM3QSCwazhLPmtg7lxcHqGPSPtsKhP8UNXopc7VOYQAAAFBBnoZFESwj/wAAFrxQtuwUtlRs1G9jruGoWJxfuVDQIw8IKjdwSX7JlV/eZV8WWUt2vzC4/ej6Kb3pBa7nsF5B0Gz39TIqhDa9/RBYveYicQAAACYBnqV0R/8AAA1/T2qlyPYvaJgZ+Om5i8g4QpLM18f3h+DvLuvSoQAAADoBnqdqR/8AACO/H4wsRyXfzQ1BhPrSRvfcJZjuNg/vx0ZHoZnEktFABaiVVmGv8v3A481RO6N36dmAAAAAgUGarEmoQWyZTAhn//6eEAAARVI9yAIkNw+k06A+Ap1tIi4sy+JA8vUN0yYK4hkT++AiEpteh31LZ56W+eRBYL2obyo3XJ9euXVitrXUprOd/K2FPiseuLjZ/87bPraKX6t0vjv4Ltm987YghtvpjOBhlurBKZlCAxyGwP0rPhr7cAAAAEBBnspFFSwj/wAAFq3vFuEr19vmxcZcLKYV79LkOq8qT9xyQAkqk1w6G19gBCnUkxv1vpNtgPJMz663myisnufBAAAAOgGe6XRH/wAAIz1q4Zp8QWT6HZ+SpMcKrigLcYuex3xB60IGOBxD0AJgcRAgJ6B9k2ALfC+Qg+QyNGAAAAA0AZ7rakf/AAAix8i7Bzx5i3qIxwAJULDJFn7ZA9orFYfvQJ2Rhce7H2/CbdSTRJjq+2OSNgAAAGdBmvBJqEFsmUwIX//+jLAAAEYl0QCFfzQBW/UmwIS66Slwa4DspAGbYogNZEXPD2YyTeNZhO5O3Wm0JtaAKnmj3O37UgdNO84BntEu+nRUZmNs6/wlhgl77OAmv8Lc8xrpTZB4ABaBAAAANkGfDkUVLCP/AAAWpaRovCz/oZJr7A/IiUiMxsqVACYU7RBKYwK3H6mz7nCYY/Z3pZvdWGNywQAAADsBny10R/8AACOUoh/YIca5fLDtveAAuerf3uqYKnNh63WURRXHfhXT5a2xsURB2Bl4t65qVul1wp77MQAAACwBny9qR/8AACOyPL+JSCuWVRPsuABZxN9G+sNkMmN0VomDcEaoY+zpmZpdnwAAAFVBmzRJqEFsmUwIX//+jLAAAEYB8n0bCG3WLcRzziRUgAwXps0BfXm5f7/RvVNm5zIR6bN4tAk6oTj813wJZ6qWzzecnTOowKuDdJNZ9p25F80z5t1gAAAAOkGfUkUVLCP/AAAWs0iuTWo5p7ixKAEsOV5A2z7kXzBv3sgs+dZ9E7ROuqMrLT4LkQJ3Idgchx6grUkAAAAwAZ9xdEf/AAAjrEJUXV+SgTgKegBY/3ADAmufMFfXqY+FgV7Mndp7BwKGrL7qI6DYAAAALwGfc2pH/wAAI78fjBsIwgAkUOgAQavfLV8pWLgs1K9gDV4UM32mulk2Ts5ruCaYAAAAhUGbeEmoQWyZTAhf//6MsAAASAICTIY4gGq/gAr3Ze1rSerZYJLnhxys7it4b3BLueFmF7olsNbV7vMCLieplQa/gE8KYCsYDvfCUi34m7+XD1CbGUNhe+1wdVl+Jxp+aU6arkws3N2C8AHXGkgd7XKTJCUsBwJgRykZJABnzA2iCrALDMEAAAAuQZ+WRRUsI/8AABdMQxZZpQ6kg4AUtx+C+BK8FrXPUD3NQBmKidLbTbQUYczUgAAAACEBn7V0R/8AACPC8IswSxaavR72IqsFiSjYjy18fOVmtSEAAAAYAZ+3akf/AAAkvwQnEslps0aEn30scA3pAAAAdUGbukmoQWyZTBRML//+jLAAAEfy7idum8u0qRAHKCm318IM0Kb/YgYMvBO6M2wf+0VUXrNBOL5MusUvtQPvE6VWKJCHhXZzfoD2QzKrAUXlr98UNfP2vGw4i4rAaEM49Le6cmpZkaIjrxg7AzTBcCUSc+CjaAAAACkBn9lqR/8AACSuHynNpqxBh1bWVhTLgQ4Ky7B22JQVpz0thu5Y1dh7gQAAAKtBm95J4QpSZTAhf/6MsAAASAHxzbwUtYBNfUoTEPHgS+H6QIncyZ6bTVtv2JOcWEpdKkO8bm4/OXu7f+tl11zxPCKkCjSd7/h8Tg165oMQXXYcfSJPk5/67o2obfeJ1ZPjktkc86uHBqOY3xvlfkZHywUMS37a6xT8CHUguFsulUV5JMCgYnLGIMD3AVBCPxLHwwL7Apf8GbR8j0Q4U9Qc6eI7cR0/gcJjpWcAAABOQZ/8RTRMI/8AABdDR0gthrreGB5AOOYBMLRS2N0gpQWivnsfbHhY46647aZ4mV+mgXTwfJtgC76MAEzUabw+JbpsC7BL1yXL/Q+sshbhAAAAOgGeG3RH/wAAJMM7+MvUCvuN3kg7DLZvmokB1hOmT0j+9gSFSK7WmbwKEABM1oc1Shw1J26/NclJwIEAAAAtAZ4dakf/AAAkscwABPozJAylVTnhgycPcWcu0rapYZaEosr9E9sY9n2riT3QAAAAS0GaAkmoQWiZTAhX//44QAABFPZA6QWbvdVIcvDaP5xVYvY7hZGMT+49YYxZCylFbDbLI68Z0apf2U78jtIDj6ToPVWbqViDseK6oAAAAFlBniBFESwj/wAAF0OX0/OqAOSLZi3EGU4KQU7oDUumQIANLt3YQ9eALzQd25+mXRYJtUn3Pecpkc93TNE+mLAWFuNlYKYMbr3GIpHXC0Q2ZuGP6aBpq10hMQAAAD8Bnl90R/8AACTAmTJt4RIa3ukGRLoiuOieL7vi6d39/RjW7j90P6lP/VYUI/fEAE5Jxr8B6gfLUuA2xW39+YEAAAApAZ5Bakf/AAAkseg0eWd8KHLYTzCQjN02Jj2iBgrembICrzvprZDTuxUAAABWQZpDSahBbJlMCF///oywAABIKYJjgEVKxjNU75AtkKEhxvB/zQwdBSVb0+gAfmtsVCu7Ttn9/mU6suDqEXAvjfmB7V8ig0OR4ARp07MYjmlUNxq3dZIAAABuQZpkSeEKUmUwIX/+jLAAAEggEmcAUDssy9dPZCwsDLyBfkiGpSHy42nsreuYXFMybt9r4Yxyt8xCanW9FSUz6W/BB2JCk4qrjTEKB4rrQNuyt/juNpVDjjwMHzTVxkdodqx4PnwXMlx3MUgvRSEAAABoQZqISeEOiZTAhf/+jLAAAEgQe0UJl05fiBuMan5tOMkkMRmfTKwsbNgHKevciEpYw8zeADt3wc0Lpq+foARWKjGMaep8d5JPjPpocB68a/S6sr/z47ORE54w/OtZp/Dmz/mmEwQC1yMAAABEQZ6mRRE8I/8AABdQRNzipOMpMwj/2QIHgAHGbU2qKM5IVaRVomDl3DAddraIgEdrnUT6bUQ3GVMT/FK29iwT5GqF2pEAAAA2AZ7FdEf/AAAkqenHFA1EHsgjSSJC6YS26YQ5II1wduIAZHd+QDYKX5FmzinNSEdKA3dgIU69AAAAMAGex2pH/wAAJJKdg5gcl/POzAwdMSYrFUF2WbyuWDhMXLS+yWLimxY78UuM/zPqQAAAAF1BmspJqEFomUwU8L/+jLAAAEgB8nzGwLaNfKTSblU1ri27jhSuymgGv/wH8TmdiLyN9oyaTddFcvuVeUFCACqKQWVVr3GUo4CGt6nsFD8t7vc8s4yS/yWi7/mHg4oAAAA1AZ7pakf/AAAkxwgsouCJzQrvt1xydR8tKVUjPQAlhDRGpWrSxUtwlYn2LxhP8ArwnxIi9qUAAABuQZruSeEKUmUwIX/+jLAAAEgzzDEF44ArVE45O9kUOfeVxZfZbQEW2pAr8/LQULNrcgJKO1waTCh9ZYVuO6ACqzXs+tBLWRCxRrTVxj6Snby9wngjRI8qWI8o9XKggn8Uhnx5h55TwQkwzXZ8a4AAAAA6QZ8MRTRMI/8AABdLY7JEOCXctW116oBAeO3vVgIegHYvrA6MaTl5RLk4VW2G+As7qsobRUbP8QnaDgAAACoBnyt0R/8AACTAmpDGSXUSyOGk5qgPFHdG+vAdEdr+PU0YOezs5lGG+YEAAAA6AZ8takf/AAAkrmAEwuUERcD8Cx+no6/Q8gimo5j4eaYxTvuGga6iNNMuZl6N74TnQX6AP9NCmIFIsQAAAGJBmy9JqEFomUwIZ//+nhAAAElFBPccYcBC8N7BtA3ws0BQtzETqfU9+PWEBTkYzS+Jh+M5lA7U7qBVDDoDro7F2qq4aeUMgy3KWGS7Don/R3E/yX+rL11rN9/mJxn9eWgZ5QAAAGJBm1NJ4QpSZTAhn/6eEAAASUPNcK8zW/PMZGORBAUDQJT9HL9pxNzT4iGwZj02ofiAA0EepyJOz14dgS6rdIxwt1wLpNl33vHNMA+UD2f9VxR83j8EnYnKvdIiTFSU+lkXUAAAAERBn3FFNEwj/wAAF9/r6LRI8+HCRN1Ewo/rI867XCdwrvcEutuhHyAAN0+y22qJ7ENbIYx9IGU3uHun9JtK6N5/fsE7SQAAAEIBn5B0R/8AACXAmJtJIl03ImmJLJ1oGlFDhAqG1HZQ1ie++YbQTCKMkrkJy1oP8mEggqDA+jQ9XCQAzjbbnokge6EAAAAxAZ+Sakf/AAAlrl7QtD/MjdyQZMvlpyHlhvCFn29Q6fMMQAszfBU80BwzeYK8SsGQIAAAAIJBm5dJqEFomUwIZ//+nhAAAElj/0BcqAG6Fivl304UUrXSoNkIKYXH+vr0129zzspMkpJvektlgO4FxZfoMH1GSrPyz6L0GEt7Xvhp4qCRcy98d1QLvBvBaOA+aJK4d5nztD8xPFNHEw/QDHE71E1mg/pZ2Mo3u8XlwhEfXfoDSp7UAAAAN0GftUURLCP/AAAX3+votEjzwytnvE2LNRmqgQ+8wxx/0fLnjDzkJ5X7BW/hvUcuz/y2tjxBKTEAAAA7AZ/UdEf/AAAlqenHE5sZVmoBnLWfNPt1vgnKlt4L3AU9+V/0zZFACFLc36a17uhJ2XA+BztAxr1ui04AAAAxAZ/Wakf/AAAlrl4zgZDEALbRfEx6tkA0hnwXAIMak8c1x9PSVYlsi/fCujMnF1nWnQAAAHtBm9tJqEFsmUwIZ//+nhAAAEu6bzxOX95s/cAyo+nAAW9gPYz+UZJ73xBiTulqYi425AWDrYrDeVxTvuF/3wd29NQapr8w/gAU2OdNbIs6XN+8Ut4Z6+iOq3kUtjwRR7DQtQhYtETB3A+13BDO+MOowruPoOqWeXQ3oNEAAAA1QZ/5RRUsI/8AABfoYycVefHoI5OdPYfJ9qcTKAhRQqqPIWc+0+pd1VTV8WlqqJZiKNlR8oEAAAAuAZ4YdEf/AAAlwDVsW0beauw/4rmrCVSEuV5gAFzakEyWfCiB5gLtxKosqisECQAAADQBnhpqR/8AACW9hAbDFgV99Qz9QAWswmAYBQ+nngRr4cN7K/Bn7qvIhZtaLS/tcPuS62z4AAAAXkGaH0moQWyZTAhf//6MsAAATAE8xMvFLGAK1ROLZXtcYcJ58K1MgI2hrHYok/sZ6rKTBGa4NI8pTSbR+3XUAVlNBxRynegEBK2Q8W37OXawOkGks1D3nID+k3DJfREAAABSQZ49RRUsI/8AABh/7FxeEOCTIntgKpLiaQAnG8SE7ltfjQfR+6U0OhW4xBO7bAS+HE1x210gtlUSjv/d2mLpGPX1EyzBi9nmDl9XnGwfzFrPgQAAAE0Bnlx0R/8AACbDEeb3mSyFwgKFlKN6BYCGYLAAlim39Nyu4znzzqOkiMY1wUgqLl+NxMAEXPDv51W6hskJXIWMmog+L6dqtjYq0E6q2AAAADgBnl5qR/8AACa9g4HKB47KK/1QAllOiMTCioBksDEcUQHrzh+aGg+TTgvFT3XkKbr60L02yU/QMAAAAJFBmkNJqEFsmUwIX//+jLAAAEwyADZadwBzD1wmWLVoAfwN7+rClioSIVAA9pymWSgWNl9LY7ydobskdN24Iwx+z4czOBh4/BS28BetpZ4XB733KfBBX71wTdZSvDbvASW/PpSVj+zcbFRRTiwattJCE/KtPfnaX0OeHT2afGMRJD0I3SEARc0qitn2tsOd/OsxAAAAMUGeYUUVLCP/AAAYf+votDzT5ixdu3B0Hg+Tn+vbKU+tuHvziA7T9OeXJ3tcIWWGgIsAAAApAZ6AdEf/AAAmwJnd6C5QKoFYzggxCvIBEofp/cVUpt1Vpab7uODDyoEAAAA3AZ6Cakf/AAAmrl4zgXlFHMQ2X1ggAWjPnZq8mnWr/t/IuhcQ+87y+ajfOczx8GQL/TbYGVGSiwAAAHNBmoVJqEFsmUwUTDP//p4QAABLQ49sILOjUX24O3QDQynjXjjWhYXa6DRkYLwWpkK+YrVMNdBFmnZrXnSfiiIR4Da7u0HCcJyiMOwRuUimAR/TMfo098v3DefSoF4ADMDsNAwH5Fu1CAJ3R1n/KZgjJcbnAAAARwGepGpH/wAAJpKj23e2CYrZpAAuolaIkUsbOa5g8yPFSm3T3LVdO0LqbBYkPWUcgI9+RlxPiknla0hvxTgyaSmRFy54IjAhAAAASkGaqUnhClJlMCGf/p4QAABLQ/hl2ABdR9uy8YER061Ue40v2k3UocherwQEX0BYVi07RhE6+bgXKW0Yc8Lwn1ccie0KWWbWbVFFAAAANUGex0U0TCP/AAAYf0QNwk2O+aKup9Ps7q9OiYr1wdtOCPwpSUNDMAiMMeKZbhU3vznCYXu5AAAAJAGe5nRH/wAAJsBmquqWe2bjNRzPPLGWEi23uLiUj38/W3hWVAAAACQBnuhqR/8AACbG6Bf9o4r5jOINN40eiNozvqc2rgcv+oCx8WAAAAA+QZrtSahBaJlMCGf//p4QAABNQ+n6c3abYkzv5WdVmvOYq9+TGEgYXTAKyC0Ru2AAFqpa0EM411isnL5wgCUAAAA4QZ8LRREsI/8AABkf6+jPyQAi5Kg2UQDg5bMdI7Cj9wEj6fv4mp8QUgCFnEE3dG4UDYMoarU5DaAAAAAjAZ8qdEf/AAAnv57ACI+WtT0xhRFBqDWHePKDwvFeLdLaruAAAAAvAZ8sakf/AAAnxVPTPHqGVITnLIgAuolvPFhH76DwDhyt0OsKa2l+W4Qg+ysYJ6cAAAB+QZsxSahBbJlMCGf//p4QAABNVKI1XwARgbwEsWzV0WJmeIeEP61P6lhGa0SzL6/AjGUp8HQcKM78FxFJKxvXPad7bUDPGhuhl3xgoQjisRfHo1qqrqqUlwAh0qQP/RAbJTB7eadBoIRpxZZZwxDVynCjn5aaRT2Snx02YMSBAAAAQ0GfT0UVLCP/AAAZH0PUOAxQcAJpP0HCyfgpnu178y6SYsHe2n6jPpiu/AkjEb00slkeiXWb3BO8pt64gPdpPXvb2oMAAAAnAZ9udEf/AAAnwFjfcxrVRYBCm2EvqirQDE8Dai0VJUPhrjAxEMWAAAAALgGfcGpH/wAAJz5+Z4qAWjM60934iObPAv0d5D+VlAB8d8l4a99SsCypmYFkNoAAAACkQZt1SahBbJlMCF///oywAABOAT9XMAIyPWuxlWaNQLj6yGfiwMKFcORxEyLyNEOzNteF0oTFEquHgv54z+CjoPNyzqroyM9PBtvczLwfPwBn92fDTwVzCXouoTXp2oE6n/lp2m6e55MXP762EMr5qM/AN2UiOUIrlMxcfVOG+IGHseXhSnfcbMBh6vIAoDreT9KzmQihLhxdj85drRfMFXBpQSUAAAA8QZ+TRRUsI/8AABkf7I+qWi1KEABOLxs6MFFaJTrLAGGsSFLi9D5wcF3CUPpzPZtm9/+vrZBmMjXDGPTaAAAAMAGfsnRH/wAAJ9tYCiJAcLT6oK5wav2WIW0JDonLQyUXcNeCZaS6junRXXz9R6fZlQAAAEcBn7RqR/8AACfFVc5zP2Jm/Ht4eRS0Z8uBFp0X4ALnq+BO9oPa7t9Wtqad8hIpIiHjtuOKDB0667wQOI41+FS2OClvgLLAgQAAAHtBm7hJqEFsmUwIZ//+nhAAAE9rCngwQpCXXD+AxduBUxjzUS5WW9J8vOYCWiEjPR3/BYANqPt4ay/G4gLobLgyAr0kaMnsPWVNJzlrkbeZuqmrdBRswEE/Fexuf6CO4HrNv72PXKgA42VTtjPadfEo9fdJ+RhNgkVDMkAAAABFQZ/WRRUsI/8AABnJfMNgJE45Kb6etYP2D+mBEtXluKPNKIU7rY0blgq9HkMvRRoTXravwAIa6awIO3huJQLCv9l1+ZPdAAAAOwGf92pH/wAAKPluOKm2iXmYM/+0GoY9iEPGJUExGLh87JBDNaH42ONAqjiPqIxj7VGhe/nS3XSmkOGVAAAAkkGb/EmoQWyZTAhf//6MsAAAUCoaPhm11fO2wgjW6nhUudKc95Z6UqAr1tswDR5k0r3W2d2wgluDswaV07svhzrxLXvwPBuyymMOmBBH55VjWibVssiYB8UqmWUBoeB3pUahUAGXkl9G+NAsKMrhJzhUQ7p1by7qUTr5CNRhDy+iQ1/X3ZgILKFpmJtvbYXW76RwAAAATkGeGkUVLCP/AAAZv+weoyw3ZbrwT8cxhhp1acODY8/XTyB5KqZnehu4o0ltFpEh8ALWspAlFnCQTn44UIWUOcQyCoWo6zwiEZzeWMjUgQAAADIBnjl0R/8AACj6nRx8yIHjDyUOghfSiQMJ04SWrZOQC/QMWGu1Q+rjEGIf/TaMo9vi2gAAADIBnjtqR/8AACjlU9M9SNINlWR4iLpcR3p8PZXC3wc0HESEfxQXzK8jvGw73PseObzfswAAALtBmiBJqEFsmUwIX//+jLAAAFAZj0nxVEAcw9cJdaYrWAH8sU6gW4qtDO+hRdPB5yItIghduJVL+tdYi9k1EXjsBM7WCj/MwDa8/G0W4cu6hqPar5J1OskzBZB0oVmWUNXGO0DH/hDi2zz9NlNl5qHN3uoXKbnWMPjcTMWPqhQmcE/JYmYEQ4zautJeXrro3p7GX7hn/gw0gohUt0tvnqVW7UForXb4aTbQ+TE8VRGtbJGfkNY1wj6GnZthAAAAZEGeXkUVLCP/AAAZsCGJFc5qehm8IAWRCgnyso2tEqdQ1LDOXc6QHlz7EkuqcctJzVNtuqJJ+PpDE5/37D70kKZzJLOnDDjy80PKyxCcylnHHKZaIcyPXn4Y/2a08nO+1fdevSAAAABHAZ59dEf/AAAo2OgOSocCQJI8iDKRkf9yZQqCX2e7+uMHNQWmIMPdcR/7bLpxoh2ol2Ek8AxKU5FTqgA+RF3v/7GceWfEd0AAAABIAZ5/akf/AAAoyDrM4epmQS6HlF92h1lnsgp670iYKlYMBeI9jOg7p/0KkgOl8LHqPcnaILPnw7zRsayhdNs9uhg/HReVJc3pAAAAhUGaYkmoQWyZTBRMM//+nhAAAE97laxABEx76GklYTKziiAs+Nhqa8gl2TUYSAcX9R7BppLZyi/6zZoFreS9ePunIScLeHxcu+mb1VuJLNfkfkX8kjYCm/hdQMs3tVKqfNRnd4+eHgD2Rsdx/luLWQ4TY98+2uhZqnLDJKyV7+nTd8kBKTAAAAA3AZ6Bakf/AAAoYCBZIf1/6TsWGkbGi1szqSCyLXHlIBqx849T7/HRtr5n1dHU5qD+W869VjvdSQAAAGlBmoZJ4QpSZTAhn/6eEAAAT3u5dTB0ZdJSRTzowjMGJ92W9o6P/VdabQJGvxWMhtFbHnK3zj84/dLe/Sd8niABEgDSDO2k2UHWrgu2Qm1Wk7DK2XCZYUPxvJA9BNHhoAJs4xHECOJm/0kAAAA4QZ6kRTRMI/8AABnIm4K1bwRts78AlUNjT0afnepoh+H5haoseNDZQOCcFBodvbiNuBmsLUhSNd0AAAAtAZ7DdEf/AAAo+1fwEGbk6iyX9cNjQ8P6KOE8nUfW1Xw0uV0sR4MEE+7Yteu5AAAAOgGexWpH/wAAKOVV00e2qp7+1XJbvpI6KdMTndAg+etQVqVSX1gl/N1wcZweX3b5VRWCvBGksp3oTh0AAABuQZrKSahBaJlMCGf//p4QAABRq3EOO8AHReoNi7zll0HwBiF4hD3Mpb03jhxaP0wyP4UkRUJtxnrxhRIhXYQ041LLWr3s1W/soh3PTRXMNOK/yLZaSc1cD8tzTXOTM/69Z6ka3fepGbGPebboZkEAAAA/QZ7oRREsI/8AABppVL4/i5K9jAbAIVBIyOXFGa3HnCa8B2Ae7AuDNYXrWlw1eihp0AYlf/EtZeA+S2+MS/8uAAAAQwGfB3RH/wAAKNjnzR2AjThVoASXYF5k2Pi6aTPWi7f3iyZ1Xa/AJCY1p0ofi+5j/lMbmXEu4ll44jAV3cFXaQjm2HAAAABBAZ8Jakf/AAAqFzImivUF0OdqUAJZTc3gN6+v83znafXoXfRQDWESd7m9gFse+zVDElasA6f4Dg8w3/d5hdFBOv0AAABTQZsOSahBbJlMCGf//p4QAABRqtIaAAsEv50F8DX2Ij5bIh4f8fvHXiR70/tw5lH+grfukkushh7E0GD68UnR69j/6+p4FB/6PiujwU8f8ivQecAAAAA2QZ8sRRUsI/8AABproyKcbgcQAIwHG/+mVluhjxvtQ470x9qPm4Q/UB5K91v4FInlPdCyV9MuAAAAOQGfS3RH/wAAKgBYm0fTIoAFvEt0nnUIWjdgsr8Prk3QsQLd46d+vfMplbzhOZc4fc9A7HTkvKKHzQAAAB4Bn01qR/8AACoXqJ489taLqodm6vJ5l4TcOumrxl0AAABgQZtSSahBbJlMCF///oywAABSfLEsqSa9LpLBjvxT0QgwKHBwYFLB5D17B6PvNFAtc7xhsIZ7puoE5LYN8Qx4t4jv4hrFHqCdfqAJm2hmmG73RjSGoAPO3pl+pHx6SMOTAAAALEGfcEUVLCP/AAAaaMqUZI3TQA0dfhlHlorCaLp2EwyNREThWgwwCgVNQzhwAAAALAGfj3RH/wAAKhC3pQNnFoXCbSbeQgs3wUzyG8AITKdywPTmH8f0CuF3YGSAAAAAHwGfkWpH/wAAKgmAcNyg1sW1EWtr+jxQlMtzdGBhGSEAAAC4QZuWSahBbJlMCF///oywAABSoHlKgC9IgCO1qCSgCoQBSpdffGLxu4fv6SKjRk5Yc1Txq+TN8Ak+heqrM7NliNWdyT36EsG5NOo0iDgf23HSIPNZ6SzNXPx78W64UCfrDa21ACIrCF+6i/+lr9fxRWoSNo6lBryhUieuW5oQmLYcYsdZoYrg84ytTrQ7aDy/eh3coDAcrBxYIy0Yog9J02oSjEYMZLs0cyvj4UzBFSbgKNUlILOD0AAAAEtBn7RFFSwj/wAAGlPVMMI1X2N4QAmrqVz2fX7Gs7YoWWTCsiWK9av3y3sJQzW9l/VxL/t7ewfpwFU99Dk9N/XpBFIhs9f3aNjBoZIAAAAeAZ/TdEf/AAAqG1cmKFbOMOBorSqE4QGy/Cy7U7uBAAAAQAGf1WpH/wAAKX77yjZ5oO8ADi3TY1ZGzUMM3wySTCjv5672K7eKtB//QYAJ1c0+A9vnSYi5NTOqgf1iHii2NUAAAACxQZvYSahBbJlMFEwz//6eEAAAVHmXP+HPSXBdAJ0EkJZtU5v05Lgy+wAmXKpTXS7/qUYqEjUk8u9v7LfZ2ZCFHbQE/yYBcn7AgqZK1JANZ4aLE2D8VZXKzOqxWlrJLJ4P1HYbD90/QVVTYyRgi1sxrmTpniEwFVVjTZhmAfNgP77mctQY8zavdO4fIN7z8tLLIAac1I2NZnfb8cS+Ie1qsOVJ1cIi7Kn0irXtSuUv/tnBAAAAMwGf92pH/wAAKchx+Ad7m4b1qIVj2fdTgQOyuybLCdCnRNmOwj/Vfs7E7fZYn/AOFg2u4QAAAJlBm/xJ4QpSZTAhf/6MsAAAVKn63dXzPoAI7VVLkQoJGQFhdQrkyA8ud+edhQzzmlgoZAXF7vyfwU6nJ7Gg2mOZdziBEYzZPb9vtlsUhQfXgVoeQ3eDpspGGMdKOldvYRKbUfpFjmeivxFWB3IdYhow1HRipeZO+684iYdWIijGrt3cLpk6y+s7dFRrWH+YmmgKjWZsMwAx8QYAAABTQZ4aRTRMI/8AABsJeR3FwVbsJU5rRC0zHnRRgSHnuB0KnMj2U3Z40lKtDkf6YtQ3tijLyJrRklIbwwCqnhSKcCNwXR/cSFDkiZ0QM2ea6XwJHDkAAABWAZ45dEf/AAAqG1fC9mkGxo+IqF4T+1MDzhaAjGJaAaR/glRAnHiL803vfnG8u/ze8E6rU5XV8suwcDJUH7n1OL8jfSKn2gzJp3mbDn++lWhUwYTzWHAAAAAzAZ47akf/AAArOW44rG1hGPENuoA7zNw7dsfd/ITX3hvWDJteXJ0ejESsRFMa9HlG+sy5AAAAZkGaIEmoQWiZTAhf//6MsAAAVMK6ZaVR9RPkLR7Pw/gNhJk5zCDH+NwKnIVeQqDVRUfD/yV9ToWpEcVKPdlt+7/0wTo1QZpihnPIGAZr4b7u9KNIAcdcnKFwlvMDRcfkfojsaSzkUQAAAE1Bnl5FESwj/wAAGwjKd4zpuXYhSVMfk75SsdpNzNCof3qN/VZDj93J+E0ygAIyOsj4EBgwEvNnWx/FKzUOTbd1vS14a8YRy6YVMoF1+AAAADYBnn10R/8AACs+NOFa4GMRog08cgkF3o7BeF4eFsGz8JFZVA2fig+KCtec3VWWCxpye5mA93AAAAA9AZ5/akf/AAArN6ieLWLHVGzACcn6YmvPE+uRWhPTGi1+b3jDClitx0xt3n4ABD2UeEay09qq7DHCA69fgQAAAGBBmmJJqEFsmUwUTDP//p4QAABT7AU/vTTI9TxLaMqm/zgNVXK89mP2tQhJy+QeeOXXeysCJQAOC+PwSi9Xg+UCvWyNcEceKOEHd7FtTqwGR578PbfVxlO9S7L1cg38FeAAAAAuAZ6Bakf/AAArJVPTPO/EVIVCtmDqAuLowRH59CyCEKnRSKpEKq9oVlpwvMAWHQAAAIBBmoZJ4QpSZTAhn/6eEAAAU+sL2gALD637E2Koyt1WyvYCZHJcidqK8mGTY5t+3v2rjZpOzfJTvbeAnqhHNm9tTpxebhvTAi06hsd0S//DIhfIu/5Gfha3u5EYPo7qScnmuIgJpge+cn2zKobWBXVotOlK6lh0CIVA+vFboi0UXwAAAF1BnqRFNEwj/wAAGv/sHuUwPm2i/0d3B6qlGaRpLDJZo+WUUZeZ8+OI9Zi2AALrbZvRZNmt1ZurMutfVXTYKseUbOzIozVURTx357dBP/YbfVgTv5kNElged94/UXEAAABEAZ7DdEf/AAArIrQinEI7fxfoZn+ntlpKjt1N+WElN3Eaj3IGd7SV3oKwnfKO3gBKk99G+sNkMdoQB4OXzHFt2KJs0tkAAAA+AZ7Fakf/AAArJVSDU/JVvUlDzSyq+14tC/qtd0F/B8tmiX5hRZcEKeW3vzv/xfHlLG3sSJjeoOwcJEVxq2kAAABlQZrKSahBaJlMCGf//p4QAABT6wvaAAXQaNkwtL/aTXz/aQcId72/Lw6odwUNl1lBSqwirrifqNsfkmBBHkfO/yO/tz7PKXONDyo4KPXqsqSwph6ioGccW2RKO/pW43lrSseGaVEAAAAxQZ7oRREsI/8AABr/6+i0PpwAu8P5kOhE+deuIljLLcwUnxpF2v3P6b9HFEBRV0XUwAAAADYBnwd0R/8AACs7VlBl4Sl+sOmChKgtUrJ9z9Oq8DzupwkRT7OsyLx3b5HgCj6MGRRqKrmiPMAAAAAjAZ8Jakf/AAArJVQQNHhEzczbkKW8rfXr8uS+HEba2XND9bUAAADBQZsOSahBbJlMCGf//p4QAABUNg7iAKS2ABxaXCvFZd6r2GetcioS8P1vbmgCsjIzLNN7wGWmtHJ8dKoAVffxi3Ao1GN1dRFXnPeK8VPO2ZOpMg19xb+7eQxHr7eHux1ZNb5jByi/d0OmIfiqoIfR79it2NhsOUCx5pCdXS2mIgqBVMaGhibYRRfOugrXODgJtYQrVuZLaLnushkocnQD0MFJcx8p1m2x+1rLGTEzRSdofoNjmxp8Vd+w2wYtmHFQIAAAAFJBnyxFFSwj/wAAGv/sj6pZNf+j3AC3ABsvwqI3WD86W2NbMyayyY8dvRocjm9aYUKCyYBVim5LEMNNHtTs0gov9u/H0T9gwWen9JyFhnHNQlbQAAAALgGfS3RH/wAAKweqgjw46UNPTMXgnrgnnyxkYLbrrCXmWT7CMiESOg/IbV9c6SEAAAA/AZ9Nakf/AAArJVXs9TyLqiWa7fxK4SYFZ4gc4rSeADgqWGumFroLzOlKcMvMrv+p/ixme+sxYQOBQLEN3MrLAAAAeUGbUkmoQWyZTAhn//6eEAAAVitec8gDlvZjO8KPQmYbDseDgBlQRf4YaFEn0Vy34uPXaiyR9rW62mh19b+Pgh5/3+Q+RZ2tyJGqv3GrJtRMlvhCK53QgjacB82+ja+IB0lYDVs4+/bqpSdGKWRewYevP/XDngCZSVEAAABWQZ9wRRUsI/8AABuf7ESlyhrk9ZSsKBXYzW6gFmoos64o93uhHyNAFSLzXKZPdJMf7CbmLnfok2bMp157AFeTYvLw/aXUubATGzB0hXHkIux8dMv5jWUAAAAyAZ+PdEf/AAAsXlnm1eTSon44P95XAhO9EFu1k2AJvmlg1XmcyyjsDRNOQFIMOWs6VVgAAAA7AZ+Rakf/AAAsV6iFk3EMnj6JPQTjWLRTvmBDPWN1rzdRDsMEzjD3aVofWScq2xc5l/YMZYkkn0gK2ssAAADWQZuWSahBbJlMCF///oywAABW/NXlAYAdIqF6MOg/9ZunfdlVlOW/NwQ8BjGw61dQEQ8TbsvdlbuvvTPtgxcS0gnnEzZzBAKzA4Tzwal2e6O/rImARY6fHZmpm6zvOmUVP6KKSwaSgaOrpmRR7EE3fLO6Fc68ED8V9brLctiHaEJVNLDE4eMMC4YM23ISOUw4CJlK+ldRvKSZicipauoYyjgRLOJLmf2x+LOREdddHjJf81ZNiPYYGD2VlSA32xK/yvG4fm2CU7HmsS6T5zEux6G5/IUM9gAAAGpBn7RFFSwj/wAAG6CH+3CMcUZ9SplfQJncTwMPL13eWrwgADjJnLb1G3HizIOimGkz0dzk1lQupnHT0bd6MtzFgKrhE1l6BeneLRRuFRpz41iwqlq4x9og1d0fViaeFQqsktnbC4ZQlmkgAAAATgGf03RH/wAALEBY92F/nWxLa/QEIpuLNitdkQISj7mFnPABaiX0i4/Lzcl/IXDkKDmpHw1BqVOZg4KCzS2QqrgnkOAE9hq/0UHCE/VfLwAAAEABn9VqR/8AACslVjhbi5pzL9gvs9hMm4c/NClBdLUDyr5oQyc7SoVNvxKmew+AWTD4nuPc4in5r7s8UXl4Ui1AAAAAXkGb2kmoQWyZTAhf//6MsAAAVxhP1MwAsPqUJbzKhVHzvjqRRDmzGAoWEOw3niNP3EHVu7Ib2CDOjERgTLXeyroqShgMdzAQecX6da5998FHx6mExQG1t2Je0Buss7EAAABCQZ/4RRUsI/8AABugVMYMwtbLfAWHvSDCCu9JNWu2YTuIUuJKOBMZc0CN2n60aDpFmRds6GXyKYZbWPRTyZynbxahAAAANQGeF3RH/wAALFtXJihXfbKrS+0LbyMcSonkqTjuhypQ+Sydg1pUGGDwGtSq54BGK5UVp4K8AAAAOQGeGWpH/wAAK1bigBzFytVZqgyDCSC8MokuWpW9GADI0PvY4FgWQHV/K0Kjyyg/6flUSAD3oJG6twAAAH9Bmh1JqEFsmUwIX//+jLAAAFc3UmC4bADjkMcargaQgHQ3c238z2nt8bp2RiK2+O2fMS/qbs4Y1ad/xnyFAIHEbYLi1fNhIKX0iEXHUyT0v3ORrHfqGk6iT0HTw7GRNGzuXD0/ap1DXvBzWPXR50+6g51BW2SZEs2gAhzHsAdAAAAAP0GeO0UVLCP/AAAblyPElCOYQZtnNMlXJ4GjBoV/fAirDBVZhid9xtEALfUPjHOg/ODt8wwNv/xQxN+/zAdQgQAAADMBnlxqR/8AACu+fmejJFQkIbKxJak4JYBvLhdesZn6ujKOaODCbE0a7LfPd6VMsacJukEAAABiQZpBSahBbJlMCF///oywAABW6XtggAtPkgp8//fEi5h1XVG/Nv3ac8YbthKizN8w9Ziyo+V4uV+zwn2FuvPmP+jzHWbOz2Mz3NUQfvmNtWsOk7CnGuzJw8QGZlV1cMEDLZwAAABZQZ5/RRUsI/8AABuP2gF8fgH8ZHPGkyoKCBG7QrDvBHPKYX94ACM0sWO7gWbjzFTos+WSYkW0SmO3ZOj/ftv6ajmEGPRX4SyvP+CN6klvnqVTY0I63hBcuoQAAAA7AZ6edEf/AAAtfioNqCW6xJMgKm2/EWRT36dnkF0sMlM7qexTlUDJkwDRmfIAQmjl2iULU9AzZZNY2bkAAAAuAZ6Aakf/AAAthAdPxe8agMnaPrf3CtZ1m1yhM7fp+9b38ZHdF1LANtXDccYtQAAAAIhBmoVJqEFsmUwIX//+jLAAAFlCuqm2OoBdMWegAWus6V8pWkLjwm9fbFycNxhxhg8j8sWbMLohnD2H8rpmpnzi3nRq0yUEe2UHKcWKnGWwzyHZtNdShtK2qseZyUUOjp6lg/5yc9nDMIKfPd3Fp/Hffh3amp1VMfTRk3edv2ojp1jdo/ucizqJAAAAPUGeo0UVLCP/AAAcW2X7H7Cn4bB2Kyy5eepGesMfCkO23QT40kHt5Q9NaMbTohvowgquQu3iQXw/awocNWwAAABJAZ7CdEf/AAAtYo64xEdVdbTGmM+RmXChTwpLPjCK9WjLBXDFhIAEtTIlwu/9mEptxEZT9GOBh1nPBjjyHR1jurFVYKCm9bH10wAAAD4BnsRqR/8AAC15WBT7qrB3DWvsHlpSIzCdD40TN8QxHiyiW22CgBHBJtuUSa0YhU2da1Uc8N7tJk2oKyaN0wAAANNBmshJqEFsmUwIV//+OEAAAVjmW5TFNAA43lUCrBtsBI8fVIrSacue2LMmy+nsG7PI5dmA7YLLkV01BChogpMtuzEEPJFic6YFoB8v3UwUvsJyPnbAgFCegR8BNc5eELTrCUQGwXZYtGzB2TdY+UbX+lq2B2OXk8cZzM7hc0zKkTQZmdoRUAFVlV7s91T+x+POuZfBrB7nQABHe234A1GQUUwbgq29k4XvFeJTvYxui4Ov+xfL0InXBh4vlm/KxZMEtd7kSMWHAjtGnkKOQrDv06lhAAAAQ0Ge5kUVLCP/AAAcTQVEaKOOEgA4oHITjZH1RGv/i8zgmyYccCW6XREEjcf4bGoc9lC2QpTluF8weJ2WgNbyZjP46tkAAABFAZ8Hakf/AAAtZVSDU/GyVI+lIAHAz82Z3EU3sc9tZZih1emAC9AQzfu8EQKN61xbdXTd0+f9q3FLomiKrJ7zreofGVQgAAAAm0GbCkmoQWyZTBRMK//+OEAAAViQpv3RsM6D9yGbyvpojA6PoAa5dUq8ZWPy0wkEr/0RnR5UgUKncgcc6WJ5/2t7Pr/kTanPLi9ysI9AsupC/EHSEUxwCn/q+xvH2cW3cCgklQbqWkuAWYDs6m2Ilh4GSWhWnPVc/iMl7DAX3Lz2rKd85WDOPGUBhFljxz6hq/Rz2AO5m26fXLKAAAAAWAGfKWpH/wAALXeE8fQGEQLIDZs1hcMAIZdvOTzratCUlAArHMzqIy++SgXwDEhEADueHsCDDYAJk0BjmcpXueY/maeWDIvXaavqWMFV9XZlczl1QZlDllEAAAC9QZsuSeEKUmUwIR/94QAABT+mojzHdADP+EH0N0GVVLtMfXH1NZYhqqSytGkAZOAH/+5t+IXD/tLvYKYwitAQLlYkUaFet/w1Gh3E8XjwtsQNfLMr+M4RwOi7u6kxSY6R5EL1Yd3J/FhqofuvrTWJAYVQTM2J5TS/0sBZybH78P8C4cO/V2zHDZnXWQ7iNKK/4woPwSdK8X2XtQ1DXvxOVHyBMNeqVQhxTvtvx4zO4SCBIIBN4UO3l/AlUZ76AAAAcUGfTEU0TCP/AAAcP5YCXHs+j/sP+YrQ7S3EOKOy+utWZZCUcghsn2PqO77ToXq8RraYgMIPo9VvDAuYESQbpsLu2Fuwp+r3EANj/PaXTaPQTw9dGp3JAUs9DDuuuLnSsr5e4nfYKww+PluTGRES0jvwAAAARQGfa3RH/wAALUgp8OsIPb5QohxH3wAuF5t/qDmOE3X1uYSJNu8UTAZhP27B4vNsxACXU9xYi/gDDhHUiL/Zo3ubhvcFuQAAAEIBn21qR/8AACvQjowP2EW+IuBXvgzTkJzb30DrDbjZPikHBaI4p1FkZvgrf4lhQTnnFnfXDCE4axpI8NGAZWvLF+EAAABiQZtvSahBaJlMCP/8hAAAFHrc9IUIoey9rKRTaOrVCRCjhn7j4Qlf0oZf3Vyf+wn11dYef6YrUcDCW+CZmejmXdT0FJxu1wYAWwspRHiuwFPn+Sbcil0mnDTp2bnWMFfJLHEAAAszbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAADcAAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAACl10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAADcAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAlgAAAGQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAA3AAAACAAABAAAAAAnVbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAyAAAAsABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAAJgG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAACUBzdGJsAAAAmHN0c2QAAAAAAAAAAQAAAIhhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAlgBkABIAAAASAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAMmF2Y0MBZAAf/+EAGWdkAB+s2UCYM+XhAAADAAEAAAMAZA8YMZYBAAZo6+PLIsAAAAAYc3R0cwAAAAAAAAABAAAAsAAAAQAAAAAUc3RzcwAAAAAAAAABAAAAAQAABXBjdHRzAAAAAAAAAKwAAAABAAACAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAgAAAgAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAIAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAEAAAAAAIAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAACAAAAABxzdHNjAAAAAAAAAAEAAAABAAAAsAAAAAEAAALUc3RzegAAAAAAAAAAAAAAsAAABOcAAADaAAAAbwAAAEYAAAA3AAAAcQAAAFQAAAAqAAAAPgAAAIUAAABEAAAAPgAAADgAAABrAAAAOgAAAD8AAAAwAAAAWQAAAD4AAAA0AAAAMwAAAIkAAAAyAAAAJQAAABwAAAB5AAAALQAAAK8AAABSAAAAPgAAADEAAABPAAAAXQAAAEMAAAAtAAAAWgAAAHIAAABsAAAASAAAADoAAAA0AAAAYQAAADkAAAByAAAAPgAAAC4AAAA+AAAAZgAAAGYAAABIAAAARgAAADUAAACGAAAAOwAAAD8AAAA1AAAAfwAAADkAAAAyAAAAOAAAAGIAAABWAAAAUQAAADwAAACVAAAANQAAAC0AAAA7AAAAdwAAAEsAAABOAAAAOQAAACgAAAAoAAAAQgAAADwAAAAnAAAAMwAAAIIAAABHAAAAKwAAADIAAACoAAAAQAAAADQAAABLAAAAfwAAAEkAAAA/AAAAlgAAAFIAAAA2AAAANgAAAL8AAABoAAAASwAAAEwAAACJAAAAOwAAAG0AAAA8AAAAMQAAAD4AAAByAAAAQwAAAEcAAABFAAAAVwAAADoAAAA9AAAAIgAAAGQAAAAwAAAAMAAAACMAAAC8AAAATwAAACIAAABEAAAAtQAAADcAAACdAAAAVwAAAFoAAAA3AAAAagAAAFEAAAA6AAAAQQAAAGQAAAAyAAAAhAAAAGEAAABIAAAAQgAAAGkAAAA1AAAAOgAAACcAAADFAAAAVgAAADIAAABDAAAAfQAAAFoAAAA2AAAAPwAAANoAAABuAAAAUgAAAEQAAABiAAAARgAAADkAAAA9AAAAgwAAAEMAAAA3AAAAZgAAAF0AAAA/AAAAMgAAAIwAAABBAAAATQAAAEIAAADXAAAARwAAAEkAAACfAAAAXAAAAMEAAAB1AAAASQAAAEYAAABmAAAAFHN0Y28AAAAAAAAAAQAAADAAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjU3LjgzLjEwMA==\" type=\"video/mp4\" /></video>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 11
-        }
-      ]
-    },
-    {
-      "metadata": {
-        "id": "2fiQesIZlnTd",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "cell_type": "code",
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 1,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
     }
-  ]
+   ],
+   "source": [
+    "%%shell\n",
+    "\n",
+    "echo \"abcd\" > mujoco_fake_key\n",
+    "\n",
+    "\n",
+    "git clone --depth 1 https://github.com/rlworkgroup/garage/\n",
+    "\n",
+    "cd garage\n",
+    "bash scripts/setup_colab.sh --mjkey ../mujoco_fake_key --no-modify-bashrc > /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 169
+    },
+    "colab_type": "code",
+    "id": "6dGO3j0txY_l",
+    "outputId": "43ea0b65-bb1b-4977-acd0-53c8d761dd27"
+   },
+   "outputs": [
+    {
+     "ename": "Exception",
+     "evalue": "ignored",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-8-ca63a73504b0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Please restart your runtime so that the added installations can be loaded, and then resume running the notebook\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mException\u001b[0m: Please restart your runtime so that the added installations can be loaded, and then resume running the notebook"
+     ]
+    }
+   ],
+   "source": [
+    "raise Exception(\"Please restart your runtime so that the installed dependencies for 'garage' can be loaded, and then resume running the notebook\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "pGyQDPC2Vs9O"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "G3KbL5sQH9m1"
+   },
+   "source": [
+    "## Prepare for the training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "IPmbM_77tk3S"
+   },
+   "outputs": [],
+   "source": [
+    "# The contents of this cell and the one after are mostly copied from garage/examples/...\n",
+    "# Note that these need to be run twice if for the first time on a colab.research.google.com instance\n",
+    "# 1st time is to create the \"personal config from template\"\n",
+    "# 2nd time is the charm\n",
+    "\n",
+    "from garage.np.baselines import LinearFeatureBaseline\n",
+    "from garage.envs import normalize\n",
+    "# from garage.envs.box2d import CartpoleEnv\n",
+    "from garage.tf.algos import TRPO\n",
+    "from garage.tf.envs import TfEnv\n",
+    "#from garage.tf.policies import GaussianMLPPolicy\n",
+    "from garage.tf.policies import CategoricalMLPPolicy\n",
+    "\n",
+    "import gym\n",
+    "\n",
+    "from garage.experiment import LocalRunner\n",
+    "from garage.logger import logger, StdOutput\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Zu0ce9h3IEF9"
+   },
+   "outputs": [],
+   "source": [
+    "# garage version of CartPole environment, has Discrete action space instead of Box\n",
+    "#env = TfEnv(normalize(CartpoleEnv()))\n",
+    "#policy = GaussianMLPPolicy(\n",
+    "#    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
+    "\n",
+    "# gym version of CartPole. Check note above\n",
+    "# env = TfEnv(normalize(gym.make(\"CartPole-v0\")))\n",
+    "\n",
+    "# garage updated method of getting env\n",
+    "env = TfEnv(env_name='CartPole-v1')\n",
+    "policy = CategoricalMLPPolicy(\n",
+    "    name=\"policy\", env_spec=env.spec, hidden_sizes=(32, 32))\n",
+    "\n",
+    "# create baseline\n",
+    "baseline = LinearFeatureBaseline(env_spec=env.spec)\n",
+    "\n",
+    "# specify an algorithm\n",
+    "algo = TRPO(\n",
+    "    env_spec=env.spec,\n",
+    "    policy=policy,\n",
+    "    baseline=baseline,\n",
+    "    \n",
+    "    # Use these settings for garage version of env\n",
+    "    # max_path_length=100,\n",
+    "    # n_itr=100,\n",
+    "    \n",
+    "    # Use these for gym version\n",
+    "    max_path_length=200,\n",
+    "    n_itr=20,\n",
+    "\n",
+    "    discount=0.99,\n",
+    "    max_kl_step=0.01\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "rjkcy1nUIFYX"
+   },
+   "source": [
+    "## Train the algorithm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "eWxt4JcxEMUC"
+   },
+   "outputs": [],
+   "source": [
+    "# start a tensorflow session so that we can keep it open after training and use the trained network to see it performing\n",
+    "import tensorflow as tf\n",
+    "sess = tf.InteractiveSession()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "or9eQFb3EVgv"
+   },
+   "outputs": [],
+   "source": [
+    "# initialize\n",
+    "sess.run(tf.compat.v1.global_variables_initializer())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "aEyXIDZPP9QP"
+   },
+   "outputs": [],
+   "source": [
+    "# log to stdout\n",
+    "logger.add_output(StdOutput())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 8799
+    },
+    "colab_type": "code",
+    "id": "ozn95FIDJEdC",
+    "outputId": "99127151-e1a8-4bd1-f266-e60dc3139f4f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:46:28 | epoch #0 | Obtaining samples...\n",
+      "2019-04-01 05:46:28 | epoch #0 | Obtaining samples for iteration 0...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/content/garage/garage/experiment/local_tf_runner.py:129: LoggerWarning: \u001b[33mLog data of type Graph was not accepted by any output\u001b[0m\n",
+      "  logger.log(self.sess.graph)\n",
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:46:34 | epoch #0 | Logging diagnostics...\n",
+      "2019-04-01 05:46:34 | epoch #0 | Optimizing policy...\n",
+      "2019-04-01 05:46:34 | epoch #0 | Computing loss before\n",
+      "2019-04-01 05:46:34 | epoch #0 | Computing KL before\n",
+      "2019-04-01 05:46:35 | epoch #0 | Optimizing\n",
+      "2019-04-01 05:46:35 | epoch #0 | Start CG optimization: #parameters: 1282, #inputs: 721, #subsample_inputs: 721\n",
+      "2019-04-01 05:46:35 | epoch #0 | computing loss before\n",
+      "2019-04-01 05:46:35 | epoch #0 | performing update\n",
+      "2019-04-01 05:46:35 | epoch #0 | computing gradient\n",
+      "2019-04-01 05:46:35 | epoch #0 | gradient computed\n",
+      "2019-04-01 05:46:35 | epoch #0 | computing descent direction\n",
+      "2019-04-01 05:46:39 | epoch #0 | descent direction computed\n",
+      "2019-04-01 05:46:40 | epoch #0 | backtrack iters: 3\n",
+      "2019-04-01 05:46:40 | epoch #0 | computing loss after\n",
+      "2019-04-01 05:46:40 | epoch #0 | optimization finished\n",
+      "2019-04-01 05:46:40 | epoch #0 | Computing KL after\n",
+      "2019-04-01 05:46:40 | epoch #0 | Computing loss after\n",
+      "2019-04-01 05:46:41 | epoch #0 | Fitting baseline...\n",
+      "2019-04-01 05:46:41 | epoch #0 | Saving snapshot...\n",
+      "2019-04-01 05:46:41 | epoch #0 | Saved\n",
+      "2019-04-01 05:46:41 | epoch #0 | Time 12.91 s\n",
+      "2019-04-01 05:46:41 | epoch #0 | EpochTime 12.91 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   12.9191\n",
+      "AverageReturn                             13.889\n",
+      "Entropy                                    0.586143\n",
+      "EnvExecTime                                0.712197\n",
+      "Extras/EpisodeRewardMean                  13.71\n",
+      "Iteration                                  0\n",
+      "LinearFeatureBaseline/ExplainedVariance   -1.55761e-08\n",
+      "MaxReturn                                 42\n",
+      "MinReturn                                  8\n",
+      "NumTrajs                                 721\n",
+      "Perplexity                                 1.79704\n",
+      "PolicyExecTime                             5.32993\n",
+      "ProcessExecTime                            0.232649\n",
+      "StdReturn                                  5.07081\n",
+      "policy/Entropy                             0.632138\n",
+      "policy/KL                                  0.00875508\n",
+      "policy/KLBefore                           -1.23854e-10\n",
+      "policy/LossAfter                          -0.0242026\n",
+      "policy/LossBefore                          4.10478e-06\n",
+      "policy/dLoss                               0.0242067\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:46:41 | epoch #1 | Obtaining samples...\n",
+      "2019-04-01 05:46:41 | epoch #1 | Obtaining samples for iteration 1...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:46:48 | epoch #1 | Logging diagnostics...\n",
+      "2019-04-01 05:46:48 | epoch #1 | Optimizing policy...\n",
+      "2019-04-01 05:46:48 | epoch #1 | Computing loss before\n",
+      "2019-04-01 05:46:48 | epoch #1 | Computing KL before\n",
+      "2019-04-01 05:46:48 | epoch #1 | Optimizing\n",
+      "2019-04-01 05:46:48 | epoch #1 | Start CG optimization: #parameters: 1282, #inputs: 599, #subsample_inputs: 599\n",
+      "2019-04-01 05:46:48 | epoch #1 | computing loss before\n",
+      "2019-04-01 05:46:48 | epoch #1 | performing update\n",
+      "2019-04-01 05:46:48 | epoch #1 | computing gradient\n",
+      "2019-04-01 05:46:48 | epoch #1 | gradient computed\n",
+      "2019-04-01 05:46:48 | epoch #1 | computing descent direction\n",
+      "2019-04-01 05:46:51 | epoch #1 | descent direction computed\n",
+      "2019-04-01 05:46:52 | epoch #1 | backtrack iters: 2\n",
+      "2019-04-01 05:46:52 | epoch #1 | computing loss after\n",
+      "2019-04-01 05:46:52 | epoch #1 | optimization finished\n",
+      "2019-04-01 05:46:52 | epoch #1 | Computing KL after\n",
+      "2019-04-01 05:46:52 | epoch #1 | Computing loss after\n",
+      "2019-04-01 05:46:52 | epoch #1 | Fitting baseline...\n",
+      "2019-04-01 05:46:52 | epoch #1 | Saving snapshot...\n",
+      "2019-04-01 05:46:52 | epoch #1 | Saved\n",
+      "2019-04-01 05:46:52 | epoch #1 | Time 24.61 s\n",
+      "2019-04-01 05:46:52 | epoch #1 | EpochTime 11.69 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   15.246\n",
+      "AverageReturn                             16.7129\n",
+      "Entropy                                    0.643499\n",
+      "EnvExecTime                                0.758384\n",
+      "Extras/EpisodeRewardMean                  17.94\n",
+      "Iteration                                  1\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.356434\n",
+      "MaxReturn                                 60\n",
+      "MinReturn                                  8\n",
+      "NumTrajs                                 599\n",
+      "Perplexity                                 1.90313\n",
+      "PolicyExecTime                             5.6485\n",
+      "ProcessExecTime                            0.242136\n",
+      "StdReturn                                  7.24996\n",
+      "policy/Entropy                             0.660685\n",
+      "policy/KL                                  0.00689534\n",
+      "policy/KLBefore                           -6.77591e-11\n",
+      "policy/LossAfter                          -0.032553\n",
+      "policy/LossBefore                         -6.93512e-08\n",
+      "policy/dLoss                               0.032553\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:46:52 | epoch #2 | Obtaining samples...\n",
+      "2019-04-01 05:46:52 | epoch #2 | Obtaining samples for iteration 2...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:46:59 | epoch #2 | Logging diagnostics...\n",
+      "2019-04-01 05:46:59 | epoch #2 | Optimizing policy...\n",
+      "2019-04-01 05:46:59 | epoch #2 | Computing loss before\n",
+      "2019-04-01 05:46:59 | epoch #2 | Computing KL before\n",
+      "2019-04-01 05:46:59 | epoch #2 | Optimizing\n",
+      "2019-04-01 05:46:59 | epoch #2 | Start CG optimization: #parameters: 1282, #inputs: 494, #subsample_inputs: 494\n",
+      "2019-04-01 05:46:59 | epoch #2 | computing loss before\n",
+      "2019-04-01 05:46:59 | epoch #2 | performing update\n",
+      "2019-04-01 05:46:59 | epoch #2 | computing gradient\n",
+      "2019-04-01 05:46:59 | epoch #2 | gradient computed\n",
+      "2019-04-01 05:46:59 | epoch #2 | computing descent direction\n",
+      "2019-04-01 05:47:02 | epoch #2 | descent direction computed\n",
+      "2019-04-01 05:47:02 | epoch #2 | backtrack iters: 1\n",
+      "2019-04-01 05:47:02 | epoch #2 | computing loss after\n",
+      "2019-04-01 05:47:02 | epoch #2 | optimization finished\n",
+      "2019-04-01 05:47:02 | epoch #2 | Computing KL after\n",
+      "2019-04-01 05:47:02 | epoch #2 | Computing loss after\n",
+      "2019-04-01 05:47:03 | epoch #2 | Fitting baseline...\n",
+      "2019-04-01 05:47:03 | epoch #2 | Saving snapshot...\n",
+      "2019-04-01 05:47:03 | epoch #2 | Saved\n",
+      "2019-04-01 05:47:03 | epoch #2 | Time 34.87 s\n",
+      "2019-04-01 05:47:03 | epoch #2 | EpochTime 10.26 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   17.871\n",
+      "AverageReturn                             20.2672\n",
+      "Entropy                                    0.666088\n",
+      "EnvExecTime                                0.721046\n",
+      "Extras/EpisodeRewardMean                  21.24\n",
+      "Iteration                                  2\n",
+      "LinearFeatureBaseline/ExplainedVariance   -0.0455278\n",
+      "MaxReturn                                 96\n",
+      "MinReturn                                  8\n",
+      "NumTrajs                                 494\n",
+      "Perplexity                                 1.94661\n",
+      "PolicyExecTime                             5.27265\n",
+      "ProcessExecTime                            0.228765\n",
+      "StdReturn                                 12.1072\n",
+      "policy/Entropy                             0.661384\n",
+      "policy/KL                                  0.00825417\n",
+      "policy/KLBefore                           -2.21965e-10\n",
+      "policy/LossAfter                          -0.0213919\n",
+      "policy/LossBefore                         -7.00825e-08\n",
+      "policy/dLoss                               0.0213919\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:03 | epoch #3 | Obtaining samples...\n",
+      "2019-04-01 05:47:03 | epoch #3 | Obtaining samples for iteration 3...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:09 | epoch #3 | Logging diagnostics...\n",
+      "2019-04-01 05:47:09 | epoch #3 | Optimizing policy...\n",
+      "2019-04-01 05:47:09 | epoch #3 | Computing loss before\n",
+      "2019-04-01 05:47:09 | epoch #3 | Computing KL before\n",
+      "2019-04-01 05:47:09 | epoch #3 | Optimizing\n",
+      "2019-04-01 05:47:09 | epoch #3 | Start CG optimization: #parameters: 1282, #inputs: 393, #subsample_inputs: 393\n",
+      "2019-04-01 05:47:09 | epoch #3 | computing loss before\n",
+      "2019-04-01 05:47:09 | epoch #3 | performing update\n",
+      "2019-04-01 05:47:09 | epoch #3 | computing gradient\n",
+      "2019-04-01 05:47:09 | epoch #3 | gradient computed\n",
+      "2019-04-01 05:47:09 | epoch #3 | computing descent direction\n",
+      "2019-04-01 05:47:12 | epoch #3 | descent direction computed\n",
+      "2019-04-01 05:47:12 | epoch #3 | backtrack iters: 1\n",
+      "2019-04-01 05:47:12 | epoch #3 | computing loss after\n",
+      "2019-04-01 05:47:12 | epoch #3 | optimization finished\n",
+      "2019-04-01 05:47:12 | epoch #3 | Computing KL after\n",
+      "2019-04-01 05:47:12 | epoch #3 | Computing loss after\n",
+      "2019-04-01 05:47:12 | epoch #3 | Fitting baseline...\n",
+      "2019-04-01 05:47:12 | epoch #3 | Saving snapshot...\n",
+      "2019-04-01 05:47:12 | epoch #3 | Saved\n",
+      "2019-04-01 05:47:12 | epoch #3 | Time 44.31 s\n",
+      "2019-04-01 05:47:12 | epoch #3 | EpochTime 9.43 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   21.7521\n",
+      "AverageReturn                             25.5013\n",
+      "Entropy                                    0.666487\n",
+      "EnvExecTime                                0.725008\n",
+      "Extras/EpisodeRewardMean                  24.77\n",
+      "Iteration                                  3\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.246326\n",
+      "MaxReturn                                 90\n",
+      "MinReturn                                  9\n",
+      "NumTrajs                                 393\n",
+      "Perplexity                                 1.94738\n",
+      "PolicyExecTime                             5.23944\n",
+      "ProcessExecTime                            0.225307\n",
+      "StdReturn                                 15.351\n",
+      "policy/Entropy                             0.662219\n",
+      "policy/KL                                  0.00899243\n",
+      "policy/KLBefore                            5.38312e-10\n",
+      "policy/LossAfter                          -0.0293233\n",
+      "policy/LossBefore                          1.24752e-07\n",
+      "policy/dLoss                               0.0293234\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:12 | epoch #4 | Obtaining samples...\n",
+      "2019-04-01 05:47:12 | epoch #4 | Obtaining samples for iteration 4...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:18 | epoch #4 | Logging diagnostics...\n",
+      "2019-04-01 05:47:18 | epoch #4 | Optimizing policy...\n",
+      "2019-04-01 05:47:18 | epoch #4 | Computing loss before\n",
+      "2019-04-01 05:47:18 | epoch #4 | Computing KL before\n",
+      "2019-04-01 05:47:19 | epoch #4 | Optimizing\n",
+      "2019-04-01 05:47:19 | epoch #4 | Start CG optimization: #parameters: 1282, #inputs: 254, #subsample_inputs: 254\n",
+      "2019-04-01 05:47:19 | epoch #4 | computing loss before\n",
+      "2019-04-01 05:47:19 | epoch #4 | performing update\n",
+      "2019-04-01 05:47:19 | epoch #4 | computing gradient\n",
+      "2019-04-01 05:47:19 | epoch #4 | gradient computed\n",
+      "2019-04-01 05:47:19 | epoch #4 | computing descent direction\n",
+      "2019-04-01 05:47:20 | epoch #4 | descent direction computed\n",
+      "2019-04-01 05:47:20 | epoch #4 | backtrack iters: 1\n",
+      "2019-04-01 05:47:20 | epoch #4 | computing loss after\n",
+      "2019-04-01 05:47:20 | epoch #4 | optimization finished\n",
+      "2019-04-01 05:47:20 | epoch #4 | Computing KL after\n",
+      "2019-04-01 05:47:20 | epoch #4 | Computing loss after\n",
+      "2019-04-01 05:47:20 | epoch #4 | Fitting baseline...\n",
+      "2019-04-01 05:47:20 | epoch #4 | Saving snapshot...\n",
+      "2019-04-01 05:47:20 | epoch #4 | Saved\n",
+      "2019-04-01 05:47:20 | epoch #4 | Time 52.72 s\n",
+      "2019-04-01 05:47:20 | epoch #4 | EpochTime 8.40 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   30.5253\n",
+      "AverageReturn                             39.5118\n",
+      "Entropy                                    0.661557\n",
+      "EnvExecTime                                0.713541\n",
+      "Extras/EpisodeRewardMean                  40.15\n",
+      "Iteration                                  4\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.0373423\n",
+      "MaxReturn                                148\n",
+      "MinReturn                                  8\n",
+      "NumTrajs                                 254\n",
+      "Perplexity                                 1.93781\n",
+      "PolicyExecTime                             5.25705\n",
+      "ProcessExecTime                            0.215813\n",
+      "StdReturn                                 27.0103\n",
+      "policy/Entropy                             0.640965\n",
+      "policy/KL                                  0.0082276\n",
+      "policy/KLBefore                           -2.02467e-10\n",
+      "policy/LossAfter                          -0.0239729\n",
+      "policy/LossBefore                          1.02532e-07\n",
+      "policy/dLoss                               0.023973\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:20 | epoch #5 | Obtaining samples...\n",
+      "2019-04-01 05:47:20 | epoch #5 | Obtaining samples for iteration 5...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:27 | epoch #5 | Logging diagnostics...\n",
+      "2019-04-01 05:47:27 | epoch #5 | Optimizing policy...\n",
+      "2019-04-01 05:47:27 | epoch #5 | Computing loss before\n",
+      "2019-04-01 05:47:27 | epoch #5 | Computing KL before\n",
+      "2019-04-01 05:47:27 | epoch #5 | Optimizing\n",
+      "2019-04-01 05:47:27 | epoch #5 | Start CG optimization: #parameters: 1282, #inputs: 162, #subsample_inputs: 162\n",
+      "2019-04-01 05:47:27 | epoch #5 | computing loss before\n",
+      "2019-04-01 05:47:27 | epoch #5 | performing update\n",
+      "2019-04-01 05:47:27 | epoch #5 | computing gradient\n",
+      "2019-04-01 05:47:27 | epoch #5 | gradient computed\n",
+      "2019-04-01 05:47:27 | epoch #5 | computing descent direction\n",
+      "2019-04-01 05:47:28 | epoch #5 | descent direction computed\n",
+      "2019-04-01 05:47:28 | epoch #5 | backtrack iters: 1\n",
+      "2019-04-01 05:47:28 | epoch #5 | computing loss after\n",
+      "2019-04-01 05:47:28 | epoch #5 | optimization finished\n",
+      "2019-04-01 05:47:28 | epoch #5 | Computing KL after\n",
+      "2019-04-01 05:47:28 | epoch #5 | Computing loss after\n",
+      "2019-04-01 05:47:28 | epoch #5 | Fitting baseline...\n",
+      "2019-04-01 05:47:28 | epoch #5 | Saving snapshot...\n",
+      "2019-04-01 05:47:28 | epoch #5 | Saved\n",
+      "2019-04-01 05:47:28 | epoch #5 | Time 60.39 s\n",
+      "2019-04-01 05:47:28 | epoch #5 | EpochTime 7.67 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   42.0991\n",
+      "AverageReturn                             61.7407\n",
+      "Entropy                                    0.645176\n",
+      "EnvExecTime                                0.716291\n",
+      "Extras/EpisodeRewardMean                  63.42\n",
+      "Iteration                                  5\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.187122\n",
+      "MaxReturn                                200\n",
+      "MinReturn                                  8\n",
+      "NumTrajs                                 162\n",
+      "Perplexity                                 1.90632\n",
+      "PolicyExecTime                             5.22226\n",
+      "ProcessExecTime                            0.208991\n",
+      "StdReturn                                 40.7597\n",
+      "policy/Entropy                             0.618815\n",
+      "policy/KL                                  0.00801669\n",
+      "policy/KLBefore                            6.41567e-11\n",
+      "policy/LossAfter                          -0.0200282\n",
+      "policy/LossBefore                         -1.79112e-07\n",
+      "policy/dLoss                               0.020028\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:28 | epoch #6 | Obtaining samples...\n",
+      "2019-04-01 05:47:28 | epoch #6 | Obtaining samples for iteration 6...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:35 | epoch #6 | Logging diagnostics...\n",
+      "2019-04-01 05:47:35 | epoch #6 | Optimizing policy...\n",
+      "2019-04-01 05:47:35 | epoch #6 | Computing loss before\n",
+      "2019-04-01 05:47:35 | epoch #6 | Computing KL before\n",
+      "2019-04-01 05:47:35 | epoch #6 | Optimizing\n",
+      "2019-04-01 05:47:35 | epoch #6 | Start CG optimization: #parameters: 1282, #inputs: 96, #subsample_inputs: 96\n",
+      "2019-04-01 05:47:35 | epoch #6 | computing loss before\n",
+      "2019-04-01 05:47:35 | epoch #6 | performing update\n",
+      "2019-04-01 05:47:35 | epoch #6 | computing gradient\n",
+      "2019-04-01 05:47:35 | epoch #6 | gradient computed\n",
+      "2019-04-01 05:47:35 | epoch #6 | computing descent direction\n",
+      "2019-04-01 05:47:35 | epoch #6 | descent direction computed\n",
+      "2019-04-01 05:47:35 | epoch #6 | backtrack iters: 1\n",
+      "2019-04-01 05:47:35 | epoch #6 | computing loss after\n",
+      "2019-04-01 05:47:35 | epoch #6 | optimization finished\n",
+      "2019-04-01 05:47:35 | epoch #6 | Computing KL after\n",
+      "2019-04-01 05:47:35 | epoch #6 | Computing loss after\n",
+      "2019-04-01 05:47:35 | epoch #6 | Fitting baseline...\n",
+      "2019-04-01 05:47:35 | epoch #6 | Saving snapshot...\n",
+      "2019-04-01 05:47:35 | epoch #6 | Saved\n",
+      "2019-04-01 05:47:35 | epoch #6 | Time 67.72 s\n",
+      "2019-04-01 05:47:35 | epoch #6 | EpochTime 7.32 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   59.7166\n",
+      "AverageReturn                            106.208\n",
+      "Entropy                                    0.620143\n",
+      "EnvExecTime                                0.726109\n",
+      "Extras/EpisodeRewardMean                 103.3\n",
+      "Iteration                                  6\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.312894\n",
+      "MaxReturn                                200\n",
+      "MinReturn                                 12\n",
+      "NumTrajs                                  96\n",
+      "Perplexity                                 1.85919\n",
+      "PolicyExecTime                             5.31482\n",
+      "ProcessExecTime                            0.212881\n",
+      "StdReturn                                 57.622\n",
+      "policy/Entropy                             0.585054\n",
+      "policy/KL                                  0.00674056\n",
+      "policy/KLBefore                            2.19351e-10\n",
+      "policy/LossAfter                          -0.0151696\n",
+      "policy/LossBefore                          5.10229e-08\n",
+      "policy/dLoss                               0.0151696\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:35 | epoch #7 | Obtaining samples...\n",
+      "2019-04-01 05:47:35 | epoch #7 | Obtaining samples for iteration 7...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:42 | epoch #7 | Logging diagnostics...\n",
+      "2019-04-01 05:47:42 | epoch #7 | Optimizing policy...\n",
+      "2019-04-01 05:47:42 | epoch #7 | Computing loss before\n",
+      "2019-04-01 05:47:42 | epoch #7 | Computing KL before\n",
+      "2019-04-01 05:47:42 | epoch #7 | Optimizing\n",
+      "2019-04-01 05:47:42 | epoch #7 | Start CG optimization: #parameters: 1282, #inputs: 63, #subsample_inputs: 63\n",
+      "2019-04-01 05:47:42 | epoch #7 | computing loss before\n",
+      "2019-04-01 05:47:42 | epoch #7 | performing update\n",
+      "2019-04-01 05:47:42 | epoch #7 | computing gradient\n",
+      "2019-04-01 05:47:42 | epoch #7 | gradient computed\n",
+      "2019-04-01 05:47:42 | epoch #7 | computing descent direction\n",
+      "2019-04-01 05:47:42 | epoch #7 | descent direction computed\n",
+      "2019-04-01 05:47:42 | epoch #7 | backtrack iters: 0\n",
+      "2019-04-01 05:47:42 | epoch #7 | computing loss after\n",
+      "2019-04-01 05:47:42 | epoch #7 | optimization finished\n",
+      "2019-04-01 05:47:42 | epoch #7 | Computing KL after\n",
+      "2019-04-01 05:47:42 | epoch #7 | Computing loss after\n",
+      "2019-04-01 05:47:42 | epoch #7 | Fitting baseline...\n",
+      "2019-04-01 05:47:42 | epoch #7 | Saving snapshot...\n",
+      "2019-04-01 05:47:42 | epoch #7 | Saved\n",
+      "2019-04-01 05:47:42 | epoch #7 | Time 74.69 s\n",
+      "2019-04-01 05:47:42 | epoch #7 | EpochTime 6.97 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   77.7217\n",
+      "AverageReturn                            160.968\n",
+      "Entropy                                    0.602291\n",
+      "EnvExecTime                                0.714021\n",
+      "Extras/EpisodeRewardMean                 141.18\n",
+      "Iteration                                  7\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.579558\n",
+      "MaxReturn                                200\n",
+      "MinReturn                                 37\n",
+      "NumTrajs                                  63\n",
+      "Perplexity                                 1.8263\n",
+      "PolicyExecTime                             5.26534\n",
+      "ProcessExecTime                            0.209869\n",
+      "StdReturn                                 45.2979\n",
+      "policy/Entropy                             0.576159\n",
+      "policy/KL                                  0.0089821\n",
+      "policy/KLBefore                            6.54432e-10\n",
+      "policy/LossAfter                          -0.014546\n",
+      "policy/LossBefore                          6.15971e-09\n",
+      "policy/dLoss                               0.014546\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:42 | epoch #8 | Obtaining samples...\n",
+      "2019-04-01 05:47:42 | epoch #8 | Obtaining samples for iteration 8...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:49 | epoch #8 | Logging diagnostics...\n",
+      "2019-04-01 05:47:49 | epoch #8 | Optimizing policy...\n",
+      "2019-04-01 05:47:49 | epoch #8 | Computing loss before\n",
+      "2019-04-01 05:47:49 | epoch #8 | Computing KL before\n",
+      "2019-04-01 05:47:49 | epoch #8 | Optimizing\n",
+      "2019-04-01 05:47:49 | epoch #8 | Start CG optimization: #parameters: 1282, #inputs: 53, #subsample_inputs: 53\n",
+      "2019-04-01 05:47:49 | epoch #8 | computing loss before\n",
+      "2019-04-01 05:47:49 | epoch #8 | performing update\n",
+      "2019-04-01 05:47:49 | epoch #8 | computing gradient\n",
+      "2019-04-01 05:47:49 | epoch #8 | gradient computed\n",
+      "2019-04-01 05:47:49 | epoch #8 | computing descent direction\n",
+      "2019-04-01 05:47:49 | epoch #8 | descent direction computed\n",
+      "2019-04-01 05:47:49 | epoch #8 | backtrack iters: 1\n",
+      "2019-04-01 05:47:49 | epoch #8 | computing loss after\n",
+      "2019-04-01 05:47:49 | epoch #8 | optimization finished\n",
+      "2019-04-01 05:47:49 | epoch #8 | Computing KL after\n",
+      "2019-04-01 05:47:49 | epoch #8 | Computing loss after\n",
+      "2019-04-01 05:47:49 | epoch #8 | Fitting baseline...\n",
+      "2019-04-01 05:47:49 | epoch #8 | Saving snapshot...\n",
+      "2019-04-01 05:47:49 | epoch #8 | Saved\n",
+      "2019-04-01 05:47:49 | epoch #8 | Time 81.60 s\n",
+      "2019-04-01 05:47:49 | epoch #8 | EpochTime 6.91 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   84.1507\n",
+      "AverageReturn                            189.415\n",
+      "Entropy                                    0.586332\n",
+      "EnvExecTime                                0.718586\n",
+      "Extras/EpisodeRewardMean                 178.3\n",
+      "Iteration                                  8\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.874438\n",
+      "MaxReturn                                200\n",
+      "MinReturn                                 45\n",
+      "NumTrajs                                  53\n",
+      "Perplexity                                 1.79738\n",
+      "PolicyExecTime                             5.25259\n",
+      "ProcessExecTime                            0.202226\n",
+      "StdReturn                                 28.9544\n",
+      "policy/Entropy                             0.562766\n",
+      "policy/KL                                  0.00847467\n",
+      "policy/KLBefore                            3.99525e-10\n",
+      "policy/LossAfter                          -0.00608158\n",
+      "policy/LossBefore                         -2.09041e-07\n",
+      "policy/dLoss                               0.00608137\n",
+      "---------------------------------------  -------------\n",
+      "2019-04-01 05:47:49 | epoch #9 | Obtaining samples...\n",
+      "2019-04-01 05:47:49 | epoch #9 | Obtaining samples for iteration 9...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "0% [##############################] 100% | ETA: 00:00:00\n",
+      "Total time elapsed: 00:00:06\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-04-01 05:47:56 | epoch #9 | Logging diagnostics...\n",
+      "2019-04-01 05:47:56 | epoch #9 | Optimizing policy...\n",
+      "2019-04-01 05:47:56 | epoch #9 | Computing loss before\n",
+      "2019-04-01 05:47:56 | epoch #9 | Computing KL before\n",
+      "2019-04-01 05:47:56 | epoch #9 | Optimizing\n",
+      "2019-04-01 05:47:56 | epoch #9 | Start CG optimization: #parameters: 1282, #inputs: 51, #subsample_inputs: 51\n",
+      "2019-04-01 05:47:56 | epoch #9 | computing loss before\n",
+      "2019-04-01 05:47:56 | epoch #9 | performing update\n",
+      "2019-04-01 05:47:56 | epoch #9 | computing gradient\n",
+      "2019-04-01 05:47:56 | epoch #9 | gradient computed\n",
+      "2019-04-01 05:47:56 | epoch #9 | computing descent direction\n",
+      "2019-04-01 05:47:56 | epoch #9 | descent direction computed\n",
+      "2019-04-01 05:47:56 | epoch #9 | backtrack iters: 0\n",
+      "2019-04-01 05:47:56 | epoch #9 | computing loss after\n",
+      "2019-04-01 05:47:56 | epoch #9 | optimization finished\n",
+      "2019-04-01 05:47:56 | epoch #9 | Computing KL after\n",
+      "2019-04-01 05:47:56 | epoch #9 | Computing loss after\n",
+      "2019-04-01 05:47:56 | epoch #9 | Fitting baseline...\n",
+      "2019-04-01 05:47:56 | epoch #9 | Saving snapshot...\n",
+      "2019-04-01 05:47:56 | epoch #9 | Saved\n",
+      "2019-04-01 05:47:56 | epoch #9 | Time 88.54 s\n",
+      "2019-04-01 05:47:56 | epoch #9 | EpochTime 6.94 s\n",
+      "---------------------------------------  -------------\n",
+      "AverageDiscountedReturn                   86.2569\n",
+      "AverageReturn                            198.196\n",
+      "Entropy                                    0.578476\n",
+      "EnvExecTime                                0.717167\n",
+      "Extras/EpisodeRewardMean                 193.47\n",
+      "Iteration                                  9\n",
+      "LinearFeatureBaseline/ExplainedVariance    0.95866\n",
+      "MaxReturn                                200\n",
+      "MinReturn                                124\n",
+      "NumTrajs                                  51\n",
+      "Perplexity                                 1.78332\n",
+      "PolicyExecTime                             5.29\n",
+      "ProcessExecTime                            0.203098\n",
+      "StdReturn                                 10.6071\n",
+      "policy/Entropy                             0.574217\n",
+      "policy/KL                                  0.00468092\n",
+      "policy/KLBefore                            3.1718e-10\n",
+      "policy/LossAfter                          -0.00568248\n",
+      "policy/LossBefore                          1.99641e-07\n",
+      "policy/dLoss                               0.00568268\n",
+      "---------------------------------------  -------------\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "198.19607843137254"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# train the algo\n",
+    "\n",
+    "runner = LocalRunner()\n",
+    "\n",
+    "runner.setup(algo=algo, env=env)\n",
+    "\n",
+    "# use n_epochs = 100 for practical example, n_epochs = 10 for quick demo, n_epochs = 1 for smoke testing\n",
+    "runner.train(n_epochs=10, batch_size=10000, plot=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "Q1PsTMwAH1Jr"
+   },
+   "source": [
+    "## Visualize a video of the algorithm playing "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 795
+    },
+    "colab_type": "code",
+    "id": "OQHSMjkYQoPq",
+    "outputId": "68193720-6fb2-4998-bdba-dae9019a3277"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Reading package lists... 0%\r",
+      "\r",
+      "Reading package lists... 0%\r",
+      "\r",
+      "Reading package lists... 0%\r",
+      "\r",
+      "Reading package lists... 8%\r",
+      "\r",
+      "Reading package lists... 8%\r",
+      "\r",
+      "Reading package lists... 8%\r",
+      "\r",
+      "Reading package lists... 8%\r",
+      "\r",
+      "Reading package lists... 73%\r",
+      "\r",
+      "Reading package lists... 75%\r",
+      "\r",
+      "Reading package lists... 75%\r",
+      "\r",
+      "Reading package lists... 76%\r",
+      "\r",
+      "Reading package lists... 76%\r",
+      "\r",
+      "Reading package lists... 81%\r",
+      "\r",
+      "Reading package lists... 81%\r",
+      "\r",
+      "Reading package lists... 81%\r",
+      "\r",
+      "Reading package lists... 81%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 89%\r",
+      "\r",
+      "Reading package lists... 92%\r",
+      "\r",
+      "Reading package lists... 92%\r",
+      "\r",
+      "Reading package lists... 92%\r",
+      "\r",
+      "Reading package lists... 92%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 93%\r",
+      "\r",
+      "Reading package lists... 94%\r",
+      "\r",
+      "Reading package lists... 94%\r",
+      "\r",
+      "Reading package lists... 94%\r",
+      "\r",
+      "Reading package lists... 94%\r",
+      "\r",
+      "Reading package lists... 98%\r",
+      "\r",
+      "Reading package lists... 98%\r",
+      "\r",
+      "Reading package lists... 98%\r",
+      "\r",
+      "Reading package lists... 98%\r",
+      "\r",
+      "Reading package lists... Done\r\n",
+      "\r",
+      "Building dependency tree... 0%\r",
+      "\r",
+      "Building dependency tree... 0%\r",
+      "\r",
+      "Building dependency tree... 50%\r",
+      "\r",
+      "Building dependency tree... 50%\r",
+      "\r",
+      "Building dependency tree       \r\n",
+      "\r",
+      "Reading state information... 0%\r",
+      "\r",
+      "Reading state information... 0%\r",
+      "\r",
+      "Reading state information... Done\r\n",
+      "ffmpeg is already the newest version (7:3.4.4-0ubuntu0.18.04.1).\n",
+      "The following package was automatically installed and is no longer required:\n",
+      "  libnvidia-common-410\n",
+      "Use 'apt autoremove' to remove it.\n",
+      "Suggested packages:\n",
+      "  libgle3\n",
+      "The following NEW packages will be installed:\n",
+      "  python-opengl xvfb\n",
+      "0 upgraded, 2 newly installed, 0 to remove and 8 not upgraded.\n",
+      "Need to get 1,280 kB of archives.\n",
+      "After this operation, 7,682 kB of additional disk space will be used.\n",
+      "Get:1 http://archive.ubuntu.com/ubuntu bionic/universe amd64 python-opengl all 3.1.0+dfsg-1 [496 kB]\n",
+      "Get:2 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 xvfb amd64 2:1.19.6-1ubuntu4.2 [783 kB]\n",
+      "Fetched 1,280 kB in 1s (1,495 kB/s)\n",
+      "Selecting previously unselected package python-opengl.\n",
+      "(Reading database ... 133568 files and directories currently installed.)\n",
+      "Preparing to unpack .../python-opengl_3.1.0+dfsg-1_all.deb ...\n",
+      "Unpacking python-opengl (3.1.0+dfsg-1) ...\n",
+      "Selecting previously unselected package xvfb.\n",
+      "Preparing to unpack .../xvfb_2%3a1.19.6-1ubuntu4.2_amd64.deb ...\n",
+      "Unpacking xvfb (2:1.19.6-1ubuntu4.2) ...\n",
+      "Setting up python-opengl (3.1.0+dfsg-1) ...\n",
+      "Setting up xvfb (2:1.19.6-1ubuntu4.2) ...\n",
+      "Processing triggers for man-db (2.8.3-2ubuntu0.1) ...\n",
+      "Collecting pyvirtualdisplay\n",
+      "  Downloading https://files.pythonhosted.org/packages/39/37/f285403a09cc261c56b6574baace1bdcf4b8c7428c8a7239cbba137bc0eb/PyVirtualDisplay-0.2.1.tar.gz\n",
+      "Collecting EasyProcess (from pyvirtualdisplay)\n",
+      "  Downloading https://files.pythonhosted.org/packages/45/3a/4eecc0c7995a13a64739bbedc0d3691fc574245b7e79cff81905aa0c2b38/EasyProcess-0.2.5.tar.gz\n",
+      "Building wheels for collected packages: pyvirtualdisplay, EasyProcess\n",
+      "  Building wheel for pyvirtualdisplay (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /root/.cache/pip/wheels/d1/8c/16/1c64227974ae29c687e4cc30fd691d5c0fd40f54446dde99da\n",
+      "  Building wheel for EasyProcess (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Stored in directory: /root/.cache/pip/wheels/41/22/19/af15ef6264c58b625a82641ed7483ad05e258fbd8925505227\n",
+      "Successfully built pyvirtualdisplay EasyProcess\n",
+      "Installing collected packages: EasyProcess, pyvirtualdisplay\n",
+      "Successfully installed EasyProcess-0.2.5 pyvirtualdisplay-0.2.1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 7,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%shell\n",
+    "\n",
+    "# Prepare display for seeing a video of the policy in action in the jupyter notebook\n",
+    "# Note that this doesn't require a runtime restart\n",
+    "# https://stackoverflow.com/a/51183488/4126114\n",
+    "\n",
+    "apt-get install python-opengl ffmpeg xvfb\n",
+    "pip install pyvirtualdisplay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 62
+    },
+    "colab_type": "code",
+    "id": "i4kwHJFkGB9R",
+    "outputId": "ffaf04a7-fb30-4daa-9776-b9501cce7250"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Display cmd_param=['Xvfb', '-br', '-nolisten', 'tcp', '-screen', '0', '1400x900x24', ':1001'] cmd=['Xvfb', '-br', '-nolisten', 'tcp', '-screen', '0', '1400x900x24', ':1001'] oserror=None return_code=None stdout=\"None\" stderr=\"None\" timeout_happened=False>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Virtual display\n",
+    "from pyvirtualdisplay import Display\n",
+    "\n",
+    "virtual_display = Display(visible=0, size=(1400, 900))\n",
+    "virtual_display.start()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "uOrLZ_UGrdgO"
+   },
+   "outputs": [],
+   "source": [
+    "# bugfix?\n",
+    "# Set an \"id\" field since missing for some reason (uncovered in monitor wrapper below)\n",
+    "env.spec.id = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "colab_type": "code",
+    "id": "GntG175cY8m0",
+    "outputId": "d75c47d4-7ad5-414e-a18b-edcb83b9d6ed"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done at step 174\n"
+     ]
+    }
+   ],
+   "source": [
+    "# wrap the gym environment for recording a video of the policy performance\n",
+    "# https://kyso.io/eoin/openai-gym-jupyter?utm_campaign=News&utm_medium=Community&utm_source=DataCamp.com\n",
+    "import gym\n",
+    "from gym import wrappers\n",
+    "\n",
+    "env = wrappers.Monitor(env, \"./gym-results\", force=True)\n",
+    "obs = env.reset()\n",
+    "for i in range(1000):\n",
+    "    #action = env.action_space.sample()\n",
+    "    action, _ = policy.get_action(obs)\n",
+    "    obs, reward, done, info = env.step(action)\n",
+    "    if done: break\n",
+    "\n",
+    "print(\"done at step %i\"%i)\n",
+    "env.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 201
+    },
+    "colab_type": "code",
+    "id": "HKAAXIuaZQo-",
+    "outputId": "e72c4b26-7385-4315-ed87-473098e19e09"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "    <video width=\"360\" height=\"auto\" alt=\"test\" controls><source src=\"data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAPXttZGF0AAACrgYF//+q3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE1MiByMjg1NCBlOWE1OTAzIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAxNyAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTMgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTQwIGludHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4wMACAAAACMWWIhAAz//727L4FNf2f0JcRLMXaSnA+KqSAgHc0wAAAAwAAAwAAFgn0I7DkqgN3QAAAHGAFBCwCPCVC2EhH2OkN/wer9sgDkZbGwFqFpQ9m7i+AI+L2+8Q56Dx6GFpxTeq4BlWDPtDxl7pW1XUMGhn9Zes6LJntDH3/XTe34HRwj/N2p8+ef0YPO6lBUWdiiPJXqg+2oJ3/Ze61G+QHlVNHgkRxcgirvUGEoBrZ1CMSQk1nBRkk8Zw4UrFt8rtMHH8lbtM3foy97e/sm50lAwUNKdAy1o32OBRDdBawfwoHcNHuI6oC3OzApKFAtovvL9HGy3w/SLzXSeAIeJwLlmhrI17zB21AmJz8mXbb0IjB6mTuAGTodKOS6nyvusJJ5BKpOMXpz7IA11JJN5iQUVvppJO8CoWSbxNVXEc/ixZLXfnLMNfyjfMktrkZdBkfr/0BbAAhNmqejJdUXM25lG8NPpJBlhQmosIZp4aqllCgAm5vVnccMvCMz4Wc38w6mjdSeVnNtdVW3rXNBbzsO3RCqI1RF547sCQV6Oddy+gfQhJbdqL/NWTjyvUgTath0dYU8BYjz0zFu/ZxhgGQg0qhT0lsm05G5YakP4wqFAAOzItV1VPAf4sz+3RrC8dmeV96dyQIfUl/q15sU+grhAdqrdMhq4ZurleNdMbibHoFd8uyuy+6LTpinlaTqwSFIe6sTXriDULnUrvtpNo36vWAi1QIODPVwAAAAwAAAwAFhQAAANZBmiRsQz/+nhAAAEVLF3gAWHOIteliSAxt/Na3NIzY/6HuF+oDb0Pe7usGSyhv13HDjsUuI/+XDsC1jlf0VrEIcPhQrIcFefezna2dbHZdg8ybO3hsEs88eHalR36PBnjn0fsNj3QUZ8h2hfSLociVAikbLFn7BRPZUUzwEkGe0WPrEctNN2SzqlbMkQIFhVydRQNtxQ1p2I/ovrkWaI2PKkw2tIaqYP79KvM/Ncpt3srym6Yev43vsJ3nIg4c5bIVLeBoABwNZgVulfvsZ4hdNCV6Zt6AAAAAa0GeQniEfwAAFrOkBgAthPJwo949r1zImXzDdDVZjF40iplIG5Q9hpv4m+dA1C6U/F1IfLbjCsduB5p0s4JJ7h3SKgrsB67Hzx0JGYxU8/9K5NnHtCoR6ERbI5n51jAAAAMACOZfSqcoywFtAAAAQgGeYXRH/wAAI7f/DorfMWLB8BmP5VnuvA2qoENDcjyD1AFDcWA94ZF5D3qwAnSxeYlJsqm0jEAAAAMAADHBZEBJwAAAADMBnmNqR/8AACKyLvu4hgq5kPV0JrZ+QOL7am/8YuZMysRkCoOfGcBRm6oABLHgjPLAWcEAAABtQZpoSahBaJlMCGf//p4QAABFRVLUAEWuP4+FFUKr0HGjTtKGDZ8xiwxteSTANK7wA0ztOmnS83ZZab8pN6Jmv02uUPtwJorsGj8Z9sryBM3QSCwazhLPmtg7lxcHqGPSPtsKhP8UNXopc7VOYQAAAFBBnoZFESwj/wAAFrxQtuwUtlRs1G9jruGoWJxfuVDQIw8IKjdwSX7JlV/eZV8WWUt2vzC4/ej6Kb3pBa7nsF5B0Gz39TIqhDa9/RBYveYicQAAACYBnqV0R/8AAA1/T2qlyPYvaJgZ+Om5i8g4QpLM18f3h+DvLuvSoQAAADoBnqdqR/8AACO/H4wsRyXfzQ1BhPrSRvfcJZjuNg/vx0ZHoZnEktFABaiVVmGv8v3A481RO6N36dmAAAAAgUGarEmoQWyZTAhn//6eEAAARVI9yAIkNw+k06A+Ap1tIi4sy+JA8vUN0yYK4hkT++AiEpteh31LZ56W+eRBYL2obyo3XJ9euXVitrXUprOd/K2FPiseuLjZ/87bPraKX6t0vjv4Ltm987YghtvpjOBhlurBKZlCAxyGwP0rPhr7cAAAAEBBnspFFSwj/wAAFq3vFuEr19vmxcZcLKYV79LkOq8qT9xyQAkqk1w6G19gBCnUkxv1vpNtgPJMz663myisnufBAAAAOgGe6XRH/wAAIz1q4Zp8QWT6HZ+SpMcKrigLcYuex3xB60IGOBxD0AJgcRAgJ6B9k2ALfC+Qg+QyNGAAAAA0AZ7rakf/AAAix8i7Bzx5i3qIxwAJULDJFn7ZA9orFYfvQJ2Rhce7H2/CbdSTRJjq+2OSNgAAAGdBmvBJqEFsmUwIX//+jLAAAEYl0QCFfzQBW/UmwIS66Slwa4DspAGbYogNZEXPD2YyTeNZhO5O3Wm0JtaAKnmj3O37UgdNO84BntEu+nRUZmNs6/wlhgl77OAmv8Lc8xrpTZB4ABaBAAAANkGfDkUVLCP/AAAWpaRovCz/oZJr7A/IiUiMxsqVACYU7RBKYwK3H6mz7nCYY/Z3pZvdWGNywQAAADsBny10R/8AACOUoh/YIca5fLDtveAAuerf3uqYKnNh63WURRXHfhXT5a2xsURB2Bl4t65qVul1wp77MQAAACwBny9qR/8AACOyPL+JSCuWVRPsuABZxN9G+sNkMmN0VomDcEaoY+zpmZpdnwAAAFVBmzRJqEFsmUwIX//+jLAAAEYB8n0bCG3WLcRzziRUgAwXps0BfXm5f7/RvVNm5zIR6bN4tAk6oTj813wJZ6qWzzecnTOowKuDdJNZ9p25F80z5t1gAAAAOkGfUkUVLCP/AAAWs0iuTWo5p7ixKAEsOV5A2z7kXzBv3sgs+dZ9E7ROuqMrLT4LkQJ3Idgchx6grUkAAAAwAZ9xdEf/AAAjrEJUXV+SgTgKegBY/3ADAmufMFfXqY+FgV7Mndp7BwKGrL7qI6DYAAAALwGfc2pH/wAAI78fjBsIwgAkUOgAQavfLV8pWLgs1K9gDV4UM32mulk2Ts5ruCaYAAAAhUGbeEmoQWyZTAhf//6MsAAASAICTIY4gGq/gAr3Ze1rSerZYJLnhxys7it4b3BLueFmF7olsNbV7vMCLieplQa/gE8KYCsYDvfCUi34m7+XD1CbGUNhe+1wdVl+Jxp+aU6arkws3N2C8AHXGkgd7XKTJCUsBwJgRykZJABnzA2iCrALDMEAAAAuQZ+WRRUsI/8AABdMQxZZpQ6kg4AUtx+C+BK8FrXPUD3NQBmKidLbTbQUYczUgAAAACEBn7V0R/8AACPC8IswSxaavR72IqsFiSjYjy18fOVmtSEAAAAYAZ+3akf/AAAkvwQnEslps0aEn30scA3pAAAAdUGbukmoQWyZTBRML//+jLAAAEfy7idum8u0qRAHKCm318IM0Kb/YgYMvBO6M2wf+0VUXrNBOL5MusUvtQPvE6VWKJCHhXZzfoD2QzKrAUXlr98UNfP2vGw4i4rAaEM49Le6cmpZkaIjrxg7AzTBcCUSc+CjaAAAACkBn9lqR/8AACSuHynNpqxBh1bWVhTLgQ4Ky7B22JQVpz0thu5Y1dh7gQAAAKtBm95J4QpSZTAhf/6MsAAASAHxzbwUtYBNfUoTEPHgS+H6QIncyZ6bTVtv2JOcWEpdKkO8bm4/OXu7f+tl11zxPCKkCjSd7/h8Tg165oMQXXYcfSJPk5/67o2obfeJ1ZPjktkc86uHBqOY3xvlfkZHywUMS37a6xT8CHUguFsulUV5JMCgYnLGIMD3AVBCPxLHwwL7Apf8GbR8j0Q4U9Qc6eI7cR0/gcJjpWcAAABOQZ/8RTRMI/8AABdDR0gthrreGB5AOOYBMLRS2N0gpQWivnsfbHhY46647aZ4mV+mgXTwfJtgC76MAEzUabw+JbpsC7BL1yXL/Q+sshbhAAAAOgGeG3RH/wAAJMM7+MvUCvuN3kg7DLZvmokB1hOmT0j+9gSFSK7WmbwKEABM1oc1Shw1J26/NclJwIEAAAAtAZ4dakf/AAAkscwABPozJAylVTnhgycPcWcu0rapYZaEosr9E9sY9n2riT3QAAAAS0GaAkmoQWiZTAhX//44QAABFPZA6QWbvdVIcvDaP5xVYvY7hZGMT+49YYxZCylFbDbLI68Z0apf2U78jtIDj6ToPVWbqViDseK6oAAAAFlBniBFESwj/wAAF0OX0/OqAOSLZi3EGU4KQU7oDUumQIANLt3YQ9eALzQd25+mXRYJtUn3Pecpkc93TNE+mLAWFuNlYKYMbr3GIpHXC0Q2ZuGP6aBpq10hMQAAAD8Bnl90R/8AACTAmTJt4RIa3ukGRLoiuOieL7vi6d39/RjW7j90P6lP/VYUI/fEAE5Jxr8B6gfLUuA2xW39+YEAAAApAZ5Bakf/AAAkseg0eWd8KHLYTzCQjN02Jj2iBgrembICrzvprZDTuxUAAABWQZpDSahBbJlMCF///oywAABIKYJjgEVKxjNU75AtkKEhxvB/zQwdBSVb0+gAfmtsVCu7Ttn9/mU6suDqEXAvjfmB7V8ig0OR4ARp07MYjmlUNxq3dZIAAABuQZpkSeEKUmUwIX/+jLAAAEggEmcAUDssy9dPZCwsDLyBfkiGpSHy42nsreuYXFMybt9r4Yxyt8xCanW9FSUz6W/BB2JCk4qrjTEKB4rrQNuyt/juNpVDjjwMHzTVxkdodqx4PnwXMlx3MUgvRSEAAABoQZqISeEOiZTAhf/+jLAAAEgQe0UJl05fiBuMan5tOMkkMRmfTKwsbNgHKevciEpYw8zeADt3wc0Lpq+foARWKjGMaep8d5JPjPpocB68a/S6sr/z47ORE54w/OtZp/Dmz/mmEwQC1yMAAABEQZ6mRRE8I/8AABdQRNzipOMpMwj/2QIHgAHGbU2qKM5IVaRVomDl3DAddraIgEdrnUT6bUQ3GVMT/FK29iwT5GqF2pEAAAA2AZ7FdEf/AAAkqenHFA1EHsgjSSJC6YS26YQ5II1wduIAZHd+QDYKX5FmzinNSEdKA3dgIU69AAAAMAGex2pH/wAAJJKdg5gcl/POzAwdMSYrFUF2WbyuWDhMXLS+yWLimxY78UuM/zPqQAAAAF1BmspJqEFomUwU8L/+jLAAAEgB8nzGwLaNfKTSblU1ri27jhSuymgGv/wH8TmdiLyN9oyaTddFcvuVeUFCACqKQWVVr3GUo4CGt6nsFD8t7vc8s4yS/yWi7/mHg4oAAAA1AZ7pakf/AAAkxwgsouCJzQrvt1xydR8tKVUjPQAlhDRGpWrSxUtwlYn2LxhP8ArwnxIi9qUAAABuQZruSeEKUmUwIX/+jLAAAEgzzDEF44ArVE45O9kUOfeVxZfZbQEW2pAr8/LQULNrcgJKO1waTCh9ZYVuO6ACqzXs+tBLWRCxRrTVxj6Snby9wngjRI8qWI8o9XKggn8Uhnx5h55TwQkwzXZ8a4AAAAA6QZ8MRTRMI/8AABdLY7JEOCXctW116oBAeO3vVgIegHYvrA6MaTl5RLk4VW2G+As7qsobRUbP8QnaDgAAACoBnyt0R/8AACTAmpDGSXUSyOGk5qgPFHdG+vAdEdr+PU0YOezs5lGG+YEAAAA6AZ8takf/AAAkrmAEwuUERcD8Cx+no6/Q8gimo5j4eaYxTvuGga6iNNMuZl6N74TnQX6AP9NCmIFIsQAAAGJBmy9JqEFomUwIZ//+nhAAAElFBPccYcBC8N7BtA3ws0BQtzETqfU9+PWEBTkYzS+Jh+M5lA7U7qBVDDoDro7F2qq4aeUMgy3KWGS7Don/R3E/yX+rL11rN9/mJxn9eWgZ5QAAAGJBm1NJ4QpSZTAhn/6eEAAASUPNcK8zW/PMZGORBAUDQJT9HL9pxNzT4iGwZj02ofiAA0EepyJOz14dgS6rdIxwt1wLpNl33vHNMA+UD2f9VxR83j8EnYnKvdIiTFSU+lkXUAAAAERBn3FFNEwj/wAAF9/r6LRI8+HCRN1Ewo/rI867XCdwrvcEutuhHyAAN0+y22qJ7ENbIYx9IGU3uHun9JtK6N5/fsE7SQAAAEIBn5B0R/8AACXAmJtJIl03ImmJLJ1oGlFDhAqG1HZQ1ie++YbQTCKMkrkJy1oP8mEggqDA+jQ9XCQAzjbbnokge6EAAAAxAZ+Sakf/AAAlrl7QtD/MjdyQZMvlpyHlhvCFn29Q6fMMQAszfBU80BwzeYK8SsGQIAAAAIJBm5dJqEFomUwIZ//+nhAAAElj/0BcqAG6Fivl304UUrXSoNkIKYXH+vr0129zzspMkpJvektlgO4FxZfoMH1GSrPyz6L0GEt7Xvhp4qCRcy98d1QLvBvBaOA+aJK4d5nztD8xPFNHEw/QDHE71E1mg/pZ2Mo3u8XlwhEfXfoDSp7UAAAAN0GftUURLCP/AAAX3+votEjzwytnvE2LNRmqgQ+8wxx/0fLnjDzkJ5X7BW/hvUcuz/y2tjxBKTEAAAA7AZ/UdEf/AAAlqenHE5sZVmoBnLWfNPt1vgnKlt4L3AU9+V/0zZFACFLc36a17uhJ2XA+BztAxr1ui04AAAAxAZ/Wakf/AAAlrl4zgZDEALbRfEx6tkA0hnwXAIMak8c1x9PSVYlsi/fCujMnF1nWnQAAAHtBm9tJqEFsmUwIZ//+nhAAAEu6bzxOX95s/cAyo+nAAW9gPYz+UZJ73xBiTulqYi425AWDrYrDeVxTvuF/3wd29NQapr8w/gAU2OdNbIs6XN+8Ut4Z6+iOq3kUtjwRR7DQtQhYtETB3A+13BDO+MOowruPoOqWeXQ3oNEAAAA1QZ/5RRUsI/8AABfoYycVefHoI5OdPYfJ9qcTKAhRQqqPIWc+0+pd1VTV8WlqqJZiKNlR8oEAAAAuAZ4YdEf/AAAlwDVsW0beauw/4rmrCVSEuV5gAFzakEyWfCiB5gLtxKosqisECQAAADQBnhpqR/8AACW9hAbDFgV99Qz9QAWswmAYBQ+nngRr4cN7K/Bn7qvIhZtaLS/tcPuS62z4AAAAXkGaH0moQWyZTAhf//6MsAAATAE8xMvFLGAK1ROLZXtcYcJ58K1MgI2hrHYok/sZ6rKTBGa4NI8pTSbR+3XUAVlNBxRynegEBK2Q8W37OXawOkGks1D3nID+k3DJfREAAABSQZ49RRUsI/8AABh/7FxeEOCTIntgKpLiaQAnG8SE7ltfjQfR+6U0OhW4xBO7bAS+HE1x210gtlUSjv/d2mLpGPX1EyzBi9nmDl9XnGwfzFrPgQAAAE0Bnlx0R/8AACbDEeb3mSyFwgKFlKN6BYCGYLAAlim39Nyu4znzzqOkiMY1wUgqLl+NxMAEXPDv51W6hskJXIWMmog+L6dqtjYq0E6q2AAAADgBnl5qR/8AACa9g4HKB47KK/1QAllOiMTCioBksDEcUQHrzh+aGg+TTgvFT3XkKbr60L02yU/QMAAAAJFBmkNJqEFsmUwIX//+jLAAAEwyADZadwBzD1wmWLVoAfwN7+rClioSIVAA9pymWSgWNl9LY7ydobskdN24Iwx+z4czOBh4/BS28BetpZ4XB733KfBBX71wTdZSvDbvASW/PpSVj+zcbFRRTiwattJCE/KtPfnaX0OeHT2afGMRJD0I3SEARc0qitn2tsOd/OsxAAAAMUGeYUUVLCP/AAAYf+votDzT5ixdu3B0Hg+Tn+vbKU+tuHvziA7T9OeXJ3tcIWWGgIsAAAApAZ6AdEf/AAAmwJnd6C5QKoFYzggxCvIBEofp/cVUpt1Vpab7uODDyoEAAAA3AZ6Cakf/AAAmrl4zgXlFHMQ2X1ggAWjPnZq8mnWr/t/IuhcQ+87y+ajfOczx8GQL/TbYGVGSiwAAAHNBmoVJqEFsmUwUTDP//p4QAABLQ49sILOjUX24O3QDQynjXjjWhYXa6DRkYLwWpkK+YrVMNdBFmnZrXnSfiiIR4Da7u0HCcJyiMOwRuUimAR/TMfo098v3DefSoF4ADMDsNAwH5Fu1CAJ3R1n/KZgjJcbnAAAARwGepGpH/wAAJpKj23e2CYrZpAAuolaIkUsbOa5g8yPFSm3T3LVdO0LqbBYkPWUcgI9+RlxPiknla0hvxTgyaSmRFy54IjAhAAAASkGaqUnhClJlMCGf/p4QAABLQ/hl2ABdR9uy8YER061Ue40v2k3UocherwQEX0BYVi07RhE6+bgXKW0Yc8Lwn1ccie0KWWbWbVFFAAAANUGex0U0TCP/AAAYf0QNwk2O+aKup9Ps7q9OiYr1wdtOCPwpSUNDMAiMMeKZbhU3vznCYXu5AAAAJAGe5nRH/wAAJsBmquqWe2bjNRzPPLGWEi23uLiUj38/W3hWVAAAACQBnuhqR/8AACbG6Bf9o4r5jOINN40eiNozvqc2rgcv+oCx8WAAAAA+QZrtSahBaJlMCGf//p4QAABNQ+n6c3abYkzv5WdVmvOYq9+TGEgYXTAKyC0Ru2AAFqpa0EM411isnL5wgCUAAAA4QZ8LRREsI/8AABkf6+jPyQAi5Kg2UQDg5bMdI7Cj9wEj6fv4mp8QUgCFnEE3dG4UDYMoarU5DaAAAAAjAZ8qdEf/AAAnv57ACI+WtT0xhRFBqDWHePKDwvFeLdLaruAAAAAvAZ8sakf/AAAnxVPTPHqGVITnLIgAuolvPFhH76DwDhyt0OsKa2l+W4Qg+ysYJ6cAAAB+QZsxSahBbJlMCGf//p4QAABNVKI1XwARgbwEsWzV0WJmeIeEP61P6lhGa0SzL6/AjGUp8HQcKM78FxFJKxvXPad7bUDPGhuhl3xgoQjisRfHo1qqrqqUlwAh0qQP/RAbJTB7eadBoIRpxZZZwxDVynCjn5aaRT2Snx02YMSBAAAAQ0GfT0UVLCP/AAAZH0PUOAxQcAJpP0HCyfgpnu178y6SYsHe2n6jPpiu/AkjEb00slkeiXWb3BO8pt64gPdpPXvb2oMAAAAnAZ9udEf/AAAnwFjfcxrVRYBCm2EvqirQDE8Dai0VJUPhrjAxEMWAAAAALgGfcGpH/wAAJz5+Z4qAWjM60934iObPAv0d5D+VlAB8d8l4a99SsCypmYFkNoAAAACkQZt1SahBbJlMCF///oywAABOAT9XMAIyPWuxlWaNQLj6yGfiwMKFcORxEyLyNEOzNteF0oTFEquHgv54z+CjoPNyzqroyM9PBtvczLwfPwBn92fDTwVzCXouoTXp2oE6n/lp2m6e55MXP762EMr5qM/AN2UiOUIrlMxcfVOG+IGHseXhSnfcbMBh6vIAoDreT9KzmQihLhxdj85drRfMFXBpQSUAAAA8QZ+TRRUsI/8AABkf7I+qWi1KEABOLxs6MFFaJTrLAGGsSFLi9D5wcF3CUPpzPZtm9/+vrZBmMjXDGPTaAAAAMAGfsnRH/wAAJ9tYCiJAcLT6oK5wav2WIW0JDonLQyUXcNeCZaS6junRXXz9R6fZlQAAAEcBn7RqR/8AACfFVc5zP2Jm/Ht4eRS0Z8uBFp0X4ALnq+BO9oPa7t9Wtqad8hIpIiHjtuOKDB0667wQOI41+FS2OClvgLLAgQAAAHtBm7hJqEFsmUwIZ//+nhAAAE9rCngwQpCXXD+AxduBUxjzUS5WW9J8vOYCWiEjPR3/BYANqPt4ay/G4gLobLgyAr0kaMnsPWVNJzlrkbeZuqmrdBRswEE/Fexuf6CO4HrNv72PXKgA42VTtjPadfEo9fdJ+RhNgkVDMkAAAABFQZ/WRRUsI/8AABnJfMNgJE45Kb6etYP2D+mBEtXluKPNKIU7rY0blgq9HkMvRRoTXravwAIa6awIO3huJQLCv9l1+ZPdAAAAOwGf92pH/wAAKPluOKm2iXmYM/+0GoY9iEPGJUExGLh87JBDNaH42ONAqjiPqIxj7VGhe/nS3XSmkOGVAAAAkkGb/EmoQWyZTAhf//6MsAAAUCoaPhm11fO2wgjW6nhUudKc95Z6UqAr1tswDR5k0r3W2d2wgluDswaV07svhzrxLXvwPBuyymMOmBBH55VjWibVssiYB8UqmWUBoeB3pUahUAGXkl9G+NAsKMrhJzhUQ7p1by7qUTr5CNRhDy+iQ1/X3ZgILKFpmJtvbYXW76RwAAAATkGeGkUVLCP/AAAZv+weoyw3ZbrwT8cxhhp1acODY8/XTyB5KqZnehu4o0ltFpEh8ALWspAlFnCQTn44UIWUOcQyCoWo6zwiEZzeWMjUgQAAADIBnjl0R/8AACj6nRx8yIHjDyUOghfSiQMJ04SWrZOQC/QMWGu1Q+rjEGIf/TaMo9vi2gAAADIBnjtqR/8AACjlU9M9SNINlWR4iLpcR3p8PZXC3wc0HESEfxQXzK8jvGw73PseObzfswAAALtBmiBJqEFsmUwIX//+jLAAAFAZj0nxVEAcw9cJdaYrWAH8sU6gW4qtDO+hRdPB5yItIghduJVL+tdYi9k1EXjsBM7WCj/MwDa8/G0W4cu6hqPar5J1OskzBZB0oVmWUNXGO0DH/hDi2zz9NlNl5qHN3uoXKbnWMPjcTMWPqhQmcE/JYmYEQ4zautJeXrro3p7GX7hn/gw0gohUt0tvnqVW7UForXb4aTbQ+TE8VRGtbJGfkNY1wj6GnZthAAAAZEGeXkUVLCP/AAAZsCGJFc5qehm8IAWRCgnyso2tEqdQ1LDOXc6QHlz7EkuqcctJzVNtuqJJ+PpDE5/37D70kKZzJLOnDDjy80PKyxCcylnHHKZaIcyPXn4Y/2a08nO+1fdevSAAAABHAZ59dEf/AAAo2OgOSocCQJI8iDKRkf9yZQqCX2e7+uMHNQWmIMPdcR/7bLpxoh2ol2Ek8AxKU5FTqgA+RF3v/7GceWfEd0AAAABIAZ5/akf/AAAoyDrM4epmQS6HlF92h1lnsgp670iYKlYMBeI9jOg7p/0KkgOl8LHqPcnaILPnw7zRsayhdNs9uhg/HReVJc3pAAAAhUGaYkmoQWyZTBRMM//+nhAAAE97laxABEx76GklYTKziiAs+Nhqa8gl2TUYSAcX9R7BppLZyi/6zZoFreS9ePunIScLeHxcu+mb1VuJLNfkfkX8kjYCm/hdQMs3tVKqfNRnd4+eHgD2Rsdx/luLWQ4TY98+2uhZqnLDJKyV7+nTd8kBKTAAAAA3AZ6Bakf/AAAoYCBZIf1/6TsWGkbGi1szqSCyLXHlIBqx849T7/HRtr5n1dHU5qD+W869VjvdSQAAAGlBmoZJ4QpSZTAhn/6eEAAAT3u5dTB0ZdJSRTzowjMGJ92W9o6P/VdabQJGvxWMhtFbHnK3zj84/dLe/Sd8niABEgDSDO2k2UHWrgu2Qm1Wk7DK2XCZYUPxvJA9BNHhoAJs4xHECOJm/0kAAAA4QZ6kRTRMI/8AABnIm4K1bwRts78AlUNjT0afnepoh+H5haoseNDZQOCcFBodvbiNuBmsLUhSNd0AAAAtAZ7DdEf/AAAo+1fwEGbk6iyX9cNjQ8P6KOE8nUfW1Xw0uV0sR4MEE+7Yteu5AAAAOgGexWpH/wAAKOVV00e2qp7+1XJbvpI6KdMTndAg+etQVqVSX1gl/N1wcZweX3b5VRWCvBGksp3oTh0AAABuQZrKSahBaJlMCGf//p4QAABRq3EOO8AHReoNi7zll0HwBiF4hD3Mpb03jhxaP0wyP4UkRUJtxnrxhRIhXYQ041LLWr3s1W/soh3PTRXMNOK/yLZaSc1cD8tzTXOTM/69Z6ka3fepGbGPebboZkEAAAA/QZ7oRREsI/8AABppVL4/i5K9jAbAIVBIyOXFGa3HnCa8B2Ae7AuDNYXrWlw1eihp0AYlf/EtZeA+S2+MS/8uAAAAQwGfB3RH/wAAKNjnzR2AjThVoASXYF5k2Pi6aTPWi7f3iyZ1Xa/AJCY1p0ofi+5j/lMbmXEu4ll44jAV3cFXaQjm2HAAAABBAZ8Jakf/AAAqFzImivUF0OdqUAJZTc3gN6+v83znafXoXfRQDWESd7m9gFse+zVDElasA6f4Dg8w3/d5hdFBOv0AAABTQZsOSahBbJlMCGf//p4QAABRqtIaAAsEv50F8DX2Ij5bIh4f8fvHXiR70/tw5lH+grfukkushh7E0GD68UnR69j/6+p4FB/6PiujwU8f8ivQecAAAAA2QZ8sRRUsI/8AABproyKcbgcQAIwHG/+mVluhjxvtQ470x9qPm4Q/UB5K91v4FInlPdCyV9MuAAAAOQGfS3RH/wAAKgBYm0fTIoAFvEt0nnUIWjdgsr8Prk3QsQLd46d+vfMplbzhOZc4fc9A7HTkvKKHzQAAAB4Bn01qR/8AACoXqJ489taLqodm6vJ5l4TcOumrxl0AAABgQZtSSahBbJlMCF///oywAABSfLEsqSa9LpLBjvxT0QgwKHBwYFLB5D17B6PvNFAtc7xhsIZ7puoE5LYN8Qx4t4jv4hrFHqCdfqAJm2hmmG73RjSGoAPO3pl+pHx6SMOTAAAALEGfcEUVLCP/AAAaaMqUZI3TQA0dfhlHlorCaLp2EwyNREThWgwwCgVNQzhwAAAALAGfj3RH/wAAKhC3pQNnFoXCbSbeQgs3wUzyG8AITKdywPTmH8f0CuF3YGSAAAAAHwGfkWpH/wAAKgmAcNyg1sW1EWtr+jxQlMtzdGBhGSEAAAC4QZuWSahBbJlMCF///oywAABSoHlKgC9IgCO1qCSgCoQBSpdffGLxu4fv6SKjRk5Yc1Txq+TN8Ak+heqrM7NliNWdyT36EsG5NOo0iDgf23HSIPNZ6SzNXPx78W64UCfrDa21ACIrCF+6i/+lr9fxRWoSNo6lBryhUieuW5oQmLYcYsdZoYrg84ytTrQ7aDy/eh3coDAcrBxYIy0Yog9J02oSjEYMZLs0cyvj4UzBFSbgKNUlILOD0AAAAEtBn7RFFSwj/wAAGlPVMMI1X2N4QAmrqVz2fX7Gs7YoWWTCsiWK9av3y3sJQzW9l/VxL/t7ewfpwFU99Dk9N/XpBFIhs9f3aNjBoZIAAAAeAZ/TdEf/AAAqG1cmKFbOMOBorSqE4QGy/Cy7U7uBAAAAQAGf1WpH/wAAKX77yjZ5oO8ADi3TY1ZGzUMM3wySTCjv5672K7eKtB//QYAJ1c0+A9vnSYi5NTOqgf1iHii2NUAAAACxQZvYSahBbJlMFEwz//6eEAAAVHmXP+HPSXBdAJ0EkJZtU5v05Lgy+wAmXKpTXS7/qUYqEjUk8u9v7LfZ2ZCFHbQE/yYBcn7AgqZK1JANZ4aLE2D8VZXKzOqxWlrJLJ4P1HYbD90/QVVTYyRgi1sxrmTpniEwFVVjTZhmAfNgP77mctQY8zavdO4fIN7z8tLLIAac1I2NZnfb8cS+Ie1qsOVJ1cIi7Kn0irXtSuUv/tnBAAAAMwGf92pH/wAAKchx+Ad7m4b1qIVj2fdTgQOyuybLCdCnRNmOwj/Vfs7E7fZYn/AOFg2u4QAAAJlBm/xJ4QpSZTAhf/6MsAAAVKn63dXzPoAI7VVLkQoJGQFhdQrkyA8ud+edhQzzmlgoZAXF7vyfwU6nJ7Gg2mOZdziBEYzZPb9vtlsUhQfXgVoeQ3eDpspGGMdKOldvYRKbUfpFjmeivxFWB3IdYhow1HRipeZO+684iYdWIijGrt3cLpk6y+s7dFRrWH+YmmgKjWZsMwAx8QYAAABTQZ4aRTRMI/8AABsJeR3FwVbsJU5rRC0zHnRRgSHnuB0KnMj2U3Z40lKtDkf6YtQ3tijLyJrRklIbwwCqnhSKcCNwXR/cSFDkiZ0QM2ea6XwJHDkAAABWAZ45dEf/AAAqG1fC9mkGxo+IqF4T+1MDzhaAjGJaAaR/glRAnHiL803vfnG8u/ze8E6rU5XV8suwcDJUH7n1OL8jfSKn2gzJp3mbDn++lWhUwYTzWHAAAAAzAZ47akf/AAArOW44rG1hGPENuoA7zNw7dsfd/ITX3hvWDJteXJ0ejESsRFMa9HlG+sy5AAAAZkGaIEmoQWiZTAhf//6MsAAAVMK6ZaVR9RPkLR7Pw/gNhJk5zCDH+NwKnIVeQqDVRUfD/yV9ToWpEcVKPdlt+7/0wTo1QZpihnPIGAZr4b7u9KNIAcdcnKFwlvMDRcfkfojsaSzkUQAAAE1Bnl5FESwj/wAAGwjKd4zpuXYhSVMfk75SsdpNzNCof3qN/VZDj93J+E0ygAIyOsj4EBgwEvNnWx/FKzUOTbd1vS14a8YRy6YVMoF1+AAAADYBnn10R/8AACs+NOFa4GMRog08cgkF3o7BeF4eFsGz8JFZVA2fig+KCtec3VWWCxpye5mA93AAAAA9AZ5/akf/AAArN6ieLWLHVGzACcn6YmvPE+uRWhPTGi1+b3jDClitx0xt3n4ABD2UeEay09qq7DHCA69fgQAAAGBBmmJJqEFsmUwUTDP//p4QAABT7AU/vTTI9TxLaMqm/zgNVXK89mP2tQhJy+QeeOXXeysCJQAOC+PwSi9Xg+UCvWyNcEceKOEHd7FtTqwGR578PbfVxlO9S7L1cg38FeAAAAAuAZ6Bakf/AAArJVPTPO/EVIVCtmDqAuLowRH59CyCEKnRSKpEKq9oVlpwvMAWHQAAAIBBmoZJ4QpSZTAhn/6eEAAAU+sL2gALD637E2Koyt1WyvYCZHJcidqK8mGTY5t+3v2rjZpOzfJTvbeAnqhHNm9tTpxebhvTAi06hsd0S//DIhfIu/5Gfha3u5EYPo7qScnmuIgJpge+cn2zKobWBXVotOlK6lh0CIVA+vFboi0UXwAAAF1BnqRFNEwj/wAAGv/sHuUwPm2i/0d3B6qlGaRpLDJZo+WUUZeZ8+OI9Zi2AALrbZvRZNmt1ZurMutfVXTYKseUbOzIozVURTx357dBP/YbfVgTv5kNElged94/UXEAAABEAZ7DdEf/AAArIrQinEI7fxfoZn+ntlpKjt1N+WElN3Eaj3IGd7SV3oKwnfKO3gBKk99G+sNkMdoQB4OXzHFt2KJs0tkAAAA+AZ7Fakf/AAArJVSDU/JVvUlDzSyq+14tC/qtd0F/B8tmiX5hRZcEKeW3vzv/xfHlLG3sSJjeoOwcJEVxq2kAAABlQZrKSahBaJlMCGf//p4QAABT6wvaAAXQaNkwtL/aTXz/aQcId72/Lw6odwUNl1lBSqwirrifqNsfkmBBHkfO/yO/tz7PKXONDyo4KPXqsqSwph6ioGccW2RKO/pW43lrSseGaVEAAAAxQZ7oRREsI/8AABr/6+i0PpwAu8P5kOhE+deuIljLLcwUnxpF2v3P6b9HFEBRV0XUwAAAADYBnwd0R/8AACs7VlBl4Sl+sOmChKgtUrJ9z9Oq8DzupwkRT7OsyLx3b5HgCj6MGRRqKrmiPMAAAAAjAZ8Jakf/AAArJVQQNHhEzczbkKW8rfXr8uS+HEba2XND9bUAAADBQZsOSahBbJlMCGf//p4QAABUNg7iAKS2ABxaXCvFZd6r2GetcioS8P1vbmgCsjIzLNN7wGWmtHJ8dKoAVffxi3Ao1GN1dRFXnPeK8VPO2ZOpMg19xb+7eQxHr7eHux1ZNb5jByi/d0OmIfiqoIfR79it2NhsOUCx5pCdXS2mIgqBVMaGhibYRRfOugrXODgJtYQrVuZLaLnushkocnQD0MFJcx8p1m2x+1rLGTEzRSdofoNjmxp8Vd+w2wYtmHFQIAAAAFJBnyxFFSwj/wAAGv/sj6pZNf+j3AC3ABsvwqI3WD86W2NbMyayyY8dvRocjm9aYUKCyYBVim5LEMNNHtTs0gov9u/H0T9gwWen9JyFhnHNQlbQAAAALgGfS3RH/wAAKweqgjw46UNPTMXgnrgnnyxkYLbrrCXmWT7CMiESOg/IbV9c6SEAAAA/AZ9Nakf/AAArJVXs9TyLqiWa7fxK4SYFZ4gc4rSeADgqWGumFroLzOlKcMvMrv+p/ixme+sxYQOBQLEN3MrLAAAAeUGbUkmoQWyZTAhn//6eEAAAVitec8gDlvZjO8KPQmYbDseDgBlQRf4YaFEn0Vy34uPXaiyR9rW62mh19b+Pgh5/3+Q+RZ2tyJGqv3GrJtRMlvhCK53QgjacB82+ja+IB0lYDVs4+/bqpSdGKWRewYevP/XDngCZSVEAAABWQZ9wRRUsI/8AABuf7ESlyhrk9ZSsKBXYzW6gFmoos64o93uhHyNAFSLzXKZPdJMf7CbmLnfok2bMp157AFeTYvLw/aXUubATGzB0hXHkIux8dMv5jWUAAAAyAZ+PdEf/AAAsXlnm1eTSon44P95XAhO9EFu1k2AJvmlg1XmcyyjsDRNOQFIMOWs6VVgAAAA7AZ+Rakf/AAAsV6iFk3EMnj6JPQTjWLRTvmBDPWN1rzdRDsMEzjD3aVofWScq2xc5l/YMZYkkn0gK2ssAAADWQZuWSahBbJlMCF///oywAABW/NXlAYAdIqF6MOg/9ZunfdlVlOW/NwQ8BjGw61dQEQ8TbsvdlbuvvTPtgxcS0gnnEzZzBAKzA4Tzwal2e6O/rImARY6fHZmpm6zvOmUVP6KKSwaSgaOrpmRR7EE3fLO6Fc68ED8V9brLctiHaEJVNLDE4eMMC4YM23ISOUw4CJlK+ldRvKSZicipauoYyjgRLOJLmf2x+LOREdddHjJf81ZNiPYYGD2VlSA32xK/yvG4fm2CU7HmsS6T5zEux6G5/IUM9gAAAGpBn7RFFSwj/wAAG6CH+3CMcUZ9SplfQJncTwMPL13eWrwgADjJnLb1G3HizIOimGkz0dzk1lQupnHT0bd6MtzFgKrhE1l6BeneLRRuFRpz41iwqlq4x9og1d0fViaeFQqsktnbC4ZQlmkgAAAATgGf03RH/wAALEBY92F/nWxLa/QEIpuLNitdkQISj7mFnPABaiX0i4/Lzcl/IXDkKDmpHw1BqVOZg4KCzS2QqrgnkOAE9hq/0UHCE/VfLwAAAEABn9VqR/8AACslVjhbi5pzL9gvs9hMm4c/NClBdLUDyr5oQyc7SoVNvxKmew+AWTD4nuPc4in5r7s8UXl4Ui1AAAAAXkGb2kmoQWyZTAhf//6MsAAAVxhP1MwAsPqUJbzKhVHzvjqRRDmzGAoWEOw3niNP3EHVu7Ib2CDOjERgTLXeyroqShgMdzAQecX6da5998FHx6mExQG1t2Je0Buss7EAAABCQZ/4RRUsI/8AABugVMYMwtbLfAWHvSDCCu9JNWu2YTuIUuJKOBMZc0CN2n60aDpFmRds6GXyKYZbWPRTyZynbxahAAAANQGeF3RH/wAALFtXJihXfbKrS+0LbyMcSonkqTjuhypQ+Sydg1pUGGDwGtSq54BGK5UVp4K8AAAAOQGeGWpH/wAAK1bigBzFytVZqgyDCSC8MokuWpW9GADI0PvY4FgWQHV/K0Kjyyg/6flUSAD3oJG6twAAAH9Bmh1JqEFsmUwIX//+jLAAAFc3UmC4bADjkMcargaQgHQ3c238z2nt8bp2RiK2+O2fMS/qbs4Y1ad/xnyFAIHEbYLi1fNhIKX0iEXHUyT0v3ORrHfqGk6iT0HTw7GRNGzuXD0/ap1DXvBzWPXR50+6g51BW2SZEs2gAhzHsAdAAAAAP0GeO0UVLCP/AAAblyPElCOYQZtnNMlXJ4GjBoV/fAirDBVZhid9xtEALfUPjHOg/ODt8wwNv/xQxN+/zAdQgQAAADMBnlxqR/8AACu+fmejJFQkIbKxJak4JYBvLhdesZn6ujKOaODCbE0a7LfPd6VMsacJukEAAABiQZpBSahBbJlMCF///oywAABW6XtggAtPkgp8//fEi5h1XVG/Nv3ac8YbthKizN8w9Ziyo+V4uV+zwn2FuvPmP+jzHWbOz2Mz3NUQfvmNtWsOk7CnGuzJw8QGZlV1cMEDLZwAAABZQZ5/RRUsI/8AABuP2gF8fgH8ZHPGkyoKCBG7QrDvBHPKYX94ACM0sWO7gWbjzFTos+WSYkW0SmO3ZOj/ftv6ajmEGPRX4SyvP+CN6klvnqVTY0I63hBcuoQAAAA7AZ6edEf/AAAtfioNqCW6xJMgKm2/EWRT36dnkF0sMlM7qexTlUDJkwDRmfIAQmjl2iULU9AzZZNY2bkAAAAuAZ6Aakf/AAAthAdPxe8agMnaPrf3CtZ1m1yhM7fp+9b38ZHdF1LANtXDccYtQAAAAIhBmoVJqEFsmUwIX//+jLAAAFlCuqm2OoBdMWegAWus6V8pWkLjwm9fbFycNxhxhg8j8sWbMLohnD2H8rpmpnzi3nRq0yUEe2UHKcWKnGWwzyHZtNdShtK2qseZyUUOjp6lg/5yc9nDMIKfPd3Fp/Hffh3amp1VMfTRk3edv2ojp1jdo/ucizqJAAAAPUGeo0UVLCP/AAAcW2X7H7Cn4bB2Kyy5eepGesMfCkO23QT40kHt5Q9NaMbTohvowgquQu3iQXw/awocNWwAAABJAZ7CdEf/AAAtYo64xEdVdbTGmM+RmXChTwpLPjCK9WjLBXDFhIAEtTIlwu/9mEptxEZT9GOBh1nPBjjyHR1jurFVYKCm9bH10wAAAD4BnsRqR/8AAC15WBT7qrB3DWvsHlpSIzCdD40TN8QxHiyiW22CgBHBJtuUSa0YhU2da1Uc8N7tJk2oKyaN0wAAANNBmshJqEFsmUwIV//+OEAAAVjmW5TFNAA43lUCrBtsBI8fVIrSacue2LMmy+nsG7PI5dmA7YLLkV01BChogpMtuzEEPJFic6YFoB8v3UwUvsJyPnbAgFCegR8BNc5eELTrCUQGwXZYtGzB2TdY+UbX+lq2B2OXk8cZzM7hc0zKkTQZmdoRUAFVlV7s91T+x+POuZfBrB7nQABHe234A1GQUUwbgq29k4XvFeJTvYxui4Ov+xfL0InXBh4vlm/KxZMEtd7kSMWHAjtGnkKOQrDv06lhAAAAQ0Ge5kUVLCP/AAAcTQVEaKOOEgA4oHITjZH1RGv/i8zgmyYccCW6XREEjcf4bGoc9lC2QpTluF8weJ2WgNbyZjP46tkAAABFAZ8Hakf/AAAtZVSDU/GyVI+lIAHAz82Z3EU3sc9tZZih1emAC9AQzfu8EQKN61xbdXTd0+f9q3FLomiKrJ7zreofGVQgAAAAm0GbCkmoQWyZTBRMK//+OEAAAViQpv3RsM6D9yGbyvpojA6PoAa5dUq8ZWPy0wkEr/0RnR5UgUKncgcc6WJ5/2t7Pr/kTanPLi9ysI9AsupC/EHSEUxwCn/q+xvH2cW3cCgklQbqWkuAWYDs6m2Ilh4GSWhWnPVc/iMl7DAX3Lz2rKd85WDOPGUBhFljxz6hq/Rz2AO5m26fXLKAAAAAWAGfKWpH/wAALXeE8fQGEQLIDZs1hcMAIZdvOTzratCUlAArHMzqIy++SgXwDEhEADueHsCDDYAJk0BjmcpXueY/maeWDIvXaavqWMFV9XZlczl1QZlDllEAAAC9QZsuSeEKUmUwIR/94QAABT+mojzHdADP+EH0N0GVVLtMfXH1NZYhqqSytGkAZOAH/+5t+IXD/tLvYKYwitAQLlYkUaFet/w1Gh3E8XjwtsQNfLMr+M4RwOi7u6kxSY6R5EL1Yd3J/FhqofuvrTWJAYVQTM2J5TS/0sBZybH78P8C4cO/V2zHDZnXWQ7iNKK/4woPwSdK8X2XtQ1DXvxOVHyBMNeqVQhxTvtvx4zO4SCBIIBN4UO3l/AlUZ76AAAAcUGfTEU0TCP/AAAcP5YCXHs+j/sP+YrQ7S3EOKOy+utWZZCUcghsn2PqO77ToXq8RraYgMIPo9VvDAuYESQbpsLu2Fuwp+r3EANj/PaXTaPQTw9dGp3JAUs9DDuuuLnSsr5e4nfYKww+PluTGRES0jvwAAAARQGfa3RH/wAALUgp8OsIPb5QohxH3wAuF5t/qDmOE3X1uYSJNu8UTAZhP27B4vNsxACXU9xYi/gDDhHUiL/Zo3ubhvcFuQAAAEIBn21qR/8AACvQjowP2EW+IuBXvgzTkJzb30DrDbjZPikHBaI4p1FkZvgrf4lhQTnnFnfXDCE4axpI8NGAZWvLF+EAAABiQZtvSahBaJlMCP/8hAAAFHrc9IUIoey9rKRTaOrVCRCjhn7j4Qlf0oZf3Vyf+wn11dYef6YrUcDCW+CZmejmXdT0FJxu1wYAWwspRHiuwFPn+Sbcil0mnDTp2bnWMFfJLHEAAAszbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAADcAAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAACl10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAADcAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAlgAAAGQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAA3AAAACAAABAAAAAAnVbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAyAAAAsABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAAJgG1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAACUBzdGJsAAAAmHN0c2QAAAAAAAAAAQAAAIhhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAlgBkABIAAAASAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGP//AAAAMmF2Y0MBZAAf/+EAGWdkAB+s2UCYM+XhAAADAAEAAAMAZA8YMZYBAAZo6+PLIsAAAAAYc3R0cwAAAAAAAAABAAAAsAAAAQAAAAAUc3RzcwAAAAAAAAABAAAAAQAABXBjdHRzAAAAAAAAAKwAAAABAAACAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAgAAAgAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAIAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAEAAAAAAIAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAACAAAAABxzdHNjAAAAAAAAAAEAAAABAAAAsAAAAAEAAALUc3RzegAAAAAAAAAAAAAAsAAABOcAAADaAAAAbwAAAEYAAAA3AAAAcQAAAFQAAAAqAAAAPgAAAIUAAABEAAAAPgAAADgAAABrAAAAOgAAAD8AAAAwAAAAWQAAAD4AAAA0AAAAMwAAAIkAAAAyAAAAJQAAABwAAAB5AAAALQAAAK8AAABSAAAAPgAAADEAAABPAAAAXQAAAEMAAAAtAAAAWgAAAHIAAABsAAAASAAAADoAAAA0AAAAYQAAADkAAAByAAAAPgAAAC4AAAA+AAAAZgAAAGYAAABIAAAARgAAADUAAACGAAAAOwAAAD8AAAA1AAAAfwAAADkAAAAyAAAAOAAAAGIAAABWAAAAUQAAADwAAACVAAAANQAAAC0AAAA7AAAAdwAAAEsAAABOAAAAOQAAACgAAAAoAAAAQgAAADwAAAAnAAAAMwAAAIIAAABHAAAAKwAAADIAAACoAAAAQAAAADQAAABLAAAAfwAAAEkAAAA/AAAAlgAAAFIAAAA2AAAANgAAAL8AAABoAAAASwAAAEwAAACJAAAAOwAAAG0AAAA8AAAAMQAAAD4AAAByAAAAQwAAAEcAAABFAAAAVwAAADoAAAA9AAAAIgAAAGQAAAAwAAAAMAAAACMAAAC8AAAATwAAACIAAABEAAAAtQAAADcAAACdAAAAVwAAAFoAAAA3AAAAagAAAFEAAAA6AAAAQQAAAGQAAAAyAAAAhAAAAGEAAABIAAAAQgAAAGkAAAA1AAAAOgAAACcAAADFAAAAVgAAADIAAABDAAAAfQAAAFoAAAA2AAAAPwAAANoAAABuAAAAUgAAAEQAAABiAAAARgAAADkAAAA9AAAAgwAAAEMAAAA3AAAAZgAAAF0AAAA/AAAAMgAAAIwAAABBAAAATQAAAEIAAADXAAAARwAAAEkAAACfAAAAXAAAAMEAAAB1AAAASQAAAEYAAABmAAAAFHN0Y28AAAAAAAAAAQAAADAAAABidWR0YQAAAFptZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAAC1pbHN0AAAAJal0b28AAAAdZGF0YQAAAAEAAAAATGF2ZjU3LjgzLjEwMA==\" type=\"video/mp4\" /></video>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Display the video in the jupyter notebook\n",
+    "# Click the play button below to watch the video\n",
+    "import io\n",
+    "import base64\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "video = io.open('./gym-results/openaigym.video.%s.video000000.mp4' % env.file_infix, 'r+b').read()\n",
+    "encoded = base64.b64encode(video)\n",
+    "\n",
+    "vid_ascii = encoded.decode('ascii')\n",
+    "HTML(data='''\n",
+    "    <video width=\"360\" height=\"auto\" alt=\"test\" controls><source src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\" /></video>'''\n",
+    ".format(vid_ascii))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "2fiQesIZlnTd"
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "trpo_gym_tf_cartpole.ipynb",
+   "provenance": [],
+   "toc_visible": true,
+   "version": "0.3.2"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/examples/np/cma_es_cartpole.py
+++ b/examples/np/cma_es_cartpole.py
@@ -8,7 +8,8 @@ Results:
     RiseTime: epoch 38 (itr 760),
               but regression is observed in the course of training.
 """
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.algos import CMAES
 from garage.np.baselines import LinearFeatureBaseline
 from garage.sampler import OnPolicyVectorizedSampler
@@ -17,16 +18,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def run_task(snapshot_config, *_):
+@wrap_experiment
+def cma_es_cartpole(ctxt=None, seed=1):
     """Train CMA_ES with Cartpole-v1 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-        *_ (object): Ignored by this function.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
         policy = CategoricalMLPPolicy(name='policy',
@@ -47,8 +51,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=100, batch_size=1000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+cma_es_cartpole()

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -5,7 +5,8 @@ Here it creates a gym environment CartPole, and trains a DQN with 50k steps.
 """
 import gym
 
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.exploration_strategies import EpsilonGreedyStrategy
 from garage.replay_buffer import SimpleReplayBuffer
 from garage.tf.algos import DQN
@@ -15,16 +16,19 @@ from garage.tf.policies import DiscreteQfDerivedPolicy
 from garage.tf.q_functions import DiscreteMLPQFunction
 
 
-def run_task(snapshot_config, *_):
-    """Run task.
+@wrap_experiment
+def dqn_cartpole(ctxt=None, seed=1):
+    """Train TRPO with CubeCrash-v0 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-        *_ (object): Ignored by this function.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
         n_epochs = 10
         steps_per_epoch = 10
         sampler_batch_size = 500
@@ -59,4 +63,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
 
 
-run_experiment(run_task, snapshot_mode='last', seed=1)
+dqn_cartpole()

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -10,7 +10,8 @@ Results (may vary by seed):
 import gym
 import tensorflow as tf
 
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.exploration_strategies import OUStrategy
 from garage.replay_buffer import HerReplayBuffer
 from garage.tf.algos import DDPG
@@ -20,16 +21,19 @@ from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
 
 
-def run_task(snapshot_config, *_):
-    """Run task.
+@wrap_experiment(snapshot_mode='last')
+def her_ddpg_fetchreach(ctxt=None, seed=1):
+    """Train DDPG + HER on the goal-conditioned FetchReach env.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-        *_ (object): Ignored by this function.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    set_seed(seed)
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
         env = TfEnv(gym.make('FetchReach-v1'))
 
         action_noise = OUStrategy(env.spec, sigma=0.2)
@@ -78,4 +82,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=50, batch_size=100)
 
 
-run_experiment(run_task, snapshot_mode='last', seed=1)
+her_ddpg_fetchreach()

--- a/examples/tf/reps_gym_cartpole.py
+++ b/examples/tf/reps_gym_cartpole.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with REPS algorithm.
+"""This is an example to train a task with REPS algorithm.
 
 Here it runs gym CartPole env with 100 iterations.
 
@@ -12,7 +11,8 @@ Results:
 
 import gym
 
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import REPS
 from garage.tf.envs import TfEnv
@@ -20,9 +20,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def run_task(snapshot_config, *_):
-    """Run task."""
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+@wrap_experiment
+def reps_gym_cartpole(ctxt=None, seed=1):
+    """Train REPS with CartPole-v0 environment.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
+    """
+    set_seed(seed)
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
         env = TfEnv(gym.make('CartPole-v0'))
 
         policy = CategoricalMLPPolicy(env_spec=env.spec, hidden_sizes=[32, 32])
@@ -39,8 +49,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=100, batch_size=4000, plot=False)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+reps_gym_cartpole()

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with VPG algorithm.
+"""This is an example to train a task with TRPO algorithm.
 
 Here it runs CartPole-v1 environment with 100 iterations.
 
@@ -8,7 +7,8 @@ Results:
     AverageReturn: 100
     RiseTime: itr 13
 """
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
@@ -16,9 +16,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def run_task(snapshot_config, *_):
-    """Run task."""
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+@wrap_experiment
+def trpo_cartpole(ctxt=None, seed=1):
+    """Train TRPO with CartPole-v1 environment.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
+    """
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
         policy = CategoricalMLPPolicy(name='policy',
@@ -38,8 +48,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=100, batch_size=4000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+trpo_cartpole()

--- a/examples/tf/trpo_cubecrash.py
+++ b/examples/tf/trpo_cubecrash.py
@@ -6,8 +6,9 @@ Here it runs CubeCrash-v0 environment with 100 iterations.
 import click
 import gym
 
+from garage import wrap_experiment
 from garage.envs import normalize
-from garage.experiment import run_experiment
+from garage.experiment.deterministic import set_seed
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.envs import TfEnv
@@ -15,19 +16,22 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalCNNPolicy
 
 
-def run_task(snapshot_config, variant_data, *_):
-    """Run task.
+@click.command()
+@click.option('--batch_size', type=int, default=4000)
+@wrap_experiment
+def trpo_cubecrash(ctxt=None, seed=1, batch_size=4000):
+    """Train TRPO with CubeCrash-v0 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-
-        variant_data (dict): Custom arguments for the task.
-
-        *_ (object): Ignored by this function.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+        batch_size (int): Number of timesteps to use in each training step.
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
         env = TfEnv(normalize(gym.make('CubeCrash-v0')))
         policy = CategoricalCNNPolicy(env_spec=env.spec,
                                       conv_filters=(32, 64),
@@ -54,28 +58,7 @@ def run_task(snapshot_config, variant_data, *_):
                     flatten_input=False)
 
         runner.setup(algo, env)
-        runner.train(n_epochs=100, batch_size=variant_data['batch_size'])
+        runner.train(n_epochs=100, batch_size=batch_size)
 
 
-@click.command()
-@click.option('--batch_size', '_batch_size', type=int, default=4000)
-def _args(_batch_size):
-    """A click command to parse arguments for automated testing purposes.
-
-    Args:
-        _batch_size (int): Number of environment steps in one batch.
-
-    Returns:
-        int: The input argument as-is.
-
-    """
-    return _batch_size
-
-
-batch_size = _args.main(standalone_mode=False)
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-    variant={'batch_size': batch_size},
-)
+trpo_cubecrash()

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -2,7 +2,8 @@
 """An example to train a task with TRPO algorithm."""
 import gym
 
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
 from garage.tf.envs import TfEnv
@@ -10,9 +11,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def run_task(snapshot_config, *_):
-    """Run task."""
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+@wrap_experiment
+def trpo_gym_tf_cartpole(ctxt=None, seed=1):
+    """Train TRPO with CartPole-v0 environment.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
+    """
+    set_seed(seed)
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
         env = TfEnv(gym.make('CartPole-v0'))
 
         policy = CategoricalMLPPolicy(name='policy',
@@ -34,8 +45,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=120, batch_size=4000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+trpo_gym_tf_cartpole()

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-This is an example to train a task with VPG algorithm.
+"""This is an example to train a task with VPG algorithm.
 
 Here it runs CartPole-v1 environment with 100 iterations.
 
@@ -8,7 +7,8 @@ Results:
     AverageReturn: 100
     RiseTime: itr 16
 """
-from garage.experiment import run_experiment
+from garage import wrap_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import VPG
 from garage.tf.envs import TfEnv
@@ -16,9 +16,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import CategoricalMLPPolicy
 
 
-def run_task(snapshot_config, *_):
-    """Run task."""
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+@wrap_experiment
+def vpg_cartpole(ctxt=None, seed=1):
+    """Train VPG with CartPole-v1 environment.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
+    """
+    set_seed(seed)
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
         env = TfEnv(env_name='CartPole-v1')
 
         policy = CategoricalMLPPolicy(name='policy',
@@ -39,8 +49,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=100, batch_size=10000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+vpg_cartpole()

--- a/examples/tf/vpgis_inverted_pendulum.py
+++ b/examples/tf/vpgis_inverted_pendulum.py
@@ -5,8 +5,9 @@ Iterations alternate between live and importance sampled iterations.
 """
 import gym
 
+from garage import wrap_experiment
 from garage.envs import normalize
-from garage.experiment import run_experiment
+from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
 from garage.sampler import ISSampler
 from garage.tf.algos import VPG
@@ -15,16 +16,19 @@ from garage.tf.experiment import LocalTFRunner
 from garage.tf.policies import GaussianMLPPolicy
 
 
-def run_task(snapshot_config, *_):
-    """Run the job.
+@wrap_experiment
+def vpgis_inverted_pendulum(ctxt=None, seed=1):
+    """Train TRPO with InvertedPendulum-v2 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): Configuration
-            values for snapshotting.
-        *_ (object): Hyperparameters (unused).
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
-    with LocalTFRunner(snapshot_config=snapshot_config) as runner:
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
         env = TfEnv(normalize(gym.make('InvertedPendulum-v2')))
 
         policy = GaussianMLPPolicy(env_spec=env.spec, hidden_sizes=(32, 32))
@@ -47,8 +51,4 @@ def run_task(snapshot_config, *_):
         runner.train(n_epochs=40, batch_size=4000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+vpgis_inverted_pendulum()

--- a/examples/torch/trpo_pendulum.py
+++ b/examples/torch/trpo_pendulum.py
@@ -5,26 +5,30 @@ Here it runs InvertedDoublePendulum-v2 environment with 100 iterations.
 """
 import torch
 
-from garage.experiment import LocalRunner, run_experiment
+from garage import wrap_experiment
+from garage.experiment import LocalRunner
+from garage.experiment.deterministic import set_seed
 from garage.tf.envs import TfEnv
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
 
 
-def run_task(snapshot_config, *_):
-    """Set up environment and algorithm and run the task.
+@wrap_experiment
+def trpo_pendulum(ctxt=None, seed=1):
+    """Train TRPO with InvertedDoublePendulum-v2 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-            If None, it will create one with default settings.
-        _ : Unused parameters
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
+    set_seed(seed)
     env = TfEnv(env_name='InvertedDoublePendulum-v2')
 
-    runner = LocalRunner(snapshot_config)
+    runner = LocalRunner(ctxt)
 
     policy = GaussianMLPPolicy(env.spec,
                                hidden_sizes=[32, 32],
@@ -47,8 +51,4 @@ def run_task(snapshot_config, *_):
     runner.train(n_epochs=100, batch_size=1024)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+trpo_pendulum(seed=1)

--- a/examples/torch/vpg_pendulum.py
+++ b/examples/torch/vpg_pendulum.py
@@ -8,26 +8,30 @@ Results:
 """
 import torch
 
-from garage.experiment import LocalRunner, run_experiment
+from garage import wrap_experiment
+from garage.experiment import LocalRunner
+from garage.experiment.deterministic import set_seed
 from garage.tf.envs import TfEnv
 from garage.torch.algos import VPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
 
 
-def run_task(snapshot_config, *_):
-    """Set up environment and algorithm and run the task.
+@wrap_experiment
+def vpg_pendulum(ctxt=None, seed=1):
+    """Train PPO with InvertedDoublePendulum-v2 environment.
 
     Args:
-        snapshot_config (garage.experiment.SnapshotConfig): The snapshot
+        ctxt (garage.experiment.ExperimentContext): The experiment
             configuration used by LocalRunner to create the snapshotter.
-            If None, it will create one with default settings.
-        _ : Unused parameters
+        seed (int): Used to seed the random number generator to produce
+            determinism.
 
     """
+    set_seed(seed)
     env = TfEnv(env_name='InvertedDoublePendulum-v2')
 
-    runner = LocalRunner(snapshot_config)
+    runner = LocalRunner(ctxt)
 
     policy = GaussianMLPPolicy(env.spec,
                                hidden_sizes=[64, 64],
@@ -50,8 +54,4 @@ def run_task(snapshot_config, *_):
     runner.train(n_epochs=100, batch_size=10000)
 
 
-run_experiment(
-    run_task,
-    snapshot_mode='last',
-    seed=1,
-)
+vpg_pendulum()


### PR DESCRIPTION
`run_experiment` is deprecated, clunky to use, makes debugging a pain, and requires weird workarounds.
But people keep using it because it's in the examples, so update all the examples not to use it.