### PR TITLE
Add TimeStepBatch

### DIFF
--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,7 +1,7 @@
 """Garage Base."""
 from garage._dtypes import InOutSpec
-from garage._dtypes import SampleBatch
 from garage._dtypes import TimeStep
+from garage._dtypes import TimeStepBatch
 from garage._dtypes import TrajectoryBatch
 from garage._functions import _Default
 from garage._functions import log_multitask_performance
@@ -12,5 +12,5 @@ from garage.experiment.experiment import wrap_experiment
 __all__ = [
     '_Default', 'make_optimizer', 'wrap_experiment', 'TimeStep',
     'TrajectoryBatch', 'log_multitask_performance', 'log_performance',
-    'InOutSpec', 'SampleBatch'
+    'InOutSpec', 'TimeStepBatch'
 ]

--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,5 +1,6 @@
 """Garage Base."""
 from garage._dtypes import InOutSpec
+from garage._dtypes import SampleBatch
 from garage._dtypes import TimeStep
 from garage._dtypes import TrajectoryBatch
 from garage._functions import _Default
@@ -9,12 +10,7 @@ from garage._functions import make_optimizer
 from garage.experiment.experiment import wrap_experiment
 
 __all__ = [
-    '_Default',
-    'make_optimizer',
-    'wrap_experiment',
-    'TimeStep',
-    'TrajectoryBatch',
-    'log_multitask_performance',
-    'log_performance',
-    'InOutSpec',
+    '_Default', 'make_optimizer', 'wrap_experiment', 'TimeStep',
+    'TrajectoryBatch', 'log_multitask_performance', 'log_performance',
+    'InOutSpec', 'SampleBatch'
 ]


### PR DESCRIPTION
This addresses [Issue #1057 ](https://github.com/rlworkgroup/garage/issues/1057).

This definition of SampleBatch follows the format of TrajectoryBatch, and provides similar helper functions.

Future plans:
1. add other helper functions (looking for suggestions!)
2. use SampleBatch in PathBuffer and change other usages accordingly.