### PR TITLE
Add PixelObservationWrapper

### DIFF
--- a/src/garage/envs/wrappers/__init__.py
+++ b/src/garage/envs/wrappers/__init__.py
@@ -15,10 +15,11 @@ from garage.envs.wrappers.fire_reset import FireReset
 from garage.envs.wrappers.grayscale import Grayscale
 from garage.envs.wrappers.max_and_skip import MaxAndSkip
 from garage.envs.wrappers.noop import Noop
+from garage.envs.wrappers.pixel_observation import (PixelObservationWrapper)
 from garage.envs.wrappers.resize import Resize
 from garage.envs.wrappers.stack_frames import StackFrames
 
 __all__ = [
     'AtariEnv', 'ClipReward', 'EpisodicLife', 'FireReset', 'Grayscale',
-    'MaxAndSkip', 'Noop', 'Resize', 'StackFrames'
+    'MaxAndSkip', 'Noop', 'PixelObservationWrapper', 'Resize', 'StackFrames'
 ]

--- a/src/garage/envs/wrappers/pixel_observation.py
+++ b/src/garage/envs/wrappers/pixel_observation.py
@@ -1,0 +1,80 @@
+"""Pixel observation wrapper for gym.Env."""
+import gym
+from gym.wrappers.pixel_observation import (PixelObservationWrapper as
+                                            gymWrapper)
+
+
+class PixelObservationWrapper(gym.Wrapper):
+    """Pixel observation wrapper for obtaining pixel observations.
+
+    Instead of returning the default environment observation, the wrapped
+    environment's render function is used to produce RGB pixel observations.
+
+    This behaves like gym.wrappers.PixelObservationWrapper but returns a
+    gym.spaces.Box observation space and observation instead of
+    a gym.spaces.Dict.
+
+    Args:
+        env (gym.Env): The environment to wrap. This environment must produce
+            non-pixel observations and have a Box observation space.
+        headless (bool): If true, this creates a window to init GLFW. Set to
+            true if running on a headless machine or with a dummy X server,
+            false otherwise.
+
+    """
+
+    def __init__(self, env, headless=True):
+        if headless:
+            # pylint: disable=import-outside-toplevel
+            # this import fails without a valid mujoco license
+            # so keep this here to avoid unecessarily requiring
+            # a mujoco license everytime the wrappers package is
+            # accessed.
+            from mujoco_py import GlfwContext
+            GlfwContext(offscreen=True)
+        env.reset()
+        env = gymWrapper(env)
+        super().__init__(env)
+        self._observation_space = env.observation_space['pixels']
+
+    @property
+    def observation_space(self):
+        """gym.spaces.Box: Environment observation space."""
+        return self._observation_space
+
+    @observation_space.setter
+    def observation_space(self, observation_space):
+        self._observation_space = observation_space
+
+    def reset(self, **kwargs):
+        """gym.Env reset function.
+
+        Args:
+            kwargs (dict): Keyword arguments to be passed to gym.Env.reset.
+
+        Returns:
+            np.ndarray: Pixel observation of shape :math:`(O*, )`
+                from the wrapped environment.
+        """
+        return self.env.reset(**kwargs)['pixels']
+
+    def step(self, action):
+        """gym.Env step function.
+
+        Performs one action step in the enviornment.
+
+        Args:
+            action (np.ndarray): Action of shape :math:`(A*, ) `
+                to pass to the environment.
+
+        Returns:
+            np.ndarray: Pixel observation of shape :math:`(O*, )`
+                from the wrapped environment.
+            float : Amount of reward returned after previous action.
+            bool : Whether the episode has ended, in which case further step()
+                calls will return undefined results.
+            dict: Contains auxiliary diagnostic information (helpful for
+                debugging, and sometimes learning).
+        """
+        obs, reward, done, info = self.env.step(action)
+        return obs['pixels'], reward, done, info

--- a/tests/garage/envs/wrappers/test_pixel_observation_wrapper.py
+++ b/tests/garage/envs/wrappers/test_pixel_observation_wrapper.py
@@ -1,0 +1,38 @@
+import gym
+import numpy as np
+import pytest
+
+from garage.envs.wrappers import PixelObservationWrapper
+
+
+@pytest.mark.mujoco
+class TestPixelObservationWrapper:
+
+    def setup_method(self):
+        self.env = gym.make('InvertedDoublePendulum-v2')
+        self.pixel_env = PixelObservationWrapper(self.env)
+
+    def teardown_method(self):
+        self.env.close()
+        self.pixel_env.close()
+
+    def test_pixel_env_invalid_environment_type(self):
+        with pytest.raises(ValueError):
+            self.env.observation_space = gym.spaces.Discrete(64)
+            PixelObservationWrapper(self.env)
+
+    def test_pixel_env_observation_space(self):
+        assert isinstance(self.pixel_env.observation_space, gym.spaces.Box)
+        assert (self.pixel_env.observation_space.low == 0).all()
+        assert (self.pixel_env.observation_space.high == 255).all()
+
+    def test_pixel_env_reset(self):
+        obs = self.pixel_env.reset()
+        assert (obs <= 255.).all() and (obs >= 0.).all()
+        assert isinstance(obs, np.ndarray)
+
+    def test_pixel_env_step(self):
+        self.pixel_env.reset()
+        action = np.full(self.pixel_env.action_space.shape, 0)
+        obs, _, _, _ = self.pixel_env.step(action)
+        assert (obs <= 255.).all() and (obs >= 0.).all()


### PR DESCRIPTION
Figured this is a nice-to-have since we'll have a documentation section on pixel observations soon. 

It wraps around gym's `PixelObservationWrapper` to return a `gym.spaces.Box` observation rather than a `gym.spaces.Dict` (which is what gym's wrapper does).