### PR TITLE
Avoid dm-tree build errors via python_requires<3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,9 @@ setup(
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     scripts=['scripts/garage'],
-    python_requires='>=3.5',
+    # Python 3.8 support disabled for now
+    # See https://github.com/rlworkgroup/garage/issues/1442
+    python_requires='>=3.5,<3.8',
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     license='MIT',


### PR DESCRIPTION
DeepMind has not yet uploaded a pre-compiled version of dm-tree to PyPI for Python 3.8, causing PIP to compile it from source. This fails without bazel, so for now, Python 3.8 support should be disabled by default.

Should close #1442 