### PR TITLE
Fix old and new distribution synchronization in on-policy algorithms

### DIFF
--- a/src/garage/tf/algos/_rl2npo.py
+++ b/src/garage/tf/algos/_rl2npo.py
@@ -100,6 +100,7 @@ class RL2NPO(NPO):
                                                    samples_data['returns'],
                                                    samples_data['valids'])
         tabular.record('{}/ExplainedVariance'.format(self.baseline.name), ev)
+        self._old_policy.model.parameters = self.policy.model.parameters
 
     def _get_baseline_prediction(self, samples_data):
         """Get baseline prediction.

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -249,6 +249,7 @@ class NPO(BatchPolopt):
 
         self.policy.build(augmented_obs_var)
         self._old_policy.build(augmented_obs_var)
+        self._old_policy.model.parameters = self.policy.model.parameters
 
         policy_loss_inputs = graph_inputs(
             'PolicyLossInputs',

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -285,6 +285,7 @@ class REPS(BatchPolopt):  # noqa: D416
 
         self.policy.build(obs_var)
         self._old_policy.build(obs_var)
+        self._old_policy.model.parameters = self.policy.model.parameters
 
         policy_loss_inputs = graph_inputs(
             'PolicyLossInputs',

--- a/tests/garage/tf/algos/test_rl2ppo.py
+++ b/tests/garage/tf/algos/test_rl2ppo.py
@@ -46,6 +46,7 @@ class TestRL2PPO(TfGraphTestCase):
                                         state_include_action=False)
         self.baseline = LinearFeatureBaseline(env_spec=self.env_spec)
 
+    @pytest.mark.timeout(100)
     def test_rl2_ppo_pendulum(self):
         with LocalTFRunner(snapshot_config, sess=self.sess) as runner:
             algo = RL2PPO(rl2_max_path_length=self.max_path_length,


### PR DESCRIPTION
In on-policy algorithms, a policy object is cloned to represent the old distribution, to be used
when calculating KL divergence between old and new policies in each optimization epoch.
The cloned policy should have the same parameters in the first place, otherwise it will result in
longer training time and large optimization error in the first epoch. This PR fixes this issue.

This also fixes RL2 to update old policy parameters at the end of each optimization epoch.