### PR TITLE
Don't collect too many rollouts in RaySampler

### DIFF
--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -58,15 +58,37 @@ class TestSampler:
         assert (trajs1[0]['observations'].shape == np.array(
             trajs2[0]['observations']).shape == (6, ))
         traj2_action_shape = np.array(trajs2[0]['actions']).shape
-        assert (trajs1[0]['actions'].shape == traj2_action_shape == (6, ))
-        assert (sum(trajs1[0]['rewards']) == sum(trajs2[0]['rewards']) == 1)
+        assert trajs1[0]['actions'].shape == traj2_action_shape == (6, )
+        assert sum(trajs1[0]['rewards']) == sum(trajs2[0]['rewards']) == 1
 
         true_obs = np.array([0, 1, 2, 6, 10, 14])
         true_actions = np.array([2, 2, 1, 1, 1, 2])
         true_rewards = np.array([0, 0, 0, 0, 0, 1])
         for trajectory in trajs1:
-            assert (np.array_equal(trajectory['observations'], true_obs))
-            assert (np.array_equal(trajectory['actions'], true_actions))
-            assert (np.array_equal(trajectory['rewards'], true_rewards))
+            assert np.array_equal(trajectory['observations'], true_obs)
+            assert np.array_equal(trajectory['actions'], true_actions)
+            assert np.array_equal(trajectory['rewards'], true_rewards)
         sampler1.shutdown_worker()
         sampler2.shutdown_worker()
+
+    def test_ray_sampler_idle_workers(self):
+        """Ensures we only call the necessary number of workers.
+
+        There is a poorly-handled case where we have more workers than we need.
+        At the moment, the fix for this is to only call rollout on workers if
+        we need samples from those workers. For example, if there are 2
+        workers, and they are each configured collect 16 samples per call, and
+        then a call to obtain samples is made asking for only 16 samples, then
+        only the first sampler worker should be started.
+
+        """
+        sampler = RaySampler(self.algo,
+                             self.env,
+                             seed=100,
+                             num_processors=2,
+                             sampler_worker_cls=SamplerWorker)
+        sampler.start_worker()
+        assert len(sampler._idle_worker_ids) == 2
+        sampler.obtain_samples(0, 16)
+        assert len(sampler._idle_worker_ids) == 2
+        sampler.shutdown_worker()


### PR DESCRIPTION
There is an edge use case where samples aren't collected from workers
because `num_samples` have already been collected from some subset of
the sampler workers, then the other workers should have their calls
to rollout canceled. At the moment, the fix for this is to only call
rollout on workers if rollout should be called on them. For example
If there are 2 workers, and they are supposed to each collect 16
samples and then a call to obtain samples is made asking for only 16
samples, then only the first sampler worker will be started. The best
way for us to handle in the future is to shutdown workers using some
ipc, but handling starting workers the way that is mentioned above
is the best fix for a backport.