### PR TITLE
Export $USER in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,7 @@ ARG uid=999
 RUN groupadd -g $uid $user && \
     useradd -m -r -u $uid -g $user $user && \
     chown -R $user:$user /home/$user
+ENV USER $user
 USER $user
 ENV HOME /home/$user
 ENV PATH "$PATH:$HOME/.local/bin"


### PR DESCRIPTION
docker doesn't export $USER by default. Exporting it
here so that any image using garage as parent, can
make use of it.