### PR TITLE
Extend 2019.10 maintenance window

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Our testing strategy has three pillars:
 ## Supported Releases
 | Release | Build Status | Last date of support |
 | ------- | ------------ | -------------------- |
-| [v2019.10](https://github.com/rlworkgroup/garage/releases/tag/v2019.10.0) | [![Build Status](https://travis-ci.com/rlworkgroup/garage.svg?branch=release-2019.10)](https://travis-ci.com/rlworkgroup/garage) | June 30th, 2019 |
+| [v2019.10](https://github.com/rlworkgroup/garage/releases/tag/v2019.10.0) | [![Build Status](https://travis-ci.com/rlworkgroup/garage.svg?branch=release-2019.10)](https://travis-ci.com/rlworkgroup/garage) | October 31st, 2020 |
 
 Garage releases a new stable version approximately every 4 months, in February, June, and October. Maintenance releases have a stable API and dependency tree, and receive bug fixes and critical improvements but not new features. We currently support each release for a window of 8 months.
 


### PR DESCRIPTION
We missed the 2020.02 release, and are on track to release for 2020.06.
Our support policy specifies that releases should get about 8 months of
support, but this also implies an overlap of 4 months to switch from
older to newer releases.

To preserve this overlap, we should support the 2019.10 release for at
least an additional 4 months. Preserving support for the older release
also allows us and users to benefit from a very-stable and yet fairly
full-featured version of garage, giving us more freedom to improve APIs
in 2020.06 and 2020.10.

v2019.10 has proven to be pretty stable and easy to backport into, so I
don't expect this to cause much maintenance burden.