### PR TITLE
Update setup_linux to ignore purge errors

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -144,18 +144,23 @@ sudo apt install -y \
 
 # Build GLFW because the Ubuntu 16.04 version is too old
 # See https://github.com/glfw/glfw/issues/1004
-sudo apt purge -y libglfw*
-GLFW_DIR="$(mktemp -d)/glfw"
-git clone https://github.com/glfw/glfw.git "${GLFW_DIR}"
-cd "${GLFW_DIR}"
-git checkout 0be4f3f75aebd9d24583ee86590a38e741db0904
-mkdir glfw-build
-cd glfw-build
-sudo cmake -DBUILD_SHARED_LIBS=ON -DGLFW_BUILD_EXAMPLES=OFF \
-  -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF ..
-sudo make -j"$(nproc)"
-sudo make install
-cd "${GARAGE_DIR}"
+# we can skip this on Ubuntu 20.04
+
+if [[ $(cat /etc/os-release | grep VERSION_ID) == 'VERSION_ID="20.04"' ]]; then
+	sudo apt-get install libglfw3-dev
+else
+	sudo apt purge -y libglfw*
+	GLFW_DIR="$(mktemp -d)/glfw"
+	git clone https://github.com/glfw/glfw.git "${GLFW_DIR}"
+	cd "${GLFW_DIR}"
+	git checkout b0796109629931b6fa6e449c15a177845256a407
+	mkdir glfw-build
+	cd glfw-build
+	sudo cmake -DBUILD_SHARED_LIBS=ON -DGLFW_BUILD_EXAMPLES=OFF \
+	  -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF ..
+	sudo make -j"$(nproc)"
+	sudo make install
+	cd "${GARAGE_DIR}"
 
 # Leave a note in ~/.bashrc for the added environment variables
 if [[ "${_arg_modify_bashrc}" = on ]]; then


### PR DESCRIPTION
`sudo apt purge -y` breaks the script if the package is not found, at least on ubuntu 20.04.