### PR TITLE
Don't check roboti.us cert in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ WORKDIR $HOME
 
 # MuJoCo 2.0 (for dm_control)
 RUN mkdir -p $HOME/.mujoco && \
-  wget https://www.roboti.us/download/mujoco200_linux.zip -O mujoco.zip && \
+  wget --no-check-certificate https://www.roboti.us/download/mujoco200_linux.zip -O mujoco.zip && \
   unzip mujoco.zip -d $HOME/.mujoco && \
   rm mujoco.zip && \
   ln -s $HOME/.mujoco/mujoco200_linux $HOME/.mujoco/mujoco200


### PR DESCRIPTION
This cert is expired, and is blocking the build.