### PR TITLE
Pin tfp to 0.8.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIRED = [
     'scikit-image',
     'scipy',
     'tensorflow' + TF_VERSION,
-    'tensorflow-probability',
+    'tensorflow-probability<0.9.0,>=0.8.0',
     'torchvision==0.4.1'
 ]
 


### PR DESCRIPTION
0.9+ versions are only tested wih TF 2.+. Also sub-dependencies
versions between tfp 0.9+ and TF 2.+ don't converge, breaking
pipenv.