### PR TITLE
Force -xz compression of local git repo

### DIFF
--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -725,8 +725,8 @@ def make_launcher_archive(*, git_root_path, log_dir):
                       'slow. Set archive_launch_repo=False in wrap_experiment '
                       'to disable this behavior.')
     archive_path = os.path.join(log_dir, 'launch_archive.tar.xz')
-    subprocess.run(('tar', '--null', '--files-from', '-', '--auto-compress',
-                    '--create', '--file', archive_path),
+    subprocess.run(('tar', '--null', '--files-from', '-', '--xz', '--create',
+                    '--file', archive_path),
                    input=b'\0'.join(files_to_archive),
                    cwd=git_root_path,
                    check=True)


### PR DESCRIPTION
Force `xz` compression to avoid using --auto-compress, which is not supported in MacOS `tar`. 

This fixes [#1455 ](https://github.com/rlworkgroup/garage/issues/1455).

subprocess call with tar is a convenient way to compress these files. Python utils like [shutil.make_archive](https://docs.python.org/3.5/library/shutil.html#shutil.make_archive) only supports compressing a folder. 