### PR TITLE
Add isort to pre-commit 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,8 +37,3 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 max_line_length = 80
-
-# Markdown
-[*.md]
-indent_style = space
-max_line_length = 80

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,8 +32,13 @@ max_line_length = 80
 indent_style = space
 indent_size = 2
 
-# shell scripts
+# Shell scripts
 [*.sh]
 indent_style = space
 indent_size = 2
+max_line_length = 80
+
+# Markdown
+[*.md]
+indent_style = space
 max_line_length = 80

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=google

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-profile=google

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,16 @@ repos:
     -   id: pretty-format-json               # Checks that all your JSON files have keys that are sorted and indented.
     -   id: trailing-whitespace              # Trims trailing whitespace.
 
+-   repo: https://github.com/markdownlint/markdownlint
+    rev: v0.9.0
+    hooks:
+      - id: markdownlint                     # Check markdown files and flag style issues
+        name: Markdownlint
+        description: Run markdownlint on your Markdown files
+        entry: mdl
+        language: ruby
+        files: \.(md|mdown|markdown)$
+
 # First pass: check format
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.28.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,16 @@ repos:
         entry: pylint
         args: [--rcfile=tests/garage/.pylintrc]
 
+-   repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+    -   id: isort
+        name: isort
+        entry: isort
+        require_serial: true
+        language: python
+        types: [python]
+
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,6 @@ repos:
     -   id: isort
         name: isort
         entry: isort
-        require_serial: true
         language: python
         types: [python]
 
@@ -63,16 +62,6 @@ repos:
     -   id: mixed-line-ending                # Replaces or checks mixed line ending.
     -   id: pretty-format-json               # Checks that all your JSON files have keys that are sorted and indented.
     -   id: trailing-whitespace              # Trims trailing whitespace.
-
--   repo: https://github.com/markdownlint/markdownlint
-    rev: v0.9.0
-    hooks:
-      - id: markdownlint                     # Check markdown files and flag style issues
-        name: Markdownlint
-        description: Run markdownlint on your Markdown files
-        entry: mdl
-        language: ruby
-        files: \.(md|mdown|markdown)$
 
 # First pass: check format
 -   repo: https://github.com/pre-commit/mirrors-yapf

--- a/benchmarks/src/garage_benchmarks/benchmark_algos.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_algos.py
@@ -8,8 +8,10 @@ from garage_benchmarks.experiments.algos import trpo_garage_pytorch
 from garage_benchmarks.experiments.algos import trpo_garage_tf
 from garage_benchmarks.experiments.algos import vpg_garage_pytorch
 from garage_benchmarks.experiments.algos import vpg_garage_tf
-from garage_benchmarks.helper import benchmark, iterate_experiments
-from garage_benchmarks.parameters import Fetch1M_ENV_SET, MuJoCo1M_ENV_SET
+from garage_benchmarks.helper import benchmark
+from garage_benchmarks.helper import iterate_experiments
+from garage_benchmarks.parameters import Fetch1M_ENV_SET
+from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
 
 
 @benchmark

--- a/benchmarks/src/garage_benchmarks/benchmark_auto.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_auto.py
@@ -7,7 +7,8 @@ from garage_benchmarks.experiments.algos import trpo_garage_pytorch
 from garage_benchmarks.experiments.algos import trpo_garage_tf
 from garage_benchmarks.experiments.algos import vpg_garage_pytorch
 from garage_benchmarks.experiments.algos import vpg_garage_tf
-from garage_benchmarks.helper import benchmark, iterate_experiments
+from garage_benchmarks.helper import benchmark
+from garage_benchmarks.helper import iterate_experiments
 from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
 
 

--- a/benchmarks/src/garage_benchmarks/benchmark_baselines.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_baselines.py
@@ -4,8 +4,10 @@ import random
 from garage_benchmarks.experiments.baselines import continuous_mlp_baseline
 from garage_benchmarks.experiments.baselines import gaussian_cnn_baseline
 from garage_benchmarks.experiments.baselines import gaussian_mlp_baseline
-from garage_benchmarks.helper import benchmark, iterate_experiments
-from garage_benchmarks.parameters import MuJoCo1M_ENV_SET, PIXEL_ENV_SET
+from garage_benchmarks.helper import benchmark
+from garage_benchmarks.helper import iterate_experiments
+from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
+from garage_benchmarks.parameters import PIXEL_ENV_SET
 
 _seeds = random.sample(range(100), 3)
 

--- a/benchmarks/src/garage_benchmarks/benchmark_policies.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_policies.py
@@ -9,9 +9,11 @@ from garage_benchmarks.experiments.policies import continuous_mlp_policy
 from garage_benchmarks.experiments.policies import gaussian_gru_policy
 from garage_benchmarks.experiments.policies import gaussian_lstm_policy
 from garage_benchmarks.experiments.policies import gaussian_mlp_policy
-from garage_benchmarks.helper import benchmark, iterate_experiments
-from garage_benchmarks.parameters import (MuJoCo1M_ENV_SET, PIXEL_ENV_SET,
-                                          STATE_ENV_SET)
+from garage_benchmarks.helper import benchmark
+from garage_benchmarks.helper import iterate_experiments
+from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
+from garage_benchmarks.parameters import PIXEL_ENV_SET
+from garage_benchmarks.parameters import STATE_ENV_SET
 
 _seeds = random.sample(range(100), 3)
 

--- a/benchmarks/src/garage_benchmarks/experiments/algos/__init__.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/__init__.py
@@ -1,15 +1,15 @@
 """Benchmarking experiments for algorithms."""
 from garage_benchmarks.experiments.algos.ddpg_garage_tf import ddpg_garage_tf
 from garage_benchmarks.experiments.algos.her_garage_tf import her_garage_tf
-from garage_benchmarks.experiments.algos.ppo_garage_pytorch import (
-    ppo_garage_pytorch)
+from garage_benchmarks.experiments.algos.ppo_garage_pytorch import \
+    ppo_garage_pytorch
 from garage_benchmarks.experiments.algos.ppo_garage_tf import ppo_garage_tf
 from garage_benchmarks.experiments.algos.td3_garage_tf import td3_garage_tf
-from garage_benchmarks.experiments.algos.trpo_garage_pytorch import (
-    trpo_garage_pytorch)
+from garage_benchmarks.experiments.algos.trpo_garage_pytorch import \
+    trpo_garage_pytorch
 from garage_benchmarks.experiments.algos.trpo_garage_tf import trpo_garage_tf
-from garage_benchmarks.experiments.algos.vpg_garage_pytorch import (
-    vpg_garage_pytorch)
+from garage_benchmarks.experiments.algos.vpg_garage_pytorch import \
+    vpg_garage_pytorch
 from garage_benchmarks.experiments.algos.vpg_garage_tf import vpg_garage_tf
 
 __all__ = [

--- a/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise

--- a/benchmarks/src/garage_benchmarks/experiments/algos/her_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/her_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise

--- a/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO as TF_PPO

--- a/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.exploration_policies import AddGaussianNoise

--- a/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline

--- a/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_tf.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/__init__.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/__init__.py
@@ -1,10 +1,10 @@
 """Benchmarking experiments for baselines."""
-from garage_benchmarks.experiments.baselines.continuous_mlp_baseline import (
-    continuous_mlp_baseline)
-from garage_benchmarks.experiments.baselines.gaussian_cnn_baseline import (
-    gaussian_cnn_baseline)
-from garage_benchmarks.experiments.baselines.gaussian_mlp_baseline import (
-    gaussian_mlp_baseline)
+from garage_benchmarks.experiments.baselines.continuous_mlp_baseline import \
+    continuous_mlp_baseline
+from garage_benchmarks.experiments.baselines.gaussian_cnn_baseline import \
+    gaussian_cnn_baseline
+from garage_benchmarks.experiments.baselines.gaussian_mlp_baseline import \
+    gaussian_mlp_baseline
 
 __all__ = [
     'continuous_mlp_baseline', 'gaussian_cnn_baseline', 'gaussian_mlp_baseline'

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/continuous_mlp_baseline.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/continuous_mlp_baseline.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_cnn_baseline.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_cnn_baseline.py
@@ -2,7 +2,8 @@
 import gym
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_mlp_baseline.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_mlp_baseline.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/policies/__init__.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/__init__.py
@@ -1,20 +1,20 @@
 """Benchmarking experiments for baselines."""
-from garage_benchmarks.experiments.policies.categorical_cnn_policy import (
-    categorical_cnn_policy)
-from garage_benchmarks.experiments.policies.categorical_gru_policy import (
-    categorical_gru_policy)
-from garage_benchmarks.experiments.policies.categorical_lstm_policy import (
-    categorical_lstm_policy)
-from garage_benchmarks.experiments.policies.categorical_mlp_policy import (
-    categorical_mlp_policy)
-from garage_benchmarks.experiments.policies.continuous_mlp_policy import (
-    continuous_mlp_policy)
-from garage_benchmarks.experiments.policies.gaussian_gru_policy import (
-    gaussian_gru_policy)
-from garage_benchmarks.experiments.policies.gaussian_lstm_policy import (
-    gaussian_lstm_policy)
-from garage_benchmarks.experiments.policies.gaussian_mlp_policy import (
-    gaussian_mlp_policy)
+from garage_benchmarks.experiments.policies.categorical_cnn_policy import \
+    categorical_cnn_policy
+from garage_benchmarks.experiments.policies.categorical_gru_policy import \
+    categorical_gru_policy
+from garage_benchmarks.experiments.policies.categorical_lstm_policy import \
+    categorical_lstm_policy
+from garage_benchmarks.experiments.policies.categorical_mlp_policy import \
+    categorical_mlp_policy
+from garage_benchmarks.experiments.policies.continuous_mlp_policy import \
+    continuous_mlp_policy
+from garage_benchmarks.experiments.policies.gaussian_gru_policy import \
+    gaussian_gru_policy
+from garage_benchmarks.experiments.policies.gaussian_lstm_policy import \
+    gaussian_lstm_policy
+from garage_benchmarks.experiments.policies.gaussian_mlp_policy import \
+    gaussian_mlp_policy
 
 __all__ = [
     'categorical_cnn_policy', 'categorical_gru_policy',

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_cnn_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_cnn_policy.py
@@ -2,7 +2,8 @@
 import gym
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_gru_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_gru_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_lstm_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_lstm_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_mlp_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline

--- a/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_gru_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_gru_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_lstm_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_lstm_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_mlp_policy.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.tf.algos import PPO

--- a/benchmarks/src/garage_benchmarks/experiments/q_functions/__init__.py
+++ b/benchmarks/src/garage_benchmarks/experiments/q_functions/__init__.py
@@ -1,5 +1,5 @@
 """Benchmarking experiments for Q-functions."""
-from garage_benchmarks.experiments.q_functions.continuous_mlp_q_function import (  # noqa: E501
-    continuous_mlp_q_function)
+from garage_benchmarks.experiments.q_functions.continuous_mlp_q_function import \
+    continuous_mlp_q_function  # noqa: E501
 
 __all__ = ['continuous_mlp_q_function']

--- a/benchmarks/src/garage_benchmarks/experiments/q_functions/continuous_mlp_q_function.py
+++ b/benchmarks/src/garage_benchmarks/experiments/q_functions/continuous_mlp_q_function.py
@@ -3,7 +3,8 @@ import gym
 import tensorflow as tf
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise

--- a/examples/tf/multi_env_trpo.py
+++ b/examples/tf/multi_env_trpo.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """This is an example to train multiple tasks with TRPO algorithm."""
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.envs import PointEnv
 from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.experiment import LocalTFRunner

--- a/examples/tf/rl2_ppo_metaworld_ml45.py
+++ b/examples/tf/rl2_ppo_metaworld_ml45.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Example script to run RL2 in ML45."""
-# pylint: disable=no-value-for-parameter, wrong-import-order
+# pylint: disable=no-value-for-parameter
 import click
 import metaworld.benchmarks as mwb
 

--- a/examples/torch/pearl_half_cheetah_vel.py
+++ b/examples/torch/pearl_half_cheetah_vel.py
@@ -3,7 +3,8 @@
 import click
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.envs.mujoco import HalfCheetahVelEnv
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed

--- a/examples/torch/pearl_metaworld_ml10.py
+++ b/examples/torch/pearl_metaworld_ml10.py
@@ -5,7 +5,8 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import EnvPoolSampler

--- a/examples/torch/pearl_metaworld_ml1_push.py
+++ b/examples/torch/pearl_metaworld_ml1_push.py
@@ -4,7 +4,8 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler

--- a/examples/torch/pearl_metaworld_ml45.py
+++ b/examples/torch/pearl_metaworld_ml45.py
@@ -5,7 +5,8 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import EnvPoolSampler

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,12 @@ extend-ignore =
     D107  # We document __init__ in the class docstring
     F841  # Unused variables are checked by pylint
 
+# isort config
+[tool:isort]
+sections=FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+force_sort_within_sections = True
+order_by_type = False
+
 [tool:pytest]
 addopts = -rfEs --strict-markers
 testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,42 @@ extend-ignore =
 
 # isort config
 [tool:isort]
-sections=FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 force_sort_within_sections = True
 order_by_type = False
+force_single_line = True
+lexicographical = True
+single_line_exclusions = ("typing",)
+known_first_party = garage
+known_third_party = akro,
+                    cached_property,
+                    click,
+                    cma,
+                    dateutil,
+                    dm_env,
+                    dm_control,
+                    dowel,
+                    git,
+                    cloudpickle,
+                    garage_benchmarks,   # flake8 identify it as third-party package
+                    glfw,
+                    google,
+                    gym,
+                    joblib,
+                    matplotlib,
+                    metaworld,
+                    numpy,
+                    psutil,
+                    pyglet,
+                    pytest,
+                    ray,
+                    setproctitle,
+                    scipy,
+                    skimage,
+                    tensorflow,
+                    tensorflow_probability,
+                    torch,
+                    torchvision
 
 [tool:pytest]
 addopts = -rfEs --strict-markers

--- a/src/garage/envs/dm_control/__init__.py
+++ b/src/garage/envs/dm_control/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     raise ImportError("To use garage's dm_control wrappers, please install "
                       'garage[dm_control].')
 
-from garage.envs.dm_control.dm_control_viewer import DmControlViewer
 from garage.envs.dm_control.dm_control_env import DmControlEnv  # noqa: I100
+from garage.envs.dm_control.dm_control_viewer import DmControlViewer
 
 __all__ = ['DmControlViewer', 'DmControlEnv']

--- a/src/garage/envs/dm_control/dm_control_viewer.py
+++ b/src/garage/envs/dm_control/dm_control_viewer.py
@@ -4,6 +4,7 @@ import glfw
 
 
 class DmControlViewer(dm_viewer_app.Application):
+
     def render(self):
         # Don't try to render into closed windows
         if not self._window._context:

--- a/src/garage/envs/mujoco/half_cheetah_dir_env.py
+++ b/src/garage/envs/mujoco/half_cheetah_dir_env.py
@@ -1,7 +1,8 @@
 """Variant of the HalfCheetahEnv with different target directions."""
 import numpy as np
 
-from garage.envs.mujoco.half_cheetah_env_meta_base import HalfCheetahEnvMetaBase  # noqa: E501
+from garage.envs.mujoco.half_cheetah_env_meta_base import \
+    HalfCheetahEnvMetaBase  # noqa: E501
 
 
 class HalfCheetahDirEnv(HalfCheetahEnvMetaBase):

--- a/src/garage/envs/mujoco/half_cheetah_vel_env.py
+++ b/src/garage/envs/mujoco/half_cheetah_vel_env.py
@@ -1,7 +1,8 @@
 """Variant of the HalfCheetahEnv with different target velocity."""
 import numpy as np
 
-from garage.envs.mujoco.half_cheetah_env_meta_base import HalfCheetahEnvMetaBase  # noqa: E501
+from garage.envs.mujoco.half_cheetah_env_meta_base import \
+    HalfCheetahEnvMetaBase  # noqa: E501
 
 
 class HalfCheetahVelEnv(HalfCheetahEnvMetaBase):

--- a/src/garage/experiment/__init__.py
+++ b/src/garage/experiment/__init__.py
@@ -4,7 +4,8 @@ from garage.experiment.experiment import to_local_command
 from garage.experiment.local_runner import LocalRunner
 from garage.experiment.local_tf_runner import LocalTFRunner
 from garage.experiment.meta_evaluator import MetaEvaluator
-from garage.experiment.snapshotter import SnapshotConfig, Snapshotter
+from garage.experiment.snapshotter import SnapshotConfig
+from garage.experiment.snapshotter import Snapshotter
 from garage.experiment.task_sampler import TaskSampler
 
 __all__ = [

--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -3,16 +3,18 @@ import copy
 import os
 import time
 
+# This is avoiding a circular import
 import cloudpickle
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import psutil
 
-from garage.experiment.deterministic import get_seed, set_seed
+from garage.experiment.deterministic import get_seed
+from garage.experiment.deterministic import set_seed
 from garage.experiment.snapshotter import Snapshotter
 from garage.sampler import parallel_sampler
-from garage.sampler.sampler_deprecated import BaseSampler
-# This is avoiding a circular import
 from garage.sampler.default_worker import DefaultWorker  # noqa: I100
+from garage.sampler.sampler_deprecated import BaseSampler
 from garage.sampler.worker_factory import WorkerFactory
 
 

--- a/src/garage/experiment/meta_evaluator.py
+++ b/src/garage/experiment/meta_evaluator.py
@@ -1,8 +1,10 @@
 """Evaluator which tests Meta-RL algorithms on test environments."""
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 
-from garage import log_multitask_performance, TrajectoryBatch
+from garage import log_multitask_performance
+from garage import TrajectoryBatch
 from garage.experiment.deterministic import get_seed
 from garage.sampler import DefaultWorker
 from garage.sampler import LocalSampler

--- a/src/garage/np/exploration_policies/__init__.py
+++ b/src/garage/np/exploration_policies/__init__.py
@@ -1,9 +1,9 @@
 """Exploration strategies which use NumPy as a numerical backend."""
 from garage.np.exploration_policies.add_gaussian_noise import AddGaussianNoise
-from garage.np.exploration_policies.add_ornstein_uhlenbeck_noise import (
-    AddOrnsteinUhlenbeckNoise)
-from garage.np.exploration_policies.epsilon_greedy_policy import (
-    EpsilonGreedyPolicy)
+from garage.np.exploration_policies.add_ornstein_uhlenbeck_noise import \
+    AddOrnsteinUhlenbeckNoise
+from garage.np.exploration_policies.epsilon_greedy_policy import \
+    EpsilonGreedyPolicy
 from garage.np.exploration_policies.exploration_policy import ExplorationPolicy
 
 __all__ = [

--- a/src/garage/np/optimizers/minibatch_dataset.py
+++ b/src/garage/np/optimizers/minibatch_dataset.py
@@ -2,6 +2,7 @@ import numpy as np
 
 
 class BatchDataset:
+
     def __init__(self, inputs, batch_size, extra_inputs=None):
         self._inputs = [i for i in inputs]
         if extra_inputs is None:

--- a/src/garage/plotter/plotter.py
+++ b/src/garage/plotter/plotter.py
@@ -66,20 +66,18 @@ class Plotter:
                     param_values, max_length = msgs[Op.DEMO].args
                     policy.set_param_values(param_values)
                     initial_rollout = False
-                    rollout(
-                        env,
-                        policy,
-                        max_path_length=max_length,
-                        animated=True,
-                        speedup=5)
-                else:
-                    if max_length:
-                        rollout(
-                            env,
+                    rollout(env,
                             policy,
                             max_path_length=max_length,
                             animated=True,
                             speedup=5)
+                else:
+                    if max_length:
+                        rollout(env,
+                                policy,
+                                max_path_length=max_length,
+                                animated=True,
+                                speedup=5)
         except KeyboardInterrupt:
             pass
 
@@ -123,8 +121,11 @@ class Plotter:
 
         # Needed in order to draw glfw window on the main thread
         if ('Darwin' in platform.platform()):
-            rollout(
-                env, policy, max_path_length=np.inf, animated=True, speedup=5)
+            rollout(env,
+                    policy,
+                    max_path_length=np.inf,
+                    animated=True,
+                    speedup=5)
 
         self._queue.put(Message(op=Op.UPDATE, args=(env, policy), kwargs=None))
 
@@ -132,7 +133,6 @@ class Plotter:
         if not Plotter.enable:
             return
         self._queue.put(
-            Message(
-                op=Op.DEMO,
-                args=(policy.get_param_values(), max_length),
-                kwargs=None))
+            Message(op=Op.DEMO,
+                    args=(policy.get_param_values(), max_length),
+                    kwargs=None))

--- a/src/garage/sampler/__init__.py
+++ b/src/garage/sampler/__init__.py
@@ -5,10 +5,10 @@ from garage.sampler.default_worker import DefaultWorker
 from garage.sampler.is_sampler import ISSampler
 from garage.sampler.local_sampler import LocalSampler
 from garage.sampler.multiprocessing_sampler import MultiprocessingSampler
-from garage.sampler.off_policy_vectorized_sampler import (
-    OffPolicyVectorizedSampler)
-from garage.sampler.on_policy_vectorized_sampler import (
-    OnPolicyVectorizedSampler)
+from garage.sampler.off_policy_vectorized_sampler import \
+    OffPolicyVectorizedSampler
+from garage.sampler.on_policy_vectorized_sampler import \
+    OnPolicyVectorizedSampler
 from garage.sampler.parallel_vec_env_executor import ParallelVecEnvExecutor
 from garage.sampler.ray_sampler import RaySampler
 from garage.sampler.sampler import Sampler

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -1,12 +1,14 @@
 """Deep Deterministic Policy Gradient (DDPG) implementation in TensorFlow."""
 from collections import deque
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import tensorflow as tf
 
-from garage import _Default, make_optimizer
+from garage import _Default
 from garage import log_performance
+from garage import make_optimizer
 from garage.np import obtain_evaluation_samples
 from garage.np import samples_to_tensors
 from garage.np.algos import RLAlgorithm

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -4,8 +4,9 @@ from dowel import tabular
 import numpy as np
 import tensorflow as tf
 
-from garage import _Default, make_optimizer
+from garage import _Default
 from garage import log_performance
+from garage import make_optimizer
 from garage.np import obtain_evaluation_samples
 from garage.np import samples_to_tensors
 from garage.np.algos import RLAlgorithm

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -2,12 +2,14 @@
 # pylint: disable=wrong-import-order
 import collections
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import tensorflow as tf
 
-from garage import log_performance, TrajectoryBatch
+from garage import log_performance
 from garage import make_optimizer
+from garage import TrajectoryBatch
 from garage.misc import tensor_utils as np_tensor_utils
 from garage.np.algos import RLAlgorithm
 from garage.sampler import OnPolicyVectorizedSampler

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -1,13 +1,16 @@
 """Relative Entropy Policy Search implementation in Tensorflow."""
 import collections
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import scipy.optimize
 import tensorflow as tf
 
-from garage import _Default, make_optimizer
-from garage import log_performance, TrajectoryBatch
+from garage import _Default
+from garage import log_performance
+from garage import make_optimizer
+from garage import TrajectoryBatch
 from garage.np.algos import RLAlgorithm
 from garage.sampler import OnPolicyVectorizedSampler
 from garage.tf import paths_to_tensors

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -6,12 +6,14 @@ minimum value of two critics instead of one to limit overestimation.
 """
 from collections import deque
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import tensorflow as tf
 
-from garage import _Default, make_optimizer
+from garage import _Default
 from garage import log_performance
+from garage import make_optimizer
 from garage.np import obtain_evaluation_samples
 from garage.np import samples_to_tensors
 from garage.np.algos import RLAlgorithm

--- a/src/garage/tf/distributions/__init__.py
+++ b/src/garage/tf/distributions/__init__.py
@@ -1,11 +1,11 @@
 # flake8: noqa
-from garage.tf.distributions.distribution import Distribution
 from garage.tf.distributions.bernoulli import Bernoulli
 from garage.tf.distributions.categorical import Categorical
 from garage.tf.distributions.diagonal_gaussian import DiagonalGaussian
+from garage.tf.distributions.distribution import Distribution
 from garage.tf.distributions.recurrent_categorical import RecurrentCategorical
-from garage.tf.distributions.recurrent_diagonal_gaussian import (
-    RecurrentDiagonalGaussian)
+from garage.tf.distributions.recurrent_diagonal_gaussian import \
+    RecurrentDiagonalGaussian
 
 __all__ = [
     'Distribution',

--- a/src/garage/tf/models/__init__.py
+++ b/src/garage/tf/models/__init__.py
@@ -15,10 +15,11 @@ from garage.tf.models.lstm_model import LSTMModel
 from garage.tf.models.mlp_dueling_model import MLPDuelingModel
 from garage.tf.models.mlp_merge_model import MLPMergeModel
 from garage.tf.models.mlp_model import MLPModel
-from garage.tf.models.model import BaseModel, Model
-from garage.tf.models.module import Module, StochasticModule
-from garage.tf.models.normalized_input_mlp_model import (
-    NormalizedInputMLPModel)
+from garage.tf.models.model import BaseModel
+from garage.tf.models.model import Model
+from garage.tf.models.module import Module
+from garage.tf.models.module import StochasticModule
+from garage.tf.models.normalized_input_mlp_model import NormalizedInputMLPModel
 from garage.tf.models.sequential import Sequential
 
 __all__ = [

--- a/src/garage/tf/models/parameter.py
+++ b/src/garage/tf/models/parameter.py
@@ -75,10 +75,10 @@ def recurrent_parameter(input_var,
     """
     with tf.compat.v1.variable_scope(name):
         p = tf.compat.v1.get_variable('parameter',
-                            shape=(length, ),
-                            dtype=dtype,
-                            initializer=initializer,
-                            trainable=trainable)
+                                      shape=(length, ),
+                                      dtype=dtype,
+                                      initializer=initializer,
+                                      trainable=trainable)
         batch_dim = tf.shape(input_var)[:2]
         step_batch_dim = tf.shape(step_input_var)[:1]
         broadcast_shape = tf.concat(axis=0, values=[batch_dim, [length]])

--- a/src/garage/tf/optimizers/__init__.py
+++ b/src/garage/tf/optimizers/__init__.py
@@ -1,7 +1,7 @@
-from garage.tf.optimizers.conjugate_gradient_optimizer import (
-    ConjugateGradientOptimizer)
-from garage.tf.optimizers.conjugate_gradient_optimizer import (
-    FiniteDifferenceHvp)
+from garage.tf.optimizers.conjugate_gradient_optimizer import \
+    ConjugateGradientOptimizer
+from garage.tf.optimizers.conjugate_gradient_optimizer import \
+    FiniteDifferenceHvp
 from garage.tf.optimizers.first_order_optimizer import FirstOrderOptimizer
 from garage.tf.optimizers.lbfgs_optimizer import LbfgsOptimizer
 from garage.tf.optimizers.penalty_lbfgs_optimizer import PenaltyLbfgsOptimizer

--- a/src/garage/tf/optimizers/conjugate_gradient_optimizer.py
+++ b/src/garage/tf/optimizers/conjugate_gradient_optimizer.py
@@ -12,7 +12,8 @@ import numpy as np
 import tensorflow as tf
 
 from garage.tf.misc import tensor_utils
-from garage.tf.optimizers.utils import LazyDict, sliced_fun
+from garage.tf.optimizers.utils import LazyDict
+from garage.tf.optimizers.utils import sliced_fun
 
 
 class HessianVectorProduct(abc.ABC):
@@ -172,7 +173,12 @@ class FiniteDifferenceHvp(HessianVectorProduct):
         self.base_eps = base_eps
         self.symmetric = symmetric
 
-    def update_hvp(self, f, target, inputs, reg_coeff, name='FiniteDifferenceHvp'):
+    def update_hvp(self,
+                   f,
+                   target,
+                   inputs,
+                   reg_coeff,
+                   name='FiniteDifferenceHvp'):
         """Build the symbolic graph to compute the Hessian-vector product.
 
         Args:

--- a/src/garage/tf/policies/__init__.py
+++ b/src/garage/tf/policies/__init__.py
@@ -4,14 +4,15 @@ from garage.tf.policies.categorical_gru_policy import CategoricalGRUPolicy
 from garage.tf.policies.categorical_lstm_policy import CategoricalLSTMPolicy
 from garage.tf.policies.categorical_mlp_policy import CategoricalMLPPolicy
 from garage.tf.policies.continuous_mlp_policy import ContinuousMLPPolicy
-from garage.tf.policies.discrete_qf_derived_policy import (
-    DiscreteQfDerivedPolicy)
+from garage.tf.policies.discrete_qf_derived_policy import \
+    DiscreteQfDerivedPolicy
 from garage.tf.policies.gaussian_gru_policy import GaussianGRUPolicy
 from garage.tf.policies.gaussian_lstm_policy import GaussianLSTMPolicy
 from garage.tf.policies.gaussian_mlp_policy import GaussianMLPPolicy
-from garage.tf.policies.gaussian_mlp_task_embedding_policy import (
-    GaussianMLPTaskEmbeddingPolicy)
-from garage.tf.policies.policy import Policy, StochasticPolicy
+from garage.tf.policies.gaussian_mlp_task_embedding_policy import \
+    GaussianMLPTaskEmbeddingPolicy
+from garage.tf.policies.policy import Policy
+from garage.tf.policies.policy import StochasticPolicy
 from garage.tf.policies.task_embedding_policy import TaskEmbeddingPolicy
 
 __all__ = [

--- a/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
@@ -1,5 +1,4 @@
 """GaussianMLPTaskEmbeddingPolicy."""
-# pylint: disable=wrong-import-order
 import akro
 import numpy as np
 import tensorflow as tf

--- a/src/garage/tf/q_functions/__init__.py
+++ b/src/garage/tf/q_functions/__init__.py
@@ -1,13 +1,13 @@
 """Q-Functions for TensorFlow-based algorithms."""
 # noqa: I100
 
-from garage.tf.q_functions.q_function import QFunction
-from garage.tf.q_functions.continuous_cnn_q_function import (  # noqa: I100
-    ContinuousCNNQFunction)
-from garage.tf.q_functions.continuous_mlp_q_function import (
-    ContinuousMLPQFunction)
+from garage.tf.q_functions.continuous_cnn_q_function import \
+    ContinuousCNNQFunction  # noqa: I100
+from garage.tf.q_functions.continuous_mlp_q_function import \
+    ContinuousMLPQFunction
 from garage.tf.q_functions.discrete_cnn_q_function import DiscreteCNNQFunction
 from garage.tf.q_functions.discrete_mlp_q_function import DiscreteMLPQFunction
+from garage.tf.q_functions.q_function import QFunction
 
 __all__ = [
     'QFunction', 'ContinuousMLPQFunction', 'DiscreteCNNQFunction',

--- a/src/garage/tf/regressors/__init__.py
+++ b/src/garage/tf/regressors/__init__.py
@@ -1,14 +1,15 @@
 """Regressors for TensorFlow-based algorithms."""
 from garage.tf.regressors.bernoulli_mlp_regressor import BernoulliMLPRegressor
-from garage.tf.regressors.categorical_mlp_regressor import (
-    CategoricalMLPRegressor)
-from garage.tf.regressors.continuous_mlp_regressor import (
-    ContinuousMLPRegressor)
+from garage.tf.regressors.categorical_mlp_regressor import \
+    CategoricalMLPRegressor
+from garage.tf.regressors.continuous_mlp_regressor import \
+    ContinuousMLPRegressor
 from garage.tf.regressors.gaussian_cnn_regressor import GaussianCNNRegressor
-from garage.tf.regressors.gaussian_cnn_regressor_model import (
-    GaussianCNNRegressorModel)
+from garage.tf.regressors.gaussian_cnn_regressor_model import \
+    GaussianCNNRegressorModel
 from garage.tf.regressors.gaussian_mlp_regressor import GaussianMLPRegressor
-from garage.tf.regressors.regressor import Regressor, StochasticRegressor
+from garage.tf.regressors.regressor import Regressor
+from garage.tf.regressors.regressor import StochasticRegressor
 
 __all__ = [
     'BernoulliMLPRegressor', 'CategoricalMLPRegressor',

--- a/src/garage/tf/regressors/gaussian_cnn_regressor.py
+++ b/src/garage/tf/regressors/gaussian_cnn_regressor.py
@@ -5,9 +5,10 @@ import tensorflow as tf
 
 from garage import make_optimizer
 from garage.tf.misc import tensor_utils
-from garage.tf.optimizers import LbfgsOptimizer, PenaltyLbfgsOptimizer
-from garage.tf.regressors.gaussian_cnn_regressor_model import (
-    GaussianCNNRegressorModel)
+from garage.tf.optimizers import LbfgsOptimizer
+from garage.tf.optimizers import PenaltyLbfgsOptimizer
+from garage.tf.regressors.gaussian_cnn_regressor_model import \
+    GaussianCNNRegressorModel
 from garage.tf.regressors.regressor import StochasticRegressor
 
 

--- a/src/garage/tf/regressors/gaussian_mlp_regressor.py
+++ b/src/garage/tf/regressors/gaussian_mlp_regressor.py
@@ -5,9 +5,10 @@ import tensorflow as tf
 
 from garage import make_optimizer
 from garage.tf.misc import tensor_utils
-from garage.tf.optimizers import LbfgsOptimizer, PenaltyLbfgsOptimizer
-from garage.tf.regressors.gaussian_mlp_regressor_model import (
-    GaussianMLPRegressorModel)
+from garage.tf.optimizers import LbfgsOptimizer
+from garage.tf.optimizers import PenaltyLbfgsOptimizer
+from garage.tf.regressors.gaussian_mlp_regressor_model import \
+    GaussianMLPRegressorModel
 from garage.tf.regressors.regressor import StochasticRegressor
 
 

--- a/src/garage/torch/algos/__init__.py
+++ b/src/garage/torch/algos/__init__.py
@@ -1,15 +1,15 @@
 """PyTorch algorithms."""
-from garage.torch.algos.ddpg import DDPG
 # VPG has to been import first because it is depended by PPO and TRPO.
-from garage.torch.algos.vpg import VPG
-from garage.torch.algos.ppo import PPO  # noqa: I100
-from garage.torch.algos.trpo import TRPO
+from garage.torch.algos.ddpg import DDPG
 from garage.torch.algos.maml_ppo import MAMLPPO  # noqa: I100
 from garage.torch.algos.maml_trpo import MAMLTRPO
 from garage.torch.algos.maml_vpg import MAMLVPG
-from garage.torch.algos.pearl import PEARL
-from garage.torch.algos.sac import SAC
 from garage.torch.algos.mtsac import MTSAC  # noqa: I100
+from garage.torch.algos.pearl import PEARL
+from garage.torch.algos.ppo import PPO  # noqa: I100
+from garage.torch.algos.sac import SAC
+from garage.torch.algos.trpo import TRPO
+from garage.torch.algos.vpg import VPG
 
 __all__ = [
     'DDPG', 'VPG', 'PPO', 'TRPO', 'MAMLPPO', 'MAMLTRPO', 'MAMLVPG', 'MTSAC',

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -2,17 +2,20 @@
 from collections import deque
 import copy
 
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import torch
 
-from garage import _Default, make_optimizer
+from garage import _Default
 from garage import log_performance
+from garage import make_optimizer
 from garage.np import obtain_evaluation_samples
 from garage.np import samples_to_tensors
 from garage.np.algos import RLAlgorithm
 from garage.sampler import OffPolicyVectorizedSampler
-from garage.torch import dict_np_to_torch, torch_to_np
+from garage.torch import dict_np_to_torch
+from garage.torch import torch_to_np
 
 
 class DDPG(RLAlgorithm):

--- a/src/garage/torch/algos/maml.py
+++ b/src/garage/torch/algos/maml.py
@@ -6,8 +6,9 @@ from dowel import tabular
 import numpy as np
 import torch
 
-from garage import _Default, make_optimizer
+from garage import _Default
 from garage import log_multitask_performance
+from garage import make_optimizer
 from garage import TrajectoryBatch
 from garage.misc import tensor_utils
 from garage.sampler import OnPolicyVectorizedSampler

--- a/src/garage/torch/algos/vpg.py
+++ b/src/garage/torch/algos/vpg.py
@@ -7,11 +7,14 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from garage import log_performance, TrajectoryBatch
+from garage import log_performance
+from garage import TrajectoryBatch
 from garage.misc import tensor_utils as tu
 from garage.np.algos.rl_algorithm import RLAlgorithm
 from garage.sampler import OnPolicyVectorizedSampler
-from garage.torch import (compute_advantages, filter_valids, pad_to_last)
+from garage.torch import compute_advantages
+from garage.torch import filter_valids
+from garage.torch import pad_to_last
 from garage.torch.optimizers import OptimizerWrapper
 
 

--- a/src/garage/torch/modules/__init__.py
+++ b/src/garage/torch/modules/__init__.py
@@ -1,8 +1,9 @@
 """Pytorch modules."""
 
 from garage.torch.modules.gaussian_mlp_module import \
-    GaussianMLPIndependentStdModule, GaussianMLPModule, \
-    GaussianMLPTwoHeadedModule
+    GaussianMLPIndependentStdModule
+from garage.torch.modules.gaussian_mlp_module import GaussianMLPModule
+from garage.torch.modules.gaussian_mlp_module import GaussianMLPTwoHeadedModule
 from garage.torch.modules.mlp_module import MLPModule
 from garage.torch.modules.multi_headed_mlp_module import MultiHeadedMLPModule
 

--- a/src/garage/torch/optimizers/__init__.py
+++ b/src/garage/torch/optimizers/__init__.py
@@ -1,6 +1,6 @@
 """PyTorch optimizers."""
-from garage.torch.optimizers.conjugate_gradient_optimizer import (
-    ConjugateGradientOptimizer)
+from garage.torch.optimizers.conjugate_gradient_optimizer import \
+    ConjugateGradientOptimizer
 from garage.torch.optimizers.differentiable_sgd import DifferentiableSGD
 from garage.torch.optimizers.optimizer_wrapper import OptimizerWrapper
 

--- a/src/garage/torch/policies/__init__.py
+++ b/src/garage/torch/policies/__init__.py
@@ -1,12 +1,12 @@
 """PyTorch Policies."""
-from garage.torch.policies.context_conditioned_policy import (
-    ContextConditionedPolicy)
-from garage.torch.policies.policy import Policy
-from garage.torch.policies.deterministic_mlp_policy import (  # noqa: I100
-    DeterministicMLPPolicy)
+from garage.torch.policies.context_conditioned_policy import \
+    ContextConditionedPolicy
+from garage.torch.policies.deterministic_mlp_policy import \
+    DeterministicMLPPolicy  # noqa: I100
 from garage.torch.policies.gaussian_mlp_policy import GaussianMLPPolicy
-from garage.torch.policies.tanh_gaussian_mlp_policy import (
-    TanhGaussianMLPPolicy)
+from garage.torch.policies.policy import Policy
+from garage.torch.policies.tanh_gaussian_mlp_policy import \
+    TanhGaussianMLPPolicy
 
 __all__ = [
     'DeterministicMLPPolicy',

--- a/src/garage/torch/q_functions/__init__.py
+++ b/src/garage/torch/q_functions/__init__.py
@@ -1,5 +1,5 @@
 """PyTorch Q-functions."""
-from garage.torch.q_functions.continuous_mlp_q_function import (
-    ContinuousMLPQFunction)
+from garage.torch.q_functions.continuous_mlp_q_function import \
+    ContinuousMLPQFunction
 
 __all__ = ['ContinuousMLPQFunction']

--- a/src/garage/torch/value_functions/__init__.py
+++ b/src/garage/torch/value_functions/__init__.py
@@ -1,6 +1,6 @@
 """Value functions which use PyTorch."""
+from garage.torch.value_functions.gaussian_mlp_value_function import \
+    GaussianMLPValueFunction  # noqa: I100,E501
 from garage.torch.value_functions.value_function import ValueFunction
-from garage.torch.value_functions.gaussian_mlp_value_function import (  # noqa: I100,E501
-    GaussianMLPValueFunction)
 
 __all__ = ['ValueFunction', 'GaussianMLPValueFunction']

--- a/tests/fixtures/distributions/__init__.py
+++ b/tests/fixtures/distributions/__init__.py
@@ -1,5 +1,5 @@
 from tests.fixtures.distributions.dummy_distribution import DummyDistribution
 
 __all__ = [
-    "DummyDistribution",
+    'DummyDistribution',
 ]

--- a/tests/fixtures/envs/dummy/__init__.py
+++ b/tests/fixtures/envs/dummy/__init__.py
@@ -4,12 +4,12 @@ from tests.fixtures.envs.dummy.dummy_box_env import DummyBoxEnv
 from tests.fixtures.envs.dummy.dummy_dict_env import DummyDictEnv
 from tests.fixtures.envs.dummy.dummy_discrete_2d_env import DummyDiscrete2DEnv
 from tests.fixtures.envs.dummy.dummy_discrete_env import DummyDiscreteEnv
-from tests.fixtures.envs.dummy.dummy_discrete_pixel_env import (
-    DummyDiscretePixelEnv)
-from tests.fixtures.envs.dummy.dummy_discrete_pixel_env_baselines import (
-    DummyDiscretePixelEnvBaselines)
-from tests.fixtures.envs.dummy.dummy_multitask_box_env import (
-    DummyMultiTaskBoxEnv)
+from tests.fixtures.envs.dummy.dummy_discrete_pixel_env import \
+    DummyDiscretePixelEnv
+from tests.fixtures.envs.dummy.dummy_discrete_pixel_env_baselines import \
+    DummyDiscretePixelEnvBaselines
+from tests.fixtures.envs.dummy.dummy_multitask_box_env import \
+    DummyMultiTaskBoxEnv
 from tests.fixtures.envs.dummy.dummy_reward_box_env import DummyRewardBoxEnv
 
 __all__ = [

--- a/tests/fixtures/envs/dummy/dummy_discrete_2d_env.py
+++ b/tests/fixtures/envs/dummy/dummy_discrete_2d_env.py
@@ -10,8 +10,10 @@ class DummyDiscrete2DEnv(DummyEnv):
     def __init__(self, random=True):
         super().__init__(random)
         self.shape = (2, 2)
-        self._observation_space = gym.spaces.Box(
-            low=-1, high=1, shape=self.shape, dtype=np.float32)
+        self._observation_space = gym.spaces.Box(low=-1,
+                                                 high=1,
+                                                 shape=self.shape,
+                                                 dtype=np.float32)
 
     @property
     def observation_space(self):
@@ -41,5 +43,5 @@ class DummyDiscrete2DEnv(DummyEnv):
                 obs = self.state + action / 10.
         else:
             raise RuntimeError(
-                "DummyEnv: reset() must be called before step()!")
+                'DummyEnv: reset() must be called before step()!')
         return obs, 0, True, dict()

--- a/tests/fixtures/envs/dummy/dummy_discrete_env.py
+++ b/tests/fixtures/envs/dummy/dummy_discrete_env.py
@@ -13,8 +13,10 @@ class DummyDiscreteEnv(DummyEnv):
     @property
     def observation_space(self):
         """Return an observation space."""
-        return gym.spaces.Box(
-            low=-1, high=1, shape=self._obs_dim, dtype=np.float32)
+        return gym.spaces.Box(low=-1,
+                              high=1,
+                              shape=self._obs_dim,
+                              dtype=np.float32)
 
     @property
     def action_space(self):
@@ -35,5 +37,5 @@ class DummyDiscreteEnv(DummyEnv):
                 obs = self.state + action / 10.
         else:
             raise RuntimeError(
-                "DummyEnv: reset() must be called before step()!")
+                'DummyEnv: reset() must be called before step()!')
         return obs, 0, True, dict()

--- a/tests/fixtures/envs/dummy/dummy_discrete_pixel_env_baselines.py
+++ b/tests/fixtures/envs/dummy/dummy_discrete_pixel_env_baselines.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyEnv
 
 
 class LazyFrames(object):
+
     def __init__(self, frames):
         """
         LazyFrames class from baselines.
@@ -39,8 +40,10 @@ class DummyDiscretePixelEnvBaselines(DummyEnv):
 
     def __init__(self):
         super().__init__(random=False, obs_dim=(10, 10, 3), action_dim=5)
-        self._observation_space = gym.spaces.Box(
-            low=0, high=255, shape=self._obs_dim, dtype=np.uint8)
+        self._observation_space = gym.spaces.Box(low=0,
+                                                 high=255,
+                                                 shape=self._obs_dim,
+                                                 dtype=np.uint8)
 
     @property
     def observation_space(self):

--- a/tests/fixtures/models/__init__.py
+++ b/tests/fixtures/models/__init__.py
@@ -1,21 +1,21 @@
 """Mock models for testing."""
-from tests.fixtures.models.simple_categorical_gru_model import (
-    SimpleCategoricalGRUModel)
-from tests.fixtures.models.simple_categorical_lstm_model import (
-    SimpleCategoricalLSTMModel)
-from tests.fixtures.models.simple_categorical_mlp_model import (
-    SimpleCategoricalMLPModel)
+from tests.fixtures.models.simple_categorical_gru_model import \
+    SimpleCategoricalGRUModel
+from tests.fixtures.models.simple_categorical_lstm_model import \
+    SimpleCategoricalLSTMModel
+from tests.fixtures.models.simple_categorical_mlp_model import \
+    SimpleCategoricalMLPModel
 from tests.fixtures.models.simple_cnn_model import SimpleCNNModel
-from tests.fixtures.models.simple_cnn_model_with_max_pooling import (
-    SimpleCNNModelWithMaxPooling)
-from tests.fixtures.models.simple_gaussian_cnn_model import (
-    SimpleGaussianCNNModel)
-from tests.fixtures.models.simple_gaussian_gru_model import (
-    SimpleGaussianGRUModel)
-from tests.fixtures.models.simple_gaussian_lstm_model import (
-    SimpleGaussianLSTMModel)
-from tests.fixtures.models.simple_gaussian_mlp_model import (
-    SimpleGaussianMLPModel)
+from tests.fixtures.models.simple_cnn_model_with_max_pooling import \
+    SimpleCNNModelWithMaxPooling
+from tests.fixtures.models.simple_gaussian_cnn_model import \
+    SimpleGaussianCNNModel
+from tests.fixtures.models.simple_gaussian_gru_model import \
+    SimpleGaussianGRUModel
+from tests.fixtures.models.simple_gaussian_lstm_model import \
+    SimpleGaussianLSTMModel
+from tests.fixtures.models.simple_gaussian_mlp_model import \
+    SimpleGaussianMLPModel
 from tests.fixtures.models.simple_gru_model import SimpleGRUModel
 from tests.fixtures.models.simple_lstm_model import SimpleLSTMModel
 from tests.fixtures.models.simple_mlp_merge_model import SimpleMLPMergeModel

--- a/tests/fixtures/policies/__init__.py
+++ b/tests/fixtures/policies/__init__.py
@@ -1,7 +1,6 @@
-from tests.fixtures.policies.dummy_policy import (DummyPolicy,
-                                                  DummyPolicyWithoutVectorized)
-from tests.fixtures.policies.dummy_recurrent_policy import (
-    DummyRecurrentPolicy)
+from tests.fixtures.policies.dummy_policy import DummyPolicy
+from tests.fixtures.policies.dummy_policy import DummyPolicyWithoutVectorized
+from tests.fixtures.policies.dummy_recurrent_policy import DummyRecurrentPolicy
 
 __all__ = [
     'DummyPolicy', 'DummyRecurrentPolicy', 'DummyPolicyWithoutVectorized'

--- a/tests/fixtures/regressors/__init__.py
+++ b/tests/fixtures/regressors/__init__.py
@@ -1,8 +1,8 @@
-from tests.fixtures.regressors.simple_gaussian_cnn_regressor import (
-    SimpleGaussianCNNRegressor)
-from tests.fixtures.regressors.simple_gaussian_mlp_regressor import (
-    SimpleGaussianMLPRegressor)
-from tests.fixtures.regressors.simple_mlp_regressor import (SimpleMLPRegressor)
+from tests.fixtures.regressors.simple_gaussian_cnn_regressor import \
+    SimpleGaussianCNNRegressor
+from tests.fixtures.regressors.simple_gaussian_mlp_regressor import \
+    SimpleGaussianMLPRegressor
+from tests.fixtures.regressors.simple_mlp_regressor import SimpleMLPRegressor
 
 __all__ = [
     'SimpleGaussianCNNRegressor', 'SimpleGaussianMLPRegressor',

--- a/tests/garage/envs/test_env_spec.py
+++ b/tests/garage/envs/test_env_spec.py
@@ -6,6 +6,7 @@ from garage.envs.env_spec import EnvSpec
 
 
 class TestEnvSpec:
+
     def test_pickleable(self):
         env_spec = EnvSpec(akro.Box(-1, 1, (1, )), akro.Box(-2, 2, (2, )))
         round_trip = pickle.loads(pickle.dumps(env_spec))

--- a/tests/garage/envs/test_grid_world_env.py
+++ b/tests/garage/envs/test_grid_world_env.py
@@ -5,6 +5,7 @@ from tests.helpers import step_env
 
 
 class TestGridWorldEnv:
+
     def test_pickleable(self):
         env = GridWorldEnv(desc='8x8')
         round_trip = pickle.loads(pickle.dumps(env))

--- a/tests/garage/envs/test_half_cheetah_meta_envs.py
+++ b/tests/garage/envs/test_half_cheetah_meta_envs.py
@@ -1,6 +1,10 @@
 import pickle
 
 import pytest
+
+from garage.envs.mujoco.half_cheetah_dir_env import HalfCheetahDirEnv
+from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -12,9 +16,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-
-from garage.envs.mujoco.half_cheetah_dir_env import HalfCheetahDirEnv
-from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 
 
 @pytest.mark.mujoco

--- a/tests/garage/envs/test_normalized_env.py
+++ b/tests/garage/envs/test_normalized_env.py
@@ -8,6 +8,7 @@ from tests.helpers import step_env
 
 
 class TestNormalizedEnv:
+
     def test_pickleable(self):
         inner_env = PointEnv(goal=(1., 2.))
         env = NormalizedEnv(inner_env, scale_reward=10.)

--- a/tests/garage/envs/wrappers/test_atari_env.py
+++ b/tests/garage/envs/wrappers/test_atari_env.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnvBaselines
 
 
 class TestFireReset:
+
     def test_atari_env(self):
         env = DummyDiscretePixelEnvBaselines()
         env_wrapped = AtariEnv(env)

--- a/tests/garage/envs/wrappers/test_clip_reward.py
+++ b/tests/garage/envs/wrappers/test_clip_reward.py
@@ -3,6 +3,7 @@ from tests.fixtures.envs.dummy import DummyRewardBoxEnv
 
 
 class TestClipReward:
+
     def test_clip_reward(self):
         # reward = 10 when action = 0, otherwise -10
         env = DummyRewardBoxEnv(random=True)

--- a/tests/garage/envs/wrappers/test_episodic_life.py
+++ b/tests/garage/envs/wrappers/test_episodic_life.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
 class TestEpisodicLife:
+
     def test_episodic_life_reset(self):
         env = EpisodicLife(DummyDiscretePixelEnv())
         obs = env.reset()

--- a/tests/garage/envs/wrappers/test_fire_reset.py
+++ b/tests/garage/envs/wrappers/test_fire_reset.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
 class TestFireReset:
+
     def test_fire_reset(self):
         env = DummyDiscretePixelEnv()
         env_wrap = FireReset(env)

--- a/tests/garage/envs/wrappers/test_grayscale_env.py
+++ b/tests/garage/envs/wrappers/test_grayscale_env.py
@@ -7,6 +7,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
 class TestGrayscale:
+
     def setup_method(self):
         self.env = DummyDiscretePixelEnv(random=False)
         self.env_g = Grayscale(DummyDiscretePixelEnv(random=False))
@@ -22,8 +23,10 @@ class TestGrayscale:
 
     def test_grayscale_invalid_environment_shape(self):
         with pytest.raises(ValueError):
-            self.env.observation_space = gym.spaces.Box(
-                low=0, high=255, shape=(4, ), dtype=np.uint8)
+            self.env.observation_space = gym.spaces.Box(low=0,
+                                                        high=255,
+                                                        shape=(4, ),
+                                                        dtype=np.uint8)
             Grayscale(self.env)
 
     def test_grayscale_observation_space(self):

--- a/tests/garage/envs/wrappers/test_max_and_skip.py
+++ b/tests/garage/envs/wrappers/test_max_and_skip.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
 class TestMaxAndSkip:
+
     def setup_method(self):
         self.env = DummyDiscretePixelEnv(random=False)
         self.env_wrap = MaxAndSkip(DummyDiscretePixelEnv(random=False), skip=4)

--- a/tests/garage/envs/wrappers/test_noop.py
+++ b/tests/garage/envs/wrappers/test_noop.py
@@ -5,6 +5,7 @@ from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
 
 
 class TestNoop:
+
     def test_noop(self):
         env = Noop(DummyDiscretePixelEnv(), noop_max=3)
 

--- a/tests/garage/envs/wrappers/test_resize_env.py
+++ b/tests/garage/envs/wrappers/test_resize_env.py
@@ -7,12 +7,14 @@ from tests.fixtures.envs.dummy import DummyDiscrete2DEnv
 
 
 class TestResize:
+
     def setup_method(self):
         self.width = 16
         self.height = 16
         self.env = DummyDiscrete2DEnv()
-        self.env_r = Resize(
-            DummyDiscrete2DEnv(), width=self.width, height=self.height)
+        self.env_r = Resize(DummyDiscrete2DEnv(),
+                            width=self.width,
+                            height=self.height)
 
     def teardown_method(self):
         self.env.close()
@@ -25,8 +27,10 @@ class TestResize:
 
     def test_resize_invalid_environment_shape(self):
         with pytest.raises(ValueError):
-            self.env.observation_space = gym.spaces.Box(
-                low=0, high=255, shape=(4, ), dtype=np.uint8)
+            self.env.observation_space = gym.spaces.Box(low=0,
+                                                        high=255,
+                                                        shape=(4, ),
+                                                        dtype=np.uint8)
             Resize(self.env, width=self.width, height=self.height)
 
     def test_resize_output_observation_space(self):

--- a/tests/garage/envs/wrappers/test_stack_frames_env.py
+++ b/tests/garage/envs/wrappers/test_stack_frames_env.py
@@ -7,11 +7,12 @@ from tests.fixtures.envs.dummy import DummyDiscrete2DEnv
 
 
 class TestStackFrames:
+
     def setup_method(self):
         self.n_frames = 4
         self.env = DummyDiscrete2DEnv(random=False)
-        self.env_s = StackFrames(
-            DummyDiscrete2DEnv(random=False), n_frames=self.n_frames)
+        self.env_s = StackFrames(DummyDiscrete2DEnv(random=False),
+                                 n_frames=self.n_frames)
         self.width, self.height = self.env.observation_space.shape
 
     def teardown_method(self):
@@ -25,8 +26,10 @@ class TestStackFrames:
 
     def test_stack_frames_invalid_environment_shape(self):
         with pytest.raises(ValueError):
-            self.env.observation_space = gym.spaces.Box(
-                low=0, high=255, shape=(4, ), dtype=np.uint8)
+            self.env.observation_space = gym.spaces.Box(low=0,
+                                                        high=255,
+                                                        shape=(4, ),
+                                                        dtype=np.uint8)
             StackFrames(self.env, n_frames=4)
 
     def test_stack_frames_output_observation_space(self):

--- a/tests/garage/experiment/test_experiment_wrapper.py
+++ b/tests/garage/experiment/test_experiment_wrapper.py
@@ -22,6 +22,7 @@ def invalid_method_call():
 
 
 class TestExperimentWrapper:
+
     def test_experiment_wrapper_method_call(self):
         data = base64.b64encode(pickle.dumps(method_call)).decode('utf-8')
         args = [

--- a/tests/garage/experiment/test_snapshotter.py
+++ b/tests/garage/experiment/test_snapshotter.py
@@ -20,6 +20,7 @@ configurations = [('all', {
 
 
 class TestSnapshotter:
+
     def setup_method(self):
         self.temp_dir = tempfile.TemporaryDirectory()
 
@@ -47,6 +48,6 @@ class TestSnapshotter:
 
     def test_invalid_snapshot_mode(self):
         with pytest.raises(ValueError):
-            snapshotter = Snapshotter(
-                snapshot_dir=self.temp_dir.name, snapshot_mode='invalid')
+            snapshotter = Snapshotter(snapshot_dir=self.temp_dir.name,
+                                      snapshot_mode='invalid')
             snapshotter.save_itr_params(2, {'testparam': 'invalid'})

--- a/tests/garage/experiment/test_task_sampler.py
+++ b/tests/garage/experiment/test_task_sampler.py
@@ -3,6 +3,10 @@ import unittest.mock
 
 import numpy as np
 import pytest
+
+from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
+from garage.experiment import task_sampler
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -14,9 +18,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-
-from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
-from garage.experiment import task_sampler
 
 
 @pytest.mark.mujoco

--- a/tests/garage/sampler/test_local_sampler.py
+++ b/tests/garage/sampler/test_local_sampler.py
@@ -7,8 +7,10 @@ from garage.envs import GarageEnv
 from garage.envs import PointEnv
 from garage.envs.grid_world_env import GridWorldEnv
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.np.policies import FixedPolicy, ScriptedPolicy
-from garage.sampler import LocalSampler, OnPolicyVectorizedSampler
+from garage.np.policies import FixedPolicy
+from garage.np.policies import ScriptedPolicy
+from garage.sampler import LocalSampler
+from garage.sampler import OnPolicyVectorizedSampler
 from garage.sampler import WorkerFactory
 
 

--- a/tests/garage/sampler/test_multiprocessing_sampler.py
+++ b/tests/garage/sampler/test_multiprocessing_sampler.py
@@ -8,8 +8,10 @@ from garage.envs import GarageEnv
 from garage.envs import PointEnv
 from garage.envs.grid_world_env import GridWorldEnv
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.np.policies import FixedPolicy, ScriptedPolicy
-from garage.sampler import LocalSampler, MultiprocessingSampler
+from garage.np.policies import FixedPolicy
+from garage.np.policies import ScriptedPolicy
+from garage.sampler import LocalSampler
+from garage.sampler import MultiprocessingSampler
 from garage.sampler import WorkerFactory
 
 

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -9,8 +9,11 @@ from garage.envs import GarageEnv
 from garage.envs import PointEnv
 from garage.envs.grid_world_env import GridWorldEnv
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.np.policies import FixedPolicy, ScriptedPolicy
-from garage.sampler import OnPolicyVectorizedSampler, RaySampler, WorkerFactory
+from garage.np.policies import FixedPolicy
+from garage.np.policies import ScriptedPolicy
+from garage.sampler import OnPolicyVectorizedSampler
+from garage.sampler import RaySampler
+from garage.sampler import WorkerFactory
 from tests.fixtures.sampler import ray_local_session_fixture
 
 

--- a/tests/garage/sampler/test_stateful_pool.py
+++ b/tests/garage/sampler/test_stateful_pool.py
@@ -6,16 +6,19 @@ def _worker_collect_once(_):
 
 
 class TestStatefulPool:
+
     def test_stateful_pool(self):
         stateful_pool = StatefulPool()
         stateful_pool.initialize(n_parallel=10)
-        results = stateful_pool.run_collect(
-            _worker_collect_once, 3, show_prog_bar=False)
+        results = stateful_pool.run_collect(_worker_collect_once,
+                                            3,
+                                            show_prog_bar=False)
         assert all([r == 'a' for r in results]) and len(results) >= 3
 
     def test_stateful_pool_over_capacity(self):
         stateful_pool = StatefulPool()
         stateful_pool.initialize(n_parallel=4)
-        results = stateful_pool.run_collect(
-            _worker_collect_once, 3, show_prog_bar=False)
+        results = stateful_pool.run_collect(_worker_collect_once,
+                                            3,
+                                            show_prog_bar=False)
         assert len(results) >= 3

--- a/tests/garage/sampler/test_vec_worker.py
+++ b/tests/garage/sampler/test_vec_worker.py
@@ -6,7 +6,9 @@ from garage.envs import GarageEnv
 from garage.envs import GridWorldEnv
 from garage.experiment.task_sampler import EnvPoolSampler
 from garage.np.policies import ScriptedPolicy
-from garage.sampler import LocalSampler, VecWorker, WorkerFactory
+from garage.sampler import LocalSampler
+from garage.sampler import VecWorker
+from garage.sampler import WorkerFactory
 
 SEED = 100
 N_TRAJ = 5

--- a/tests/garage/test_functions.py
+++ b/tests/garage/test_functions.py
@@ -5,14 +5,18 @@ import tempfile
 
 import akro
 import dowel
-from dowel import logger, tabular
+from dowel import logger
+from dowel import tabular
 import numpy as np
 import pytest
 import tensorflow as tf
 import torch
 
-from garage import _Default, make_optimizer
-from garage import log_multitask_performance, log_performance, TrajectoryBatch
+from garage import _Default
+from garage import log_multitask_performance
+from garage import log_performance
+from garage import make_optimizer
+from garage import TrajectoryBatch
 from garage.envs import EnvSpec
 from tests.fixtures import TfGraphTestCase
 

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -6,7 +6,8 @@ import gym
 import pytest
 import tensorflow as tf
 
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import PPO
@@ -16,7 +17,8 @@ from garage.tf.policies import CategoricalMLPPolicy
 from garage.tf.policies import GaussianGRUPolicy
 from garage.tf.policies import GaussianLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
 from tests.fixtures.envs.wrappers import ReshapeObservation
 
 

--- a/tests/garage/tf/algos/test_rl2ppo.py
+++ b/tests/garage/tf/algos/test_rl2ppo.py
@@ -4,17 +4,6 @@ performance is too low.
 """
 import numpy as np
 import pytest
-try:
-    # pylint: disable=unused-import
-    import mujoco_py  # noqa: F401
-except ImportError:
-    pytest.skip('To use mujoco-based features, please install garage[mujoco].',
-                allow_module_level=True)
-except Exception:  # pylint: disable=broad-except
-    pytest.skip(
-        'Skipping tests, failed to import mujoco. Do you have a '
-        'valid mujoco key installed?',
-        allow_module_level=True)
 
 from garage.envs import normalize
 from garage.envs.mujoco import HalfCheetahDirEnv
@@ -27,7 +16,20 @@ from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env
 from garage.tf.algos.rl2 import RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
+
+try:
+    # pylint: disable=unused-import
+    import mujoco_py  # noqa: F401
+except ImportError:
+    pytest.skip('To use mujoco-based features, please install garage[mujoco].',
+                allow_module_level=True)
+except Exception:  # pylint: disable=broad-except
+    pytest.skip(
+        'Skipping tests, failed to import mujoco. Do you have a '
+        'valid mujoco key installed?',
+        allow_module_level=True)
 
 
 @pytest.mark.mujoco

--- a/tests/garage/tf/algos/test_rl2trpo.py
+++ b/tests/garage/tf/algos/test_rl2trpo.py
@@ -3,17 +3,6 @@ This script creates a test that fails when garage.tf.algos.RL2TRPO
 performance is too low.
 """
 import pytest
-try:
-    # pylint: disable=unused-import
-    import mujoco_py  # noqa: F401
-except ImportError:
-    pytest.skip('To use mujoco-based features, please install garage[mujoco].',
-                allow_module_level=True)
-except Exception:  # pylint: disable=broad-except
-    pytest.skip(
-        'Skipping tests, failed to import mujoco. Do you have a '
-        'valid mujoco key installed?',
-        allow_module_level=True)
 
 from garage.envs import normalize
 from garage.envs.mujoco import HalfCheetahDirEnv
@@ -28,7 +17,20 @@ from garage.tf.optimizers import ConjugateGradientOptimizer
 from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.optimizers import PenaltyLbfgsOptimizer
 from garage.tf.policies import GaussianGRUPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
+
+try:
+    # pylint: disable=unused-import
+    import mujoco_py  # noqa: F401
+except ImportError:
+    pytest.skip('To use mujoco-based features, please install garage[mujoco].',
+                allow_module_level=True)
+except Exception:  # pylint: disable=broad-except
+    pytest.skip(
+        'Skipping tests, failed to import mujoco. Do you have a '
+        'valid mujoco key installed?',
+        allow_module_level=True)
 
 
 @pytest.mark.mujoco

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -6,7 +6,8 @@ import gym
 import pytest
 import tensorflow as tf
 
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment import LocalTFRunner
 from garage.experiment import snapshotter
@@ -19,7 +20,8 @@ from garage.tf.policies import CategoricalCNNPolicy
 from garage.tf.policies import CategoricalGRUPolicy
 from garage.tf.policies import CategoricalLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
 
 
 class TestTRPO(TfGraphTestCase):

--- a/tests/garage/tf/embeddings/test_gaussian_mlp_encoder.py
+++ b/tests/garage/tf/embeddings/test_gaussian_mlp_encoder.py
@@ -1,7 +1,6 @@
 import pickle
 from unittest import mock
 
-# pylint: disable=wrong-import-order
 import akro
 import numpy as np
 import pytest

--- a/tests/garage/tf/policies/test_categorical_policies.py
+++ b/tests/garage/tf/policies/test_categorical_policies.py
@@ -5,7 +5,8 @@ garage.tf.policies.
 import gym
 import pytest
 
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
@@ -14,7 +15,8 @@ from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import CategoricalGRUPolicy
 from garage.tf.policies import CategoricalLSTMPolicy
 from garage.tf.policies import CategoricalMLPPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
 
 policies = [CategoricalGRUPolicy, CategoricalLSTMPolicy, CategoricalMLPPolicy]
 

--- a/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
@@ -2,7 +2,6 @@ from itertools import chain
 import pickle
 from unittest import mock
 
-# pylint: disable=wrong-import-order
 import akro
 import numpy as np
 import pytest

--- a/tests/garage/tf/policies/test_gaussian_policies.py
+++ b/tests/garage/tf/policies/test_gaussian_policies.py
@@ -1,7 +1,8 @@
 import gym
 import pytest
 
-from garage.envs import GarageEnv, normalize
+from garage.envs import GarageEnv
+from garage.envs import normalize
 from garage.experiment import LocalTFRunner
 from garage.np.baselines import LinearFeatureBaseline
 from garage.tf.algos import TRPO
@@ -10,7 +11,8 @@ from garage.tf.optimizers import FiniteDifferenceHvp
 from garage.tf.policies import GaussianGRUPolicy
 from garage.tf.policies import GaussianLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
-from tests.fixtures import snapshot_config, TfGraphTestCase
+from tests.fixtures import snapshot_config
+from tests.fixtures import TfGraphTestCase
 
 policies = [GaussianGRUPolicy, GaussianLSTMPolicy, GaussianMLPPolicy]
 

--- a/tests/garage/tf/policies/test_policies.py
+++ b/tests/garage/tf/policies/test_policies.py
@@ -9,7 +9,8 @@ from garage.tf.policies import GaussianGRUPolicy
 from garage.tf.policies import GaussianLSTMPolicy
 from garage.tf.policies import GaussianMLPPolicy
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import DummyBoxEnv
+from tests.fixtures.envs.dummy import DummyDiscreteEnv
 
 
 class TestDiscretePolicies(TfGraphTestCase):

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -10,10 +10,12 @@ from unittest.mock import Mock
 
 import ray
 
-from garage.envs import GarageEnv, GridWorldEnv
-from garage.np.policies import ScriptedPolicy
-from garage.sampler import RaySampler, WorkerFactory
 # pylint: disable=unused-import
+from garage.envs import GarageEnv
+from garage.envs import GridWorldEnv
+from garage.np.policies import ScriptedPolicy
+from garage.sampler import RaySampler
+from garage.sampler import WorkerFactory
 from tests.fixtures.sampler import ray_local_session_fixture
 
 

--- a/tests/garage/torch/algos/test_maml.py
+++ b/tests/garage/torch/algos/test_maml.py
@@ -2,6 +2,17 @@
 from functools import partial
 
 import pytest
+import torch
+
+from garage.envs import GarageEnv
+from garage.envs import normalize
+from garage.envs.mujoco import HalfCheetahDirEnv
+from garage.sampler import LocalSampler
+from garage.sampler import WorkerFactory
+from garage.torch.algos import MAMLPPO
+from garage.torch.policies import GaussianMLPPolicy
+from garage.torch.value_functions import GaussianMLPValueFunction
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -13,14 +24,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-import torch
-
-from garage.envs import GarageEnv, normalize
-from garage.envs.mujoco import HalfCheetahDirEnv
-from garage.sampler import LocalSampler, WorkerFactory
-from garage.torch.algos import MAMLPPO
-from garage.torch.policies import GaussianMLPPolicy
-from garage.torch.value_functions import GaussianMLPValueFunction
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/algos/test_maml_ppo.py
+++ b/tests/garage/torch/algos/test_maml_ppo.py
@@ -1,5 +1,17 @@
 """This script is a test that fails when MAML-TRPO performance is too low."""
 import pytest
+import torch
+
+from garage.envs import GarageEnv
+from garage.envs import normalize
+from garage.envs.mujoco import HalfCheetahDirEnv
+from garage.experiment import deterministic
+from garage.experiment import LocalRunner
+from garage.torch.algos import MAMLPPO
+from garage.torch.policies import GaussianMLPPolicy
+from garage.torch.value_functions import GaussianMLPValueFunction
+from tests.fixtures import snapshot_config
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -11,15 +23,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-import torch
-
-from garage.envs import GarageEnv, normalize
-from garage.envs.mujoco import HalfCheetahDirEnv
-from garage.experiment import deterministic, LocalRunner
-from garage.torch.algos import MAMLPPO
-from garage.torch.policies import GaussianMLPPolicy
-from garage.torch.value_functions import GaussianMLPValueFunction
-from tests.fixtures import snapshot_config
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/algos/test_maml_trpo.py
+++ b/tests/garage/torch/algos/test_maml_trpo.py
@@ -1,5 +1,17 @@
 """This script is a test that fails when MAML-TRPO performance is too low."""
 import pytest
+import torch
+
+from garage.envs import GarageEnv
+from garage.envs import normalize
+from garage.envs.mujoco import HalfCheetahDirEnv
+from garage.experiment import LocalRunner
+from garage.torch.algos import MAMLTRPO
+from garage.torch.policies import GaussianMLPPolicy
+from garage.torch.value_functions import GaussianMLPValueFunction
+from tests.fixtures import snapshot_config
+from tests.fixtures.envs.dummy import DummyMultiTaskBoxEnv
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -11,16 +23,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-import torch
-
-from garage.envs import GarageEnv, normalize
-from garage.envs.mujoco import HalfCheetahDirEnv
-from garage.experiment import LocalRunner
-from garage.torch.algos import MAMLTRPO
-from garage.torch.policies import GaussianMLPPolicy
-from garage.torch.value_functions import GaussianMLPValueFunction
-from tests.fixtures import snapshot_config
-from tests.fixtures.envs.dummy import DummyMultiTaskBoxEnv
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/algos/test_maml_vpg.py
+++ b/tests/garage/torch/algos/test_maml_vpg.py
@@ -1,5 +1,19 @@
 """This script is a test that fails when MAML-VPG performance is too low."""
 import pytest
+import torch
+
+from garage.envs import GarageEnv
+from garage.envs import normalize
+from garage.envs.mujoco import HalfCheetahDirEnv
+from garage.experiment import deterministic
+from garage.experiment import LocalRunner
+from garage.experiment import MetaEvaluator
+from garage.experiment.task_sampler import SetTaskSampler
+from garage.torch.algos import MAMLVPG
+from garage.torch.policies import GaussianMLPPolicy
+from garage.torch.value_functions import GaussianMLPValueFunction
+from tests.fixtures import snapshot_config
+
 try:
     # pylint: disable=unused-import
     import mujoco_py  # noqa: F401
@@ -11,16 +25,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-import torch
-
-from garage.envs import GarageEnv, normalize
-from garage.envs.mujoco import HalfCheetahDirEnv
-from garage.experiment import deterministic, LocalRunner, MetaEvaluator
-from garage.experiment.task_sampler import SetTaskSampler
-from garage.torch.algos import MAMLVPG
-from garage.torch.policies import GaussianMLPPolicy
-from garage.torch.value_functions import GaussianMLPValueFunction
-from tests.fixtures import snapshot_config
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/algos/test_pearl.py
+++ b/tests/garage/torch/algos/test_pearl.py
@@ -1,7 +1,24 @@
 """This script is a test that fails when PEARL performance is too low."""
 import pickle
 
+from metaworld.benchmarks import ML1  # noqa: I100, I202
 import pytest
+
+from garage.envs import GarageEnv
+from garage.envs import normalize
+from garage.envs import PointEnv
+from garage.experiment import LocalRunner
+from garage.experiment.deterministic import set_seed
+from garage.experiment.task_sampler import SetTaskSampler
+from garage.sampler import LocalSampler
+from garage.torch import set_gpu_mode
+from garage.torch.algos import PEARL
+from garage.torch.algos.pearl import PEARLWorker
+from garage.torch.embeddings import MLPEncoder
+from garage.torch.policies import ContextConditionedPolicy
+from garage.torch.policies import TanhGaussianMLPPolicy
+from garage.torch.q_functions import ContinuousMLPQFunction
+from tests.fixtures import snapshot_config
 
 try:
     # pylint: disable=unused-import
@@ -14,21 +31,6 @@ except Exception:  # pylint: disable=broad-except
         'Skipping tests, failed to import mujoco. Do you have a '
         'valid mujoco key installed?',
         allow_module_level=True)
-from metaworld.benchmarks import ML1  # noqa: I100, I202
-
-from garage.envs import GarageEnv, normalize, PointEnv
-from garage.experiment import LocalRunner
-from garage.experiment.deterministic import set_seed
-from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler
-from garage.torch import set_gpu_mode
-from garage.torch.algos import PEARL
-from garage.torch.algos.pearl import PEARLWorker
-from garage.torch.embeddings import MLPEncoder
-from garage.torch.policies import (ContextConditionedPolicy,
-                                   TanhGaussianMLPPolicy)
-from garage.torch.q_functions import ContinuousMLPQFunction
-from tests.fixtures import snapshot_config
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/modules/test_gaussian_mlp_module.py
+++ b/tests/garage/torch/modules/test_gaussian_mlp_module.py
@@ -2,9 +2,10 @@ import pytest
 import torch
 from torch import nn
 
-from garage.torch.modules.gaussian_mlp_module \
-    import GaussianMLPIndependentStdModule, GaussianMLPModule, \
-    GaussianMLPTwoHeadedModule
+from garage.torch.modules.gaussian_mlp_module import \
+    GaussianMLPIndependentStdModule
+from garage.torch.modules.gaussian_mlp_module import GaussianMLPModule
+from garage.torch.modules.gaussian_mlp_module import GaussianMLPTwoHeadedModule
 
 plain_settings = [
     (1, 1, (1, )),
@@ -40,21 +41,20 @@ different_std_settings = [(1, 1, (1, ), (1, )), (1, 2, (2, ), (2, )),
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_std_share_network_output_values(input_dim, output_dim, hidden_sizes):
-    module = GaussianMLPTwoHeadedModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPTwoHeadedModule(input_dim=input_dim,
+                                        output_dim=output_dim,
+                                        hidden_sizes=hidden_sizes,
+                                        hidden_nonlinearity=None,
+                                        std_parameterization='exp',
+                                        hidden_w_init=nn.init.ones_,
+                                        output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
         (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
@@ -64,14 +64,13 @@ def test_std_share_network_output_values(input_dim, output_dim, hidden_sizes):
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_std_share_network_output_values_with_batch(input_dim, output_dim,
                                                     hidden_sizes):
-    module = GaussianMLPTwoHeadedModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPTwoHeadedModule(input_dim=input_dim,
+                                        output_dim=output_dim,
+                                        hidden_sizes=hidden_sizes,
+                                        hidden_nonlinearity=None,
+                                        std_parameterization='exp',
+                                        hidden_w_init=nn.init.ones_,
+                                        output_w_init=nn.init.ones_)
 
     batch_size = 5
     dist = module(torch.ones([batch_size, input_dim]))
@@ -79,8 +78,8 @@ def test_std_share_network_output_values_with_batch(input_dim, output_dim,
     exp_mean = torch.full(
         (batch_size, output_dim),
         input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(
@@ -92,15 +91,14 @@ def test_std_share_network_output_values_with_batch(input_dim, output_dim,
 def test_std_network_output_values(input_dim, output_dim, hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
@@ -118,15 +116,14 @@ def test_std_network_output_values_with_batch(input_dim, output_dim,
                                               hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     batch_size = 5
     dist = module(torch.ones([batch_size, input_dim]))
@@ -147,24 +144,23 @@ def test_std_network_output_values_with_batch(input_dim, output_dim,
     different_std_settings)
 def test_std_adaptive_network_output_values(input_dim, output_dim,
                                             hidden_sizes, std_hidden_sizes):
-    module = GaussianMLPIndependentStdModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        std_hidden_sizes=std_hidden_sizes,
-        hidden_nonlinearity=None,
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_,
-        std_hidden_nonlinearity=None,
-        std_hidden_w_init=nn.init.ones_,
-        std_output_w_init=nn.init.ones_)
+    module = GaussianMLPIndependentStdModule(input_dim=input_dim,
+                                             output_dim=output_dim,
+                                             hidden_sizes=hidden_sizes,
+                                             std_hidden_sizes=std_hidden_sizes,
+                                             hidden_nonlinearity=None,
+                                             hidden_w_init=nn.init.ones_,
+                                             output_w_init=nn.init.ones_,
+                                             std_hidden_nonlinearity=None,
+                                             std_hidden_w_init=nn.init.ones_,
+                                             std_output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
         (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
@@ -176,15 +172,14 @@ def test_softplus_std_network_output_values(input_dim, output_dim,
                                             hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
@@ -200,16 +195,15 @@ def test_softplus_std_network_output_values(input_dim, output_dim,
 def test_exp_min_std(input_dim, output_dim, hidden_sizes):
     min_value = 10.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=1.,
-        min_std=min_value,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=1.,
+                               min_std=min_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
@@ -222,16 +216,15 @@ def test_exp_min_std(input_dim, output_dim, hidden_sizes):
 def test_exp_max_std(input_dim, output_dim, hidden_sizes):
     max_value = 1.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=10.,
-        max_std=max_value,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=10.,
+                               max_std=max_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
@@ -244,16 +237,15 @@ def test_exp_max_std(input_dim, output_dim, hidden_sizes):
 def test_softplus_min_std(input_dim, output_dim, hidden_sizes):
     min_value = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=1.,
-        min_std=min_value,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=1.,
+                               min_std=min_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
@@ -266,16 +258,15 @@ def test_softplus_min_std(input_dim, output_dim, hidden_sizes):
 def test_softplus_max_std(input_dim, output_dim, hidden_sizes):
     max_value = 1.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=10,
-        max_std=max_value,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=10,
+                               max_std=max_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
@@ -287,5 +278,6 @@ def test_softplus_max_std(input_dim, output_dim, hidden_sizes):
 
 def test_unknown_std_parameterization():
     with pytest.raises(NotImplementedError):
-        GaussianMLPModule(
-            input_dim=1, output_dim=1, std_parameterization='unknown')
+        GaussianMLPModule(input_dim=1,
+                          output_dim=1,
+                          std_parameterization='unknown')

--- a/tests/garage/torch/test_functions.py
+++ b/tests/garage/torch/test_functions.py
@@ -5,9 +5,13 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from garage.torch import compute_advantages, pad_to_last
-from garage.torch import dict_np_to_torch, global_device
-from garage.torch import product_of_gaussians, set_gpu_mode, torch_to_np
+from garage.torch import compute_advantages
+from garage.torch import dict_np_to_torch
+from garage.torch import global_device
+from garage.torch import pad_to_last
+from garage.torch import product_of_gaussians
+from garage.torch import set_gpu_mode
+from garage.torch import torch_to_np
 import garage.torch._functions as tu
 from tests.fixtures import TfGraphTestCase
 

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -2,5 +2,6 @@ from unittest import mock
 
 
 class PickleableMagicMock(mock.MagicMock):
+
     def __reduce__(self):
         return (mock.MagicMock, ())

--- a/tests/wrappers.py
+++ b/tests/wrappers.py
@@ -4,7 +4,7 @@ import gym
 class AutoStopEnv(gym.Wrapper):
     """A env wrapper that stops rollout at step max_path_length."""
 
-    def __init__(self, env=None, env_name="", max_path_length=100):
+    def __init__(self, env=None, env_name='', max_path_length=100):
         if env_name:
             super().__init__(gym.make(env_name))
         else:


### PR DESCRIPTION
isort is now added to pre-commit to save us from sorting import orders manually!

Packages Import order is ordered in sections like this:
```
FUTURE
STDLIB
THIRDPARTY
FIRSTPARTY
LOCALFOLDER
``` 

The sorting is tested against this [example]( https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_google.py)

Note, It's not perfect:
1. We need to explicitly specify third party packages for now, in `setup.cfg` under the `[tool:isort]` section > `known_third_party`. Good news is the isort release 5.0 may solve the issue 👍 

2. The relative path is not sorted as desired. BUT, in garage, we are not using relative path anyway

