### PR TITLE
Fix tf plotter policy build

### DIFF
--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -58,6 +58,7 @@ class Plotter:
         ) if graph is None else graph
         with self.sess.as_default(), self.graph.as_default():
             self._policy = policy.clone('plotter_policy')
+            self._policy.build(policy.model.input)
         self.rollout = rollout
         self.worker_thread = Thread(target=self._start_worker, daemon=True)
         self.queue = Queue()


### PR DESCRIPTION
Usually when a policy is cloned, the owner of the policy, i.e. algorithm, would have to build the cloned policy. This PR fixes the issue in tf.plotter when the cloned policy is not built.