### PR TITLE
Refactoring CategoricalMLPRegressor with tfp

### DIFF
--- a/src/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor.py
@@ -140,8 +140,8 @@ class CategoricalMLPRegressor(StochasticRegressor):
 
             y_hat = self._network.y_hat
 
-            dist = self._network.categorical_dist
-            old_dist = self._old_network.categorical_dist
+            dist = self._network.dist
+            old_dist = self._old_network.dist
 
             mean_kl = tf.reduce_mean(old_dist.kl_divergence(dist))
 

--- a/src/garage/tf/regressors/categorical_mlp_regressor.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor.py
@@ -4,10 +4,10 @@ import numpy as np
 import tensorflow as tf
 
 from garage import make_optimizer
-from garage.tf.distributions import Categorical
 from garage.tf.misc import tensor_utils
-from garage.tf.models import NormalizedInputMLPModel
 from garage.tf.optimizers import ConjugateGradientOptimizer, LbfgsOptimizer
+from garage.tf.regressors.categorical_mlp_regressor_model import (
+    CategoricalMLPRegressorModel)
 from garage.tf.regressors.regressor import StochasticRegressor
 
 
@@ -106,7 +106,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
                                                     **tr_optimizer_args)
             self._first_optimized = False
 
-        self.model = NormalizedInputMLPModel(
+        self.model = CategoricalMLPRegressorModel(
             input_shape,
             output_dim,
             hidden_sizes=hidden_sizes,
@@ -118,38 +118,34 @@ class CategoricalMLPRegressor(StochasticRegressor):
             output_b_init=output_b_init,
             layer_normalization=layer_normalization)
 
+        # model for old distribution, used when trusted region is on
+        self._old_model = self.model.clone(name='model_for_old_dist')
         self._network = None
-
+        self._old_network = None
         self._initialize()
 
     def _initialize(self):
         input_var = tf.compat.v1.placeholder(tf.float32,
                                              shape=(None, ) +
                                              self._input_shape)
+        self._old_network = self._old_model.build(input_var)
 
         with tf.compat.v1.variable_scope(self._variable_scope):
             self._network = self.model.build(input_var)
+            self._old_model.parameters = self.model.parameters
 
             ys_var = tf.compat.v1.placeholder(dtype=tf.float32,
                                               name='ys',
                                               shape=(None, self._output_dim))
 
-            old_prob_var = tf.compat.v1.placeholder(dtype=tf.float32,
-                                                    name='old_prob',
-                                                    shape=(None,
-                                                           self._output_dim))
-
             y_hat = self._network.y_hat
 
-            old_info_vars = dict(prob=old_prob_var)
-            info_vars = dict(prob=y_hat)
+            dist = self._network.categorical_dist
+            old_dist = self._old_network.categorical_dist
 
-            self._dist = Categorical(self._output_dim)
-            mean_kl = tf.reduce_mean(
-                self._dist.kl_sym(old_info_vars, info_vars))
+            mean_kl = tf.reduce_mean(old_dist.kl_divergence(dist))
 
-            loss = -tf.reduce_mean(
-                self._dist.log_likelihood_sym(ys_var, info_vars))
+            loss = -tf.reduce_mean(dist.log_prob(ys_var))
 
             # pylint: disable=no-value-for-parameter
             predicted = tf.one_hot(tf.argmax(y_hat, axis=1),
@@ -157,16 +153,15 @@ class CategoricalMLPRegressor(StochasticRegressor):
 
             self._f_predict = tensor_utils.compile_function([input_var],
                                                             predicted)
-            self._f_prob = tensor_utils.compile_function([input_var], y_hat)
 
             self._optimizer.update_opt(loss=loss,
                                        target=self,
                                        inputs=[input_var, ys_var])
-            self._tr_optimizer.update_opt(
-                loss=loss,
-                target=self,
-                inputs=[input_var, ys_var, old_prob_var],
-                leq_constraint=(mean_kl, self._max_kl_step))
+            self._tr_optimizer.update_opt(loss=loss,
+                                          target=self,
+                                          inputs=[input_var, ys_var],
+                                          leq_constraint=(mean_kl,
+                                                          self._max_kl_step))
 
     def fit(self, xs, ys):
         """Fit with input data xs and label ys.
@@ -180,14 +175,14 @@ class CategoricalMLPRegressor(StochasticRegressor):
             # recompute normalizing constants for inputs
             self._network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
             self._network.x_std.load(np.std(xs, axis=0, keepdims=True))
+            self._old_network.x_mean.load(np.mean(xs, axis=0, keepdims=True))
+            self._old_network.x_std.load(np.std(xs, axis=0, keepdims=True))
 
+        inputs = [xs, ys]
         if self._use_trust_region:
             # To use trust region constraint and optimizer
-            old_prob = self._f_prob(xs)
-            inputs = [xs, ys, old_prob]
             optimizer = self._tr_optimizer
         else:
-            inputs = [xs, ys]
             optimizer = self._optimizer
         loss_before = optimizer.loss(inputs)
         tabular.record('{}/LossBefore'.format(self._name), loss_before)
@@ -196,6 +191,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
         tabular.record('{}/LossAfter'.format(self._name), loss_after)
         tabular.record('{}/dLoss'.format(self._name), loss_before - loss_after)
         self._first_optimized = True
+        self._old_model.parameters = self.model.parameters
 
     def predict(self, xs):
         """Predict ys based on input xs.
@@ -208,58 +204,6 @@ class CategoricalMLPRegressor(StochasticRegressor):
 
         """
         return self._f_predict(xs)
-
-    def predict_log_likelihood(self, xs, ys):
-        """Predict log-likelihood of output data conditioned on the input data.
-
-        Args:
-            xs (numpy.ndarray): Input data.
-            ys (numpy.ndarray): Output labels in one hot representation.
-
-        Return:
-            numpy.ndarray: The predicted log likelihoods.
-
-        """
-        prob = self._f_prob(xs)
-        return self._dist.log_likelihood(ys, dict(prob=prob))
-
-    def dist_info_sym(self, input_var, state_info_vars=None, name=None):
-        """Build a symbolic graph of the distribution parameters.
-
-        Args:
-            input_var (tf.Tensor): Input tf.Tensor for the input data.
-            state_info_vars (dict): a dictionary whose values should contain
-                information about the state of the regressor at the time it
-                received the input.
-            name (str): Name of the new graph.
-
-        Return:
-            dict[tf.Tensor]: Output of the symbolic graph of the distribution
-                parameters.
-
-        """
-        del state_info_vars
-        with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(input_var, name=name).outputs
-
-        return dict(prob=prob)
-
-    def log_likelihood_sym(self, x_var, y_var, name=None):
-        """Build a symbolic graph of the log-likelihood.
-
-        Args:
-            x_var (tf.Tensor): Input tf.Tensor for the input data.
-            y_var (tf.Tensor): Input tf.Tensor for the one hot label of data.
-            name (str): Name of the new graph.
-
-        Return:
-            tf.Tensor: Output of the symbolic log-likelihood graph.
-
-        """
-        with tf.compat.v1.variable_scope(self._variable_scope):
-            prob, _, _ = self.model.build(x_var, name=name).outputs
-
-        return self._dist.log_likelihood_sym(y_var, dict(prob=prob))
 
     @property
     def recurrent(self):
@@ -274,7 +218,7 @@ class CategoricalMLPRegressor(StochasticRegressor):
     @property
     def distribution(self):
         """garage.tf.distributions.DiagonalGaussian: Distribution."""
-        return self._dist
+        return self._network.dist
 
     def __getstate__(self):
         """Object.__getstate__.
@@ -285,9 +229,8 @@ class CategoricalMLPRegressor(StochasticRegressor):
         """
         new_dict = super().__getstate__()
         del new_dict['_f_predict']
-        del new_dict['_f_prob']
-        del new_dict['_dist']
         del new_dict['_network']
+        del new_dict['_old_network']
         return new_dict
 
     def __setstate__(self, state):

--- a/src/garage/tf/regressors/categorical_mlp_regressor_model.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor_model.py
@@ -1,0 +1,121 @@
+"""CategoricalMLPRegressorModel."""
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from garage.tf.models import NormalizedInputMLPModel
+
+
+class CategoricalMLPRegressorModel(NormalizedInputMLPModel):
+    """CategoricalMLPRegressorModel based on garage.tf.models.Model class.
+
+    This class can be used to perform regression by fitting a Categorical
+    distribution to the outputs.
+
+    Args:
+        input_shape (tuple[int]): Input shape of the training data.
+        output_dim (int): Output dimension of the model.
+        name (str): Model name, also the variable scope.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        hidden_nonlinearity (callable): Activation function for intermediate
+            dense layer(s). It should return a tf.Tensor. Set it to
+            None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            tf.Tensor.
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a tf.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            tf.Tensor.
+        layer_normalization (bool): Bool for using layer normalization or not.
+
+    """
+
+    def __init__(self,
+                 input_shape,
+                 output_dim,
+                 name='CategoricalMLPRegressorModel',
+                 hidden_sizes=(32, 32),
+                 hidden_nonlinearity=tf.nn.relu,
+                 hidden_w_init=tf.initializers.glorot_uniform(),
+                 hidden_b_init=tf.zeros_initializer(),
+                 output_nonlinearity=None,
+                 output_w_init=tf.initializers.glorot_uniform(),
+                 output_b_init=tf.zeros_initializer(),
+                 layer_normalization=False):
+        super().__init__(input_shape=input_shape,
+                         output_dim=output_dim,
+                         name=name,
+                         hidden_sizes=hidden_sizes,
+                         hidden_nonlinearity=hidden_nonlinearity,
+                         hidden_w_init=hidden_w_init,
+                         hidden_b_init=hidden_b_init,
+                         output_nonlinearity=output_nonlinearity,
+                         output_w_init=output_w_init,
+                         output_b_init=output_b_init,
+                         layer_normalization=layer_normalization)
+
+    def network_output_spec(self):
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
+        return ['y_hat', 'x_mean', 'x_std', 'categorical_dist']
+
+    def _build(self, state_input, name=None):
+        """Build model.
+
+        Args:
+            state_input (tf.Tensor): Observation inputs.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Returns:
+            tf.Tensor: Tensor output of the model.
+            tf.Tensor: Mean for data.
+            tf.Tensor: log_std for data.
+            tfp.distributions.OneHotCategorical: Categorical distribution.
+
+        """
+        y_hat, x_mean_var, x_std_var = super()._build(state_input, name=name)
+        dist = tfp.distributions.OneHotCategorical(probs=y_hat)
+        return y_hat, x_mean_var, x_std_var, dist
+
+    def clone(self, name):
+        """Return a clone of the model.
+
+        It only copies the configuration of the primitive,
+        not the parameters.
+
+        Args:
+            name (str): Name of the newly created model. It has to be
+                different from source model if cloned under the same
+                computational graph.
+
+        Returns:
+            garage.tf.policies.GaussianMLPModel: Newly cloned model.
+
+        """
+        return self.__class__(name=name,
+                              input_shape=self._input_shape,
+                              output_dim=self._output_dim,
+                              hidden_sizes=self._hidden_sizes,
+                              hidden_nonlinearity=self._hidden_nonlinearity,
+                              hidden_w_init=self._hidden_w_init,
+                              hidden_b_init=self._hidden_b_init,
+                              output_nonlinearity=self._output_nonlinearity,
+                              output_w_init=self._output_w_init,
+                              output_b_init=self._output_b_init,
+                              layer_normalization=self._layer_normalization)

--- a/src/garage/tf/regressors/categorical_mlp_regressor_model.py
+++ b/src/garage/tf/regressors/categorical_mlp_regressor_model.py
@@ -71,7 +71,7 @@ class CategoricalMLPRegressorModel(NormalizedInputMLPModel):
             list[str]: List of key(str) for the network outputs.
 
         """
-        return ['y_hat', 'x_mean', 'x_std', 'categorical_dist']
+        return ['y_hat', 'x_mean', 'x_std', 'dist']
 
     def _build(self, state_input, name=None):
         """Build model.
@@ -105,7 +105,8 @@ class CategoricalMLPRegressorModel(NormalizedInputMLPModel):
                 computational graph.
 
         Returns:
-            garage.tf.policies.GaussianMLPModel: Newly cloned model.
+            garage.tf.regressors.CategoricalMLPRegressorModel: Newly cloned
+                model.
 
         """
         return self.__class__(name=name,

--- a/tests/garage/tf/regressors/test_categorical_mlp_regressor.py
+++ b/tests/garage/tf/regressors/test_categorical_mlp_regressor.py
@@ -4,6 +4,7 @@ from unittest import mock
 import numpy as np
 import pytest
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from garage.tf.optimizers import ConjugateGradientOptimizer, LbfgsOptimizer
 from garage.tf.regressors import CategoricalMLPRegressor
@@ -57,6 +58,11 @@ def get_test_data(input_shape):
 
 class TestCategoricalMLPRegressor(TfGraphTestCase):
 
+    def test_dist(self):
+        cmr = CategoricalMLPRegressor(input_shape=(1, ), output_dim=2)
+        dist = cmr._network.dist
+        assert isinstance(dist, tfp.distributions.OneHotCategorical)
+
     @pytest.mark.parametrize('input_shape, output_dim', [((1, ), 2),
                                                          ((2, ), 2)])
     def test_fit_normalized(self, input_shape, output_dim):
@@ -77,9 +83,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
+        x_mean = self.sess.run(cmr._network.x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(cmr.model._networks['default'].x_std)
+        x_std = self.sess.run(cmr._network.x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -106,9 +112,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
+        x_mean = self.sess.run(cmr._network.x_mean)
         x_mean_expected = np.zeros_like(x_mean)
-        x_std = self.sess.run(cmr.model._networks['default'].x_std)
+        x_std = self.sess.run(cmr._network.x_std)
         x_std_expected = np.ones_like(x_std)
 
         assert np.allclose(x_mean, x_mean_expected)
@@ -135,9 +141,9 @@ class TestCategoricalMLPRegressor(TfGraphTestCase):
 
         assert np.allclose(prediction, expected, rtol=0, atol=0.1)
 
-        x_mean = self.sess.run(cmr.model._networks['default'].x_mean)
+        x_mean = self.sess.run(cmr._network.x_mean)
         x_mean_expected = np.mean(observations, axis=0, keepdims=True)
-        x_std = self.sess.run(cmr.model._networks['default'].x_std)
+        x_std = self.sess.run(cmr._network.x_std)
         x_std_expected = np.std(observations, axis=0, keepdims=True)
 
         assert np.allclose(x_mean, x_mean_expected)


### PR DESCRIPTION
Refactoring categorical mlp regressor with tfp. [issue 1372](https://github.com/rlworkgroup/garage/issues/1372).

Below is the benchmark with [launcher script](https://github.com/rlworkgroup/garage/blob/test_categorical_mlp_baseline/tests/benchmarks/benchmark_categotical_mlp_policy.py).

environments:
` 'LunarLander-v2',
    'Assault-ramDeterministic-v4',
    'Breakout-ramDeterministic-v4',
    'ChopperCommand-ramDeterministic-v4',
    'Tutankham-ramDeterministic-v4',
![Tutankham-ramDeterministic-v4_benchmark_mean](https://user-images.githubusercontent.com/31981600/85185188-d12c8780-b247-11ea-8745-9eabceaa55c3.png)

   
results: (Garage = baseline without tfp, Garage2 = baseline with tfp)

![LunarLander-v2_benchmark_mean](https://user-images.githubusercontent.com/31981600/85185150-a5a99d00-b247-11ea-993b-ee4ff0d3f360.png)
![Assault-ramDeterministic-v4_benchmark_mean](https://user-images.githubusercontent.com/31981600/85185161-b0643200-b247-11ea-9be8-9c6594bcaeee.png)
![Breakout-ramDeterministic-v4_benchmark_mean](https://user-images.githubusercontent.com/31981600/85185167-b8bc6d00-b247-11ea-80db-7dc639bcb911.png)
![ChopperCommand-ramDeterministic-v4_benchmark_mean](https://user-images.githubusercontent.com/31981600/85185173-c3770200-b247-11ea-8499-091e7c1d6abc.png)
