### PR TITLE
Update installation instructions for zsh users

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -93,7 +93,7 @@ pip:
 
 .. code-block:: bash
 
-    pip install garage[mujoco,dm_control]
+    pip install 'garage[mujoco,dm_control]'
 
 Extra Steps for Garage Developers
 ---------------------------------
@@ -107,7 +107,7 @@ If you would like to contribute changes back to garage, please also read :code:`
 
     cd path/to/garage/repo
     pipenv --three
-    pipenv install --pre -e .[all,dev]
+    pipenv install --pre -e '.[all,dev]'
 
 
 - conda
@@ -117,7 +117,7 @@ If you would like to contribute changes back to garage, please also read :code:`
     conda activate myenv
     pip uninstall garage  # To ensure no existing install gets in the way.
     cd path/to/garage/repo
-    pip install -e .[all,dev]
+    pip install -e '.[all,dev]'
 
 
 - virtualenv
@@ -127,4 +127,4 @@ If you would like to contribute changes back to garage, please also read :code:`
     source myenv/bin/activate
     pip uninstall garage  # To ensure no existing install gets in the way.
     cd path/to/garage/repo
-    pip install -e .[all,dev]
+    pip install -e '.[all,dev]'


### PR DESCRIPTION
Because zsh likes to be weird, arguments like `.[all,dev]` get treated as commands and simply don't work. When installing, users must instead put quotes around the arguments (i.e. `pip install garage"[mujoco,dm_control]"`). I've updated the docs to include this information, since new Macs come with zsh installed by default.