### PR TITLE
Use PathBuffer in off-policy algos

### DIFF
--- a/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
@@ -6,7 +6,7 @@ from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -60,10 +60,8 @@ def ddpg_garage_tf(ctxt, env_id, seed):
             hidden_sizes=hyper_parameters['qf_hidden_sizes'],
             hidden_nonlinearity=tf.nn.relu)
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec,
-            size_in_transitions=hyper_parameters['replay_buffer_size'],
-            time_horizon=hyper_parameters['n_rollout_steps'])
+        replay_buffer = PathBuffer(
+            capacity_in_transitions=hyper_parameters['replay_buffer_size'])
 
         algo = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
@@ -6,7 +6,7 @@ from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddGaussianNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import TD3
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -75,10 +75,8 @@ def td3_garage_tf(ctxt, env_id, seed):
             action_merge_layer=0,
             hidden_nonlinearity=tf.nn.relu)
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec,
-            size_in_transitions=hyper_parameters['replay_buffer_size'],
-            time_horizon=hyper_parameters['n_rollout_steps'])
+        replay_buffer = PathBuffer(
+            capacity_in_transitions=hyper_parameters['replay_buffer_size'])
 
         td3 = TD3(env.spec,
                   policy=policy,

--- a/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
@@ -5,8 +5,8 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic
-from garage.np.exploraton_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -62,10 +62,8 @@ def continuous_mlp_policy(ctxt, env_id, seed):
             hidden_nonlinearity=tf.nn.relu,
             name='ContinuousMLPQFunction')
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec,
-            size_in_transitions=hyper_params['replay_buffer_size'],
-            time_horizon=hyper_params['n_rollout_steps'])
+        replay_buffer = PathBuffer(
+            capacity_in_transitions=hyper_params['replay_buffer_size'])
 
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/benchmarks/src/garage_benchmarks/experiments/q_functions/continuous_mlp_q_function.py
+++ b/benchmarks/src/garage_benchmarks/experiments/q_functions/continuous_mlp_q_function.py
@@ -6,7 +6,7 @@ from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -62,10 +62,8 @@ def continuous_mlp_q_function(ctxt, env_id, seed):
             hidden_nonlinearity=tf.nn.relu,
             name='ContinuousMLPQFunction')
 
-        replay_buffer = SimpleReplayBuffer(
-            env_spec=env.spec,
-            size_in_transitions=hyper_params['replay_buffer_size'],
-            time_horizon=hyper_params['n_rollout_steps'])
+        replay_buffer = PathBuffer(
+            capacity_in_transitions=hyper_params['replay_buffer_size'])
 
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -14,7 +14,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -50,9 +50,7 @@ def ddpg_pendulum(ctxt=None, seed=1):
                                     hidden_sizes=[64, 64],
                                     hidden_nonlinearity=tf.nn.relu)
 
-        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                           size_in_transitions=int(1e6),
-                                           time_horizon=100)
+        replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -8,7 +8,7 @@ import gym
 from garage import wrap_experiment
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DQN
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -34,9 +34,8 @@ def dqn_cartpole(ctxt=None, seed=1):
         sampler_batch_size = 500
         num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
         env = TfEnv(gym.make('CartPole-v0'))
-        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                           size_in_transitions=int(1e4),
-                                           time_horizon=1)
+
+        replay_buffer = PathBuffer(capacity_in_transitions=int(1e4))
         qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
         policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
         exploration_policy = EpsilonGreedyPolicy(env_spec=env.spec,

--- a/examples/tf/td3_pendulum.py
+++ b/examples/tf/td3_pendulum.py
@@ -14,7 +14,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddGaussianNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import TD3
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -59,9 +59,7 @@ def td3_pendulum(ctxt=None, seed=1):
                                      action_merge_layer=0,
                                      hidden_nonlinearity=tf.nn.relu)
 
-        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                           size_in_transitions=int(1e6),
-                                           time_horizon=250)
+        replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
         td3 = TD3(env_spec=env.spec,
                   policy=policy,

--- a/examples/torch/ddpg_pendulum.py
+++ b/examples/torch/ddpg_pendulum.py
@@ -15,7 +15,7 @@ from garage.envs import normalize
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.torch.algos import DDPG
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -48,9 +48,7 @@ def ddpg_pendulum(ctxt=None, seed=1, lr=1e-4):
                                 hidden_sizes=[64, 64],
                                 hidden_nonlinearity=F.relu)
 
-    replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                       size_in_transitions=int(1e6),
-                                       time_horizon=100)
+    replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
     policy_optimizer = (torch.optim.Adagrad, {'lr': lr, 'lr_decay': 0.99})
 

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -232,16 +232,19 @@ class DQN(OffPolicyRLAlgorithm):
         del itr
         del samples_data
 
-        transitions = self.replay_buffer.sample(self.buffer_batch_size)
+        transitions = self.replay_buffer.sample_transitions(
+            self.buffer_batch_size)
 
-        observations = transitions['observation']
-        rewards = transitions['reward']
-        actions = transitions['action']
-        next_observations = transitions['next_observation']
-        dones = transitions['terminal']
+        observations = transitions['observations']
+        rewards = transitions['rewards']
+        actions = self.env_spec.action_space.unflatten_n(
+            transitions['actions'])
+        next_observations = transitions['next_observations']
+        dones = transitions['terminals']
 
         if isinstance(self.env_spec.observation_space, akro.Image):
-            if len(self.env_spec.observation_space.shape) < 3:
+            if len(observations.shape[1:]) < len(
+                    self.env_spec.observation_space.shape):
                 observations = self.env_spec.observation_space.unflatten_n(
                     observations)
                 next_observations = self.env_spec.observation_space.\

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -8,6 +8,7 @@ minimum value of two critics instead of one to limit overestimation.
 import numpy as np
 import tensorflow as tf
 
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.misc import tensor_utils
 
@@ -271,15 +272,28 @@ class TD3(DDPG):
             qval(float): Q value predicted by the q network.
 
         """
-        transitions = self.replay_buffer.sample(self.buffer_batch_size)
-        observations = transitions['observation']
-        rewards = transitions['reward']
-        actions = transitions['action']
-        next_observations = transitions['next_observation']
-        terminals = transitions['terminal']
+        # pylint: disable=fixme
+        # TODO: remove this check once HER uses PathBuffer.
+        # See garage issue #1338.
+        # pylint: enable=fixme
 
-        rewards = rewards.reshape(-1, 1)
-        terminals = terminals.reshape(-1, 1)
+        if isinstance(self.replay_buffer, PathBuffer):
+            transitions = self.replay_buffer.sample_transitions(
+                self.buffer_batch_size)
+
+            observations = transitions['observations']
+            rewards = transitions['rewards']
+            actions = transitions['actions']
+            next_observations = transitions['next_observations']
+            terminals = transitions['terminals']
+        else:
+            transitions = self.replay_buffer.sample(self.buffer_batch_size)
+
+            observations = transitions['observation']
+            rewards = transitions['reward'].reshape(-1, 1)
+            actions = transitions['action']
+            next_observations = transitions['next_observation']
+            terminals = transitions['terminal'].reshape(-1, 1)
 
         next_inputs = next_observations
         inputs = observations

--- a/tests/garage/sampler/test_off_policy_vectorized_sampler_integration.py
+++ b/tests/garage/sampler/test_off_policy_vectorized_sampler_integration.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 from garage.envs import normalize
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.sampler import OffPolicyVectorizedSampler
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
@@ -36,9 +36,7 @@ class TestOffPolicyVectorizedSampler(TfGraphTestCase):
             qf = ContinuousMLPQFunction(env_spec=env.spec,
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e6),
-                                               time_horizon=100)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 
 from garage.envs import normalize
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DDPG
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -34,9 +34,7 @@ class TestDDPG(TfGraphTestCase):
             qf = ContinuousMLPQFunction(env_spec=env.spec,
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e5),
-                                               time_horizon=100)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e5))
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -75,9 +73,8 @@ class TestDDPG(TfGraphTestCase):
             qf = ContinuousMLPQFunction(env_spec=env.spec,
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e6),
-                                               time_horizon=100)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
+
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -116,9 +113,7 @@ class TestDDPG(TfGraphTestCase):
             qf = ContinuousMLPQFunction(env_spec=env.spec,
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e6),
-                                               time_horizon=100)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -10,7 +10,7 @@ import pytest
 import tensorflow as tf
 
 from garage.np.exploration_policies import EpsilonGreedyPolicy
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import DQN
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -30,9 +30,7 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e4),
-                                               time_horizon=1)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e4))
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_policy = EpsilonGreedyPolicy(
@@ -72,9 +70,7 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e4),
-                                               time_horizon=1)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e4))
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_policy = EpsilonGreedyPolicy(
@@ -114,9 +110,7 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e4),
-                                               time_horizon=1)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e4))
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_policy = EpsilonGreedyPolicy(
@@ -156,9 +150,7 @@ class TestDQN(TfGraphTestCase):
             sampler_batch_size = 500
             num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
             env = TfEnv(gym.make('CartPole-v0'))
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e4),
-                                               time_horizon=1)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e4))
             qf = DiscreteMLPQFunction(env_spec=env.spec, hidden_sizes=(64, 64))
             policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
             epilson_greedy_policy = EpsilonGreedyPolicy(

--- a/tests/garage/tf/algos/test_td3.py
+++ b/tests/garage/tf/algos/test_td3.py
@@ -5,7 +5,7 @@ import pytest
 import tensorflow as tf
 
 from garage.np.exploration_policies import AddGaussianNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.tf.algos import TD3
 from garage.tf.envs import TfEnv
 from garage.tf.experiment import LocalTFRunner
@@ -45,9 +45,7 @@ class TestTD3(TfGraphTestCase):
                                          action_merge_layer=0,
                                          hidden_nonlinearity=tf.nn.relu)
 
-            replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                               size_in_transitions=int(1e6),
-                                               time_horizon=250)
+            replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
             algo = TD3(env_spec=env.spec,
                        policy=policy,

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -8,7 +8,7 @@ from garage.envs import GarageEnv
 from garage.envs import normalize
 from garage.experiment import deterministic, LocalRunner
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
-from garage.replay_buffer import SimpleReplayBuffer
+from garage.replay_buffer import PathBuffer
 from garage.torch.algos import DDPG
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -37,9 +37,7 @@ class TestDDPG:
                                     hidden_sizes=[64, 64],
                                     hidden_nonlinearity=F.relu)
 
-        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                           size_in_transitions=int(1e6),
-                                           time_horizon=100)
+        replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
         algo = DDPG(env_spec=env.spec,
                     policy=policy,
@@ -81,9 +79,7 @@ class TestDDPG:
                                     hidden_sizes=[64, 64],
                                     hidden_nonlinearity=F.relu)
 
-        replay_buffer = SimpleReplayBuffer(env_spec=env.spec,
-                                           size_in_transitions=int(1e6),
-                                           time_horizon=100)
+        replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
         algo = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -89,10 +89,12 @@ def test_dqn_pong():
     """
     env = os.environ.copy()
     env['GARAGE_EXAMPLE_TEST_N_EPOCHS'] = '1'
-    assert subprocess.run(
-        [str(EXAMPLES_ROOT_DIR / 'tf/dqn_pong.py'), '--buffer_size', '5'],
-        check=False,
-        env=env).returncode == 0
+    assert subprocess.run([
+        str(EXAMPLES_ROOT_DIR / 'tf/dqn_pong.py'), '--buffer_size', '5',
+        '--max_path_length', '5'
+    ],
+                          check=False,
+                          env=env).returncode == 0
 
 
 @pytest.mark.no_cover


### PR DESCRIPTION
Fixes #1337. Modified `OffPolicyVectorizedSampler` and off-policy algos to use `PathBuffer`, and updated the tests, examples, and benchmarks to reflect this.

I also ran ddpg benchmarks with the changes to make sure there are no regressions:
https://tensorboard.dev/experiment/zF8t5K8aRQaozMaOZniDCw/