### PR TITLE
Remove itr param from optimize_policy()

### DIFF
--- a/src/garage/np/algos/nop.py
+++ b/src/garage/np/algos/nop.py
@@ -8,11 +8,10 @@ class NOP(RLAlgorithm):
     def init_opt(self):
         """Initialize the optimization procedure."""
 
-    def optimize_policy(self, itr, paths):
+    def optimize_policy(self, paths):
         """Optimize the policy using the samples.
 
         Args:
-            itr (int): Iteration number.
             paths (list[dict]): A list of collected paths.
 
         """

--- a/src/garage/np/algos/off_policy_rl_algorithm.py
+++ b/src/garage/np/algos/off_policy_rl_algorithm.py
@@ -160,17 +160,6 @@ class OffPolicyRLAlgorithm(RLAlgorithm):
         """
 
     @abc.abstractmethod
-    def optimize_policy(self, itr, samples_data):
-        """Optimize policy network.
-
-        Args:
-            itr (int): Iterations.
-            samples_data (list): Processed batch data.
-
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def train_once(self, itr, paths):
         """Perform one step of policy optimization given one batch of samples.
 

--- a/src/garage/tf/algos/_rl2npo.py
+++ b/src/garage/tf/algos/_rl2npo.py
@@ -62,11 +62,10 @@ class RL2NPO(NPO):
 
     """
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize policy.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed sample data.
                 See garage.tf.paths_to_tensors() for details.
 

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -36,8 +36,8 @@ class DDPG(OffPolicyRLAlgorithm):
         buffer_batch_size (int): Batch size of replay buffer.
         min_buffer_size (int): The minimum buffer size for replay buffer.
         rollout_batch_size (int): Roll out batch size.
-        exploration_policy (garage.np.exploration_policies.ExplorationPolicy): # noqa: E501
-                Exploration strategy.
+        exploration_policy (garage.np.exploration_policies.ExplorationPolicy):
+            Exploration strategy.
         target_update_tau (float): Interpolation parameter for doing the
             soft target update.
         policy_lr (float): Learning rate for training policy network.
@@ -283,8 +283,7 @@ class DDPG(OffPolicyRLAlgorithm):
         self.log_diagnostics(paths)
         for _ in range(self.n_train_steps):
             if self._buffer_prefilled:
-                qf_loss, y_s, qval, policy_loss = self.optimize_policy(
-                    itr, paths)
+                qf_loss, y_s, qval, policy_loss = self.optimize_policy()
 
                 self.episode_policy_losses.append(policy_loss)
                 self.episode_qf_losses.append(qf_loss)
@@ -320,12 +319,8 @@ class DDPG(OffPolicyRLAlgorithm):
             self.success_history.clear()
         return last_average_return
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self):
         """Perform algorithm optimizing.
-
-        Args:
-            itr (int): Iterations.
-            samples_data (list): Processed batch data.
 
         Returns:
             float: Loss of action predicted by the policy network

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -200,7 +200,7 @@ class DQN(OffPolicyRLAlgorithm):
         last_average_return = np.mean(self.episode_rewards)
         for _ in range(self.n_train_steps):
             if self._buffer_prefilled:
-                qf_loss = self.optimize_policy(epoch, None)
+                qf_loss = self.optimize_policy(None)
                 self.episode_qf_losses.append(qf_loss)
 
         if self._buffer_prefilled:
@@ -218,18 +218,16 @@ class DQN(OffPolicyRLAlgorithm):
                                mean100ep_qf_loss)
         return last_average_return
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize network using experiences from replay buffer.
 
         Args:
-            itr (int): Iterations.
             samples_data (list): Processed batch data.
 
         Returns:
             numpy.float64: Loss of policy.
 
         """
-        del itr
         del samples_data
 
         transitions = self.replay_buffer.sample_transitions(

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -242,7 +242,7 @@ class NPO(RLAlgorithm):
 
         self.log_diagnostics(samples_data)
         logger.log('Optimizing policy...')
-        self.optimize_policy(itr, samples_data)
+        self.optimize_policy(samples_data)
         return samples_data['average_return']
 
     def log_diagnostics(self, paths):
@@ -256,12 +256,10 @@ class NPO(RLAlgorithm):
         self.policy.log_diagnostics(paths)
         self._baseline.log_diagnostics(paths)
 
-    # pylint: disable=unused-argument
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize policy.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed sample data.
                 See garage.tf.paths_to_tensors() for details.
 

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -202,7 +202,7 @@ class REPS(RLAlgorithm):  # noqa: D416
 
         self.log_diagnostics(samples_data)
         logger.log('Optimizing policy...')
-        self.optimize_policy(itr, samples_data)
+        self.optimize_policy(samples_data)
         return samples_data['average_return']
 
     def log_diagnostics(self, paths):
@@ -243,12 +243,10 @@ class REPS(RLAlgorithm):  # noqa: D416
         self._name_scope = tf.name_scope(self._name)
         self.init_opt()
 
-    # pylint: disable=unused-argument
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize the policy using the samples.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed sample data.
                 See garage.tf.paths_to_tensors() for details.
 

--- a/src/garage/tf/algos/rl2.py
+++ b/src/garage/tf/algos/rl2.py
@@ -340,7 +340,7 @@ class RL2(MetaRLAlgorithm, abc.ABC):
         """
         paths = self._process_samples(itr, paths)
         logger.log('Optimizing policy...')
-        self._inner_algo.optimize_policy(itr, paths)
+        self._inner_algo.optimize_policy(paths)
         return paths['average_return']
 
     def get_exploration_policy(self):

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -183,7 +183,7 @@ class DDPG(OffPolicyRLAlgorithm):
                 else:
                     samples = self.replay_buffer.sample(self.buffer_batch_size)
                 qf_loss, y, q, policy_loss = tu.torch_to_np(
-                    self.optimize_policy(itr, samples))
+                    self.optimize_policy(samples))
 
                 self._episode_policy_losses.append(policy_loss)
                 self._episode_qf_losses.append(qf_loss)
@@ -220,11 +220,10 @@ class DDPG(OffPolicyRLAlgorithm):
 
         return last_average_return
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Perform algorithm optimizing.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed batch data.
 
         Returns:

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -224,7 +224,7 @@ class SAC(OffPolicyRLAlgorithm):
             samples = self.replay_buffer.sample_transitions(
                 self.buffer_batch_size)
             samples = tu.dict_np_to_torch(samples)
-            policy_loss, qf1_loss, qf2_loss = self.optimize_policy(0, samples)
+            policy_loss, qf1_loss, qf2_loss = self.optimize_policy(samples)
             self._update_targets()
 
         return policy_loss, qf1_loss, qf2_loss
@@ -382,11 +382,10 @@ class SAC(OffPolicyRLAlgorithm):
                 t_param.data.copy_(t_param.data * (1.0 - self._tau) +
                                    param.data * self._tau)
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize the policy q_functions, and temperature coefficient.
 
         Args:
-            itr (int): Iterations.
             samples_data (dict): Transitions(S,A,R,S') that are sampled from
                 the replay buffer. It should have the keys 'observation',
                 'action', 'reward', 'terminal', and 'next_observations'.

--- a/tests/fixtures/algos/dummy_tf_algo.py
+++ b/tests/fixtures/algos/dummy_tf_algo.py
@@ -13,11 +13,10 @@ class DummyTFAlgo(RLAlgorithm):
 
         """
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize the policy using the samples.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed sample data.
                 See garage.tf.paths_to_tensors() for details.
 

--- a/tests/fixtures/tf/algos/dummy_off_policy_algo.py
+++ b/tests/fixtures/tf/algos/dummy_off_policy_algo.py
@@ -27,11 +27,10 @@ class DummyOffPolicyAlgo(OffPolicyRLAlgorithm):
 
         """
 
-    def optimize_policy(self, itr, samples_data):
+    def optimize_policy(self, samples_data):
         """Optimize the policy using the samples.
 
         Args:
-            itr (int): Iteration number.
             samples_data (dict): Processed sample data.
                 See garage.tf.paths_to_tensors() for details.
 


### PR DESCRIPTION
1. Remove unused `itr` from `optimize_policy()` function signature
2. Remove `optimize_policy()` from `OffPolicyRLAlgorithm` so it becomes a private function of sub algo class; each sub algo class now can have its own signature of this function.
3. Make `TD3` inherit from `OffPolicyRLAlgorithm` directly, to avoid function signature conflict of inherited `optimize_policy()`. (`TD3.optimize_policy()` has signature `optimize_policy(itr)` whereas its parent has `TD3.optimize_policy()`)

Related background can be found [here](https://github.com/rlworkgroup/garage/pull/1504#discussion_r435507618)