### PR TITLE
Policy build automatically in constructor and __setstate__

### DIFF
--- a/src/garage/np/algos/cem.py
+++ b/src/garage/np/algos/cem.py
@@ -69,12 +69,6 @@ class CEM(RLAlgorithm):
         self._all_params = None
         self._n_best = None
         self._n_params = None
-        self._initialize()
-
-    def _initialize(self):
-        input_var = self._env_spec.observation_space.to_tf_placeholder(
-            name='obs', batch_dims=2)
-        self.policy.build(input_var)
 
     def _sample_params(self, epoch):
         """Return sample parameters.
@@ -194,13 +188,3 @@ class CEM(RLAlgorithm):
 
         logger.log(tabular)
         return rtn
-
-    def __setstate__(self, state):
-        """Parameters to restore from snapshot.
-
-        Args:
-            state (dict): Parameters to restore from.
-
-        """
-        self.__dict__ = state
-        self._initialize()

--- a/src/garage/np/algos/cma_es.py
+++ b/src/garage/np/algos/cma_es.py
@@ -54,12 +54,6 @@ class CMAES(RLAlgorithm):
         self._all_params = None
         self._cur_params = None
         self._all_returns = None
-        self._initialize()
-
-    def _initialize(self):
-        input_var = self._env_spec.observation_space.to_tf_placeholder(
-            name='obs', batch_dims=2)
-        self.policy.build(input_var)
 
     def _sample_params(self):
         """Return sample parameters.
@@ -159,13 +153,3 @@ class CMAES(RLAlgorithm):
 
         logger.log(tabular)
         return rtn
-
-    def __setstate__(self, state):
-        """Parameters to restore from snapshot.
-
-        Args:
-            state (dict): Parameters to restore from.
-
-        """
-        self.__dict__ = state
-        self._initialize()

--- a/src/garage/sampler/parallel_sampler.py
+++ b/src/garage/sampler/parallel_sampler.py
@@ -118,10 +118,6 @@ def set_seed(seed):
 
 def _worker_set_policy_params(g, params, scope=None):
     g = _get_scoped_g(g, scope)
-    if tf and 'default' not in g.policy.model.networks:
-        obs_ph = tf.compat.v1.placeholder(tf.float32,
-                                          shape=(None, None, g.policy.obs_dim))
-        g.policy.build(obs_ph)
     g.policy.set_param_values(params)
 
 

--- a/src/garage/sampler/parallel_sampler.py
+++ b/src/garage/sampler/parallel_sampler.py
@@ -12,12 +12,6 @@ from garage.sampler.stateful_pool import SharedGlobal
 from garage.sampler.stateful_pool import singleton_pool
 from garage.sampler.utils import rollout
 
-tf = False
-try:
-    import tensorflow as tf
-except ImportError:
-    pass
-
 
 def _worker_init(g, id):
     if singleton_pool.n_parallel > 1:

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -123,6 +123,7 @@ class NPO(RLAlgorithm):
         self._name = name
         self._name_scope = tf.name_scope(self._name)
         self._old_policy = policy.clone('old_policy')
+        self._old_policy.model.parameters = policy.model.parameters
         self._use_softplus_entropy = use_softplus_entropy
         self._use_neg_logli_entropy = use_neg_logli_entropy
         self._stop_entropy_gradient = stop_entropy_gradient
@@ -337,19 +338,6 @@ class NPO(RLAlgorithm):
             policy_state_info_vars_list = [
                 policy_state_info_vars[k] for k in self.policy.state_info_keys
             ]
-
-        # concat the action input with obs_var to become the final
-        # state input
-        augmented_obs_var = obs_var
-        for k in self.policy.state_info_keys:
-            extra_state_var = policy_state_info_vars[k]
-            extra_state_var = tf.cast(extra_state_var, tf.float32)
-            augmented_obs_var = tf.concat([augmented_obs_var, extra_state_var],
-                                          -1)
-
-        self.policy.build(augmented_obs_var)
-        self._old_policy.build(augmented_obs_var)
-        self._old_policy.model.parameters = self.policy.model.parameters
 
         policy_loss_inputs = graph_inputs(
             'PolicyLossInputs',

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -538,6 +538,7 @@ class NPO(RLAlgorithm):
             samples_data['agent_infos'][k] for k in self.policy.state_info_keys
         ]
 
+        # pylint: disable=unexpected-keyword-arg
         policy_opt_input_values = self._policy_opt_inputs._replace(
             obs_var=samples_data['observations'],
             action_var=samples_data['actions'],

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -97,6 +97,7 @@ class REPS(RLAlgorithm):  # noqa: D416
         self._name = name
         self._name_scope = tf.name_scope(self._name)
         self._old_policy = policy.clone('old_policy')
+        self._old_policy.model.parameters = self.policy.model.parameters
 
         self._feat_diff = None
         self._param_eta = None
@@ -385,10 +386,6 @@ class REPS(RLAlgorithm):  # noqa: D416
                 policy_state_info_vars[k]
                 for k in self.policy.state_info_keys
             ]  # yapf: disable
-
-        self.policy.build(obs_var)
-        self._old_policy.build(obs_var)
-        self._old_policy.model.parameters = self.policy.model.parameters
 
         policy_loss_inputs = graph_inputs(
             'PolicyLossInputs',

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -167,17 +167,36 @@ class TD3(RLAlgorithm):
         """Build the loss function and init the optimizer."""
         with tf.name_scope(self._name):
             # Create target policy (actor) and qf (critic) networks
+            with tf.name_scope('inputs'):
+                obs_dim = self.env_spec.observation_space.flat_dim
+                y = tf.compat.v1.placeholder(tf.float32,
+                                             shape=(None, 1),
+                                             name='input_y')
+                obs = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, obs_dim),
+                                               name='input_observation')
+                actions = tf.compat.v1.placeholder(
+                    tf.float32,
+                    shape=(None, self.env_spec.action_space.flat_dim),
+                    name='input_action')
+
+            policy_network_outputs = self._target_policy.get_action_sym(
+                obs, name='policy')
+            target_qf_outputs = self._target_qf.get_qval_sym(obs,
+                                                             actions,
+                                                             name='qf')
+            target_qf2_outputs = self._target_qf2.get_qval_sym(obs,
+                                                               actions,
+                                                               name='qf')
+
             self.target_policy_f_prob_online = tensor_utils.compile_function(
-                inputs=[self._target_policy.model.networks['default'].input],
-                outputs=self._target_policy.model.networks['default'].outputs)
+                inputs=[obs], outputs=policy_network_outputs)
 
             self.target_qf_f_prob_online = tensor_utils.compile_function(
-                inputs=self._target_qf.model.networks['default'].inputs,
-                outputs=self._target_qf.model.networks['default'].outputs)
+                inputs=[obs, actions], outputs=target_qf_outputs)
 
             self.target_qf2_f_prob_online = tensor_utils.compile_function(
-                inputs=self._target_qf2.model.networks['default'].inputs,
-                outputs=self._target_qf2.model.networks['default'].outputs)
+                inputs=[obs, actions], outputs=target_qf2_outputs)
 
             # Set up target init and update functions
             with tf.name_scope('setup_target'):
@@ -198,19 +217,6 @@ class TD3(RLAlgorithm):
                 inputs=[], outputs=target_init_op)
             f_update_target = tensor_utils.compile_function(
                 inputs=[], outputs=target_update_op)
-
-            with tf.name_scope('inputs'):
-                obs_dim = self.env_spec.observation_space.flat_dim
-                y = tf.compat.v1.placeholder(tf.float32,
-                                             shape=(None, 1),
-                                             name='input_y')
-                obs = tf.compat.v1.placeholder(tf.float32,
-                                               shape=(None, obs_dim),
-                                               name='input_observation')
-                actions = tf.compat.v1.placeholder(
-                    tf.float32,
-                    shape=(None, self.env_spec.action_space.flat_dim),
-                    name='input_action')
 
             # Set up policy training function
             next_action = self.policy.get_action_sym(obs, name='policy_action')

--- a/src/garage/tf/embeddings/gaussian_mlp_encoder.py
+++ b/src/garage/tf/embeddings/gaussian_mlp_encoder.py
@@ -119,8 +119,9 @@ class GaussianMLPEncoder(StochasticEncoder, StochasticModule):
 
     def _initialize(self):
         """Initialize encoder."""
-        embedding_input = tf.placeholder(tf.float32,
-                                         shape=(None, None, self._input_dim))
+        embedding_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          self._input_dim))
         with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
             self._dist, mean_var, log_std_var = self.model.build(

--- a/src/garage/tf/models/categorical_cnn_model.py
+++ b/src/garage/tf/models/categorical_cnn_model.py
@@ -88,6 +88,15 @@ class CategoricalCNNModel(Model):
             layer_normalization=layer_normalization,
             name='MLPModel')
 
+    def network_output_spec(self):
+        """Network output spec.
+
+        Returns:
+            list[str]: Name of the model outputs, in order.
+
+        """
+        return self._mlp_model.network_output_spec
+
     # pylint: disable=arguments-differ
     def _build(self, state_input, name=None):
         """Build model.

--- a/src/garage/tf/models/categorical_cnn_model.py
+++ b/src/garage/tf/models/categorical_cnn_model.py
@@ -95,7 +95,7 @@ class CategoricalCNNModel(Model):
             list[str]: Name of the model outputs, in order.
 
         """
-        return self._mlp_model.network_output_spec
+        return self._mlp_model.network_output_spec()
 
     # pylint: disable=arguments-differ
     def _build(self, state_input, name=None):
@@ -114,8 +114,8 @@ class CategoricalCNNModel(Model):
         time_dim = tf.shape(state_input)[1]
         dim = state_input.get_shape()[2:].as_list()
         state_input = tf.reshape(state_input, [-1, *dim])
-        cnn_output = self._cnn_model.build(state_input, name=name)
+        cnn_output = self._cnn_model.build(state_input, name=name).outputs
         dim = cnn_output.get_shape()[-1]
         cnn_output = tf.reshape(cnn_output, [-1, time_dim, dim])
-        mlp_output = self._mlp_model.build(cnn_output, name=name)
+        mlp_output = self._mlp_model.build(cnn_output, name=name).dist
         return mlp_output

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -59,6 +59,15 @@ class CategoricalMLPModel(MLPModel):
                          output_w_init, output_b_init, layer_normalization)
         self._output_normalization_fn = output_nonlinearity
 
+    def network_output_spec(self):
+        """Network output spec.
+
+        Returns:
+            list[str]: Name of the model outputs, in order.
+
+        """
+        return ['dist']
+
     def _build(self, state_input, name=None):
         """Build model.
 

--- a/src/garage/tf/models/cnn_mlp_merge_model.py
+++ b/src/garage/tf/models/cnn_mlp_merge_model.py
@@ -157,6 +157,7 @@ class CNNMLPMergeModel(Model):
             tf.Tensor: Output of the model of shape (N, output_dim).
 
         """
-        cnn_out = self.cnn_model.build(state, name=name)
-        mlp_out = self.mlp_merge_model.build(cnn_out, action, name=name)
+        cnn_out = self.cnn_model.build(state, name=name).outputs
+        mlp_out = self.mlp_merge_model.build(cnn_out, action,
+                                             name=name).outputs
         return mlp_out

--- a/src/garage/tf/models/gaussian_lstm_model.py
+++ b/src/garage/tf/models/gaussian_lstm_model.py
@@ -188,13 +188,13 @@ class GaussianLSTMModel(Model):
                 garage.tf.models.Sequential.
 
         Returns:
+            tfp.distributions.MultivariateNormalDiag: Policy distribution.
             tf.Tensor: Step means, with shape :math:`(N, S^*)`.
             tf.Tensor: Step log std, with shape :math:`(N, S^*)`.
             tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`.
             tf.Tensor: Step cell state, with shape :math:`(N, S^*)`.
             tf.Tensor: Initial hidden state, with shape :math:`(S^*)`.
             tf.Tensor: Initial cell state, with shape :math:`(S^*)`
-            tfp.distributions.MultivariateNormalDiag: Policy distribution.
 
         """
         del name

--- a/src/garage/tf/models/model.py
+++ b/src/garage/tf/models/model.py
@@ -257,6 +257,17 @@ class Model(BaseModel):
                 'network_output_spec must have same length as outputs!')
             out_spec.extend(custom_out_spec)
             out_args.extend(network.outputs)
+        elif len(custom_out_spec) > 0:
+            if not isinstance(network.outputs, tuple):
+                assert len(custom_out_spec) == 1, (
+                    'network_input_spec must have same length as outputs!')
+                out_spec.extend(custom_out_spec)
+                out_args.extend([network.outputs])
+            else:
+                assert len(custom_out_spec) == len(network.outputs), (
+                    'network_input_spec must have same length as outputs!')
+                out_spec.extend(custom_out_spec)
+                out_args.extend(network.outputs)
 
         c = namedtuple(network_name, [*in_spec, *out_spec])
         all_args = in_args + out_args

--- a/src/garage/tf/models/model.py
+++ b/src/garage/tf/models/model.py
@@ -271,9 +271,10 @@ class Model(BaseModel):
 
         c = namedtuple(network_name, [*in_spec, *out_spec])
         all_args = in_args + out_args
-        self._networks[network_name] = c(*all_args)
+        out_network = c(*all_args)
+        self._networks[network_name] = out_network
 
-        return network.outputs
+        return out_network
 
     def _build(self, *inputs, name=None):
         """Output of the model given input placeholder(s).

--- a/src/garage/tf/models/model.py
+++ b/src/garage/tf/models/model.py
@@ -138,8 +138,7 @@ class Model(BaseModel):
     A TfModel contains zero or more Network.
 
     When a Network is created, it reuses the parameter from the
-    model and can be accessed by calling model.networks['network_name'],
-    If a Network is built without given a name, the name "default" will
+    model. If a Network is built without given a name, the name "default" will
     be used.
 
     ***
@@ -168,8 +167,8 @@ class Model(BaseModel):
     =================================================
             |                            |
             |                            |
-    (model.networks['default'].outputs)  |
-                        model.networks['Network2'].outputs
+    (outputs from 'default' networks)    |
+                        outputs from ['Network2'] network
 
 
     Examples are also available in tests/garage/tf/models/test_model.
@@ -316,16 +315,6 @@ class Model(BaseModel):
         return []
 
     @property
-    def networks(self):
-        """Networks of the model.
-
-        Returns:
-            dict[str: Network]: Networks.
-
-        """
-        return self._networks
-
-    @property
     def parameters(self):
         """Parameters of the model.
 
@@ -384,7 +373,7 @@ class Model(BaseModel):
             tf.Tensor: Default input of the model.
 
         """
-        return self.networks['default'].input
+        return self._networks['default'].input
 
     @property
     def output(self):
@@ -398,7 +387,7 @@ class Model(BaseModel):
             tf.Tensor: Default output of the model.
 
         """
-        return self.networks['default'].output
+        return self._networks['default'].output
 
     @property
     def inputs(self):
@@ -412,7 +401,7 @@ class Model(BaseModel):
             list[tf.Tensor]: Default inputs of the model.
 
         """
-        return self.networks['default'].inputs
+        return self._networks['default'].inputs
 
     @property
     def outputs(self):
@@ -426,7 +415,7 @@ class Model(BaseModel):
             list[tf.Tensor]: Default outputs of the model.
 
         """
-        return self.networks['default'].outputs
+        return self._networks['default'].outputs
 
     def _get_variables(self):
         """Get variables of this model.

--- a/src/garage/tf/models/sequential.py
+++ b/src/garage/tf/models/sequential.py
@@ -20,29 +20,41 @@ class Sequential(Model):
         super().__init__(name)
         self._models = models
 
+    # pylint: disable=arguments-differ
     def _build(self, input_var, name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            input_var (tf.Tensor): Tensor input.
+            name (str): Inner model name, also the variable scope of the
+                inner model.
+
+        Return:
+            tf.Tensor: Tensor output of the model.
+
+        """
         out = input_var
         for model in self._models:
-            out = model.build(out, name=name)
+            out = model.build(out, name=name).outputs
 
         return out
 
     @property
     def input(self):
-        """tf.Tensor input of the model by default."""
+        """tf.Tensor: input of the model by default."""
         return self._models[0].networks['default'].input
 
     @property
     def output(self):
-        """tf.Tensor output of the model by default."""
+        """tf.Tensor: output of the model by default."""
         return self._models[-1].networks['default'].output
 
     @property
     def inputs(self):
-        """tf.Tensor inputs of the model by default."""
+        """tf.Tensor: inputs of the model by default."""
         return self._models[0].networks['default'].inputs
 
     @property
     def outputs(self):
-        """tf.Tensor outputs of the model by default."""
+        """tf.Tensor: outputs of the model by default."""
         return self._models[-1].networks['default'].outputs

--- a/src/garage/tf/models/sequential.py
+++ b/src/garage/tf/models/sequential.py
@@ -75,3 +75,14 @@ class Sequential(Model):
         del new_dict['_first_network']
         del new_dict['_last_network']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._first_network = None
+        self._last_network = None

--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -58,7 +58,6 @@ class Plotter:
         ) if graph is None else graph
         with self.sess.as_default(), self.graph.as_default():
             self._policy = policy.clone('plotter_policy')
-            self._policy.build(policy.model.input)
         self.rollout = rollout
         self.worker_thread = Thread(target=self._start_worker, daemon=True)
         self.queue = Queue()

--- a/src/garage/tf/policies/categorical_cnn_policy.py
+++ b/src/garage/tf/policies/categorical_cnn_policy.py
@@ -123,7 +123,7 @@ class CategoricalCNNPolicy(StochasticPolicy):
                 augmented_state_input /= 255.0
             else:
                 augmented_state_input = state_input
-            self._dist = self.model.build(augmented_state_input)
+            self._dist = self.model.build(augmented_state_input).dist
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
                 [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])

--- a/src/garage/tf/policies/categorical_cnn_policy.py
+++ b/src/garage/tf/policies/categorical_cnn_policy.py
@@ -109,25 +109,48 @@ class CategoricalCNNPolicy(StochasticPolicy):
             output_b_init=output_b_init,
             layer_normalization=layer_normalization)
 
-    def build(self, state_input, name=None):
-        """Build model.
+        self._initialize()
 
-        Args:
-          state_input (tf.Tensor) : State input.
-          name (str): Name of the model, which is also the name scope.
-
-        """
+    def _initialize(self):
+        """Initialize policy."""
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None) +
+                                                   self._obs_dim)
             if isinstance(self.env_spec.observation_space, akro.Image):
                 augmented_state_input = tf.cast(state_input, tf.float32)
                 augmented_state_input /= 255.0
             else:
                 augmented_state_input = state_input
-            self._dist = self.model.build(augmented_state_input, name=name)
+            self._dist = self.model.build(augmented_state_input)
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
                 [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])
+
+    def build(self, state_input, name=None):
+        """Build policy.
+
+        Args:
+            state_input (tf.Tensor) : State input.
+            name (str): Name of the policy, which is also the name scope.
+
+        Returns:
+            tfp.distributions.OneHotCategorical: Policy distribution.
+
+        """
+        with tf.compat.v1.variable_scope(self._variable_scope):
+            if isinstance(self.env_spec.observation_space, akro.Image):
+                augmented_state_input = tf.cast(state_input, tf.float32)
+                augmented_state_input /= 255.0
+            else:
+                augmented_state_input = state_input
+            return self.model.build(augmented_state_input, name=name)
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._obs_dim
 
     @property
     def distribution(self):
@@ -217,3 +240,13 @@ class CategoricalCNNPolicy(StochasticPolicy):
         del new_dict['_f_prob']
         del new_dict['_dist']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -123,16 +123,16 @@ class CategoricalGRUPolicy(StochasticPolicy):
         self._prev_actions = None
         self._prev_hiddens = None
 
-    def build(self, state_input, name=None):
-        """Build model.
+        self._initialize()
 
-        Args:
-          state_input (tf.Tensor) : State input.
-          name (str): Name of the model, which is also the name scope.
-
-        """
+    def _initialize(self):
+        """Initialize policy."""
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
+            state_input = tf.compat.v1.placeholder(shape=(None, None,
+                                                          self._input_dim),
+                                                   name='state_input',
+                                                   dtype=tf.float32)
             step_input_var = tf.compat.v1.placeholder(shape=(None,
                                                              self._input_dim),
                                                       name='step_input',
@@ -141,10 +141,7 @@ class CategoricalGRUPolicy(StochasticPolicy):
                 shape=(None, self._hidden_dim),
                 name='step_hidden_input',
                 dtype=tf.float32)
-            self.model.build(state_input,
-                             step_input_var,
-                             step_hidden_var,
-                             name=name)
+            self.model.build(state_input, step_input_var, step_hidden_var)
 
         self._f_step_prob = tf.compat.v1.get_default_session().make_callable(
             [
@@ -152,6 +149,33 @@ class CategoricalGRUPolicy(StochasticPolicy):
                 self.model.networks['default'].step_hidden
             ],
             feed_list=[step_input_var, step_hidden_var])
+
+    def build(self, state_input, name=None):
+        """Build policy.
+
+        Args:
+            state_input (tf.Tensor) : State input.
+            name (str): Name of the policy, which is also the name scope.
+
+        Returns:
+            tfp.distributions.OneHotCategorical: Policy distribution.
+            tf.Tensor: Step output, with shape :math:`(N, S^*)`.
+            tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`.
+            tf.Tensor: Initial hidden state , used to reset the hidden state
+                when policy resets. Shape: :math:`(S^*)`.
+
+        """
+        with tf.compat.v1.variable_scope(self._variable_scope):
+            _, step_input_var, step_hidden_var = self.model.inputs
+            return self.model.build(state_input,
+                                    step_input_var,
+                                    step_hidden_var,
+                                    name=name)
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._input_dim
 
     @property
     def vectorized(self):
@@ -296,3 +320,13 @@ class CategoricalGRUPolicy(StochasticPolicy):
         new_dict = super().__getstate__()
         del new_dict['_f_step_prob']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -122,6 +122,8 @@ class CategoricalGRUPolicy(StochasticPolicy):
 
         self._prev_actions = None
         self._prev_hiddens = None
+        self._dist = None
+        self._init_hidden = None
 
         self._initialize()
 
@@ -141,13 +143,12 @@ class CategoricalGRUPolicy(StochasticPolicy):
                 shape=(None, self._hidden_dim),
                 name='step_hidden_input',
                 dtype=tf.float32)
-            self.model.build(state_input, step_input_var, step_hidden_var)
+            (self._dist, step_out, step_hidden,
+             self._init_hidden) = self.model.build(state_input, step_input_var,
+                                                   step_hidden_var).outputs
 
         self._f_step_prob = tf.compat.v1.get_default_session().make_callable(
-            [
-                self.model.networks['default'].step_output,
-                self.model.networks['default'].step_hidden
-            ],
+            [step_out, step_hidden],
             feed_list=[step_input_var, step_hidden_var])
 
     def build(self, state_input, name=None):
@@ -209,8 +210,7 @@ class CategoricalGRUPolicy(StochasticPolicy):
             self._prev_hiddens = np.zeros((len(do_resets), self._hidden_dim))
 
         self._prev_actions[do_resets] = 0.
-        self._prev_hiddens[do_resets] = self.model.networks[
-            'default'].init_hidden.eval()
+        self._prev_hiddens[do_resets] = self._init_hidden.eval()
 
     def get_action(self, observation):
         """Return a single action.
@@ -261,7 +261,7 @@ class CategoricalGRUPolicy(StochasticPolicy):
             tfp.Distribution.OneHotCategorical: Policy distribution.
 
         """
-        return self.model.networks['default'].dist
+        return self._dist
 
     @property
     def state_info_specs(self):
@@ -319,6 +319,8 @@ class CategoricalGRUPolicy(StochasticPolicy):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_step_prob']
+        del new_dict['_dist']
+        del new_dict['_init_hidden']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -139,6 +139,9 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         self._prev_actions = None
         self._prev_hiddens = None
         self._prev_cells = None
+        self._dist = None
+        self._init_hidden = None
+        self._init_cell = None
 
         self._initialize()
 
@@ -162,15 +165,13 @@ class CategoricalLSTMPolicy(StochasticPolicy):
                                                             self._hidden_dim),
                                                      name='step_cell_input',
                                                      dtype=tf.float32)
-            self.model.build(state_input, step_input_var, step_hidden_var,
-                             step_cell_var)
+            (self._dist, step_out, step_hidden, step_cell, self._init_hidden,
+             self._init_cell) = self.model.build(state_input, step_input_var,
+                                                 step_hidden_var,
+                                                 step_cell_var).outputs
 
         self._f_step_prob = tf.compat.v1.get_default_session().make_callable(
-            [
-                self.model.networks['default'].step_output,
-                self.model.networks['default'].step_hidden,
-                self.model.networks['default'].step_cell
-            ],
+            [step_out, step_hidden, step_cell],
             feed_list=[step_input_var, step_hidden_var, step_cell_var])
 
     def build(self, state_input, name=None):
@@ -237,10 +238,8 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             self._prev_cells = np.zeros((len(do_resets), self._hidden_dim))
 
         self._prev_actions[do_resets] = 0.
-        self._prev_hiddens[do_resets] = self.model.networks[
-            'default'].init_hidden.eval()
-        self._prev_cells[do_resets] = self.model.networks[
-            'default'].init_cell.eval()
+        self._prev_hiddens[do_resets] = self._init_hidden.eval()
+        self._prev_cells[do_resets] = self._init_cell.eval()
 
     def get_action(self, observation):
         """Return a single action.
@@ -294,7 +293,7 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             tfp.Distribution.OneHotCategorical: Policy distribution.
 
         """
-        return self.model.networks['default'].dist
+        return self._dist
 
     @property
     def state_info_specs(self):
@@ -355,6 +354,9 @@ class CategoricalLSTMPolicy(StochasticPolicy):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_step_prob']
+        del new_dict['_dist']
+        del new_dict['_init_hidden']
+        del new_dict['_init_cell']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -99,7 +99,7 @@ class CategoricalMLPPolicy(StochasticPolicy):
             state_input = tf.compat.v1.placeholder(tf.float32,
                                                    shape=(None, None,
                                                           self._obs_dim))
-            self._dist = self.model.build(state_input)
+            self._dist = self.model.build(state_input).dist
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
                 [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -63,8 +63,8 @@ class CategoricalMLPPolicy(StochasticPolicy):
             raise ValueError('CategoricalMLPPolicy only works'
                              'with akro.Discrete action space.')
         super().__init__(name, env_spec)
-        self.obs_dim = env_spec.observation_space.flat_dim
-        self.action_dim = env_spec.action_space.n
+        self._obs_dim = env_spec.observation_space.flat_dim
+        self._action_dim = env_spec.action_space.n
 
         self._hidden_sizes = hidden_sizes
         self._hidden_nonlinearity = hidden_nonlinearity
@@ -79,7 +79,7 @@ class CategoricalMLPPolicy(StochasticPolicy):
         self._dist = None
 
         self.model = CategoricalMLPModel(
-            output_dim=self.action_dim,
+            output_dim=self._action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
             hidden_w_init=hidden_w_init,
@@ -90,20 +90,38 @@ class CategoricalMLPPolicy(StochasticPolicy):
             layer_normalization=layer_normalization,
             name='CategoricalMLPModel')
 
-    def build(self, state_input, name=None):
-        """Build model.
+        self._initialize()
 
-        Args:
-          state_input (tf.Tensor) : State input.
-          name (str): Name of the model, which is also the name scope.
-
-        """
+    def _initialize(self):
+        """Initialize policy."""
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self._dist = self.model.build(state_input, name=name)
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          self._obs_dim))
+            self._dist = self.model.build(state_input)
             self._f_prob = tf.compat.v1.get_default_session().make_callable(
                 [tf.argmax(self._dist.sample(), -1), self._dist.probs],
                 feed_list=[state_input])
+
+    def build(self, state_input, name=None):
+        """Build policy.
+
+        Args:
+            state_input (tf.Tensor) : State input.
+            name (str): Name of the policy, which is also the name scope.
+
+        Returns:
+            tfp.distributions.OneHotCategorical: Policy distribution.
+
+        """
+        with tf.compat.v1.variable_scope(self._variable_scope):
+            return self.model.build(state_input, name=name)
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._obs_dim
 
     @property
     def distribution(self):
@@ -206,3 +224,13 @@ class CategoricalMLPPolicy(StochasticPolicy):
         del new_dict['_f_prob']
         del new_dict['_dist']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -86,11 +86,10 @@ class ContinuousMLPPolicy(Policy):
 
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self.model.build(state_input)
+            outputs = self.model.build(state_input).outputs
 
         self._f_prob = tf.compat.v1.get_default_session().make_callable(
-            self.model.networks['default'].outputs,
-            feed_list=[self.model.networks['default'].input])
+            outputs, feed_list=[state_input])
 
     @property
     def input_dim(self):

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -108,7 +108,7 @@ class ContinuousMLPPolicy(Policy):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            return self.model.build(obs_var, name=name)
+            return self.model.build(obs_var, name=name).outputs
 
     def get_action(self, observation):
         """Get single action from this policy for the input observation.

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -65,7 +65,7 @@ class ContinuousMLPPolicy(Policy):
         self._output_w_init = output_w_init
         self._output_b_init = output_b_init
         self._layer_normalization = layer_normalization
-        self.obs_dim = env_spec.observation_space.flat_dim
+        self._obs_dim = env_spec.observation_space.flat_dim
 
         self.model = MLPModel(output_dim=action_dim,
                               name='MLPModel',
@@ -82,7 +82,7 @@ class ContinuousMLPPolicy(Policy):
 
     def _initialize(self):
         state_input = tf.compat.v1.placeholder(tf.float32,
-                                               shape=(None, self.obs_dim))
+                                               shape=(None, self._obs_dim))
 
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
@@ -91,6 +91,11 @@ class ContinuousMLPPolicy(Policy):
         self._f_prob = tf.compat.v1.get_default_session().make_callable(
             self.model.networks['default'].outputs,
             feed_list=[self.model.networks['default'].input])
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._obs_dim
 
     def get_action_sym(self, obs_var, name=None):
         """Symbolic graph of the action.

--- a/src/garage/tf/policies/gaussian_gru_policy.py
+++ b/src/garage/tf/policies/gaussian_gru_policy.py
@@ -134,16 +134,16 @@ class GaussianGRUPolicy(StochasticPolicy):
         self._prev_actions = None
         self._prev_hiddens = None
 
-    def build(self, state_input, name=None):
-        """Build model.
+        self._initialize()
 
-        Args:
-          state_input (tf.Tensor): State input.
-          name (str): Name of the model, which is also the name scope.
-
-        """
+    def _initialize(self):
+        """Initialize policy."""
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
+            state_input = tf.compat.v1.placeholder(shape=(None, None,
+                                                          self._input_dim),
+                                                   name='state_input',
+                                                   dtype=tf.float32)
             step_input_var = tf.compat.v1.placeholder(shape=(None,
                                                              self._input_dim),
                                                       name='step_input',
@@ -152,10 +152,7 @@ class GaussianGRUPolicy(StochasticPolicy):
                 shape=(None, self._hidden_dim),
                 name='step_hidden_input',
                 dtype=tf.float32)
-            self.model.build(state_input,
-                             step_input_var,
-                             step_hidden_var,
-                             name=name)
+            self.model.build(state_input, step_input_var, step_hidden_var)
 
         self._f_step_mean_std = (
             tf.compat.v1.get_default_session().make_callable(
@@ -165,6 +162,33 @@ class GaussianGRUPolicy(StochasticPolicy):
                     self.model.networks['default'].step_hidden
                 ],
                 feed_list=[step_input_var, step_hidden_var]))
+
+    def build(self, state_input, name=None):
+        """Build policy.
+
+        Args:
+            state_input (tf.Tensor) : State input.
+            name (str): Name of the policy, which is also the name scope.
+
+        Returns:
+            tfp.distributions.MultivariateNormalDiag: Policy distribution.
+            tf.Tensor: Step means, with shape :math:`(N, S^*)`.
+            tf.Tensor: Step log std, with shape :math:`(N, S^*)`.
+            tf.Tensor: Step hidden state, with shape :math:`(N, S^*)`.
+            tf.Tensor: Initial hidden state, with shape :math:`(S^*)`.
+
+        """
+        with tf.compat.v1.variable_scope(self._variable_scope):
+            _, step_input_var, step_hidden_var = self.model.inputs
+            return self.model.build(state_input,
+                                    step_input_var,
+                                    step_hidden_var,
+                                    name=name)
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._input_dim
 
     @property
     def vectorized(self):
@@ -331,3 +355,13 @@ class GaussianGRUPolicy(StochasticPolicy):
         new_dict = super().__getstate__()
         del new_dict['_f_step_mean_std']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/gaussian_lstm_policy.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy.py
@@ -150,6 +150,9 @@ class GaussianLSTMPolicy(StochasticPolicy):
         self._prev_actions = None
         self._prev_hiddens = None
         self._prev_cells = None
+        self._dist = None
+        self._init_hidden = None
+        self._init_cell = None
 
         self._initialize()
 
@@ -173,17 +176,15 @@ class GaussianLSTMPolicy(StochasticPolicy):
                                                             self._hidden_dim),
                                                      name='step_cell_input',
                                                      dtype=tf.float32)
-            self.model.build(state_input, step_input_var, step_hidden_var,
-                             step_cell_var)
+            (self._dist, step_mean, step_log_std, step_hidden, step_cell,
+             self._init_hidden,
+             self._init_cell) = self.model.build(state_input, step_input_var,
+                                                 step_hidden_var,
+                                                 step_cell_var).outputs
 
         self._f_step_mean_std = tf.compat.v1.get_default_session(
         ).make_callable(
-            [
-                self.model.networks['default'].step_mean,
-                self.model.networks['default'].step_log_std,
-                self.model.networks['default'].step_hidden,
-                self.model.networks['default'].step_cell
-            ],
+            [step_mean, step_log_std, step_hidden, step_cell],
             feed_list=[step_input_var, step_hidden_var, step_cell_var])
 
     def build(self, state_input, name=None):
@@ -248,10 +249,8 @@ class GaussianLSTMPolicy(StochasticPolicy):
             self._prev_cells = np.zeros((len(do_resets), self._hidden_dim))
 
         self._prev_actions[do_resets] = 0.
-        self._prev_hiddens[do_resets] = self.model.networks[
-            'default'].init_hidden.eval()
-        self._prev_cells[do_resets] = self.model.networks[
-            'default'].init_cell.eval()
+        self._prev_hiddens[do_resets] = self._init_hidden.eval()
+        self._prev_cells[do_resets] = self._init_cell.eval()
 
     def get_action(self, observation):
         """Get single action from this policy for the input observation.
@@ -322,7 +321,7 @@ class GaussianLSTMPolicy(StochasticPolicy):
             tfp.Distribution.MultivariateNormalDiag: Policy distribution.
 
         """
-        return self.model.networks['default'].dist
+        return self._dist
 
     @property
     def state_info_specs(self):
@@ -387,6 +386,9 @@ class GaussianLSTMPolicy(StochasticPolicy):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_step_mean_std']
+        del new_dict['_dist']
+        del new_dict['_init_hidden']
+        del new_dict['_init_cell']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/policies/gaussian_mlp_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy.py
@@ -151,10 +151,9 @@ class GaussianMLPPolicy(StochasticPolicy):
             state_input = tf.compat.v1.placeholder(tf.float32,
                                                    shape=(None, None,
                                                           self._obs_dim))
-            self._dist, mean_var, log_std_var = self.model.build(state_input)
+            self._dist, mean, log_std = self.model.build(state_input).outputs
             self._f_dist = tf.compat.v1.get_default_session().make_callable(
-                [self._dist.sample(), mean_var, log_std_var],
-                feed_list=[state_input])
+                [self._dist.sample(), mean, log_std], feed_list=[state_input])
 
     @property
     def input_dim(self):

--- a/src/garage/tf/policies/gaussian_mlp_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy.py
@@ -95,8 +95,8 @@ class GaussianMLPPolicy(StochasticPolicy):
                              'akro.Box action space, but not {}'.format(
                                  env_spec.action_space))
         super().__init__(name, env_spec)
-        self.obs_dim = env_spec.observation_space.flat_dim
-        self.action_dim = env_spec.action_space.flat_dim
+        self._obs_dim = env_spec.observation_space.flat_dim
+        self._action_dim = env_spec.action_space.flat_dim
 
         self._hidden_sizes = hidden_sizes
         self._hidden_nonlinearity = hidden_nonlinearity
@@ -121,7 +121,7 @@ class GaussianMLPPolicy(StochasticPolicy):
         self._dist = None
 
         self.model = GaussianMLPModel(
-            output_dim=self.action_dim,
+            output_dim=self._action_dim,
             hidden_sizes=hidden_sizes,
             hidden_nonlinearity=hidden_nonlinearity,
             hidden_w_init=hidden_w_init,
@@ -142,21 +142,40 @@ class GaussianMLPPolicy(StochasticPolicy):
             layer_normalization=layer_normalization,
             name='GaussianMLPModel')
 
-    def build(self, state_input, name=None):
-        """Build model.
+        self._initialize()
 
-        Args:
-          state_input (tf.Tensor): State input.
-          name (str): Name of the model, which is also the name scope.
-
-        """
+    def _initialize(self):
+        """Initialize policy."""
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self._dist, mean_var, log_std_var = self.model.build(state_input,
-                                                                 name=name)
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          self._obs_dim))
+            self._dist, mean_var, log_std_var = self.model.build(state_input)
             self._f_dist = tf.compat.v1.get_default_session().make_callable(
                 [self._dist.sample(), mean_var, log_std_var],
                 feed_list=[state_input])
+
+    @property
+    def input_dim(self):
+        """int: Dimension of the policy input."""
+        return self._obs_dim
+
+    def build(self, state_input, name=None):
+        """Build policy.
+
+        Args:
+            state_input (tf.Tensor) : State input.
+            name (str): Name of the policy, which is also the name scope.
+
+        Returns:
+            tfp.distributions.MultivariateNormalDiag: Distribution.
+            tf.tensor: Mean.
+            tf.Tensor: Log of standard deviation.
+
+        """
+        with tf.compat.v1.variable_scope(self._variable_scope):
+            return self.model.build(state_input, name=name)
 
     @property
     def vectorized(self):
@@ -273,3 +292,13 @@ class GaussianMLPPolicy(StochasticPolicy):
         del new_dict['_f_dist']
         del new_dict['_dist']
         return new_dict
+
+    def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
+        super().__setstate__(state)
+        self._initialize()

--- a/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
@@ -133,13 +133,13 @@ class GaussianMLPTaskEmbeddingPolicy(TaskEmbeddingPolicy):
             with tf.compat.v1.variable_scope('concat_obs_latent'):
                 obs_latent_input = tf.concat([obs_input, latent_input], -1)
             self._dist, mean_var, log_std_var = self.model.build(
-                obs_latent_input, name='given_latent')
+                obs_latent_input, name='given_latent').outputs
 
             with tf.compat.v1.variable_scope('concat_obs_latent_var'):
                 embed_state_input = tf.concat([obs_input, latent_var], -1)
 
             dist_given_task, mean_g_t, log_std_g_t = self.model.build(
-                embed_state_input, name='given_task')
+                embed_state_input, name='given_task').outputs
 
         self._f_dist_obs_latent = tf.compat.v1.get_default_session(
         ).make_callable([self._dist.sample(), mean_var, log_std_var],

--- a/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
@@ -117,17 +117,14 @@ class GaussianMLPTaskEmbeddingPolicy(TaskEmbeddingPolicy):
         self._initialize()
 
     def _initialize(self):
+        """Initialize policy."""
         obs_input = tf.compat.v1.placeholder(tf.float32,
                                              shape=(None, None, self._obs_dim))
-        task_input = tf.compat.v1.placeholder(tf.float32,
-                                              shape=(None, None,
-                                                     self._encoder.input_dim))
         latent_input = tf.compat.v1.placeholder(
             tf.float32, shape=(None, None, self._encoder.output_dim))
 
         # Encoder should be outside policy scope
         with tf.compat.v1.variable_scope('concat_obs_task'):
-            self._encoder.build(task_input, name='dist_info_sym')
             latent_var = self._encoder.distribution.sample()
 
         with tf.compat.v1.variable_scope(self.name) as vs:
@@ -150,7 +147,7 @@ class GaussianMLPTaskEmbeddingPolicy(TaskEmbeddingPolicy):
 
         self._f_dist_obs_task = tf.compat.v1.get_default_session(
         ).make_callable([dist_given_task.sample(), mean_g_t, log_std_g_t],
-                        feed_list=[obs_input, task_input])
+                        feed_list=[obs_input, self._encoder.input])
 
     @property
     def distribution(self):

--- a/src/garage/tf/q_functions/continuous_cnn_q_function.py
+++ b/src/garage/tf/q_functions/continuous_cnn_q_function.py
@@ -64,6 +64,7 @@ class ContinuousCNNQFunction(QFunction):
             of output dense layer(s) in the MLP. The function should return
             a tf.Tensor.
         layer_normalization (bool): Bool for using layer normalization or not.
+
     """
 
     def __init__(self,
@@ -214,7 +215,7 @@ class ContinuousCNNQFunction(QFunction):
                                                 tf.float32) / 255.0
             return self.model.build(augmented_state_input,
                                     action_input,
-                                    name=name)
+                                    name=name).outputs
 
     def clone(self, name):
         """Return a clone of the Q-function.
@@ -227,6 +228,7 @@ class ContinuousCNNQFunction(QFunction):
 
         Return:
             ContinuousCNNQFunction: Cloned Q function.
+
         """
         return self.__class__(
             name=name,

--- a/src/garage/tf/q_functions/continuous_cnn_q_function.py
+++ b/src/garage/tf/q_functions/continuous_cnn_q_function.py
@@ -156,10 +156,9 @@ class ContinuousCNNQFunction(QFunction):
             augmented_obs_ph = obs_ph
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self.model.build(augmented_obs_ph, action_ph)
+            outputs = self.model.build(augmented_obs_ph, action_ph).outputs
         self._f_qval = tf.compat.v1.get_default_session().make_callable(
-            self.model.networks['default'].outputs,
-            feed_list=[obs_ph, action_ph])
+            outputs, feed_list=[obs_ph, action_ph])
 
         self._obs_input = obs_ph
         self._act_input = action_ph

--- a/src/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/src/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -139,7 +139,8 @@ class ContinuousMLPQFunction(QFunction):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            return self.model.build(state_input, action_input, name=name)
+            return self.model.build(state_input, action_input,
+                                    name=name).outputs
 
     def clone(self, name):
         """Return a clone of the Q-function.

--- a/src/garage/tf/q_functions/continuous_mlp_q_function.py
+++ b/src/garage/tf/q_functions/continuous_mlp_q_function.py
@@ -135,7 +135,7 @@ class ContinuousMLPQFunction(QFunction):
             name (str): Network variable scope.
 
         Return:
-            tf.Tensor: The output of Discrete MLP QFunction.
+            tf.Tensor: The output of Continuous MLP QFunction.
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):

--- a/src/garage/tf/q_functions/discrete_cnn_q_function.py
+++ b/src/garage/tf/q_functions/discrete_cnn_q_function.py
@@ -154,6 +154,7 @@ class DiscreteCNNQFunction(QFunction):
                 layer_normalization=layer_normalization)
 
         self.model = Sequential(cnn_model, output_model)
+        self._network = None
 
         self._initialize()
 
@@ -172,7 +173,7 @@ class DiscreteCNNQFunction(QFunction):
 
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self.model.build(augmented_obs_ph)
+            self._network = self.model.build(augmented_obs_ph)
 
         self._obs_input = obs_ph
 
@@ -184,7 +185,7 @@ class DiscreteCNNQFunction(QFunction):
             list[tf.Tensor]: Q values.
 
         """
-        return self.model.networks['default'].outputs
+        return self._network.outputs
 
     @property
     def input(self):
@@ -265,4 +266,5 @@ class DiscreteCNNQFunction(QFunction):
         """
         new_dict = self.__dict__.copy()
         del new_dict['_obs_input']
+        del new_dict['_network']
         return new_dict

--- a/src/garage/tf/q_functions/discrete_cnn_q_function.py
+++ b/src/garage/tf/q_functions/discrete_cnn_q_function.py
@@ -214,7 +214,7 @@ class DiscreteCNNQFunction(QFunction):
             if isinstance(self._env_spec.observation_space, akro.Image):
                 augmented_state_input = tf.cast(state_input,
                                                 tf.float32) / 255.0
-            return self.model.build(augmented_state_input, name=name)
+            return self.model.build(augmented_state_input, name=name).outputs
 
     def clone(self, name):
         """Return a clone of the Q-function.

--- a/src/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/src/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -91,6 +91,8 @@ class DiscreteMLPQFunction(QFunction):
                 output_b_init=output_b_init,
                 layer_normalization=layer_normalization)
 
+        self._network = None
+
         self._initialize()
 
     def _initialize(self):
@@ -100,7 +102,7 @@ class DiscreteMLPQFunction(QFunction):
 
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
-            self.model.build(obs_ph)
+            self._network = self.model.build(obs_ph)
 
     @property
     def q_vals(self):
@@ -110,7 +112,7 @@ class DiscreteMLPQFunction(QFunction):
             list[tf.Tensor]: Q values.
 
         """
-        return self.model.networks['default'].outputs
+        return self._network.outputs
 
     @property
     def input(self):
@@ -120,7 +122,7 @@ class DiscreteMLPQFunction(QFunction):
             tf.Tensor: QFunction Input.
 
         """
-        return self.model.networks['default'].input
+        return self._network.input
 
     # pylint: disable=arguments-differ
     def get_qval_sym(self, state_input, name):
@@ -161,6 +163,17 @@ class DiscreteMLPQFunction(QFunction):
                               output_b_init=self._output_b_init,
                               dueling=self._dueling,
                               layer_normalization=self._layer_normalization)
+
+    def __getstate__(self):
+        """Object.__getstate__.
+
+        Returns:
+            dict: The state.
+
+        """
+        new_dict = self.__dict__.copy()
+        del new_dict['_network']
+        return new_dict
 
     def __setstate__(self, state):
         """Object.__setstate__.

--- a/src/garage/tf/q_functions/discrete_mlp_q_function.py
+++ b/src/garage/tf/q_functions/discrete_mlp_q_function.py
@@ -135,7 +135,7 @@ class DiscreteMLPQFunction(QFunction):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            return self.model.build(state_input, name=name)
+            return self.model.build(state_input, name=name).outputs
 
     def clone(self, name):
         """Return a clone of the Q-function.

--- a/src/garage/tf/regressors/bernoulli_mlp_regressor.py
+++ b/src/garage/tf/regressors/bernoulli_mlp_regressor.py
@@ -244,7 +244,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(x_var, name=name)
+            prob, _, _ = self.model.build(x_var, name=name).outputs
 
         return self._dist.log_likelihood_sym(y_var, dict(p=prob))
 
@@ -265,7 +265,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(input_var, name=name)
+            prob, _, _ = self.model.build(input_var, name=name).outputs
 
         return dict(prob=prob)
 

--- a/src/garage/tf/regressors/bernoulli_mlp_regressor.py
+++ b/src/garage/tf/regressors/bernoulli_mlp_regressor.py
@@ -113,6 +113,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
             layer_normalization=layer_normalization)
 
         self._dist = Bernoulli(output_dim)
+        self._network = None
 
         self._initialize()
 
@@ -122,7 +123,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
                                              self._input_shape)
 
         with tf.compat.v1.variable_scope(self._variable_scope):
-            self.model.build(input_var)
+            self._network = self.model.build(input_var)
 
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',
@@ -133,7 +134,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
                                                     shape=(None,
                                                            self._output_dim))
 
-            y_hat = self.model.networks['default'].y_hat
+            y_hat = self._network.y_hat
 
             old_info_vars = dict(p=old_prob_var)
             info_vars = dict(p=y_hat)
@@ -169,10 +170,8 @@ class BernoulliMLPRegressor(StochasticRegressor):
         """
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            self.model.networks['default'].x_mean.load(
-                np.mean(xs, axis=0, keepdims=True))
-            self.model.networks['default'].x_std.load(
-                np.std(xs, axis=0, keepdims=True) + 1e-8)
+            self._network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._network.x_std.load(np.std(xs, axis=0, keepdims=True) + 1e-8)
 
         if self._use_trust_region and self._first_optimized:
             # To use trust region constraint and optimizer
@@ -282,7 +281,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
     @property
     def distribution(self):
         """garage.tf.distributions.DiagonalGaussian: Distribution."""
-        return self.model.networks['default'].dist
+        return self._dist
 
     def __getstate__(self):
         """Object.__getstate__.
@@ -294,6 +293,7 @@ class BernoulliMLPRegressor(StochasticRegressor):
         new_dict = super().__getstate__()
         del new_dict['_f_predict']
         del new_dict['_f_prob']
+        del new_dict['_network']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor.py
@@ -240,7 +240,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
         """
         del state_info_vars
         with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(input_var, name=name)
+            prob, _, _ = self.model.build(input_var, name=name).outputs
 
         return dict(prob=prob)
 
@@ -257,7 +257,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(x_var, name=name)
+            prob, _, _ = self.model.build(x_var, name=name).outputs
 
         return self._dist.log_likelihood_sym(y_var, dict(prob=prob))
 

--- a/src/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor.py
@@ -118,6 +118,8 @@ class CategoricalMLPRegressor(StochasticRegressor):
             output_b_init=output_b_init,
             layer_normalization=layer_normalization)
 
+        self._network = None
+
         self._initialize()
 
     def _initialize(self):
@@ -126,7 +128,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
                                              self._input_shape)
 
         with tf.compat.v1.variable_scope(self._variable_scope):
-            self.model.build(input_var)
+            self._network = self.model.build(input_var)
 
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',
@@ -137,7 +139,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
                                                     shape=(None,
                                                            self._output_dim))
 
-            y_hat = self.model.networks['default'].y_hat
+            y_hat = self._network.y_hat
 
             old_info_vars = dict(prob=old_prob_var)
             info_vars = dict(prob=y_hat)
@@ -176,10 +178,8 @@ class CategoricalMLPRegressor(StochasticRegressor):
         """
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            self.model.networks['default'].x_mean.load(
-                np.mean(xs, axis=0, keepdims=True))
-            self.model.networks['default'].x_std.load(
-                np.std(xs, axis=0, keepdims=True))
+            self._network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._network.x_std.load(np.std(xs, axis=0, keepdims=True))
 
         if self._use_trust_region:
             # To use trust region constraint and optimizer
@@ -274,7 +274,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
     @property
     def distribution(self):
         """garage.tf.distributions.DiagonalGaussian: Distribution."""
-        return self.model.networks['default'].dist
+        return self._dist
 
     def __getstate__(self):
         """Object.__getstate__.
@@ -287,6 +287,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
         del new_dict['_f_predict']
         del new_dict['_f_prob']
         del new_dict['_dist']
+        del new_dict['_network']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/regressors/continuous_mlp_regressor.py
+++ b/src/garage/tf/regressors/continuous_mlp_regressor.py
@@ -160,7 +160,7 @@ class ContinuousMLPRegressor(Regressor):
 
         """
         with tf.compat.v1.variable_scope(self._variable_scope):
-            y_hat, _, _ = self.model.build(xs, name=name)
+            y_hat, _, _ = self.model.build(xs, name=name).outputs
 
         return y_hat
 

--- a/src/garage/tf/regressors/continuous_mlp_regressor.py
+++ b/src/garage/tf/regressors/continuous_mlp_regressor.py
@@ -84,6 +84,8 @@ class ContinuousMLPRegressor(Regressor):
             output_w_init=output_w_init,
             output_b_init=output_b_init)
 
+        self._network = None
+
         self._initialize()
 
     def _initialize(self):
@@ -93,12 +95,12 @@ class ContinuousMLPRegressor(Regressor):
 
         with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
-            self.model.build(input_var)
+            self._network = self.model.build(input_var)
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',
                                               shape=(None, self._output_dim))
 
-            y_hat = self.model.networks['default'].y_hat
+            y_hat = self._network.y_hat
             loss = tf.reduce_mean(tf.square(y_hat - ys_var))
 
             self._f_predict = tensor_utils.compile_function([input_var], y_hat)
@@ -123,10 +125,8 @@ class ContinuousMLPRegressor(Regressor):
         """
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            self.model.networks['default'].x_mean.load(
-                np.mean(xs, axis=0, keepdims=True))
-            self.model.networks['default'].x_std.load(
-                np.std(xs, axis=0, keepdims=True) + 1e-8)
+            self._network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._network.x_std.load(np.std(xs, axis=0, keepdims=True) + 1e-8)
 
         inputs = [xs, ys]
         loss_before = self._optimizer.loss(inputs)
@@ -183,6 +183,7 @@ class ContinuousMLPRegressor(Regressor):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_predict']
+        del new_dict['_network']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -260,6 +260,8 @@ class GaussianMLPRegressor(StochasticRegressor):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_predict']
+        del new_dict['_network']
+        del new_dict['_old_network']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -141,10 +141,10 @@ class GaussianMLPRegressor(StochasticRegressor):
                                              shape=(None, ) +
                                              self._input_shape)
         self._old_model.build(input_var)
-        self._old_model.parameters = self.model.parameters
 
         with tf.compat.v1.variable_scope(self._variable_scope):
             self.model.build(input_var)
+            self._old_model.parameters = self.model.parameters
 
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',

--- a/src/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -134,36 +134,36 @@ class GaussianMLPRegressor(StochasticRegressor):
 
         # model for old distribution, used when trusted region is on
         self._old_model = self.model.clone(name='model_for_old_dist')
+        self._network = None
+        self._old_network = None
+
         self._initialize()
 
     def _initialize(self):
         input_var = tf.compat.v1.placeholder(tf.float32,
                                              shape=(None, ) +
                                              self._input_shape)
-        self._old_model.build(input_var)
+        self._old_network = self._old_model.build(input_var)
 
         with tf.compat.v1.variable_scope(self._variable_scope):
-            self.model.build(input_var)
+            self._network = self.model.build(input_var)
             self._old_model.parameters = self.model.parameters
 
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',
                                               shape=(None, self._output_dim))
 
-            y_mean_var = self.model.networks['default'].y_mean
-            y_std_var = self.model.networks['default'].y_std
-            means_var = self.model.networks['default'].mean
+            y_mean_var = self._network.y_mean
+            y_std_var = self._network.y_std
+            means_var = self._network.mean
 
-            normalized_means_var = self.model.networks[
-                'default'].normalized_mean
-            normalized_log_stds_var = self.model.networks[
-                'default'].normalized_log_std
+            normalized_means_var = self._network.normalized_mean
+            normalized_log_stds_var = self._network.normalized_log_std
 
             normalized_ys_var = (ys_var - y_mean_var) / y_std_var
 
-            old_normalized_dist = self._old_model.networks[
-                'default'].normalized_dist
-            normalized_dist = self.model.networks['default'].normalized_dist
+            old_normalized_dist = self._old_network.normalized_dist
+            normalized_dist = self._network.normalized_dist
 
             mean_kl = tf.reduce_mean(
                 old_normalized_dist.kl_divergence(normalized_dist))
@@ -205,23 +205,17 @@ class GaussianMLPRegressor(StochasticRegressor):
 
         if self._normalize_inputs:
             # recompute normalizing constants for inputs
-            self.model.networks['default'].x_mean.load(
-                np.mean(xs, axis=0, keepdims=True))
-            self.model.networks['default'].x_std.load(
-                np.std(xs, axis=0, keepdims=True) + 1e-8)
-            self._old_model.networks['default'].x_mean.load(
-                np.mean(xs, axis=0, keepdims=True))
-            self._old_model.networks['default'].x_std.load(
+            self._network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._network.x_std.load(np.std(xs, axis=0, keepdims=True) + 1e-8)
+            self._old_network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._old_network.x_std.load(
                 np.std(xs, axis=0, keepdims=True) + 1e-8)
         if self._normalize_outputs:
             # recompute normalizing constants for outputs
-            self.model.networks['default'].y_mean.load(
-                np.mean(ys, axis=0, keepdims=True))
-            self.model.networks['default'].y_std.load(
-                np.std(ys, axis=0, keepdims=True) + 1e-8)
-            self._old_model.networks['default'].y_mean.load(
-                np.mean(ys, axis=0, keepdims=True))
-            self._old_model.networks['default'].y_std.load(
+            self._network.y_mean.load(np.mean(ys, axis=0, keepdims=True))
+            self._network.y_std.load(np.std(ys, axis=0, keepdims=True) + 1e-8)
+            self._old_network.y_mean.load(np.mean(ys, axis=0, keepdims=True))
+            self._old_network.y_std.load(
                 np.std(ys, axis=0, keepdims=True) + 1e-8)
         inputs = [xs, ys]
         loss_before = self._optimizer.loss(inputs)
@@ -255,7 +249,7 @@ class GaussianMLPRegressor(StochasticRegressor):
     @property
     def distribution(self):
         """garage.tf.distributions.DiagonalGaussian: Distribution."""
-        return self.model.networks['default'].dist
+        return self._network.dist
 
     def __getstate__(self):
         """Object.__getstate__.

--- a/src/garage/tf/samplers/worker.py
+++ b/src/garage/tf/samplers/worker.py
@@ -1,5 +1,4 @@
 """Default TensorFlow sampler Worker."""
-import numpy as np
 import tensorflow as tf
 
 from garage.sampler import Worker
@@ -115,15 +114,6 @@ class TFWorkerWrapper(Worker):
                 argument depends on the `Worker` implementation.
 
         """
-        # flake8: noqa
-        if not isinstance(
-                agent_update,
-            (dict, tuple, np.ndarray)) and (agent_update is not None) and (
-                'default' not in agent_update.model.networks):
-            obs_ph = tf.compat.v1.placeholder(tf.float32,
-                                              shape=(None, None,
-                                                     agent_update.obs_dim))
-            agent_update.build(obs_ph)
         self._inner_worker.update_agent(agent_update)
 
     def update_env(self, env_update):

--- a/tests/fixtures/q_functions/simple_q_function.py
+++ b/tests/fixtures/q_functions/simple_q_function.py
@@ -1,3 +1,4 @@
+"""Simple QFunction for testing."""
 import tensorflow as tf
 
 from garage.tf.q_functions import QFunction
@@ -5,7 +6,13 @@ from tests.fixtures.models import SimpleMLPModel
 
 
 class SimpleQFunction(QFunction):
-    """Simple QFunction for testing."""
+    """Simple QFunction for testing.
+
+    Args:
+        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
+        name (str): Name of the q-function, also serves as the variable scope.
+
+    """
 
     def __init__(self, env_spec, name='SimpleQFunction'):
         super().__init__(name)
@@ -13,20 +20,46 @@ class SimpleQFunction(QFunction):
         action_dim = env_spec.observation_space.flat_dim
         self.model = SimpleMLPModel(output_dim=action_dim)
 
+        self._q_val = None
+
         self._initialize()
 
     def _initialize(self):
+        """Initialize QFunction."""
         obs_ph = tf.compat.v1.placeholder(tf.float32, (None, ) + self.obs_dim,
                                           name='obs')
 
         with tf.compat.v1.variable_scope(self.name, reuse=False) as vs:
             self._variable_scope = vs
-            self.model.build(obs_ph)
+            self._q_val = self.model.build(obs_ph).outputs
 
     @property
     def q_vals(self):
-        return self.model.networks['default'].outputs
+        """Return the Q values, the output of the network.
+
+        Return:
+            list[tf.Tensor]: Q values.
+
+        """
+        return self._q_val
 
     def __setstate__(self, state):
+        """Object.__setstate__.
+
+        Args:
+            state (dict): Unpickled state.
+
+        """
         self.__dict__.update(state)
         self._initialize()
+
+    def __getstate__(self):
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
+        new_dict = self.__dict__.copy()
+        del new_dict['_q_val']
+        return new_dict

--- a/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_gaussian_mlp_regressor.py
@@ -24,6 +24,8 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
         self.model = SimpleGaussianMLPModel(output_dim=self._output_dim)
 
         self._ys = None
+        self._network = None
+
         self._initialize()
 
     @property
@@ -39,7 +41,7 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
     @property
     def distribution(self):
         """garage.tf.distributions.DiagonalGaussian: Distribution."""
-        return self.model.networks['default'].dist
+        return self._network.dist
 
     def dist_info_sym(self, input_var, state_info_vars=None, name='default'):
         """Create a symbolic graph of the distribution parameters.
@@ -56,11 +58,12 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
                 graph.
 
         """
+        del state_info_vars
         with tf.compat.v1.variable_scope(self._variable_scope):
-            self.model.build(input_var, name=name)
+            network = self.model.build(input_var, name=name)
 
-        means_var = self.model.networks[name].means
-        log_stds_var = self.model.networks[name].log_stds
+        means_var = network.means
+        log_stds_var = network.log_stds
 
         return dict(mean=means_var, log_std=log_stds_var)
 
@@ -70,7 +73,7 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
                                             shape=(None, ) + self._input_shape)
         with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
-            self.model.build(input_ph)
+            self._network = self.model.build(input_ph)
 
     def fit(self, xs, ys):
         """Fit with input data xs and label ys.
@@ -94,8 +97,7 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
         """
         if self._ys is None:
             mean = tf.compat.v1.get_default_session().run(
-                self.model.networks['default'].mean,
-                feed_dict={self.model.networks['default'].input: xs})
+                self._network.mean, feed_dict={self._network.input: xs})
             self._ys = np.full((len(xs), 1), mean)
 
         return self._ys
@@ -109,6 +111,17 @@ class SimpleGaussianMLPRegressor(StochasticRegressor):
 
         """
         return self._variable_scope.trainable_variables()
+
+    def __getstate__(self):
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
+        new_dict = super().__getstate__()
+        del new_dict['_network']
+        return new_dict
 
     def __setstate__(self, state):
         """Object.__setstate__.

--- a/tests/fixtures/regressors/simple_mlp_regressor.py
+++ b/tests/fixtures/regressors/simple_mlp_regressor.py
@@ -24,6 +24,8 @@ class SimpleMLPRegressor(Regressor):
                                     name='SimpleMLPModel')
 
         self._ys = None
+        self._network = None
+
         self._initialize()
 
     def _initialize(self):
@@ -32,7 +34,7 @@ class SimpleMLPRegressor(Regressor):
                                             shape=(None, ) + self._input_shape)
         with tf.compat.v1.variable_scope(self._name) as vs:
             self._variable_scope = vs
-            self.model.build(input_ph)
+            self._network = self.model.build(input_ph)
 
     @property
     def recurrent(self):
@@ -66,8 +68,7 @@ class SimpleMLPRegressor(Regressor):
         """
         if self._ys is None:
             outputs = tf.compat.v1.get_default_session().run(
-                self.model.networks['default'].outputs,
-                feed_dict={self.model.networks['default'].input: xs})
+                self._network.outputs, feed_dict={self._network.input: xs})
             self._ys = outputs
 
         return self._ys
@@ -81,6 +82,17 @@ class SimpleMLPRegressor(Regressor):
 
         """
         return self._variable_scope.trainable_variables()
+
+    def __getstate__(self):
+        """Object.__getstate__.
+
+        Returns:
+            dict: the state to be pickled for the instance.
+
+        """
+        new_dict = super().__getstate__()
+        del new_dict['_network']
+        return new_dict
 
     def __setstate__(self, state):
         """Object.__setstate__.

--- a/tests/garage/experiment/test_meta_evaluator.py
+++ b/tests/garage/experiment/test_meta_evaluator.py
@@ -127,33 +127,6 @@ class MockAlgo:
             exploration_trajectories.lengths) == self.n_exploration_traj)
 
 
-class MockTFAlgo(MockAlgo):
-
-    sampler_cls = LocalSampler
-
-    def __init__(self, env, policy, max_path_length, n_exploration_traj,
-                 meta_eval):
-        super().__init__(env, policy, max_path_length, n_exploration_traj,
-                         meta_eval)
-        self._build()
-
-    def _build(self):
-        input_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=(None, None, self.env.observation_space.flat_dim))
-        self.policy.build(input_var)
-
-    def __setstate__(self, state):
-        """Parameters to restore from snapshot.
-
-        Args:
-            state (dict): Parameters to restore from.
-
-        """
-        self.__dict__ = state
-        self._build()
-
-
 def test_pickle_meta_evaluator():
     set_seed(100)
     tasks = SetTaskSampler(lambda: GarageEnv(PointEnv()))
@@ -197,7 +170,7 @@ def test_meta_evaluator_with_tf():
                                       n_test_tasks=10,
                                       n_exploration_traj=n_traj)
             policy = GaussianMLPPolicy(env.spec)
-            algo = MockTFAlgo(env, policy, max_path_length, n_traj, meta_eval)
+            algo = MockAlgo(env, policy, max_path_length, n_traj, meta_eval)
             runner.setup(algo, env)
             log_file = tempfile.NamedTemporaryFile()
             csv_output = CsvOutput(log_file.name)

--- a/tests/garage/tf/embeddings/test_gaussian_mlp_encoder.py
+++ b/tests/garage/tf/embeddings/test_gaussian_mlp_encoder.py
@@ -30,10 +30,6 @@ class TestGaussianMLPEncoder(TfGraphTestCase):
         embedding_spec = InOutSpec(input_space=env.spec.observation_space,
                                    output_space=env.spec.action_space)
         embedding = GaussianMLPEncoder(embedding_spec)
-        task_input = tf.compat.v1.placeholder(tf.float32,
-                                              shape=(None, None,
-                                                     embedding.input_dim))
-        embedding.build(task_input)
 
         env.reset()
         obs, _, _, _ = env.step(1)
@@ -54,10 +50,6 @@ class TestGaussianMLPEncoder(TfGraphTestCase):
         embedding_spec = InOutSpec(input_space=env.spec.observation_space,
                                    output_space=env.spec.action_space)
         embedding = GaussianMLPEncoder(embedding_spec)
-        task_input = tf.compat.v1.placeholder(tf.float32,
-                                              shape=(None, None,
-                                                     embedding.input_dim))
-        embedding.build(task_input)
 
         env.reset()
         obs, _, _, _ = env.step(1)
@@ -77,9 +69,6 @@ class TestGaussianMLPEncoder(TfGraphTestCase):
         p = pickle.dumps(embedding)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             embedding_pickled = pickle.loads(p)
-            task_input = tf.compat.v1.placeholder(
-                tf.float32, shape=(None, None, embedding_pickled.input_dim))
-            embedding_pickled.build(task_input)
 
             output2 = sess.run(
                 [
@@ -96,10 +85,6 @@ class TestGaussianMLPEncoder(TfGraphTestCase):
                                    output_space=latent_space)
         embedding = GaussianMLPEncoder(embedding_spec,
                                        hidden_sizes=[32, 32, 32])
-        task_input = tf.compat.v1.placeholder(tf.float32,
-                                              shape=(None, None,
-                                                     embedding.input_dim))
-        embedding.build(task_input)
         # 9 Layers: (3 hidden + 1 output) * (1 weight + 1 bias) + 1 log_std
         assert len(embedding.get_params()) == 9
         assert len(embedding.get_global_vars()) == 9
@@ -113,7 +98,7 @@ class TestGaussianMLPEncoder(TfGraphTestCase):
             None, None, latent_space.shape[0]
         ])
         assert (embedding.latent_std_param.shape.as_list() == [
-            None, None, latent_space.shape[0]
+            None, 1, latent_space.shape[0]
         ])
 
         # To increase coverage in embeddings/base.py

--- a/tests/garage/tf/models/test_categorical_cnn_model.py
+++ b/tests/garage/tf/models/test_categorical_cnn_model.py
@@ -30,7 +30,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                     filters=((5, (3, 3)), ),
                                     strides=(1, ),
                                     padding='VALID')
-        dist = model.build(self._input_ph)
+        dist = model.build(self._input_ph).dist
         assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
     def test_instantiate_with_different_name(self):
@@ -61,7 +61,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                     hidden_nonlinearity=None,
                                     hidden_w_init=tf.ones_initializer(),
                                     output_w_init=tf.ones_initializer())
-        dist = model.build(self._input_ph)
+        dist = model.build(self._input_ph).dist
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalCNNModel', reuse=True):
             cnn_bias = tf.compat.v1.get_variable('CNNModel/cnn/h0/bias')
@@ -79,7 +79,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                                  shape=(None, None) +
                                                  self._input_shape)
             model_pickled = pickle.loads(h)
-            dist2 = model_pickled.build(input_var)
+            dist2 = model_pickled.build(input_var).dist
             output2 = sess.run(dist2.probs,
                                feed_dict={input_var: self._obs_input})
 

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -34,9 +34,9 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                    name='step_hidden',
                                                    dtype=tf.float32)
-        model.build(self.input_var, self.step_input_var, step_hidden_var)
-        assert isinstance(model.networks['default'].dist,
-                          tfp.distributions.OneHotCategorical)
+        dist = model.build(self.input_var, self.step_input_var,
+                           step_hidden_var).dist
+        assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
     def test_output_nonlinearity(self):
         model = CategoricalGRUModel(output_dim=1,
@@ -46,7 +46,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         step_obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
         step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         obs = np.ones((1, 1, 1))
-        dist, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph)
+        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph).dist
         probs = tf.compat.v1.get_default_session().run(dist.probs,
                                                        feed_dict={obs_ph: obs})
         assert probs == [0.5]
@@ -60,7 +60,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
                                                shape=(None, output_dim))
         step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         obs = np.ones((1, 1, output_dim))
-        dist, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph)
+        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph).dist
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
@@ -71,7 +71,8 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                    name='step_hidden',
                                                    dtype=tf.float32)
-        model.build(self.input_var, self.step_input_var, step_hidden_var)
+        dist = model.build(self.input_var, self.step_input_var,
+                           step_hidden_var).dist
 
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalGRUModel/gru',
@@ -82,7 +83,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
 
         hidden = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].dist.probs,
+        outputs1 = self.sess.run(dist.probs,
                                  feed_dict={self.input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
@@ -111,8 +112,9 @@ class TestCategoricalGRUModel(TfGraphTestCase):
                                                        name='initial_hidden',
                                                        dtype=tf.float32)
 
-            model_pickled.build(input_var, step_input_var, step_hidden_var)
-            outputs2 = sess.run(model_pickled.networks['default'].dist.probs,
+            dist2 = model_pickled.build(input_var, step_input_var,
+                                        step_hidden_var).dist
+            outputs2 = sess.run(dist2.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -71,9 +71,9 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                    name='step_hidden',
                                                    dtype=tf.float32)
-        dist = model.build(self.input_var, self.step_input_var,
-                           step_hidden_var).dist
-
+        network = model.build(self.input_var, self.step_input_var,
+                              step_hidden_var)
+        dist = network.dist
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalGRUModel/gru',
                                          reuse=True):
@@ -86,10 +86,7 @@ class TestCategoricalGRUModel(TfGraphTestCase):
         outputs1 = self.sess.run(dist.probs,
                                  feed_dict={self.input_var: self.obs_inputs})
         output1 = self.sess.run(
-            [
-                model.networks['default'].step_output,
-                model.networks['default'].step_hidden
-            ],
+            [network.step_output, network.step_hidden],
             # yapf: disable
             feed_dict={
                 self.step_input_var: self.obs_input,
@@ -112,15 +109,13 @@ class TestCategoricalGRUModel(TfGraphTestCase):
                                                        name='initial_hidden',
                                                        dtype=tf.float32)
 
-            dist2 = model_pickled.build(input_var, step_input_var,
-                                        step_hidden_var).dist
+            network2 = model_pickled.build(input_var, step_input_var,
+                                           step_hidden_var)
+            dist2 = network2.dist
             outputs2 = sess.run(dist2.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
-                [
-                    model_pickled.networks['default'].step_output,
-                    model_pickled.networks['default'].step_hidden
-                ],
+                [network2.step_output, network2.step_hidden],
                 # yapf: disable
                 feed_dict={
                     step_input_var: self.obs_input,

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -37,10 +37,9 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                  name='step_cell',
                                                  dtype=tf.float32)
-        model.build(self._input_var, self._step_input_var, step_hidden_var,
-                    step_cell_var)
-        assert isinstance(model.networks['default'].dist,
-                          tfp.distributions.OneHotCategorical)
+        dist = model.build(self._input_var, self._step_input_var,
+                           step_hidden_var, step_cell_var).dist
+        assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
     def test_output_nonlinearity(self):
         model = CategoricalLSTMModel(output_dim=1,
@@ -51,8 +50,8 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         step_cell_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         obs = np.ones((1, 1, 1))
-        dist, _, _, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph,
-                                          step_cell_ph)
+        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph,
+                           step_cell_ph).dist
         probs = tf.compat.v1.get_default_session().run(dist.probs,
                                                        feed_dict={obs_ph: obs})
         assert probs == [0.5]
@@ -67,8 +66,8 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         step_cell_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
         obs = np.ones((1, 1, output_dim))
-        dist, _, _, _, _, _ = model.build(obs_ph, step_obs_ph, step_hidden_ph,
-                                          step_cell_ph)
+        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph,
+                           step_cell_ph).dist
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
@@ -82,8 +81,8 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                  name='step_cell',
                                                  dtype=tf.float32)
-        model.build(self._input_var, self._step_input_var, step_hidden_var,
-                    step_cell_var)
+        dist = model.build(self._input_var, self._step_input_var,
+                           step_hidden_var, step_cell_var).dist
 
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalLSTMModel/lstm',
@@ -95,7 +94,7 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         hidden = np.zeros((self.batch_size, 1))
         cell = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].dist.probs,
+        outputs1 = self.sess.run(dist.probs,
                                  feed_dict={self._input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
@@ -128,9 +127,9 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
                                                      name='initial_cell',
                                                      dtype=tf.float32)
 
-            model_pickled.build(input_var, step_input_var, step_hidden_var,
-                                step_cell_var)
-            outputs2 = sess.run(model_pickled.networks['default'].dist.probs,
+            dist2 = model_pickled.build(input_var, step_input_var,
+                                        step_hidden_var, step_cell_var).dist
+            outputs2 = sess.run(dist2.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -81,9 +81,9 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                  name='step_cell',
                                                  dtype=tf.float32)
-        dist = model.build(self._input_var, self._step_input_var,
-                           step_hidden_var, step_cell_var).dist
-
+        network = model.build(self._input_var, self._step_input_var,
+                              step_hidden_var, step_cell_var)
+        dist = network.dist
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalLSTMModel/lstm',
                                          reuse=True):
@@ -97,11 +97,7 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
         outputs1 = self.sess.run(dist.probs,
                                  feed_dict={self._input_var: self.obs_inputs})
         output1 = self.sess.run(
-            [
-                model.networks['default'].step_output,
-                model.networks['default'].step_hidden,
-                model.networks['default'].step_cell
-            ],
+            [network.step_output, network.step_hidden, network.step_cell],
             feed_dict={
                 self._step_input_var: self.obs_input,
                 step_hidden_var: hidden,
@@ -127,15 +123,15 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
                                                      name='initial_cell',
                                                      dtype=tf.float32)
 
-            dist2 = model_pickled.build(input_var, step_input_var,
-                                        step_hidden_var, step_cell_var).dist
+            network2 = model_pickled.build(input_var, step_input_var,
+                                           step_hidden_var, step_cell_var)
+            dist2 = network2.dist
             outputs2 = sess.run(dist2.probs,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [
-                    model_pickled.networks['default'].step_output,
-                    model_pickled.networks['default'].step_hidden,
-                    model_pickled.networks['default'].step_cell
+                    network2.step_output, network2.step_hidden,
+                    network2.step_cell
                 ],
                 feed_dict={
                     step_input_var: self.obs_input,

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -18,7 +18,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
 
     def test_dist(self):
         model = CategoricalMLPModel(output_dim=1)
-        dist = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
         assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
     @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
@@ -26,7 +26,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
         model = CategoricalMLPModel(output_dim=output_dim)
         obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, output_dim))
         obs = np.ones((1, output_dim))
-        dist = model.build(obs_ph)
+        dist = model.build(obs_ph).dist
         probs = tf.compat.v1.get_default_session().run(tf.reduce_sum(
             dist.probs),
                                                        feed_dict={obs_ph: obs})
@@ -37,7 +37,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                     output_nonlinearity=lambda x: x / 2)
         obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
         obs = np.ones((1, 1))
-        dist = model.build(obs_ph)
+        dist = model.build(obs_ph).dist
         probs = tf.compat.v1.get_default_session().run(dist.probs,
                                                        feed_dict={obs_ph: obs})
         assert probs == [0.5]
@@ -57,7 +57,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                     hidden_nonlinearity=None,
                                     hidden_w_init=tf.ones_initializer(),
                                     output_w_init=tf.ones_initializer())
-        dist = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
         # assign bias to all one
         with tf.compat.v1.variable_scope('CategoricalMLPModel/mlp',
                                          reuse=True):
@@ -72,7 +72,7 @@ class TestCategoricalMLPModel(TfGraphTestCase):
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
-            dist2 = model_pickled.build(input_var)
+            dist2 = model_pickled.build(input_var).dist
             output2 = sess.run(dist2.probs, feed_dict={input_var: self.obs})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_cnn_mlp_merge_model.py
+++ b/tests/garage/tf/models/test_cnn_mlp_merge_model.py
@@ -55,7 +55,7 @@ class TestCNNMLPMergeModel(TfGraphTestCase):
                                  cnn_hidden_w_init=tf.constant_initializer(1),
                                  hidden_nonlinearity=self.hidden_nonlinearity)
 
-        model_out = model.build(self.obs_ph, self.action_ph)
+        model_out = model.build(self.obs_ph, self.action_ph).outputs
         filter_sum = 1
 
         # filter value after 3 layers of conv
@@ -130,7 +130,7 @@ class TestCNNMLPMergeModel(TfGraphTestCase):
                                  cnn_hidden_w_init=tf.constant_initializer(1),
                                  hidden_nonlinearity=self.hidden_nonlinearity)
 
-        model_out = model.build(self.obs_ph, self.action_ph)
+        model_out = model.build(self.obs_ph, self.action_ph).outputs
 
         filter_sum = 1
         # filter value after 3 layers of conv
@@ -202,7 +202,7 @@ class TestCNNMLPMergeModel(TfGraphTestCase):
                                  padding='VALID',
                                  cnn_hidden_w_init=tf.constant_initializer(1),
                                  hidden_nonlinearity=None)
-        outputs = model.build(self.obs_ph)
+        outputs = model.build(self.obs_ph).outputs
 
         with tf.compat.v1.variable_scope(
                 'cnn_mlp_merge_model/MLPMergeModel/mlp_concat', reuse=True):
@@ -218,7 +218,7 @@ class TestCNNMLPMergeModel(TfGraphTestCase):
                                                 shape=(None, ) +
                                                 self.input_shape,
                                                 name='input')
-            outputs = model_pickled.build(input_ph)
+            outputs = model_pickled.build(input_ph).outputs
             output2 = sess.run(outputs, feed_dict={input_ph: self.obs_input})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_cnn_model.py
+++ b/tests/garage/tf/models/test_cnn_model.py
@@ -18,6 +18,7 @@ class TestCNNModel(TfGraphTestCase):
         self.input_height = 10
         self.obs_input = np.ones(
             (self.batch_size, self.input_width, self.input_height, 3))
+        # pylint: disable=unsubscriptable-object
         input_shape = self.obs_input.shape[1:]  # height, width, channel
         self._input_ph = tf.compat.v1.placeholder(tf.float32,
                                                   shape=(None, ) + input_shape,
@@ -41,7 +42,7 @@ class TestCNNModel(TfGraphTestCase):
                          hidden_w_init=tf.constant_initializer(1),
                          hidden_nonlinearity=None)
 
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         output = self.sess.run(outputs,
                                feed_dict={self._input_ph: self.obs_input})
 
@@ -91,7 +92,7 @@ class TestCNNModel(TfGraphTestCase):
             hidden_w_init=tf.constant_initializer(1),
             hidden_nonlinearity=None)
 
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         output = self.sess.run(outputs,
                                feed_dict={self._input_ph: self.obs_input})
 
@@ -136,7 +137,7 @@ class TestCNNModel(TfGraphTestCase):
                          padding='VALID',
                          hidden_w_init=tf.constant_initializer(1),
                          hidden_nonlinearity=None)
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         with tf.compat.v1.variable_scope('cnn_model/cnn/h0', reuse=True):
             bias = tf.compat.v1.get_variable('bias')
         bias.load(tf.ones_like(bias).eval())
@@ -146,11 +147,12 @@ class TestCNNModel(TfGraphTestCase):
         h = pickle.dumps(model)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
+            # pylint: disable=unsubscriptable-object
             input_shape = self.obs_input.shape[1:]  # height, width, channel
             input_ph = tf.compat.v1.placeholder(tf.float32,
                                                 shape=(None, ) + input_shape,
                                                 name='input')
-            outputs = model_pickled.build(input_ph)
+            outputs = model_pickled.build(input_ph).outputs
             output2 = sess.run(outputs, feed_dict={input_ph: self.obs_input})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_gaussian_cnn_model.py
+++ b/tests/garage/tf/models/test_gaussian_cnn_model.py
@@ -47,7 +47,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  std_parameterization='exp',
                                  hidden_w_init=tf.constant_initializer(0.01),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
 
         action, mean, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
@@ -135,7 +135,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  std_parameterization='exp',
                                  hidden_w_init=tf.constant_initializer(0.01),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
 
         action, mean, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
@@ -231,7 +231,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             output_w_init=tf.constant_initializer(1),
             std_hidden_w_init=tf.constant_initializer(0.01),
             std_output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
 
         action, mean, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
@@ -328,7 +328,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  hidden_sizes=hidden_sizes,
                                  output_dim=output_dim,
                                  std_share_network=True)
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
@@ -344,7 +344,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
-            outputs = model_pickled.build(input_var)
+            outputs = model_pickled.build(input_var).outputs
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
 
             assert np.array_equal(output1, output2)
@@ -365,7 +365,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  output_dim=output_dim,
                                  std_share_network=False,
                                  adaptive_std=False)
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
@@ -381,7 +381,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
-            outputs = model_pickled.build(input_var)
+            outputs = model_pickled.build(input_var).outputs
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
             assert np.array_equal(output1, output2)
 
@@ -412,7 +412,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  output_w_init=tf.constant_initializer(1),
                                  std_hidden_w_init=tf.constant_initializer(1),
                                  std_output_w_init=tf.constant_initializer(1))
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianCNNModel', reuse=True):
@@ -427,7 +427,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, 10, 10, 3))
             model_pickled = pickle.loads(h)
-            outputs = model_pickled.build(input_var)
+            outputs = model_pickled.build(input_var).outputs
             output2 = sess.run(outputs[:-1], feed_dict={input_var: self.obs})
             assert np.array_equal(output1, output2)
 
@@ -454,7 +454,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  std_parameterization='softplus',
                                  hidden_w_init=tf.constant_initializer(0.01),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
 
         action, mean, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
@@ -511,7 +511,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  min_std=10,
                                  hidden_w_init=tf.constant_initializer(0.01),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
 
@@ -540,7 +540,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  max_std=1.0,
                                  hidden_w_init=tf.constant_initializer(0.01),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
 
@@ -569,7 +569,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  min_std=10,
                                  hidden_w_init=tf.constant_initializer(0.1),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
 
@@ -599,7 +599,7 @@ class TestGaussianCNNModel(TfGraphTestCase):
                                  max_std=1.0,
                                  hidden_w_init=tf.constant_initializer(0.1),
                                  output_w_init=tf.constant_initializer(1))
-        outputs = model.build(self._input_ph)
+        outputs = model.build(self._input_ph).outputs
         _, _, log_std, std_param = self.sess.run(
             outputs[:-1], feed_dict={self._input_ph: self.obs})
 

--- a/tests/garage/tf/models/test_gaussian_gru_model.py
+++ b/tests/garage/tf/models/test_gaussian_gru_model.py
@@ -36,9 +36,9 @@ class TestGaussianGRUModel(TfGraphTestCase):
         step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                    name='step_hidden',
                                                    dtype=tf.float32)
-        model.build(self.input_var, self.step_input_var, step_hidden_var)
-        assert isinstance(model.networks['default'].dist,
-                          tfp.distributions.MultivariateNormalDiag)
+        dist = model.build(self.input_var, self.step_input_var,
+                           step_hidden_var).dist
+        assert isinstance(dist, tfp.distributions.MultivariateNormalDiag)
 
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_dim', [
@@ -65,7 +65,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                                    dtype=tf.float32)
         (_, step_mean_var, step_log_std_var, step_hidden,
          hidden_init_var) = model.build(self.input_var, self.step_input_var,
-                                        step_hidden_var)
+                                        step_hidden_var).outputs
 
         hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
                                     hidden_init_var.eval())
@@ -157,7 +157,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                                    dtype=tf.float32)
         (_, step_mean_var, step_log_std_var, step_hidden,
          hidden_init_var) = model.build(self.input_var, self.step_input_var,
-                                        step_hidden_var)
+                                        step_hidden_var).outputs
 
         hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
                                     hidden_init_var.eval())
@@ -248,7 +248,8 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                                    name='step_hidden',
                                                    dtype=tf.float32)
         (dist, step_mean_var, step_log_std_var, step_hidden,
-         _) = model.build(self.input_var, self.step_input_var, step_hidden_var)
+         _) = model.build(self.input_var, self.step_input_var,
+                          step_hidden_var).outputs
 
         # output layer is a tf.keras.layers.Dense object,
         # which cannot be access by tf.compat.v1.variable_scope.
@@ -286,7 +287,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
 
             (dist2, step_mean_var2, step_log_std_var2, step_hidden2,
              _) = model_pickled.build(input_var, step_input_var,
-                                      step_hidden_var)
+                                      step_hidden_var).outputs
 
             outputs2 = sess.run([dist2.loc, dist2.scale.diag],
                                 feed_dict={input_var: self.obs_inputs})
@@ -323,7 +324,8 @@ class TestGaussianGRUModel(TfGraphTestCase):
                                                    name='step_hidden',
                                                    dtype=tf.float32)
         (dist, step_mean_var, step_log_std_var, step_hidden,
-         _) = model.build(self.input_var, self.step_input_var, step_hidden_var)
+         _) = model.build(self.input_var, self.step_input_var,
+                          step_hidden_var).outputs
 
         # output layer is a tf.keras.layers.Dense object,
         # which cannot be access by tf.compat.v1.variable_scope.
@@ -360,7 +362,7 @@ class TestGaussianGRUModel(TfGraphTestCase):
 
             (dist2, step_mean_var2, step_log_std_var2, step_hidden2,
              _) = model_pickled.build(input_var, step_input_var,
-                                      step_hidden_var)
+                                      step_hidden_var).outputs
 
             outputs2 = sess.run([dist2.loc, dist2.scale.diag],
                                 feed_dict={input_var: self.obs_inputs})

--- a/tests/garage/tf/models/test_gaussian_lstm_model.py
+++ b/tests/garage/tf/models/test_gaussian_lstm_model.py
@@ -39,10 +39,9 @@ class TestGaussianLSTMModel(TfGraphTestCase):
         step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                  name='step_cell',
                                                  dtype=tf.float32)
-        model.build(self.input_var, self.step_input_var, step_hidden_var,
-                    step_cell_var)
-        assert isinstance(model.networks['default'].dist,
-                          tfp.distributions.MultivariateNormalDiag)
+        dist = model.build(self.input_var, self.step_input_var,
+                           step_hidden_var, step_cell_var).dist
+        assert isinstance(dist, tfp.distributions.MultivariateNormalDiag)
 
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_dim', [

--- a/tests/garage/tf/models/test_gaussian_lstm_model.py
+++ b/tests/garage/tf/models/test_gaussian_lstm_model.py
@@ -75,7 +75,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
          hidden_init_var, cell_init_var) = model.build(self.input_var,
                                                        self.step_input_var,
                                                        step_hidden_var,
-                                                       step_cell_var)
+                                                       step_cell_var).outputs
 
         hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
                                     hidden_init_var.eval())
@@ -179,7 +179,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
          hidden_init_var, cell_init_var) = model.build(self.input_var,
                                                        self.step_input_var,
                                                        step_hidden_var,
-                                                       step_cell_var)
+                                                       step_cell_var).outputs
 
         hidden1 = hidden2 = np.full((self.batch_size, hidden_dim),
                                     hidden_init_var.eval())
@@ -285,7 +285,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
                                                  dtype=tf.float32)
         (dist, step_mean_var, step_log_std_var, step_hidden, step_cell, _,
          _) = model.build(self.input_var, self.step_input_var, step_hidden_var,
-                          step_cell_var)
+                          step_cell_var).outputs
 
         # output layer is a tf.keras.layers.Dense object,
         # which cannot be access by tf.compat.v1.variable_scope.
@@ -331,7 +331,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             (dist2, step_mean_var2, step_log_std_var2, step_hidden2,
              step_cell2, _, _) = model_pickled.build(input_var, step_input_var,
                                                      step_hidden_var,
-                                                     step_cell_var)
+                                                     step_cell_var).outputs
 
             outputs2 = sess.run([dist2.loc, dist2.scale.diag],
                                 feed_dict={input_var: self.obs_inputs})
@@ -374,7 +374,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
                                                  dtype=tf.float32)
         (dist, step_mean_var, step_log_std_var, step_hidden, step_cell, _,
          _) = model.build(self.input_var, self.step_input_var, step_hidden_var,
-                          step_cell_var)
+                          step_cell_var).outputs
 
         # output layer is a tf.keras.layers.Dense object,
         # which cannot be access by tf.compat.v1.variable_scope.
@@ -420,7 +420,7 @@ class TestGaussianLSTMModel(TfGraphTestCase):
             (dist2, step_mean_var2, step_log_std_var2, step_hidden2,
              step_cell2, _, _) = model_pickled.build(input_var, step_input_var,
                                                      step_hidden_var,
-                                                     step_cell_var)
+                                                     step_cell_var).outputs
 
             outputs2 = sess.run([dist2.loc, dist2.scale.diag],
                                 feed_dict={input_var: self.obs_inputs})

--- a/tests/garage/tf/models/test_gaussian_mlp_model.py
+++ b/tests/garage/tf/models/test_gaussian_mlp_model.py
@@ -19,7 +19,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
     def test_dist(self):
         model = GaussianMLPModel(output_dim=1)
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
         assert isinstance(dist, tfp.distributions.MultivariateNormalDiag)
 
     @pytest.mark.parametrize('output_dim, hidden_sizes',
@@ -33,7 +33,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  std_parameterization='exp',
                                  hidden_w_init=tf.ones_initializer(),
                                  output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         mean, log_std = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
@@ -75,7 +75,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  hidden_nonlinearity=None,
                                  hidden_w_init=tf.ones_initializer(),
                                  output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         mean, log_std = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
@@ -123,7 +123,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  std_hidden_nonlinearity=None,
                                  std_hidden_w_init=tf.ones_initializer(),
                                  std_output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         mean, log_std = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
@@ -166,14 +166,13 @@ class TestGaussianMLPModel(TfGraphTestCase):
                              [(1, (0, )), (1, (1, )), (1, (2, )), (2, (3, )),
                               (2, (1, 1)), (3, (2, 2))])
     def test_std_share_network_is_pickleable(self, output_dim, hidden_sizes):
-        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 5))
         model = GaussianMLPModel(output_dim=output_dim,
                                  hidden_sizes=hidden_sizes,
                                  std_share_network=True,
                                  hidden_nonlinearity=None,
                                  hidden_w_init=tf.ones_initializer(),
                                  output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(input_var)
+        dist = model.build(self.input_var).dist
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
@@ -184,14 +183,14 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
         output1 = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
-            feed_dict={input_var: self.obs})
+            feed_dict={self.input_var: self.obs})
 
         h = pickle.dumps(model)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, None, 5))
             model_pickled = pickle.loads(h)
-            dist2, _, _ = model_pickled.build(input_var)
+            dist2 = model_pickled.build(input_var).dist
             output2 = sess.run(
                 [dist2.loc, tf.math.log(dist2.stddev())],
                 feed_dict={input_var: self.obs})
@@ -203,7 +202,6 @@ class TestGaussianMLPModel(TfGraphTestCase):
                               (2, (1, 1)), (3, (2, 2))])
     def test_without_std_share_network_is_pickleable(self, output_dim,
                                                      hidden_sizes):
-        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 5))
         model = GaussianMLPModel(output_dim=output_dim,
                                  hidden_sizes=hidden_sizes,
                                  std_share_network=False,
@@ -211,7 +209,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  hidden_nonlinearity=None,
                                  hidden_w_init=tf.ones_initializer(),
                                  output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(input_var)
+        dist = model.build(self.input_var).dist
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
@@ -222,14 +220,14 @@ class TestGaussianMLPModel(TfGraphTestCase):
 
         output1 = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
-            feed_dict={input_var: self.obs})
+            feed_dict={self.input_var: self.obs})
 
         h = pickle.dumps(model)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, None, 5))
             model_pickled = pickle.loads(h)
-            dist2, _, _ = model_pickled.build(input_var)
+            dist2 = model_pickled.build(input_var).dist
             output2 = sess.run(
                 [dist2.loc, tf.math.log(dist2.stddev())],
                 feed_dict={input_var: self.obs})
@@ -241,7 +239,6 @@ class TestGaussianMLPModel(TfGraphTestCase):
                               (2, (1, 1), (1, 1)), (3, (2, 2), (2, 2))])
     def test_adaptive_std_is_pickleable(self, output_dim, hidden_sizes,
                                         std_hidden_sizes):
-        input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 5))
         model = GaussianMLPModel(output_dim=output_dim,
                                  hidden_sizes=hidden_sizes,
                                  std_hidden_sizes=std_hidden_sizes,
@@ -253,7 +250,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  std_hidden_nonlinearity=None,
                                  std_hidden_w_init=tf.ones_initializer(),
                                  std_output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(input_var)
+        dist = model.build(self.input_var).dist
 
         # get output bias
         with tf.compat.v1.variable_scope('GaussianMLPModel', reuse=True):
@@ -265,12 +262,12 @@ class TestGaussianMLPModel(TfGraphTestCase):
         h = pickle.dumps(model)
         output1 = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
-            feed_dict={input_var: self.obs})
+            feed_dict={self.input_var: self.obs})
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32,
                                                  shape=(None, None, 5))
             model_pickled = pickle.loads(h)
-            dist2, _, _ = model_pickled.build(input_var)
+            dist2 = model_pickled.build(input_var).dist
             output2 = sess.run(
                 [dist2.loc, tf.math.log(dist2.stddev())],
                 feed_dict={input_var: self.obs})
@@ -290,7 +287,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  std_parameterization='softplus',
                                  hidden_w_init=tf.ones_initializer(),
                                  output_w_init=tf.ones_initializer())
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         mean, log_std = self.sess.run(
             [dist.loc, tf.math.log(dist.stddev())],
@@ -312,7 +309,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  init_std=1,
                                  min_std=10,
                                  std_parameterization='exp')
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         log_std = self.sess.run(tf.math.log(dist.stddev()),
                                 feed_dict={self.input_var: self.obs})
@@ -330,7 +327,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  init_std=10,
                                  max_std=1,
                                  std_parameterization='exp')
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         log_std = self.sess.run(tf.math.log(dist.stddev()),
                                 feed_dict={self.input_var: self.obs})
@@ -348,7 +345,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  init_std=1,
                                  min_std=10,
                                  std_parameterization='softplus')
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         log_std = self.sess.run(tf.math.log(dist.stddev()),
                                 feed_dict={self.input_var: self.obs})
@@ -367,7 +364,7 @@ class TestGaussianMLPModel(TfGraphTestCase):
                                  init_std=10,
                                  max_std=1,
                                  std_parameterization='softplus')
-        dist, _, _ = model.build(self.input_var)
+        dist = model.build(self.input_var).dist
 
         log_std = self.sess.run(tf.math.log(dist.stddev()),
                                 feed_dict={self.input_var: self.obs})

--- a/tests/garage/tf/models/test_gru_model.py
+++ b/tests/garage/tf/models/test_gru_model.py
@@ -9,6 +9,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestGRUModel(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.batch_size = 1
@@ -20,40 +21,42 @@ class TestGRUModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self.input_var = tf.compat.v1.placeholder(
-            tf.float32, shape=(None, None, self.feature_shape), name='input')
+        self.input_var = tf.compat.v1.placeholder(tf.float32,
+                                                  shape=(None, None,
+                                                         self.feature_shape),
+                                                  name='input')
         self.step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='input')
 
     @pytest.mark.parametrize('output_dim, hidden_dim', [(1, 1), (1, 2),
                                                         (3, 3)])
     def test_output_values(self, output_dim, hidden_dim):
-        model = GRUModel(
-            output_dim=output_dim,
-            hidden_dim=hidden_dim,
-            hidden_nonlinearity=None,
-            recurrent_nonlinearity=None,
-            hidden_w_init=tf.constant_initializer(1),
-            recurrent_w_init=tf.constant_initializer(1),
-            output_w_init=tf.constant_initializer(1))
+        model = GRUModel(output_dim=output_dim,
+                         hidden_dim=hidden_dim,
+                         hidden_nonlinearity=None,
+                         recurrent_nonlinearity=None,
+                         hidden_w_init=tf.constant_initializer(1),
+                         recurrent_w_init=tf.constant_initializer(1),
+                         output_w_init=tf.constant_initializer(1))
 
-        step_hidden_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, hidden_dim),
-            name='step_hidden',
-            dtype=tf.float32)
+        step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                          hidden_dim),
+                                                   name='step_hidden',
+                                                   dtype=tf.float32)
 
         outputs = model.build(self.input_var, self.step_input_var,
-                              step_hidden_var)
-        output = self.sess.run(
-            outputs[0], feed_dict={self.input_var: self.obs_inputs})
+                              step_hidden_var).outputs
+        output = self.sess.run(outputs[0],
+                               feed_dict={self.input_var: self.obs_inputs})
         expected_output = np.full(
             [self.batch_size, self.time_step, output_dim], hidden_dim * -2)
         assert np.array_equal(output, expected_output)
 
     def test_is_pickleable(self):
         model = GRUModel(output_dim=1, hidden_dim=1)
-        step_hidden_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, 1), name='step_hidden', dtype=tf.float32)
+        step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
+                                                   name='step_hidden',
+                                                   dtype=tf.float32)
         model.build(self.input_var, self.step_input_var, step_hidden_var)
 
         # assign bias to all one
@@ -64,9 +67,8 @@ class TestGRUModel(TfGraphTestCase):
 
         hidden = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(
-            model.networks['default'].all_output,
-            feed_dict={self.input_var: self.obs_inputs})
+        outputs1 = self.sess.run(model.networks['default'].all_output,
+                                 feed_dict={self.input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
                 model.networks['default'].step_output,
@@ -83,21 +85,20 @@ class TestGRUModel(TfGraphTestCase):
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
 
-            input_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=(None, None, self.feature_shape),
-                name='input')
+            input_var = tf.compat.v1.placeholder(tf.float32,
+                                                 shape=(None, None,
+                                                        self.feature_shape),
+                                                 name='input')
             step_input_var = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, self.feature_shape), name='input')
-            step_hidden_var = tf.compat.v1.placeholder(
-                shape=(self.batch_size, 1),
-                name='initial_hidden',
-                dtype=tf.float32)
+            step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                              1),
+                                                       name='initial_hidden',
+                                                       dtype=tf.float32)
 
             model_pickled.build(input_var, step_input_var, step_hidden_var)
-            outputs2 = sess.run(
-                model_pickled.networks['default'].all_output,
-                feed_dict={input_var: self.obs_inputs})
+            outputs2 = sess.run(model_pickled.networks['default'].all_output,
+                                feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [
                     model_pickled.networks['default'].step_output,

--- a/tests/garage/tf/models/test_gru_model.py
+++ b/tests/garage/tf/models/test_gru_model.py
@@ -57,7 +57,8 @@ class TestGRUModel(TfGraphTestCase):
         step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                    name='step_hidden',
                                                    dtype=tf.float32)
-        model.build(self.input_var, self.step_input_var, step_hidden_var)
+        network = model.build(self.input_var, self.step_input_var,
+                              step_hidden_var)
 
         # assign bias to all one
         with tf.compat.v1.variable_scope('GRUModel/gru', reuse=True):
@@ -67,13 +68,10 @@ class TestGRUModel(TfGraphTestCase):
 
         hidden = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].all_output,
+        outputs1 = self.sess.run(network.all_output,
                                  feed_dict={self.input_var: self.obs_inputs})
         output1 = self.sess.run(
-            [
-                model.networks['default'].step_output,
-                model.networks['default'].step_hidden
-            ],
+            [network.step_output, network.step_hidden],
             # yapf: disable
             feed_dict={
                 self.step_input_var: self.obs_input,
@@ -96,14 +94,12 @@ class TestGRUModel(TfGraphTestCase):
                                                        name='initial_hidden',
                                                        dtype=tf.float32)
 
-            model_pickled.build(input_var, step_input_var, step_hidden_var)
-            outputs2 = sess.run(model_pickled.networks['default'].all_output,
+            network2 = model_pickled.build(input_var, step_input_var,
+                                           step_hidden_var)
+            outputs2 = sess.run(network2.all_output,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
-                [
-                    model_pickled.networks['default'].step_output,
-                    model_pickled.networks['default'].step_hidden
-                ],
+                [network2.step_output, network2.step_hidden],
                 # yapf: disable
                 feed_dict={
                     step_input_var: self.obs_input,

--- a/tests/garage/tf/models/test_lstm_model.py
+++ b/tests/garage/tf/models/test_lstm_model.py
@@ -9,6 +9,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestLSTMModel(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.batch_size = 1
@@ -20,46 +21,49 @@ class TestLSTMModel(TfGraphTestCase):
             (self.batch_size, self.time_step, self.feature_shape), 1.)
         self.obs_input = np.full((self.batch_size, self.feature_shape), 1.)
 
-        self._input_var = tf.compat.v1.placeholder(
-            tf.float32, shape=(None, None, self.feature_shape), name='input')
+        self._input_var = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          self.feature_shape),
+                                                   name='input')
         self._step_input_var = tf.compat.v1.placeholder(
             tf.float32, shape=(None, self.feature_shape), name='input')
 
     @pytest.mark.parametrize('output_dim, hidden_dim', [(1, 1), (1, 2),
                                                         (3, 3)])
     def test_output_values(self, output_dim, hidden_dim):
-        model = LSTMModel(
-            output_dim=output_dim,
-            hidden_dim=hidden_dim,
-            hidden_nonlinearity=None,
-            recurrent_nonlinearity=None,
-            hidden_w_init=tf.constant_initializer(1),
-            recurrent_w_init=tf.constant_initializer(1),
-            output_w_init=tf.constant_initializer(1))
+        model = LSTMModel(output_dim=output_dim,
+                          hidden_dim=hidden_dim,
+                          hidden_nonlinearity=None,
+                          recurrent_nonlinearity=None,
+                          hidden_w_init=tf.constant_initializer(1),
+                          recurrent_w_init=tf.constant_initializer(1),
+                          output_w_init=tf.constant_initializer(1))
 
-        step_hidden_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, hidden_dim),
-            name='step_hidden',
-            dtype=tf.float32)
-        step_cell_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, hidden_dim),
-            name='step_cell',
-            dtype=tf.float32)
+        step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                          hidden_dim),
+                                                   name='step_hidden',
+                                                   dtype=tf.float32)
+        step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                        hidden_dim),
+                                                 name='step_cell',
+                                                 dtype=tf.float32)
 
         outputs = model.build(self._input_var, self._step_input_var,
-                              step_hidden_var, step_cell_var)
-        output = self.sess.run(
-            outputs[0], feed_dict={self._input_var: self.obs_inputs})
+                              step_hidden_var, step_cell_var).outputs
+        output = self.sess.run(outputs[0],
+                               feed_dict={self._input_var: self.obs_inputs})
         expected_output = np.full(
             [self.batch_size, self.time_step, output_dim], hidden_dim * 8)
         assert np.array_equal(output, expected_output)
 
     def test_is_pickleable(self):
         model = LSTMModel(output_dim=1, hidden_dim=1)
-        step_hidden_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, 1), name='step_hidden', dtype=tf.float32)
-        step_cell_var = tf.compat.v1.placeholder(
-            shape=(self.batch_size, 1), name='step_cell', dtype=tf.float32)
+        step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
+                                                   name='step_hidden',
+                                                   dtype=tf.float32)
+        step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
+                                                 name='step_cell',
+                                                 dtype=tf.float32)
         model.build(self._input_var, self._step_input_var, step_hidden_var,
                     step_cell_var)
 
@@ -72,9 +76,8 @@ class TestLSTMModel(TfGraphTestCase):
         hidden = np.zeros((self.batch_size, 1))
         cell = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(
-            model.networks['default'].all_output,
-            feed_dict={self._input_var: self.obs_inputs})
+        outputs1 = self.sess.run(model.networks['default'].all_output,
+                                 feed_dict={self._input_var: self.obs_inputs})
         output1 = self.sess.run(
             [
                 model.networks['default'].step_output,
@@ -91,26 +94,25 @@ class TestLSTMModel(TfGraphTestCase):
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             model_pickled = pickle.loads(h)
 
-            input_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=(None, None, self.feature_shape),
-                name='input')
+            input_var = tf.compat.v1.placeholder(tf.float32,
+                                                 shape=(None, None,
+                                                        self.feature_shape),
+                                                 name='input')
             step_input_var = tf.compat.v1.placeholder(
                 tf.float32, shape=(None, self.feature_shape), name='input')
-            step_hidden_var = tf.compat.v1.placeholder(
-                shape=(self.batch_size, 1),
-                name='initial_hidden',
-                dtype=tf.float32)
-            step_cell_var = tf.compat.v1.placeholder(
-                shape=(self.batch_size, 1),
-                name='initial_cell',
-                dtype=tf.float32)
+            step_hidden_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                              1),
+                                                       name='initial_hidden',
+                                                       dtype=tf.float32)
+            step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size,
+                                                            1),
+                                                     name='initial_cell',
+                                                     dtype=tf.float32)
 
             model_pickled.build(input_var, step_input_var, step_hidden_var,
                                 step_cell_var)
-            outputs2 = sess.run(
-                model_pickled.networks['default'].all_output,
-                feed_dict={input_var: self.obs_inputs})
+            outputs2 = sess.run(model_pickled.networks['default'].all_output,
+                                feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [
                     model_pickled.networks['default'].step_output,

--- a/tests/garage/tf/models/test_lstm_model.py
+++ b/tests/garage/tf/models/test_lstm_model.py
@@ -64,8 +64,8 @@ class TestLSTMModel(TfGraphTestCase):
         step_cell_var = tf.compat.v1.placeholder(shape=(self.batch_size, 1),
                                                  name='step_cell',
                                                  dtype=tf.float32)
-        model.build(self._input_var, self._step_input_var, step_hidden_var,
-                    step_cell_var)
+        network = model.build(self._input_var, self._step_input_var,
+                              step_hidden_var, step_cell_var)
 
         # assign bias to all one
         with tf.compat.v1.variable_scope('LSTMModel/lstm', reuse=True):
@@ -76,14 +76,10 @@ class TestLSTMModel(TfGraphTestCase):
         hidden = np.zeros((self.batch_size, 1))
         cell = np.zeros((self.batch_size, 1))
 
-        outputs1 = self.sess.run(model.networks['default'].all_output,
+        outputs1 = self.sess.run(network.all_output,
                                  feed_dict={self._input_var: self.obs_inputs})
         output1 = self.sess.run(
-            [
-                model.networks['default'].step_output,
-                model.networks['default'].step_hidden,
-                model.networks['default'].step_cell
-            ],
+            [network.step_output, network.step_hidden, network.step_cell],
             feed_dict={
                 self._step_input_var: self.obs_input,
                 step_hidden_var: hidden,
@@ -109,15 +105,14 @@ class TestLSTMModel(TfGraphTestCase):
                                                      name='initial_cell',
                                                      dtype=tf.float32)
 
-            model_pickled.build(input_var, step_input_var, step_hidden_var,
-                                step_cell_var)
-            outputs2 = sess.run(model_pickled.networks['default'].all_output,
+            network2 = model_pickled.build(input_var, step_input_var,
+                                           step_hidden_var, step_cell_var)
+            outputs2 = sess.run(network2.all_output,
                                 feed_dict={input_var: self.obs_inputs})
             output2 = sess.run(
                 [
-                    model_pickled.networks['default'].step_output,
-                    model_pickled.networks['default'].step_hidden,
-                    model_pickled.networks['default'].step_cell
+                    network2.step_output, network2.step_hidden,
+                    network2.step_cell
                 ],
                 feed_dict={
                     step_input_var: self.obs_input,

--- a/tests/garage/tf/models/test_mlp_model.py
+++ b/tests/garage/tf/models/test_mlp_model.py
@@ -11,6 +11,7 @@ from tests.fixtures import TfGraphTestCase
 
 
 class TestMLPModel(TfGraphTestCase):
+
     def setup_method(self):
         super().setup_method()
         self.input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
@@ -27,13 +28,12 @@ class TestMLPModel(TfGraphTestCase):
     ])
     # yapf: enable
     def test_output_values(self, output_dim, hidden_sizes):
-        model = MLPModel(
-            output_dim=output_dim,
-            hidden_sizes=hidden_sizes,
-            hidden_nonlinearity=None,
-            hidden_w_init=tf.ones_initializer(),
-            output_w_init=tf.ones_initializer())
-        outputs = model.build(self.input_var)
+        model = MLPModel(output_dim=output_dim,
+                         hidden_sizes=hidden_sizes,
+                         hidden_nonlinearity=None,
+                         hidden_w_init=tf.ones_initializer(),
+                         output_w_init=tf.ones_initializer())
+        outputs = model.build(self.input_var).outputs
         output = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
 
         expected_output = np.full([1, output_dim], 5 * np.prod(hidden_sizes))
@@ -51,13 +51,12 @@ class TestMLPModel(TfGraphTestCase):
     ])
     # yapf: enable
     def test_output_values_dueling(self, output_dim, hidden_sizes):
-        model = MLPDuelingModel(
-            output_dim=output_dim,
-            hidden_sizes=hidden_sizes,
-            hidden_nonlinearity=None,
-            hidden_w_init=tf.ones_initializer(),
-            output_w_init=tf.ones_initializer())
-        outputs = model.build(self.input_var)
+        model = MLPDuelingModel(output_dim=output_dim,
+                                hidden_sizes=hidden_sizes,
+                                hidden_nonlinearity=None,
+                                hidden_w_init=tf.ones_initializer(),
+                                output_w_init=tf.ones_initializer())
+        outputs = model.build(self.input_var).outputs
         output = self.sess.run(outputs, feed_dict={self.input_var: self.obs})
 
         expected_output = np.full([1, output_dim], 5 * np.prod(hidden_sizes))
@@ -75,23 +74,22 @@ class TestMLPModel(TfGraphTestCase):
     ])
     # yapf: enable
     def test_output_values_merging(self, output_dim, hidden_sizes):
-        model = MLPMergeModel(
-            output_dim=output_dim,
-            hidden_sizes=hidden_sizes,
-            concat_layer=0,
-            hidden_nonlinearity=None,
-            hidden_w_init=tf.ones_initializer(),
-            output_w_init=tf.ones_initializer())
+        model = MLPMergeModel(output_dim=output_dim,
+                              hidden_sizes=hidden_sizes,
+                              concat_layer=0,
+                              hidden_nonlinearity=None,
+                              hidden_w_init=tf.ones_initializer(),
+                              output_w_init=tf.ones_initializer())
 
         input_var2 = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         obs2 = np.ones((1, 5))
 
-        outputs = model.build(self.input_var, input_var2)
-        output = self.sess.run(
-            outputs, feed_dict={
-                self.input_var: self.obs,
-                input_var2: obs2
-            })
+        outputs = model.build(self.input_var, input_var2).outputs
+        output = self.sess.run(outputs,
+                               feed_dict={
+                                   self.input_var: self.obs,
+                                   input_var2: obs2
+                               })
 
         expected_output = np.full([1, output_dim], 10 * np.prod(hidden_sizes))
         assert np.array_equal(output, expected_output)
@@ -107,13 +105,12 @@ class TestMLPModel(TfGraphTestCase):
     ])
     # yapf: enable
     def test_is_pickleable(self, output_dim, hidden_sizes):
-        model = MLPModel(
-            output_dim=output_dim,
-            hidden_sizes=hidden_sizes,
-            hidden_nonlinearity=None,
-            hidden_w_init=tf.ones_initializer(),
-            output_w_init=tf.ones_initializer())
-        outputs = model.build(self.input_var)
+        model = MLPModel(output_dim=output_dim,
+                         hidden_sizes=hidden_sizes,
+                         hidden_nonlinearity=None,
+                         hidden_w_init=tf.ones_initializer(),
+                         output_w_init=tf.ones_initializer())
+        outputs = model.build(self.input_var).outputs
 
         # assign bias to all one
         with tf.compat.v1.variable_scope('MLPModel/mlp', reuse=True):
@@ -127,7 +124,7 @@ class TestMLPModel(TfGraphTestCase):
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(h)
-            outputs = model_pickled.build(input_var)
+            outputs = model_pickled.build(input_var).outputs
             output2 = sess.run(outputs, feed_dict={input_var: self.obs})
 
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -58,8 +58,8 @@ class ComplicatedModel(Model):
     # pylint: disable=arguments-differ
     def _build(self, obs_input, name=None):
         del name
-        h1, _ = self._simple_model_1.build(obs_input)
-        return self._simple_model_2.build(h1)
+        h1, _ = self._simple_model_1.build(obs_input).outputs
+        return self._simple_model_2.build(h1).outputs
 
 
 # This model takes another model as constructor argument
@@ -77,8 +77,8 @@ class ComplicatedModel2(Model):
     # pylint: disable=arguments-differ
     def _build(self, obs_input, name=None):
         del name
-        h1, _ = self._parent_model.build(obs_input)
-        return self._output_model.build(h1)
+        h1, _ = self._parent_model.build(obs_input).outputs
+        return self._output_model.build(h1).outputs
 
 
 class TestModel(TfGraphTestCase):
@@ -86,7 +86,7 @@ class TestModel(TfGraphTestCase):
     def test_model_creation(self):
         input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2)
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
             [outputs, model.networks['default'].outputs],
@@ -97,7 +97,7 @@ class TestModel(TfGraphTestCase):
     def test_model_creation_with_custom_name(self):
         input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = SimpleModel(output_dim=2, name='MySimpleModel')
-        outputs = model.build(input_var, name='network_2')
+        outputs = model.build(input_var, name='network_2').outputs
         data = np.ones((3, 5))
         result, result2 = self.sess.run(
             [outputs, model.networks['network_2'].outputs],
@@ -123,8 +123,8 @@ class TestModel(TfGraphTestCase):
         another_input_var = tf.compat.v1.placeholder(tf.float32,
                                                      shape=(None, 5))
         model = SimpleModel(output_dim=2)
-        outputs_1 = model.build(input_var)
-        outputs_2 = model.build(another_input_var, name='network_2')
+        outputs_1 = model.build(input_var).outputs
+        outputs_2 = model.build(another_input_var, name='network_2').outputs
         data = np.ones((3, 5))
         results_1, results_2 = self.sess.run([outputs_1, outputs_2],
                                              feed_dict={
@@ -138,8 +138,8 @@ class TestModel(TfGraphTestCase):
         another_input_var = tf.compat.v1.placeholder(tf.float32,
                                                      shape=(None, 5))
         model = SimpleModel(output_dim=2)
-        outputs_1 = model.build(input_var, name='network_1')
-        outputs_2 = model.build(another_input_var)
+        outputs_1 = model.build(input_var, name='network_1').outputs
+        outputs_2 = model.build(another_input_var).outputs
         data = np.ones((3, 5))
         results_1, results_2 = self.sess.run([outputs_1, outputs_2],
                                              feed_dict={
@@ -151,7 +151,7 @@ class TestModel(TfGraphTestCase):
     def test_model_in_model(self):
         input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         model = ComplicatedModel(output_dim=2)
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
             [outputs, model.networks['default'].outputs],
@@ -163,7 +163,7 @@ class TestModel(TfGraphTestCase):
         input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
         parent_model = SimpleModel(output_dim=4)
         model = ComplicatedModel2(parent_model=parent_model, output_dim=2)
-        outputs = model.build(input_var)
+        outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
             [outputs, model.networks['default'].outputs],
@@ -192,7 +192,7 @@ class TestModel(TfGraphTestCase):
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
             model_pickled = pickle.loads(model_data)
-            outputs = model_pickled.build(input_var)
+            outputs = model_pickled.build(input_var).outputs
 
             results2 = sess.run(outputs, feed_dict={input_var: data})
 
@@ -212,7 +212,7 @@ class TestModel(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
-            outputs = model.build(input_var)
+            outputs = model.build(input_var).outputs
 
             # assign bias to all one
             with tf.compat.v1.variable_scope(
@@ -242,7 +242,7 @@ class TestModel(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             input_var = tf.compat.v1.placeholder(tf.float32, shape=(None, 5))
-            outputs = model.build(input_var)
+            outputs = model.build(input_var).outputs
 
             # assign bias to all one
             with tf.compat.v1.variable_scope(

--- a/tests/garage/tf/models/test_model.py
+++ b/tests/garage/tf/models/test_model.py
@@ -89,8 +89,8 @@ class TestModel(TfGraphTestCase):
         outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
-            [outputs, model.networks['default'].outputs],
-            feed_dict={model.networks['default'].input: data})
+            [outputs, model._networks['default'].outputs],
+            feed_dict={model._networks['default'].input: data})
         assert np.array_equal(out, model_out)
         assert model.name == type(model).__name__
 
@@ -100,8 +100,8 @@ class TestModel(TfGraphTestCase):
         outputs = model.build(input_var, name='network_2').outputs
         data = np.ones((3, 5))
         result, result2 = self.sess.run(
-            [outputs, model.networks['network_2'].outputs],
-            feed_dict={model.networks['network_2'].input: data})
+            [outputs, model._networks['network_2'].outputs],
+            feed_dict={model._networks['network_2'].input: data})
         assert np.array_equal(result, result2)
         assert model.name == 'MySimpleModel'
 
@@ -154,8 +154,8 @@ class TestModel(TfGraphTestCase):
         outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
-            [outputs, model.networks['default'].outputs],
-            feed_dict={model.networks['default'].input: data})
+            [outputs, model._networks['default'].outputs],
+            feed_dict={model._networks['default'].input: data})
 
         assert np.array_equal(out, model_out)
 
@@ -166,8 +166,8 @@ class TestModel(TfGraphTestCase):
         outputs = model.build(input_var).outputs
         data = np.ones((3, 5))
         out, model_out = self.sess.run(
-            [outputs, model.networks['default'].outputs],
-            feed_dict={model.networks['default'].input: data})
+            [outputs, model._networks['default'].outputs],
+            feed_dict={model._networks['default'].input: data})
 
         assert np.array_equal(out, model_out)
 
@@ -185,8 +185,8 @@ class TestModel(TfGraphTestCase):
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
-                model.networks['default'].outputs,
-                feed_dict={model.networks['default'].input: data})
+                model._networks['default'].outputs,
+                feed_dict={model._networks['default'].input: data})
             model_data = pickle.dumps(model)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
@@ -221,7 +221,7 @@ class TestModel(TfGraphTestCase):
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
-                outputs, feed_dict={model.networks['default'].input: data})
+                outputs, feed_dict={model._networks['default'].input: data})
             model_data = pickle.dumps(model)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
@@ -229,7 +229,7 @@ class TestModel(TfGraphTestCase):
             model_pickled = pickle.loads(model_data)
             model_pickled.build(input_var)
 
-            results2 = sess.run(model_pickled.networks['default'].outputs,
+            results2 = sess.run(model_pickled._networks['default'].outputs,
                                 feed_dict={input_var: data})
 
         assert np.array_equal(results, results2)
@@ -251,7 +251,7 @@ class TestModel(TfGraphTestCase):
             bias.load(tf.ones_like(bias).eval())
 
             results = sess.run(
-                outputs, feed_dict={model.networks['default'].input: data})
+                outputs, feed_dict={model._networks['default'].input: data})
             model_data = pickle.dumps(model)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
@@ -259,7 +259,7 @@ class TestModel(TfGraphTestCase):
             model_pickled = pickle.loads(model_data)
             model_pickled.build(input_var)
 
-            results2 = sess.run(model_pickled.networks['default'].outputs,
+            results2 = sess.run(model_pickled._networks['default'].outputs,
                                 feed_dict={input_var: data})
 
         assert np.array_equal(results, results2)

--- a/tests/garage/tf/policies/test_categorical_cnn_policy.py
+++ b/tests/garage/tf/policies/test_categorical_cnn_policy.py
@@ -25,11 +25,6 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
                                       strides=strides,
                                       padding=padding,
                                       hidden_sizes=hidden_sizes)
-        obs_var = tf.compat.v1.placeholder(tf.float32,
-                                           shape=(None, None) +
-                                           env.observation_space.shape,
-                                           name='obs')
-        policy.build(obs_var)
 
         env.reset()
         obs, _, _, _ = env.step(1)
@@ -41,6 +36,34 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
+    @pytest.mark.parametrize('filter_dims, num_filters, '
+                             'strides, padding, hidden_sizes', [
+                                 ((3, ), (3, ), (1, ), 'VALID', (4, )),
+                                 ((3, 3), (3, 3), (1, 1), 'VALID', (4, 4)),
+                                 ((3, 3), (3, 3), (2, 2), 'SAME', (4, 4)),
+                             ])
+    def test_build(self, filter_dims, num_filters, strides, padding,
+                   hidden_sizes):
+        env = GarageEnv(DummyDiscretePixelEnv())
+        policy = CategoricalCNNPolicy(env_spec=env.spec,
+                                      filter_dims=filter_dims,
+                                      num_filters=num_filters,
+                                      strides=strides,
+                                      padding=padding,
+                                      hidden_sizes=hidden_sizes)
+
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None) +
+                                               policy.input_dim)
+        dist_sym = policy.build(state_input, name='dist_sym')
+        output1 = self.sess.run([policy.distribution.probs],
+                                feed_dict={policy.model.input: [[obs]]})
+        output2 = self.sess.run([dist_sym.probs],
+                                feed_dict={state_input: [[obs]]})
+        assert np.array_equal(output1, output2)
+
     def test_is_pickleable(self):
         env = GarageEnv(DummyDiscretePixelEnv())
         policy = CategoricalCNNPolicy(env_spec=env.spec,
@@ -48,11 +71,6 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
                                       strides=(1, ),
                                       padding='SAME',
                                       hidden_sizes=(4, ))
-        obs_var = tf.compat.v1.placeholder(tf.float32,
-                                           shape=(None, None) +
-                                           env.observation_space.shape,
-                                           name='obs')
-        policy.build(obs_var)
 
         env.reset()
         obs, _, _, _ = env.step(1)
@@ -71,11 +89,6 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(tf.float32,
-                                               shape=(None, None) +
-                                               env.observation_space.shape,
-                                               name='obs')
-            policy_pickled.build(obs_var)
             output2 = sess.run(policy_pickled.distribution.probs,
                                feed_dict={policy_pickled.model.input: [[obs]]})
             assert np.array_equal(output1, output2)

--- a/tests/garage/tf/policies/test_categorical_cnn_policy.py
+++ b/tests/garage/tf/policies/test_categorical_cnn_policy.py
@@ -36,18 +36,15 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
-    @pytest.mark.parametrize('filter_dims, num_filters, '
-                             'strides, padding, hidden_sizes', [
-                                 ((3, ), (3, ), (1, ), 'VALID', (4, )),
-                                 ((3, 3), (3, 3), (1, 1), 'VALID', (4, 4)),
-                                 ((3, 3), (3, 3), (2, 2), 'SAME', (4, 4)),
-                             ])
-    def test_build(self, filter_dims, num_filters, strides, padding,
-                   hidden_sizes):
+    @pytest.mark.parametrize('filters, strides, padding, hidden_sizes', [
+        (((3, (3, 3)), ), (1, ), 'VALID', (4, )),
+        (((3, (3, 3)), (3, (3, 3))), (1, 1), 'VALID', (4, 4)),
+        (((3, (3, 3)), (3, (3, 3))), (2, 2), 'SAME', (4, 4)),
+    ])
+    def test_build(self, filters, strides, padding, hidden_sizes):
         env = GarageEnv(DummyDiscretePixelEnv())
         policy = CategoricalCNNPolicy(env_spec=env.spec,
-                                      filter_dims=filter_dims,
-                                      num_filters=num_filters,
+                                      filters=filters,
                                       strides=strides,
                                       padding=padding,
                                       hidden_sizes=hidden_sizes)
@@ -57,7 +54,7 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None) +
                                                policy.input_dim)
-        dist_sym = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run([policy.distribution.probs],
                                 feed_dict={policy.model.input: [[obs]]})
         output2 = self.sess.run([dist_sym.probs],

--- a/tests/garage/tf/policies/test_categorical_gru_policy.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy.py
@@ -59,7 +59,7 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
@@ -89,7 +89,7 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run(
             [policy.distribution.probs],
             feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})

--- a/tests/garage/tf/policies/test_categorical_gru_policy.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy.py
@@ -28,14 +28,9 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
                                              hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim + action_dim],
-            name='obs')
         policy = CategoricalGRUPolicy(env_spec=env.spec,
                                       hidden_dim=hidden_dim,
                                       state_include_action=True)
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -52,17 +47,69 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         ((1, 1), 1, 4),
         ((2, 2), 2, 4),
     ])
-    def test_get_action(self, obs_dim, action_dim, hidden_dim):
+    def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
+        policy = CategoricalGRUPolicy(env_spec=env.spec,
+                                      hidden_dim=hidden_dim,
+                                      state_include_action=True)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
+        output1 = self.sess.run(
+            [policy.distribution.probs],
+            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym.probs],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        assert np.array_equal(output1, output2)
+
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), 1, 4),
+        ((2, ), 2, 4),
+        ((1, 1), 1, 4),
+        ((2, 2), 2, 4),
+    ])
+    def test_build_state_not_include_action(self, obs_dim, action_dim,
+                                            hidden_dim):
+        env = GarageEnv(
+            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
         policy = CategoricalGRUPolicy(env_spec=env.spec,
                                       hidden_dim=hidden_dim,
                                       state_include_action=False)
-        policy.build(obs_var)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _ = policy.build(state_input, name='dist_sym')
+        output1 = self.sess.run(
+            [policy.distribution.probs],
+            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym.probs],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), 1, 4),
+        ((2, ), 2, 4),
+        ((1, 1), 1, 4),
+        ((2, 2), 2, 4),
+    ])
+    def test_get_action(self, obs_dim, action_dim, hidden_dim):
+        env = GarageEnv(
+            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = CategoricalGRUPolicy(env_spec=env.spec,
+                                      hidden_dim=hidden_dim,
+                                      state_include_action=False)
         policy.reset(do_resets=None)
         obs = env.reset()
 
@@ -75,13 +122,8 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
 
     def test_is_pickleable(self):
         env = GarageEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalGRUPolicy(env_spec=env.spec,
                                       state_include_action=False)
-        policy.build(obs_var)
 
         obs = env.reset()
         policy.model._gru_cell.weights[0].load(
@@ -95,11 +137,6 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=[None, None, env.observation_space.flat_dim],
-                name='obs')
-            policy_pickled.build(obs_var)
             # yapf: disable
             output2 = sess.run(
                 [policy_pickled.distribution.probs],

--- a/tests/garage/tf/policies/test_categorical_lstm_policy.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy.py
@@ -83,7 +83,7 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
@@ -113,7 +113,7 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run(
             [policy.distribution.probs],
             feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})

--- a/tests/garage/tf/policies/test_categorical_lstm_policy.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy.py
@@ -28,15 +28,10 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
                                              hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim + action_dim],
-            name='obs')
         policy = CategoricalLSTMPolicy(env_spec=env.spec,
                                        hidden_dim=hidden_dim,
                                        state_include_action=True)
 
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -56,15 +51,10 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
     def test_get_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalLSTMPolicy(env_spec=env.spec,
                                        hidden_dim=hidden_dim,
                                        state_include_action=False)
 
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -75,16 +65,68 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), 1, 4),
+        ((2, ), 2, 4),
+        ((1, 1), 1, 4),
+        ((2, 2), 2, 4),
+    ])
+    def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
+        env = GarageEnv(
+            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = CategoricalLSTMPolicy(env_spec=env.spec,
+                                       hidden_dim=hidden_dim,
+                                       state_include_action=True)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
+        output1 = self.sess.run(
+            [policy.distribution.probs],
+            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym.probs],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        assert np.array_equal(output1, output2)
+
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), 1, 4),
+        ((2, ), 2, 4),
+        ((1, 1), 1, 4),
+        ((2, 2), 2, 4),
+    ])
+    def test_build_state_not_include_action(self, obs_dim, action_dim,
+                                            hidden_dim):
+        env = GarageEnv(
+            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = CategoricalLSTMPolicy(env_spec=env.spec,
+                                       hidden_dim=hidden_dim,
+                                       state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        output1 = self.sess.run(
+            [policy.distribution.probs],
+            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym.probs],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
     def test_is_pickleable(self):
         env = GarageEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalLSTMPolicy(env_spec=env.spec,
                                        state_include_action=False)
 
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -99,11 +141,6 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=[None, None, env.observation_space.flat_dim],
-                name='obs')
-            policy_pickled.build(obs_var)
             output2 = sess.run([policy_pickled.distribution.probs],
                                feed_dict={
                                    policy_pickled.model.input:

--- a/tests/garage/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy.py
@@ -27,13 +27,7 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
     def test_get_action(self, obs_dim, action_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalMLPPolicy(env_spec=env.spec)
-
-        policy.build(obs_var)
         obs = env.reset()
 
         action, _ = policy.get_action(obs.flatten())
@@ -51,16 +45,33 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
         ((1, 1), 1),
         ((2, 2), 2),
     ])
+    def test_build(self, obs_dim, action_dim):
+        env = GarageEnv(
+            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = CategoricalMLPPolicy(env_spec=env.spec)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym = policy.build(state_input, name='dist_sym')
+        output1 = self.sess.run(
+            [policy.distribution.probs],
+            feed_dict={policy.model.input: [[obs.flatten()]]})
+        output2 = self.sess.run([dist_sym.probs],
+                                feed_dict={state_input: [[obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
+    @pytest.mark.parametrize('obs_dim, action_dim', [
+        ((1, ), 1),
+        ((2, ), 2),
+        ((1, 1), 1),
+        ((2, 2), 2),
+    ])
     def test_is_pickleable(self, obs_dim, action_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalMLPPolicy(env_spec=env.spec)
-
-        policy.build(obs_var)
         obs = env.reset()
 
         with tf.compat.v1.variable_scope(
@@ -76,11 +87,6 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=[None, None, env.observation_space.flat_dim],
-                name='obs')
-            policy_pickled.build(obs_var)
             output2 = sess.run(
                 [policy_pickled.distribution.probs],
                 feed_dict={policy_pickled.model.input: [[obs.flatten()]]})
@@ -95,12 +101,7 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
     def test_get_regularizable_vars(self, obs_dim, action_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = CategoricalMLPPolicy(env_spec=env.spec)
-        policy.build(obs_var)
         reg_vars = policy.get_regularizable_vars()
         assert len(reg_vars) == 2
         for var in reg_vars:

--- a/tests/garage/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy.py
@@ -54,7 +54,7 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run(
             [policy.distribution.probs],
             feed_dict={policy.model.input: [[obs.flatten()]]})

--- a/tests/garage/tf/policies/test_continuous_mlp_policy.py
+++ b/tests/garage/tf/policies/test_continuous_mlp_policy.py
@@ -71,8 +71,7 @@ class TestContinuousMLPPolicy(TfGraphTestCase):
         obs_dim = env.spec.observation_space.flat_dim
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, obs_dim))
-        action_sym = policy.get_action_sym(state_input,
-                                           name='action_sym').outputs
+        action_sym = policy.get_action_sym(state_input, name='action_sym')
 
         expected_action = np.full(action_dim, 0.5)
 

--- a/tests/garage/tf/policies/test_continuous_mlp_policy.py
+++ b/tests/garage/tf/policies/test_continuous_mlp_policy.py
@@ -71,7 +71,8 @@ class TestContinuousMLPPolicy(TfGraphTestCase):
         obs_dim = env.spec.observation_space.flat_dim
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, obs_dim))
-        action_sym = policy.get_action_sym(state_input, name='action_sym')
+        action_sym = policy.get_action_sym(state_input,
+                                           name='action_sym').outputs
 
         expected_action = np.full(action_dim, 0.5)
 

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -29,18 +29,9 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
     def test_get_action_state_include_action(self, obs_dim, action_dim,
                                              hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[
-                None, None,
-                env.observation_space.flat_dim + np.prod(action_dim)
-            ],
-            name='obs')
         policy = GaussianGRUPolicy(env_spec=env.spec,
                                    hidden_dim=hidden_dim,
                                    state_include_action=True)
-
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -63,15 +54,9 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
     # yapf: enable
     def test_get_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianGRUPolicy(env_spec=env.spec,
                                    hidden_dim=hidden_dim,
                                    state_include_action=False)
-
-        policy.build(obs_var)
         policy.reset(do_resets=None)
         obs = env.reset()
 
@@ -82,16 +67,70 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
+    # yapf: disable
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4)
+    ])
+    # yapf: enable
+    def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
+        env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = GaussianGRUPolicy(env_spec=env.spec,
+                                   hidden_dim=hidden_dim,
+                                   state_include_action=True)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
+        output1 = self.sess.run(
+            [policy.distribution.loc],
+            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym.loc],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        assert np.array_equal(output1, output2)
+
+    # yapf: disable
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4)
+    ])
+    # yapf: enable
+    def test_build_state_not_include_action(self, obs_dim, action_dim,
+                                            hidden_dim):
+        env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = GaussianGRUPolicy(env_spec=env.spec,
+                                   hidden_dim=hidden_dim,
+                                   state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        output1 = self.sess.run(
+            [policy.distribution.loc],
+            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym.loc],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
     def test_is_pickleable(self):
         env = GarageEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianGRUPolicy(env_spec=env.spec,
                                    state_include_action=False)
-
-        policy.build(obs_var)
         env.reset()
         obs = env.reset()
         with tf.compat.v1.variable_scope('GaussianGRUPolicy/GaussianGRUModel',
@@ -110,11 +149,6 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=[None, None, env.observation_space.flat_dim],
-                name='obs')
-            policy_pickled.build(obs_var)
             # yapf: disable
             output2 = sess.run(
                 [

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -86,7 +86,7 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
@@ -117,7 +117,7 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         output1 = self.sess.run(
             [policy.distribution.loc],

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy.py
@@ -86,7 +86,7 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
@@ -117,7 +117,7 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
 
         output1 = self.sess.run(
             [policy.distribution.loc],

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy.py
@@ -29,17 +29,9 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
     def test_get_action_state_include_action(self, obs_dim, action_dim,
                                              hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[
-                None, None,
-                env.observation_space.flat_dim + np.prod(action_dim)
-            ],
-            name='obs')
         policy = GaussianLSTMPolicy(env_spec=env.spec,
                                     hidden_dim=hidden_dim,
                                     state_include_action=True)
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
         action, _ = policy.get_action(obs.flatten())
@@ -61,15 +53,10 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
     # yapf: enable
     def test_get_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianLSTMPolicy(env_spec=env.spec,
                                     hidden_dim=hidden_dim,
                                     state_include_action=False)
 
-        policy.build(obs_var)
         policy.reset()
         obs = env.reset()
 
@@ -80,16 +67,70 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
+    # yapf: disable
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4)
+    ])
+    # yapf: enable
+    def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
+        env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = GaussianLSTMPolicy(env_spec=env.spec,
+                                    hidden_dim=hidden_dim,
+                                    state_include_action=True)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
+        output1 = self.sess.run(
+            [policy.distribution.loc],
+            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym.loc],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        assert np.array_equal(output1, output2)
+
+    # yapf: disable
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
+        ((1, ), (1, ), 4),
+        ((2, ), (2, ), 4),
+        ((1, 1), (1, ), 4),
+        ((2, 2), (2, ), 4)
+    ])
+    # yapf: enable
+    def test_build_state_not_include_action(self, obs_dim, action_dim,
+                                            hidden_dim):
+        env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = GaussianLSTMPolicy(env_spec=env.spec,
+                                    hidden_dim=hidden_dim,
+                                    state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _, _, _, _, _ = policy.build(state_input, name='dist_sym')
+
+        output1 = self.sess.run(
+            [policy.distribution.loc],
+            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym.loc],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
     def test_is_pickleable(self):
         env = GarageEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianLSTMPolicy(env_spec=env.spec,
                                     state_include_action=False)
-
-        policy.build(obs_var)
         env.reset()
         obs = env.reset()
         with tf.compat.v1.variable_scope(
@@ -108,11 +149,6 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         # yapf: disable
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            obs_var = tf.compat.v1.placeholder(
-                        tf.float32,
-                        shape=[None, None, env.observation_space.flat_dim],
-                        name='obs')
-            policy_pickled.build(obs_var)
             output2 = sess.run(
                 [
                     policy_pickled.distribution.loc,

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -57,7 +57,7 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
         state_input = tf.compat.v1.placeholder(tf.float32,
                                                shape=(None, None,
                                                       policy.input_dim))
-        dist_sym, _, _ = policy.build(state_input, name='dist_sym')
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run(
             [policy.distribution.loc],
             feed_dict={policy.model.input: [[obs.flatten()]]})

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -28,13 +28,8 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
     ])
     def test_get_action(self, obs_dim, action_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianMLPPolicy(env_spec=env.spec)
 
-        policy.build(obs_var)
         env.reset()
         obs, _, _, _ = env.step(1)
 
@@ -54,15 +49,34 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
         ((1, 1), (2, 2)),
         ((2, 2), (2, 2)),
     ])
+    def test_build(self, obs_dim, action_dim):
+        env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
+        policy = GaussianMLPPolicy(env_spec=env.spec)
+        obs = env.reset()
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym, _, _ = policy.build(state_input, name='dist_sym')
+        output1 = self.sess.run(
+            [policy.distribution.loc],
+            feed_dict={policy.model.input: [[obs.flatten()]]})
+        output2 = self.sess.run([dist_sym.loc],
+                                feed_dict={state_input: [[obs.flatten()]]})
+        assert np.array_equal(output1, output2)
+
+    @pytest.mark.parametrize('obs_dim, action_dim', [
+        ((1, ), (1, )),
+        ((1, ), (2, )),
+        ((2, ), (2, )),
+        ((1, 1), (1, 1)),
+        ((1, 1), (2, 2)),
+        ((2, 2), (2, 2)),
+    ])
     def test_is_pickleable(self, obs_dim, action_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
-        obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, env.observation_space.flat_dim],
-            name='obs')
         policy = GaussianMLPPolicy(env_spec=env.spec)
 
-        policy.build(obs_var)
         obs = env.reset()
 
         with tf.compat.v1.variable_scope('GaussianMLPPolicy/GaussianMLPModel',
@@ -78,12 +92,7 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
 
         p = pickle.dumps(policy)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
-            obs_var = tf.compat.v1.placeholder(
-                tf.float32,
-                shape=[None, None, env.observation_space.flat_dim],
-                name='obs')
             policy_pickled = pickle.loads(p)
-            policy_pickled.build(obs_var)
             output2 = sess.run(
                 [
                     policy_pickled.distribution.loc,

--- a/tests/garage/tf/policies/test_policies.py
+++ b/tests/garage/tf/policies/test_policies.py
@@ -17,10 +17,6 @@ class TestDiscretePolicies(TfGraphTestCase):
     def setup_method(self):
         super().setup_method()
         self.env = GarageEnv(DummyDiscreteEnv())
-        self.obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, self.env.observation_space.flat_dim],
-            name='obs')
 
     def teardown_method(self):
         self.env.close()
@@ -29,8 +25,6 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorial_gru_policy(self):
         categorical_gru_policy = CategoricalGRUPolicy(
             env_spec=self.env, hidden_dim=1, state_include_action=False)
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-        categorical_gru_policy.build(self.obs_var)
         categorical_gru_policy.reset()
 
         obs = self.env.observation_space.high
@@ -39,8 +33,6 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorical_lstm_policy(self):
         categorical_lstm_policy = CategoricalLSTMPolicy(
             env_spec=self.env, hidden_dim=1, state_include_action=False)
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-        categorical_lstm_policy.build(self.obs_var)
         categorical_lstm_policy.reset()
 
         obs = self.env.observation_space.high
@@ -49,9 +41,6 @@ class TestDiscretePolicies(TfGraphTestCase):
     def test_categorial_mlp_policy(self):
         categorical_mlp_policy = CategoricalMLPPolicy(env_spec=self.env,
                                                       hidden_sizes=(1, ))
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-        categorical_mlp_policy.build(self.obs_var)
-
         obs = self.env.observation_space.high
         assert categorical_mlp_policy.get_action(obs)
 
@@ -61,10 +50,6 @@ class TestContinuousPolicies(TfGraphTestCase):
     def setup_method(self):
         super().setup_method()
         self.env = GarageEnv(DummyBoxEnv())
-        self.obs_var = tf.compat.v1.placeholder(
-            tf.float32,
-            shape=[None, None, self.env.observation_space.flat_dim],
-            name='obs')
 
     def teardown_method(self):
         self.env.close()
@@ -73,8 +58,6 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_continuous_mlp_policy(self):
         continuous_mlp_policy = ContinuousMLPPolicy(env_spec=self.env,
                                                     hidden_sizes=(1, ))
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-
         obs = self.env.observation_space.high
         assert continuous_mlp_policy.get_action(obs)
 
@@ -82,9 +65,6 @@ class TestContinuousPolicies(TfGraphTestCase):
         gaussian_gru_policy = GaussianGRUPolicy(env_spec=self.env,
                                                 hidden_dim=1,
                                                 state_include_action=False)
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-
-        gaussian_gru_policy.build(self.obs_var)
         gaussian_gru_policy.reset()
 
         obs = self.env.observation_space.high
@@ -94,9 +74,6 @@ class TestContinuousPolicies(TfGraphTestCase):
         gaussian_lstm_policy = GaussianLSTMPolicy(env_spec=self.env,
                                                   hidden_dim=1,
                                                   state_include_action=False)
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-
-        gaussian_lstm_policy.build(self.obs_var)
         gaussian_lstm_policy.reset()
 
         obs = self.env.observation_space.high
@@ -105,8 +82,5 @@ class TestContinuousPolicies(TfGraphTestCase):
     def test_gaussian_mlp_policy(self):
         gaussian_mlp_policy = GaussianMLPPolicy(env_spec=self.env,
                                                 hidden_sizes=(1, ))
-        self.sess.run(tf.compat.v1.global_variables_initializer())
-        gaussian_mlp_policy.build(self.obs_var)
-
         obs = self.env.observation_space.high
         assert gaussian_mlp_policy.get_action(obs)

--- a/tests/garage/tf/regressors/test_bernoulli_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_bernoulli_mlp_regressor.py
@@ -88,9 +88,9 @@ class TestBernoulliMLPRegressor(TfGraphTestCase):
         prediction = np.cast['int'](bmr.predict(paths['observations']))
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(bmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std = self.sess.run(bmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -119,9 +119,9 @@ class TestBernoulliMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(bmr.model._networks['default'].x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std = self.sess.run(bmr.model._networks['default'].x_std)
         x_std_expected = np.ones_like(x_std)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -149,9 +149,9 @@ class TestBernoulliMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(bmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(bmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(bmr.model.networks['default'].x_std)
+        x_std = self.sess.run(bmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -274,9 +274,9 @@ class TestBernoulliMLPRegressor(TfGraphTestCase):
                 'BernoulliMLPRegressor/NormalizedInputMLPModel', reuse=True):
             x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
-        x1 = bmr.model.networks['default'].x_mean.eval()
+        x1 = bmr.model._networks['default'].x_mean.eval()
         h = pickle.dumps(bmr)
         with tf.compat.v1.Session(graph=tf.Graph()):
             bmr_pickled = pickle.loads(h)
-            x2 = bmr_pickled.model.networks['default'].x_mean.eval()
+            x2 = bmr_pickled.model._networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_categorical_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_categorical_mlp_regressor.py
@@ -77,9 +77,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(cmr.model.networks['default'].x_std)
+        x_std = self.sess.run(cmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -106,9 +106,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(cmr.model.networks['default'].x_std)
+        x_std = self.sess.run(cmr.model._networks['default'].x_std)
         x_std_expected = np.ones_like(x_std)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -135,9 +135,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(cmr.model.networks['default'].x_std)
+        x_std = self.sess.run(cmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -241,9 +241,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
                 'CategoricalMLPRegressor/NormalizedInputMLPModel', reuse=True):
             x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
-        x1 = cmr.model.networks['default'].x_mean.eval()
+        x1 = cmr.model._networks['default'].x_mean.eval()
         h = pickle.dumps(cmr)
         with tf.compat.v1.Session(graph=tf.Graph()):
             cmr_pickled = pickle.loads(h)
-            x2 = cmr_pickled.model.networks['default'].x_mean.eval()
+            x2 = cmr_pickled.model._networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_continuous_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_continuous_mlp_regressor.py
@@ -32,9 +32,9 @@ class TestContinuousMLPRegressor(TfGraphTestCase):
         expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(cmr.model.networks['default'].x_std)
+        x_std = self.sess.run(cmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -62,9 +62,9 @@ class TestContinuousMLPRegressor(TfGraphTestCase):
         expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(cmr.model.networks['default'].x_std)
+        x_std = self.sess.run(cmr.model._networks['default'].x_std)
         x_std_expected = np.ones_like(x_std)
         assert np.array_equal(x_mean, x_mean_expected)
         assert np.array_equal(x_std, x_std_expected)

--- a/tests/garage/tf/regressors/test_gaussian_cnn_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_cnn_regressor.py
@@ -57,17 +57,17 @@ class TestGaussianCNNRegressor(TfGraphTestCase):
         average_error /= len(expected)
         assert average_error <= 0.1
 
-        x_mean = self.sess.run(gcr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(gcr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(gcr.model.networks['default'].x_std)
+        x_std = self.sess.run(gcr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
         assert np.allclose(x_std, x_std_expected)
 
-        y_mean = self.sess.run(gcr.model.networks['default'].y_mean)
+        y_mean = self.sess.run(gcr.model._networks['default'].y_mean)
         y_mean_expected = np.mean(returns, axis=0, keepdims=True)
-        y_std = self.sess.run(gcr.model.networks['default'].y_std)
+        y_std = self.sess.run(gcr.model._networks['default'].y_std)
         y_std_expected = np.std(returns, axis=0, keepdims=True)
 
         assert np.allclose(y_mean, y_mean_expected)
@@ -100,16 +100,16 @@ class TestGaussianCNNRegressor(TfGraphTestCase):
         average_error /= len(expected)
         assert average_error <= 0.1
 
-        x_mean = self.sess.run(gcr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(gcr.model._networks['default'].x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(gcr.model.networks['default'].x_std)
+        x_std = self.sess.run(gcr.model._networks['default'].x_std)
         x_std_expected = np.ones_like(x_std)
         assert np.array_equal(x_mean, x_mean_expected)
         assert np.array_equal(x_std, x_std_expected)
 
-        y_mean = self.sess.run(gcr.model.networks['default'].y_mean)
+        y_mean = self.sess.run(gcr.model._networks['default'].y_mean)
         y_mean_expected = np.zeros_like(y_mean)
-        y_std = self.sess.run(gcr.model.networks['default'].y_std)
+        y_std = self.sess.run(gcr.model._networks['default'].y_std)
         y_std_expected = np.ones_like(y_std)
 
         assert np.allclose(y_mean, y_mean_expected)
@@ -195,7 +195,7 @@ class TestGaussianCNNRegressor(TfGraphTestCase):
                                         new_ys_var: [label]
                                     })
         mean, log_std = gcr._f_pdists([data])
-        ll = gcr.model.networks['default'].dist.log_likelihood(
+        ll = gcr.model._networks['default'].dist.log_likelihood(
             [label], dict(mean=mean, log_std=log_std))
         assert np.allclose(ll, ll_from_sym, rtol=0, atol=1e-5)
 
@@ -258,9 +258,9 @@ class TestGaussianCNNRegressor(TfGraphTestCase):
                 'GaussianCNNRegressor/GaussianCNNRegressorModel', reuse=True):
             x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
-        x1 = gcr.model.networks['default'].x_mean.eval()
+        x1 = gcr.model._networks['default'].x_mean.eval()
         h = pickle.dumps(gcr)
         with tf.compat.v1.Session(graph=tf.Graph()):
             gcr_pickled = pickle.loads(h)
-            x2 = gcr_pickled.model.networks['default'].x_mean.eval()
+            x2 = gcr_pickled.model._networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)

--- a/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_gaussian_mlp_regressor.py
@@ -33,17 +33,17 @@ class TestGaussianMLPRegressor(TfGraphTestCase):
         expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(gmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(gmr.model._networks['default'].x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(gmr.model.networks['default'].x_std)
+        x_std = self.sess.run(gmr.model._networks['default'].x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
         assert np.allclose(x_std, x_std_expected)
 
-        y_mean = self.sess.run(gmr.model.networks['default'].y_mean)
+        y_mean = self.sess.run(gmr.model._networks['default'].y_mean)
         y_mean_expected = np.mean(returns, axis=0, keepdims=True)
-        y_std = self.sess.run(gmr.model.networks['default'].y_std)
+        y_std = self.sess.run(gmr.model._networks['default'].y_std)
         y_std_expected = np.std(returns, axis=0, keepdims=True)
 
         assert np.allclose(y_mean, y_mean_expected)
@@ -75,16 +75,16 @@ class TestGaussianMLPRegressor(TfGraphTestCase):
         expected = [[0], [-1], [-0.707], [0], [0.707], [1], [0]]
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(gmr.model.networks['default'].x_mean)
+        x_mean = self.sess.run(gmr.model._networks['default'].x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(gmr.model.networks['default'].x_std)
+        x_std = self.sess.run(gmr.model._networks['default'].x_std)
         x_std_expected = np.ones_like(x_std)
         assert np.array_equal(x_mean, x_mean_expected)
         assert np.array_equal(x_std, x_std_expected)
 
-        y_mean = self.sess.run(gmr.model.networks['default'].y_mean)
+        y_mean = self.sess.run(gmr.model._networks['default'].y_mean)
         y_mean_expected = np.zeros_like(y_mean)
-        y_std = self.sess.run(gmr.model.networks['default'].y_std)
+        y_std = self.sess.run(gmr.model._networks['default'].y_std)
         y_std_expected = np.ones_like(y_std)
 
         assert np.allclose(y_mean, y_mean_expected)
@@ -162,11 +162,11 @@ class TestGaussianMLPRegressor(TfGraphTestCase):
                 'GaussianMLPRegressor/GaussianMLPRegressorModel', reuse=True):
             x_mean = tf.compat.v1.get_variable('normalized_vars/x_mean')
         x_mean.load(tf.ones_like(x_mean).eval())
-        x1 = gmr.model.networks['default'].x_mean.eval()
+        x1 = gmr.model._networks['default'].x_mean.eval()
         h = pickle.dumps(gmr)
         with tf.compat.v1.Session(graph=tf.Graph()):
             gmr_pickled = pickle.loads(h)
-            x2 = gmr_pickled.model.networks['default'].x_mean.eval()
+            x2 = gmr_pickled.model._networks['default'].x_mean.eval()
             assert np.array_equal(x1, x2)
 
     def test_auxiliary(self):


### PR DESCRIPTION
Currently, policies have to be built by the owner explicitly. However, this can be done as policies have information about the input placeholder(s), and this will make it much easier to use policies. As a result, policies will be ready to be used right after instantiation, and owners, e.g. algorithms, do not have to build them.