### PR TITLE
Ensure TF and torch are optional

### DIFF
--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -4,9 +4,9 @@ from dowel import logger, tabular
 
 from garage import log_multitask_performance, TrajectoryBatch
 from garage.experiment.deterministic import get_seed
+from garage.sampler import DefaultWorker
 from garage.sampler import LocalSampler
-from garage.sampler.default_worker import DefaultWorker
-from garage.sampler.worker_factory import WorkerFactory
+from garage.sampler import WorkerFactory
 
 
 class MetaEvaluator:

--- a/src/garage/sampler/__init__.py
+++ b/src/garage/sampler/__init__.py
@@ -19,7 +19,7 @@ from garage.sampler.worker import Worker
 from garage.sampler.worker_factory import WorkerFactory
 
 __all__ = [
-    'BatchSampler', 'Sampler', 'ISSampler', 'singleton_pool', 'LocalSampler',
+    'BatchSampler', 'ISSampler', 'Sampler', 'singleton_pool', 'LocalSampler',
     'RaySampler', 'MultiprocessingSampler', 'ParallelVecEnvExecutor',
     'VecEnvExecutor', 'VecWorker', 'OffPolicyVectorizedSampler',
     'OnPolicyVectorizedSampler', 'WorkerFactory', 'Worker', 'DefaultWorker'

--- a/src/garage/sampler/is_sampler.py
+++ b/src/garage/sampler/is_sampler.py
@@ -6,11 +6,16 @@ import random
 
 import numpy as np
 from numpy import var
-import tensorflow as tf
-import tensorflow_probability as tfp
 
 from garage.sampler.batch_sampler import BatchSampler
 from garage.sampler.utils import truncate_paths
+
+tf = False
+try:
+    import tensorflow as tf
+    import tensorflow_probability as tfp
+except ImportError:
+    pass
 
 
 class ISSampler(BatchSampler):
@@ -246,3 +251,17 @@ class ISSampler(BatchSampler):
                 return []
 
         return samples
+
+
+class __FakeISSampler:
+    # noqa: E501; pylint: disable=missing-param-doc,too-few-public-methods,no-method-argument
+    """Raises an ImportError for environments without TensorFlow."""
+
+    def __init__(*args, **kwargs):
+        raise ImportError(
+            'ISSampler requires TensorFlow. To use it, please install '
+            'TensorFlow.')
+
+
+if not tf:
+    ISSampler = __FakeISSampler  # noqa: F811

--- a/src/garage/sampler/parallel_sampler.py
+++ b/src/garage/sampler/parallel_sampler.py
@@ -6,12 +6,17 @@ import signal
 import cloudpickle
 from dowel import logger
 import numpy as np
-import tensorflow as tf
 
 from garage.experiment import deterministic
 from garage.sampler.stateful_pool import SharedGlobal
 from garage.sampler.stateful_pool import singleton_pool
 from garage.sampler.utils import rollout
+
+tf = False
+try:
+    import tensorflow as tf
+except ImportError:
+    pass
 
 
 def _worker_init(g, id):
@@ -113,7 +118,7 @@ def set_seed(seed):
 
 def _worker_set_policy_params(g, params, scope=None):
     g = _get_scoped_g(g, scope)
-    if 'default' not in g.policy.model.networks:
+    if tf and 'default' not in g.policy.model.networks:
         obs_ph = tf.compat.v1.placeholder(tf.float32,
                                           shape=(None, None, g.policy.obs_dim))
         g.policy.build(obs_ph)


### PR DESCRIPTION
This PR ensures that all packages in garage (except garage.tf and
garage.torch, respectively) can be imported without installing either
of the numerical frameworks.