### PR TITLE
tf.Policy inherit from tf.Model

### DIFF
--- a/src/garage/tf/algos/_rl2npo.py
+++ b/src/garage/tf/algos/_rl2npo.py
@@ -96,7 +96,7 @@ class RL2NPO(NPO):
                                                    samples_data['returns'],
                                                    samples_data['valids'])
         tabular.record('{}/ExplainedVariance'.format(self._baseline.name), ev)
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
 
     def _get_baseline_prediction(self, samples_data):
         """Get baseline prediction.

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -149,8 +149,8 @@ class DDPG(RLAlgorithm):
                     shape=(None, self.env_spec.action_space.flat_dim),
                     name='input_action')
 
-            policy_network_outputs = self._target_policy.get_action_sym(
-                obs, name='policy')
+            policy_network_outputs = self._target_policy.build(obs,
+                                                               name='policy')
             target_qf_outputs = self._target_qf.get_qval_sym(obs,
                                                              actions,
                                                              name='qf')
@@ -190,7 +190,7 @@ class DDPG(RLAlgorithm):
                     shape=(None, self.env_spec.action_space.flat_dim),
                     name='input_action')
             # Set up policy training function
-            next_action = self.policy.get_action_sym(obs, name='policy_action')
+            next_action = self.policy.build(obs, name='policy_action')
             next_qval = self._qf.get_qval_sym(obs,
                                               next_action,
                                               name='policy_action_qval')

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -117,7 +117,7 @@ class NPO(RLAlgorithm):
         self._name = name
         self._name_scope = tf.name_scope(self._name)
         self._old_policy = policy.clone('old_policy')
-        self._old_policy.model.parameters = policy.model.parameters
+        self._old_policy.parameters = policy.parameters
         self._use_softplus_entropy = use_softplus_entropy
         self._use_neg_logli_entropy = use_neg_logli_entropy
         self._stop_entropy_gradient = stop_entropy_gradient
@@ -285,7 +285,7 @@ class NPO(RLAlgorithm):
                                                    samples_data['valids'])
 
         tabular.record('{}/ExplainedVariance'.format(self._baseline.name), ev)
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
 
     def _build_inputs(self):
         """Build input variables.

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -95,7 +95,7 @@ class REPS(RLAlgorithm):  # noqa: D416
         self._name = name
         self._name_scope = tf.name_scope(self._name)
         self._old_policy = policy.clone('old_policy')
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
 
         self._feat_diff = None
         self._param_eta = None
@@ -331,7 +331,7 @@ class REPS(RLAlgorithm):  # noqa: D416
         tabular.record('{}/KLBefore'.format(self.policy.name),
                        policy_kl_before)
         tabular.record('{}/KL'.format(self.policy.name), policy_kl)
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
 
     def _build_inputs(self):
         """Build input variables.

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -174,8 +174,8 @@ class TD3(RLAlgorithm):
                     shape=(None, self.env_spec.action_space.flat_dim),
                     name='input_action')
 
-            policy_network_outputs = self._target_policy.get_action_sym(
-                obs, name='policy')
+            policy_network_outputs = self._target_policy.build(obs,
+                                                               name='policy')
             target_qf_outputs = self._target_qf.get_qval_sym(obs,
                                                              actions,
                                                              name='qf')
@@ -213,7 +213,7 @@ class TD3(RLAlgorithm):
                 inputs=[], outputs=target_update_op)
 
             # Set up policy training function
-            next_action = self.policy.get_action_sym(obs, name='policy_action')
+            next_action = self.policy.build(obs, name='policy_action')
             next_qval = self.qf.get_qval_sym(obs,
                                              next_action,
                                              name='policy_action_qval')

--- a/src/garage/tf/algos/te_npo.py
+++ b/src/garage/tf/algos/te_npo.py
@@ -123,7 +123,7 @@ class TENPO(RLAlgorithm):
         self._name = name
         self._name_scope = tf.name_scope(self._name)
         self._old_policy = policy.clone('old_policy')
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
         self._old_policy.encoder.model.parameters = (
             self.policy.encoder.model.parameters)
         self._use_softplus_entropy = use_softplus_entropy
@@ -268,7 +268,7 @@ class TENPO(RLAlgorithm):
         logger.log('Fitting baseline...')
         self._baseline.fit(paths)
 
-        self._old_policy.model.parameters = self.policy.model.parameters
+        self._old_policy.parameters = self.policy.parameters
         self._old_policy.encoder.model.parameters = (
             self.policy.encoder.model.parameters)
         self._old_inference.model.parameters = self._inference.model.parameters
@@ -768,6 +768,7 @@ class TENPO(RLAlgorithm):
             samples_data['latent_infos'][k]
             for k in self.policy.encoder.state_info_keys
         ]
+        # pylint: disable=unexpected-keyword-arg
         policy_opt_input_values = self._policy_opt_inputs._replace(
             obs_var=samples_data['observations'],
             action_var=samples_data['actions'],

--- a/src/garage/tf/models/categorical_cnn_model.py
+++ b/src/garage/tf/models/categorical_cnn_model.py
@@ -68,7 +68,7 @@ class CategoricalCNNModel(Model):
                  hidden_nonlinearity=tf.nn.relu,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):

--- a/src/garage/tf/models/categorical_gru_model.py
+++ b/src/garage/tf/models/categorical_gru_model.py
@@ -60,7 +60,7 @@ class CategoricalGRUModel(GRUModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -75,13 +75,12 @@ class CategoricalGRUModel(GRUModel):
             hidden_b_init=hidden_b_init,
             recurrent_nonlinearity=recurrent_nonlinearity,
             recurrent_w_init=recurrent_w_init,
-            output_nonlinearity=tf.nn.softmax,
+            output_nonlinearity=output_nonlinearity,
             output_w_init=output_w_init,
             output_b_init=output_b_init,
             hidden_state_init=hidden_state_init,
             hidden_state_init_trainable=hidden_state_init_trainable,
             layer_normalization=layer_normalization)
-        self._output_normalization_fn = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -117,7 +116,5 @@ class CategoricalGRUModel(GRUModel):
         """
         outputs, step_output, step_hidden, init_hidden = super()._build(
             state_input, step_input, step_hidden, name=name)
-        if self._output_normalization_fn:
-            outputs = self._output_normalization_fn(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return dist, step_output, step_hidden, init_hidden

--- a/src/garage/tf/models/categorical_lstm_model.py
+++ b/src/garage/tf/models/categorical_lstm_model.py
@@ -67,7 +67,7 @@ class CategoricalLSTMModel(LSTMModel):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),
@@ -85,7 +85,7 @@ class CategoricalLSTMModel(LSTMModel):
             hidden_b_init=hidden_b_init,
             recurrent_nonlinearity=recurrent_nonlinearity,
             recurrent_w_init=recurrent_w_init,
-            output_nonlinearity=tf.nn.softmax,
+            output_nonlinearity=output_nonlinearity,
             output_w_init=output_w_init,
             output_b_init=output_b_init,
             hidden_state_init=hidden_state_init,
@@ -94,7 +94,6 @@ class CategoricalLSTMModel(LSTMModel):
             cell_state_init_trainable=cell_state_init_trainable,
             forget_bias=forget_bias,
             layer_normalization=layer_normalization)
-        self._output_normalization_fn = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -147,8 +146,6 @@ class CategoricalLSTMModel(LSTMModel):
                                      step_hidden,
                                      step_cell,
                                      name=name)
-        if self._output_normalization_fn:
-            outputs = self._output_normalization_fn(outputs)
         dist = tfp.distributions.OneHotCategorical(probs=outputs)
         return (dist, step_output, step_hidden, step_cell, init_hidden,
                 init_cell)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -68,7 +68,7 @@ class CategoricalMLPModel(MLPModel):
         """
         return ['dist']
 
-    def _build(self, state_input, name=None):
+    def _build_model(self, state_input, name=None):
         """Build model.
 
         Args:
@@ -81,7 +81,7 @@ class CategoricalMLPModel(MLPModel):
             tfp.distributions.OneHotCategorical: Policy distribution.
 
         """
-        prob = super()._build(state_input, name=name)
+        prob = super()._build_model(state_input, name=name)
         if self._output_normalization_fn:
             prob = self._output_normalization_fn(prob)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/categorical_mlp_model.py
+++ b/src/garage/tf/models/categorical_mlp_model.py
@@ -50,14 +50,13 @@ class CategoricalMLPModel(MLPModel):
                  hidden_nonlinearity=tf.nn.tanh,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):
         super().__init__(output_dim, name, hidden_sizes, hidden_nonlinearity,
-                         hidden_w_init, hidden_b_init, tf.nn.softmax,
+                         hidden_w_init, hidden_b_init, output_nonlinearity,
                          output_w_init, output_b_init, layer_normalization)
-        self._output_normalization_fn = output_nonlinearity
 
     def network_output_spec(self):
         """Network output spec.
@@ -68,7 +67,7 @@ class CategoricalMLPModel(MLPModel):
         """
         return ['dist']
 
-    def _build_model(self, state_input, name=None):
+    def _build(self, state_input, name=None):
         """Build model.
 
         Args:
@@ -81,7 +80,5 @@ class CategoricalMLPModel(MLPModel):
             tfp.distributions.OneHotCategorical: Policy distribution.
 
         """
-        prob = super()._build_model(state_input, name=name)
-        if self._output_normalization_fn:
-            prob = self._output_normalization_fn(prob)
+        prob = super()._build(state_input, name=name)
         return tfp.distributions.OneHotCategorical(probs=prob)

--- a/src/garage/tf/models/mlp_model.py
+++ b/src/garage/tf/models/mlp_model.py
@@ -63,7 +63,7 @@ class MLPModel(Model):
         self._layer_normalization = layer_normalization
 
     # pylint: disable=arguments-differ
-    def _build(self, state_input, name=None):
+    def _build_model(self, state_input, name=None):
         """Build model given input placeholder(s).
 
         Args:

--- a/src/garage/tf/models/mlp_model.py
+++ b/src/garage/tf/models/mlp_model.py
@@ -63,7 +63,7 @@ class MLPModel(Model):
         self._layer_normalization = layer_normalization
 
     # pylint: disable=arguments-differ
-    def _build_model(self, state_input, name=None):
+    def _build(self, state_input, name=None):
         """Build model given input placeholder(s).
 
         Args:

--- a/src/garage/tf/models/model.py
+++ b/src/garage/tf/models/model.py
@@ -5,6 +5,8 @@ import warnings
 
 import tensorflow as tf
 
+from garage.tf.models.module import Module
+
 
 class BaseModel(abc.ABC):
     """Interface-only abstract class for models.
@@ -130,7 +132,7 @@ class Network:
         return self._outputs
 
 
-class Model(BaseModel):
+class Model(BaseModel, Module):
     r"""Model class for TensorFlow.
 
     A TfModel only contains the structure/configuration of the underlying
@@ -180,14 +182,14 @@ class Model(BaseModel):
     """
 
     def __init__(self, name):
-        super().__init__()
-        self._name = name or type(self).__name__  # name default to class
+        super().__init__(name or type(self).__name__)
+        # self._name = name or type(self).__name__  # name default to class
         self._networks = {}
         self._default_parameters = None
         self._variable_scope = None
 
     # pylint: disable=protected-access, assignment-from-no-return
-    def build(self, *inputs, name=None):
+    def _build_network(self, *inputs, name=None):
         """Build a Network with the given input(s).
 
         ***
@@ -223,7 +225,7 @@ class Model(BaseModel):
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
-                    network._outputs = self._build(*inputs, name)
+                    network._outputs = self._build_model(*inputs, name)
                 variables = self._get_variables().values()
                 tf.compat.v1.get_default_session().run(
                     tf.compat.v1.variables_initializer(variables))
@@ -239,7 +241,7 @@ class Model(BaseModel):
                 with tf.name_scope(name=network_name):
                     network = Network()
                     network._inputs = inputs
-                    network._outputs = self._build(*inputs, name)
+                    network._outputs = self._build_model(*inputs, name)
         custom_in_spec = self.network_input_spec()
         custom_out_spec = self.network_output_spec()
         in_spec = ['input', 'inputs']
@@ -275,10 +277,10 @@ class Model(BaseModel):
 
         return out_network
 
-    def _build(self, *inputs, name=None):
-        """Output of the model given input placeholder(s).
+    def _build_model(self, *inputs, name=None):
+        """Build this model given input placeholder(s).
 
-        User should implement _build() inside their subclassed model,
+        User should implement _build_model() inside their subclassed model,
         and construct the computation graphs in this function.
 
         Args:

--- a/src/garage/tf/policies/__init__.py
+++ b/src/garage/tf/policies/__init__.py
@@ -11,13 +11,13 @@ from garage.tf.policies.gaussian_lstm_policy import GaussianLSTMPolicy
 from garage.tf.policies.gaussian_mlp_policy import GaussianMLPPolicy
 from garage.tf.policies.gaussian_mlp_task_embedding_policy import (
     GaussianMLPTaskEmbeddingPolicy)
-from garage.tf.policies.policy import Policy, StochasticPolicy
+from garage.tf.policies.policy import Policy
 from garage.tf.policies.task_embedding_policy import TaskEmbeddingPolicy
 
 __all__ = [
-    'Policy', 'StochasticPolicy', 'CategoricalCNNPolicy',
-    'CategoricalGRUPolicy', 'CategoricalLSTMPolicy', 'CategoricalMLPPolicy',
-    'ContinuousMLPPolicy', 'DiscreteQfDerivedPolicy', 'GaussianGRUPolicy',
-    'GaussianLSTMPolicy', 'GaussianMLPPolicy',
-    'GaussianMLPTaskEmbeddingPolicy', 'TaskEmbeddingPolicy'
+    'Policy', 'CategoricalCNNPolicy', 'CategoricalGRUPolicy',
+    'CategoricalLSTMPolicy', 'CategoricalMLPPolicy', 'ContinuousMLPPolicy',
+    'DiscreteQfDerivedPolicy', 'GaussianGRUPolicy', 'GaussianLSTMPolicy',
+    'GaussianMLPPolicy', 'GaussianMLPTaskEmbeddingPolicy',
+    'TaskEmbeddingPolicy'
 ]

--- a/src/garage/tf/policies/categorical_cnn_policy.py
+++ b/src/garage/tf/policies/categorical_cnn_policy.py
@@ -71,7 +71,7 @@ class CategoricalCNNPolicy(CategoricalCNNModel, Policy):
                  hidden_nonlinearity=tf.nn.relu,
                  hidden_w_init=tf.initializers.glorot_uniform(),
                  hidden_b_init=tf.zeros_initializer(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  layer_normalization=False):

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -69,7 +69,7 @@ class CategoricalGRUPolicy(CategoricalGRUModel, Policy):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -76,7 +76,7 @@ class CategoricalLSTMPolicy(CategoricalLSTMModel, Policy):
                  hidden_b_init=tf.zeros_initializer(),
                  recurrent_nonlinearity=tf.nn.sigmoid,
                  recurrent_w_init=tf.initializers.glorot_uniform(),
-                 output_nonlinearity=None,
+                 output_nonlinearity=tf.nn.softmax,
                  output_w_init=tf.initializers.glorot_uniform(),
                  output_b_init=tf.zeros_initializer(),
                  hidden_state_init=tf.zeros_initializer(),

--- a/src/garage/tf/policies/policy.py
+++ b/src/garage/tf/policies/policy.py
@@ -2,21 +2,10 @@
 import abc
 
 from garage.np.policies import Policy as BasePolicy
-from garage.tf.models import Module, StochasticModule
 
 
-class Policy(Module, BasePolicy):
-    """Base class for policies in TensorFlow.
-
-    Args:
-        name (str): Policy name, also the variable scope.
-        env_spec (garage.envs.env_spec.EnvSpec): Environment specification.
-
-    """
-
-    def __init__(self, name, env_spec):
-        super().__init__(name)
-        self._env_spec = env_spec
+class Policy(BasePolicy):
+    """Base class for policies in TensorFlow."""
 
     @abc.abstractmethod
     def get_action(self, observation):
@@ -45,16 +34,6 @@ class Policy(Module, BasePolicy):
         """
 
     @property
-    def env_spec(self):
-        """Policy environment specification.
-
-        Returns:
-            garage.EnvSpec: Environment specification.
-
-        """
-        return self._env_spec
-
-    @property
     def state_info_specs(self):
         """State info specification.
 
@@ -78,5 +57,10 @@ class Policy(Module, BasePolicy):
 
 
 # pylint: disable=abstract-method
-class StochasticPolicy(Policy, StochasticModule):
+class StochasticPolicy(Policy):
     """Stochastic Policy."""
+
+    @property
+    @abc.abstractmethod
+    def distribution(self):
+        """Distribution."""

--- a/src/garage/tf/policies/policy.py
+++ b/src/garage/tf/policies/policy.py
@@ -54,13 +54,3 @@ class Policy(BasePolicy):
 
         """
         return [k for k, _ in self.state_info_specs]
-
-
-# pylint: disable=abstract-method
-class StochasticPolicy(Policy):
-    """Stochastic Policy."""
-
-    @property
-    @abc.abstractmethod
-    def distribution(self):
-        """Distribution."""

--- a/src/garage/tf/policies/task_embedding_policy.py
+++ b/src/garage/tf/policies/task_embedding_policy.py
@@ -1,36 +1,18 @@
 """Policy class for Task Embedding envs."""
 import abc
 
-import akro
-
-from garage.tf.policies.policy import StochasticPolicy
+from garage.tf.policies.policy import Policy
 
 
-class TaskEmbeddingPolicy(StochasticPolicy):
+class TaskEmbeddingPolicy(Policy):
     """Base class for Task Embedding policies in TensorFlow.
 
     This policy needs a task id in addition to observation to sample an action.
-
-    Args:
-        name (str): Policy name, also the variable scope.
-        env_spec (garage.envs.EnvSpec): Environment specification.
-        encoder (garage.tf.embeddings.StochasticEncoder):
-            A encoder that embeds a task id to a latent.
-
     """
-
-    # pylint: disable=too-many-public-methods
-
-    def __init__(self, name, env_spec, encoder):
-        super().__init__(name, env_spec)
-        self._encoder = encoder
-        self._augmented_observation_space = akro.concat(
-            self._env_spec.observation_space, self.task_space)
 
     @property
     def encoder(self):
         """garage.tf.embeddings.encoder.Encoder: Encoder."""
-        return self._encoder
 
     def get_latent(self, task_id):
         """Get embedded task id in latent space.
@@ -61,7 +43,6 @@ class TaskEmbeddingPolicy(StochasticPolicy):
     @property
     def augmented_observation_space(self):
         """akro.Box: Concatenated observation space and one-hot task id."""
-        return self._augmented_observation_space
 
     @property
     def encoder_distribution(self):
@@ -174,34 +155,6 @@ class TaskEmbeddingPolicy(StochasticPolicy):
             dict: Action distribution information.
 
         """
-
-    def get_trainable_vars(self):
-        """Get trainable variables.
-
-        The trainable vars of a multitask policy should be the trainable vars
-        of its model and the trainable vars of its embedding model.
-
-        Returns:
-            List[tf.Variable]: A list of trainable variables in the current
-                variable scope.
-
-        """
-        return (self._variable_scope.trainable_variables() +
-                self.encoder.get_trainable_vars())
-
-    def get_global_vars(self):
-        """Get global variables.
-
-        The global vars of a multitask policy should be the global vars
-        of its model and the trainable vars of its embedding model.
-
-        Returns:
-            List[tf.Variable]: A list of global variables in the current
-                variable scope.
-
-        """
-        return (self._variable_scope.global_variables() +
-                self.encoder.get_global_vars())
 
     def split_augmented_observation(self, collated):
         """Splits up observation into one-hot task and environment observation.

--- a/src/garage/tf/policies/uniform_control_policy.py
+++ b/src/garage/tf/policies/uniform_control_policy.py
@@ -10,21 +10,8 @@ class UniformControlPolicy(Policy):
 
     """
 
-    def __init__(
-            self,
-            env_spec,
-    ):
-        super().__init__(env_spec=env_spec)
-
-    @property
-    def vectorized(self):
-        """Vectorized or not.
-
-        Returns:
-            Bool: True if primitive supports vectorized operations.
-
-        """
-        return True
+    def __init__(self, env_spec):
+        self._env_spec = env_spec
 
     def get_action(self, observation):
         """Get single action from this policy for the input observation.

--- a/src/garage/tf/regressors/gaussian_cnn_regressor_model.py
+++ b/src/garage/tf/regressors/gaussian_cnn_regressor_model.py
@@ -87,6 +87,7 @@ class GaussianCNNRegressorModel(GaussianCNNModel):
                exponential transformation
             - softplus: the std will be computed as log(1+exp(x))
         layer_normalization (bool): Bool for using layer normalization or not.
+
     """
 
     def __init__(self,

--- a/tests/fixtures/models/simple_gaussian_cnn_model.py
+++ b/tests/fixtures/models/simple_gaussian_cnn_model.py
@@ -1,3 +1,4 @@
+"""Simple GaussianCNNModel for testing."""
 import tensorflow as tf
 
 from garage.tf.distributions import DiagonalGaussian
@@ -5,20 +6,53 @@ from garage.tf.models import Model
 
 
 class SimpleGaussianCNNModel(Model):
-    """Simple GaussianCNNModel for testing."""
+    """Simple GaussianCNNModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
-                 name='SimpleGaussianCNNModel',
                  *args,
+                 name='SimpleGaussianCNNModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
 
     def network_output_spec(self):
-        return ['sample', 'mean', 'log_std', 'std_param', 'dist']
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
+        return ['sample', 'mean', 'log_std', 'dist']
 
     def _build(self, obs_input, name=None):
+        """Build model.
+
+        Args:
+            obs_input (tf.Tensor): Entire time-series observation input.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Returns:
+            tf.tensor: Action.
+            tf.tensor: Mean.
+            tf.Tensor: Log of standard deviation.
+            garage.distributions.DiagonalGaussian: Distribution.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)
@@ -26,4 +60,4 @@ class SimpleGaussianCNNModel(Model):
         action = mean + log_std * 0.5
         dist = DiagonalGaussian(self.output_dim)
         # action will be 0.5 + 0.5 * 0.5 = 0.75
-        return action, mean, log_std, log_std, dist
+        return action, mean, log_std, dist

--- a/tests/fixtures/models/simple_gaussian_gru_model.py
+++ b/tests/fixtures/models/simple_gaussian_gru_model.py
@@ -1,3 +1,4 @@
+"""Simple GaussianGRUModel for testing."""
 import tensorflow as tf
 
 from garage.tf.distributions import DiagonalGaussian
@@ -5,35 +6,74 @@ from garage.tf.models import Model
 
 
 class SimpleGaussianGRUModel(Model):
-    """Simple GaussianGRUModel for testing."""
+    """Simple GaussianGRUModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        hidden_dim (int): Hidden dimension for GRU cell.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
                  hidden_dim,
-                 name='SimpleGaussianGRUModel',
                  *args,
+                 name='SimpleGaussianGRUModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
         self.hidden_dim = hidden_dim
 
     def network_input_spec(self):
-        """Network input spec."""
+        """Network input spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return ['full_input', 'step_input', 'step_hidden_input']
 
     def network_output_spec(self):
-        """Network output spec."""
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return [
             'mean', 'step_mean', 'log_std', 'step_log_std', 'step_hidden',
             'init_hidden', 'dist'
         ]
 
-    def _build(self,
-               obs_input,
-               step_obs_input,
-               step_hidden,
-               step_cell,
-               name=None):
+    def _build(self, obs_input, step_obs_input, step_hidden, name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Place holder for entire time-series
+                inputs.
+            step_obs_input (tf.Tensor): Place holder for step inputs.
+            step_hidden (tf.Tensor): Place holder for step hidden state.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Entire time-series means.
+            tf.Tensor: Step mean.
+            tf.Tensor: Entire time-series log std.
+            tf.Tensor: Step log std.
+            tf.Tensor: Step hidden state.
+            tf.Tensor: Initial hidden state.
+            garage.distributions.DiagonalGaussian: Distribution.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = log_std = tf.fill(

--- a/tests/fixtures/models/simple_gaussian_lstm_model.py
+++ b/tests/fixtures/models/simple_gaussian_lstm_model.py
@@ -1,3 +1,4 @@
+"""Simple GaussianGRUModel for testing."""
 import tensorflow as tf
 
 from garage.tf.distributions import DiagonalGaussian
@@ -5,26 +6,48 @@ from garage.tf.models import Model
 
 
 class SimpleGaussianLSTMModel(Model):
-    """Simple GaussianLSTMModel for testing."""
+    """Simple GaussianLSTMModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        hidden_dim (int): Hidden dimension for LSTM cell.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
                  hidden_dim,
-                 name='SimpleGaussianLSTMModel',
                  *args,
+                 name='SimpleGaussianLSTMModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
         self.hidden_dim = hidden_dim
 
     def network_input_spec(self):
-        """Network input spec."""
+        """Network input spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return [
             'full_input', 'step_input', 'step_hidden_input', 'step_cell_input'
         ]
 
     def network_output_spec(self):
-        """Network output spec."""
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return [
             'mean', 'step_mean', 'log_std', 'step_log_std', 'step_hidden',
             'step_cell', 'init_hidden', 'init_cell', 'dist'
@@ -36,6 +59,31 @@ class SimpleGaussianLSTMModel(Model):
                step_hidden,
                step_cell,
                name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Place holder for entire time-series
+                inputs.
+            step_obs_input (tf.Tensor): Place holder for step inputs.
+            step_hidden (tf.Tensor): Place holder for step hidden state.
+            step_cell (tf.Tensor): Place holder for step cell state.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Entire time-series means.
+            tf.Tensor: Step mean.
+            tf.Tensor: Entire time-series log std.
+            tf.Tensor: Step log std.
+            tf.Tensor: Step hidden state.
+            tf.Tensor: Step cell state.
+            tf.Tensor: Initial hidden state.
+            tf.Tensor: Initial cell state.
+            garage.distributions.DiagonalGaussian: Distribution.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = log_std = tf.fill(

--- a/tests/fixtures/models/simple_gaussian_mlp_model.py
+++ b/tests/fixtures/models/simple_gaussian_mlp_model.py
@@ -1,3 +1,4 @@
+"""Simple GaussianMLPModel for testing."""
 import numpy as np
 import tensorflow as tf
 
@@ -6,20 +7,52 @@ from garage.tf.models import Model
 
 
 class SimpleGaussianMLPModel(Model):
-    """Simple GaussianMLPModel for testing."""
+    """Simple SimpleGaussianMLPModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
-                 name='SimpleGaussianMLPModel',
                  *args,
+                 name='SimpleGaussianMLPModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
 
     def network_output_spec(self):
-        return ['mean', 'log_std', 'std_param', 'dist']
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
+        return ['mean', 'log_std', 'dist']
 
     def _build(self, obs_input, name=None):
+        """Build model.
+
+        Args:
+            obs_input (tf.Tensor): Entire time-series observation input.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Returns:
+            tf.tensor: Mean.
+            tf.Tensor: Log of standard deviation.
+            garage.distributions.DiagonalGaussian: Distribution.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         mean = tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)
@@ -27,4 +60,4 @@ class SimpleGaussianMLPModel(Model):
                           np.log(0.5))
         dist = DiagonalGaussian(self.output_dim)
         # action will be 0.5 + 0.5 * 0.5 = 0.75
-        return mean, log_std, log_std, dist
+        return mean, log_std, dist

--- a/tests/fixtures/models/simple_gru_model.py
+++ b/tests/fixtures/models/simple_gru_model.py
@@ -1,30 +1,73 @@
+"""Simple GRUModel for testing."""
 import tensorflow as tf
 
 from garage.tf.models import Model
 
 
 class SimpleGRUModel(Model):
-    """Simple GRUModel for testing."""
+    """Simple GRUModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        hidden_dim (int): Hidden dimension for GRU cell.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
                  hidden_dim,
-                 name='SimpleGRUModel',
                  *args,
+                 name='SimpleGRUModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
         self.hidden_dim = hidden_dim
 
     def network_input_spec(self):
-        """Network input spec."""
+        """Network input spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return ['full_input', 'step_input', 'step_hidden_input']
 
     def network_output_spec(self):
-        """Network output spec."""
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return ['all_output', 'step_output', 'step_hidden', 'init_hidden']
 
+    # pylint: disable=arguments-differ
     def _build(self, obs_input, step_obs_input, step_hidden, name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Place holder for entire time-series
+                inputs.
+            step_obs_input (tf.Tensor): Place holder for step inputs.
+            step_hidden (tf.Tensor): Place holder for step hidden state.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Entire time-series outputs.
+            tf.Tensor: Step output.
+            tf.Tensor: Step hidden state.
+            tf.Tensor: Initial hidden state.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         outputs = tf.fill(

--- a/tests/fixtures/models/simple_lstm_model.py
+++ b/tests/fixtures/models/simple_lstm_model.py
@@ -1,40 +1,86 @@
+"""Simple LSTModel for testing."""
 import tensorflow as tf
 
 from garage.tf.models import Model
 
 
 class SimpleLSTMModel(Model):
-    """Simple LSTMModel for testing."""
+    """Simple LSTModel for testing.
 
+    Args:
+        output_dim (int): Dimension of the network output.
+        hidden_dim (int): Hidden dimension for LSTM cell.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
     def __init__(self,
                  output_dim,
                  hidden_dim,
-                 name='SimpleLSTMModel',
                  *args,
+                 name='SimpleLSTMModel',
                  **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
         self.hidden_dim = hidden_dim
 
     def network_input_spec(self):
-        """Network input spec."""
+        """Network input spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return [
             'full_input', 'step_input', 'step_hidden_input', 'step_cell_input'
         ]
 
     def network_output_spec(self):
-        """Network output spec."""
+        """Network output spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return [
             'all_output', 'step_output', 'step_hidden', 'step_cell',
             'init_hidden', 'init_cell'
         ]
 
+    # pylint: disable=arguments-differ
     def _build(self,
                obs_input,
                step_obs_input,
                step_hidden,
                step_cell,
                name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Place holder for entire time-series
+                inputs.
+            step_obs_input (tf.Tensor): Place holder for step inputs.
+            step_hidden (tf.Tensor): Place holder for step hidden state.
+            step_cell (tf.Tensor): Place holder for step cell state.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Entire time-series outputs.
+            tf.Tensor: Step output.
+            tf.Tensor: Step hidden state.
+            tf.Tensor: Step cell state.
+            tf.Tensor: Initial hidden state.
+            tf.Tensor: Initial cell state.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         outputs = tf.fill(

--- a/tests/fixtures/models/simple_mlp_merge_model.py
+++ b/tests/fixtures/models/simple_mlp_merge_model.py
@@ -1,20 +1,53 @@
+"""Simple MLPMergeModel for testing."""
 import tensorflow as tf
 
 from garage.tf.models import Model
 
 
 class SimpleMLPMergeModel(Model):
-    """Simple MLPMergeModel for testing."""
+    """Simple SimpleGaussianMLPModel for testing.
 
-    def __init__(self, output_dim, name=None, *args, **kwargs):
+    Args:
+        output_dim (int): Dimension of the network output.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
+
+    def __init__(self, output_dim, *args, name=None, **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
 
     def network_input_spec(self):
-        """Network input spec."""
+        """Network input spec.
+
+        Return:
+            list[str]: List of key(str) for the network outputs.
+
+        """
         return ['input_var1', 'input_var2']
 
     def _build(self, obs_input, act_input, name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Tensor input for state.
+            act_input (tf.Tensor): Tensor input for action.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Tensor output of the model.
+
+        """
+        del name
+        del act_input
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/fixtures/models/simple_mlp_model.py
+++ b/tests/fixtures/models/simple_mlp_model.py
@@ -1,16 +1,41 @@
+"""Simple MLPModel for testing."""
 import tensorflow as tf
 
 from garage.tf.models import Model
 
 
 class SimpleMLPModel(Model):
-    """Simple MLPModel for testing."""
+    """Simple MLPModel for testing.
 
-    def __init__(self, output_dim, name=None, *args, **kwargs):
+    Args:
+        output_dim (int): Dimension of the network output.
+        name (str): Model name, also the variable scope.
+        args (list): Unused positionl arguments.
+        kwargs (dict): Unused keyword arguments.
+
+    """
+
+    # pylint: disable=arguments-differ
+    def __init__(self, output_dim, *args, name=None, **kwargs):
+        del args
+        del kwargs
         super().__init__(name)
         self.output_dim = output_dim
 
     def _build(self, obs_input, name=None):
+        """Build model given input placeholder(s).
+
+        Args:
+            obs_input (tf.Tensor): Tensor input for state.
+            name (str): Inner model name, also the variable scope of the
+                inner model, if exist. One example is
+                garage.tf.models.Sequential.
+
+        Return:
+            tf.Tensor: Tensor output of the model.
+
+        """
+        del name
         return_var = tf.compat.v1.get_variable(
             'return_var', (), initializer=tf.constant_initializer(0.5))
         return tf.fill((tf.shape(obs_input)[0], self.output_dim), return_var)

--- a/tests/garage/tf/models/test_categorical_gru_model.py
+++ b/tests/garage/tf/models/test_categorical_gru_model.py
@@ -38,19 +38,6 @@ class TestCategoricalGRUModel(TfGraphTestCase):
                            step_hidden_var).dist
         assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
-    def test_output_nonlinearity(self):
-        model = CategoricalGRUModel(output_dim=1,
-                                    hidden_dim=4,
-                                    output_nonlinearity=lambda x: x / 2)
-        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 1))
-        step_obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
-        step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
-        obs = np.ones((1, 1, 1))
-        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph).dist
-        probs = tf.compat.v1.get_default_session().run(dist.probs,
-                                                       feed_dict={obs_ph: obs})
-        assert probs == [0.5]
-
     @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
     def test_output_normalized(self, output_dim):
         model = CategoricalGRUModel(output_dim=output_dim, hidden_dim=4)

--- a/tests/garage/tf/models/test_categorical_lstm_model.py
+++ b/tests/garage/tf/models/test_categorical_lstm_model.py
@@ -41,21 +41,6 @@ class TestCategoricalLSTMModel(TfGraphTestCase):
                            step_hidden_var, step_cell_var).dist
         assert isinstance(dist, tfp.distributions.OneHotCategorical)
 
-    def test_output_nonlinearity(self):
-        model = CategoricalLSTMModel(output_dim=1,
-                                     hidden_dim=4,
-                                     output_nonlinearity=lambda x: x / 2)
-        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 1))
-        step_obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
-        step_hidden_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
-        step_cell_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 4))
-        obs = np.ones((1, 1, 1))
-        dist = model.build(obs_ph, step_obs_ph, step_hidden_ph,
-                           step_cell_ph).dist
-        probs = tf.compat.v1.get_default_session().run(dist.probs,
-                                                       feed_dict={obs_ph: obs})
-        assert probs == [0.5]
-
     @pytest.mark.parametrize('output_dim', [1, 2, 5, 10])
     def test_output_normalized(self, output_dim):
         model = CategoricalLSTMModel(output_dim=output_dim, hidden_dim=4)

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -32,20 +32,6 @@ class TestCategoricalMLPModel(TfGraphTestCase):
                                                        feed_dict={obs_ph: obs})
         assert np.isclose(probs, 1.0)
 
-    def test_output_nonlinearity(self):
-        model = CategoricalMLPModel(output_dim=1,
-                                    hidden_nonlinearity=None,
-                                    hidden_w_init=tf.ones_initializer(),
-                                    output_w_init=tf.ones_initializer(),
-                                    hidden_sizes=(1, ),
-                                    output_nonlinearity=lambda x: x / 2)
-        obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
-        obs = np.ones((1, 1))
-        dist = model.build(obs_ph).dist
-        probs = tf.compat.v1.get_default_session().run(dist.probs,
-                                                       feed_dict={obs_ph: obs})
-        assert probs == [0.5]
-
     # yapf: disable
     @pytest.mark.parametrize('output_dim, hidden_sizes', [
         (1, (1, )),

--- a/tests/garage/tf/models/test_categorical_mlp_model.py
+++ b/tests/garage/tf/models/test_categorical_mlp_model.py
@@ -34,6 +34,10 @@ class TestCategoricalMLPModel(TfGraphTestCase):
 
     def test_output_nonlinearity(self):
         model = CategoricalMLPModel(output_dim=1,
+                                    hidden_nonlinearity=None,
+                                    hidden_w_init=tf.ones_initializer(),
+                                    output_w_init=tf.ones_initializer(),
+                                    hidden_sizes=(1, ),
                                     output_nonlinearity=lambda x: x / 2)
         obs_ph = tf.compat.v1.placeholder(tf.float32, shape=(None, 1))
         obs = np.ones((1, 1))

--- a/tests/garage/tf/optimizers/test_conjugate_gradient_optimizer.py
+++ b/tests/garage/tf/optimizers/test_conjugate_gradient_optimizer.py
@@ -5,17 +5,18 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from garage.tf.models import Module
 from garage.tf.optimizers.conjugate_gradient_optimizer import (
     cg, ConjugateGradientOptimizer, FiniteDifferenceHvp, PearlmutterHvp)
 from garage.tf.policies import Policy
 from tests.fixtures import TfGraphTestCase
 
 
-class HelperPolicy(Policy):
+class HelperPolicy(Module, Policy):
     """Helper policy class for testing hvp classes"""
 
     def __init__(self, n_vars, name='OneParamPolicy'):
-        super().__init__(name, None)
+        super().__init__(name)
         with tf.compat.v1.variable_scope(self.name) as vs:
             self._variable_scope = vs
             _ = [tf.Variable([0.]) for _ in range(n_vars)]

--- a/tests/garage/tf/policies/test_categorical_cnn_policy.py
+++ b/tests/garage/tf/policies/test_categorical_cnn_policy.py
@@ -55,9 +55,10 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
                                                shape=(None, None) +
                                                policy.input_dim)
         dist_sym = policy.build(state_input, name='dist_sym').dist
-        output1 = self.sess.run([policy.distribution.probs],
-                                feed_dict={policy.model.input: [[obs]]})
-        output2 = self.sess.run([dist_sym.probs],
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
+        output1 = self.sess.run([dist_sym.probs],
+                                feed_dict={state_input: [[obs]]})
+        output2 = self.sess.run([dist_sym2.probs],
                                 feed_dict={state_input: [[obs]]})
         assert np.array_equal(output1, output2)
 
@@ -72,22 +73,29 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         env.reset()
         obs, _, _, _ = env.step(1)
 
-        with tf.compat.v1.variable_scope(
-                'CategoricalCNNPolicy/CategoricalCNNModel', reuse=True):
+        with tf.compat.v1.variable_scope('CategoricalCNNPolicy', reuse=True):
             cnn_bias = tf.compat.v1.get_variable('CNNModel/cnn/h0/bias')
             bias = tf.compat.v1.get_variable('MLPModel/mlp/hidden_0/bias')
 
         cnn_bias.load(tf.ones_like(cnn_bias).eval())
         bias.load(tf.ones_like(bias).eval())
 
-        output1 = self.sess.run(policy.distribution.probs,
-                                feed_dict={policy.model.input: [[obs]]})
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None) +
+                                               policy.input_dim)
+        dist_sym = policy.build(state_input, name='dist_sym').dist
+        output1 = self.sess.run(dist_sym.probs,
+                                feed_dict={state_input: [[obs]]})
         p = pickle.dumps(policy)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            output2 = sess.run(policy_pickled.distribution.probs,
-                               feed_dict={policy_pickled.model.input: [[obs]]})
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None) +
+                                                   policy.input_dim)
+            dist_sym = policy_pickled.build(state_input, name='dist_sym').dist
+            output2 = sess.run(dist_sym.probs,
+                               feed_dict={state_input: [[obs]]})
             assert np.array_equal(output1, output2)
 
     @pytest.mark.parametrize('filters, strides, padding, hidden_sizes', [

--- a/tests/garage/tf/policies/test_categorical_gru_policy.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy.py
@@ -47,6 +47,7 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         ((1, 1), 1, 4),
         ((2, 2), 2, 4),
     ])
+    # pylint: disable=no-member
     def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
@@ -77,6 +78,7 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         ((1, 1), 1, 4),
         ((2, 2), 2, 4),
     ])
+    # pylint: disable=no-member
     def test_build_state_not_include_action(self, obs_dim, action_dim,
                                             hidden_dim):
         env = GarageEnv(
@@ -122,6 +124,7 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
         for action in actions:
             assert env.action_space.contains(action)
 
+    # pylint: disable=no-member
     def test_is_pickleable(self):
         env = GarageEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
         policy = CategoricalGRUPolicy(env_spec=env.spec,

--- a/tests/garage/tf/policies/test_categorical_lstm_policy.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy.py
@@ -84,13 +84,14 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
-            [policy.distribution.probs],
-            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
-        output2 = self.sess.run(
             [dist_sym.probs],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym2.probs],
             feed_dict={state_input: [[concat_obs], [concat_obs]]})
         assert np.array_equal(output1, output2)
 
@@ -114,11 +115,12 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
         output1 = self.sess.run(
-            [policy.distribution.probs],
-            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
-        output2 = self.sess.run(
             [dist_sym.probs],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym2.probs],
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
@@ -130,22 +132,28 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         policy.reset()
         obs = env.reset()
 
-        policy.model._lstm_cell.weights[0].load(
-            tf.ones_like(policy.model._lstm_cell.weights[0]).eval())
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym = policy.build(state_input, name='dist_sym').dist
+        policy._lstm_cell.weights[0].load(
+            tf.ones_like(policy._lstm_cell.weights[0]).eval())
 
         output1 = self.sess.run(
-            [policy.distribution.probs],
-            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+            [dist_sym.probs],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
 
         p = pickle.dumps(policy)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            output2 = sess.run([policy_pickled.distribution.probs],
-                               feed_dict={
-                                   policy_pickled.model.input:
-                                   [[obs.flatten()], [obs.flatten()]]
-                               })  # noqa: E126
+            state_input = tf.compat.v1.placeholder(
+                tf.float32, shape=(None, None, policy_pickled.input_dim))
+            dist_sym = policy_pickled.build(state_input, name='dist_sym').dist
+            output2 = sess.run(
+                [dist_sym.probs],
+                feed_dict={state_input: [[obs.flatten()],
+                                         [obs.flatten()]]})  # noqa: E126
             assert np.array_equal(output1, output2)
 
     def test_state_info_specs(self):

--- a/tests/garage/tf/policies/test_categorical_lstm_policy.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy.py
@@ -71,6 +71,7 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         ((1, 1), 1, 4),
         ((2, 2), 2, 4),
     ])
+    # pylint: disable=no-member
     def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(
             DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
@@ -101,6 +102,7 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         ((1, 1), 1, 4),
         ((2, 2), 2, 4),
     ])
+    # pylint: disable=no-member
     def test_build_state_not_include_action(self, obs_dim, action_dim,
                                             hidden_dim):
         env = GarageEnv(
@@ -124,6 +126,7 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
+    # pylint: disable=no-member
     def test_is_pickleable(self):
         env = GarageEnv(DummyDiscreteEnv(obs_dim=(1, ), action_dim=1))
         policy = CategoricalLSTMPolicy(env_spec=env.spec,

--- a/tests/garage/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy.py
@@ -55,9 +55,10 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
-        output1 = self.sess.run([policy.distribution.probs],
-                                feed_dict={policy.input: [[obs.flatten()]]})
-        output2 = self.sess.run([dist_sym.probs],
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
+        output1 = self.sess.run([dist_sym.probs],
+                                feed_dict={state_input: [[obs.flatten()]]})
+        output2 = self.sess.run([dist_sym2.probs],
                                 feed_dict={state_input: [[obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
@@ -77,16 +78,23 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
             bias = tf.compat.v1.get_variable('mlp/hidden_0/bias')
         # assign it to all one
         bias.load(tf.ones_like(bias).eval())
-        output1 = self.sess.run([policy.distribution.probs],
-                                feed_dict={policy.input: [[obs.flatten()]]})
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym = policy.build(state_input, name='dist_sym').dist
+        output1 = self.sess.run([dist_sym.probs],
+                                feed_dict={state_input: [[obs.flatten()]]})
 
         p = pickle.dumps(policy)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            output2 = sess.run(
-                [policy_pickled.distribution.probs],
-                feed_dict={policy_pickled.input: [[obs.flatten()]]})
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          policy.input_dim))
+            dist_sym = policy_pickled.build(state_input, name='dist_sym').dist
+            output2 = sess.run([dist_sym.probs],
+                               feed_dict={state_input: [[obs.flatten()]]})
             assert np.array_equal(output1, output2)
 
     @pytest.mark.parametrize('obs_dim, action_dim', [

--- a/tests/garage/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy.py
@@ -55,9 +55,8 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
-        output1 = self.sess.run(
-            [policy.distribution.probs],
-            feed_dict={policy.model.input: [[obs.flatten()]]})
+        output1 = self.sess.run([policy.distribution.probs],
+                                feed_dict={policy.input: [[obs.flatten()]]})
         output2 = self.sess.run([dist_sym.probs],
                                 feed_dict={state_input: [[obs.flatten()]]})
         assert np.array_equal(output1, output2)
@@ -74,14 +73,12 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
         policy = CategoricalMLPPolicy(env_spec=env.spec)
         obs = env.reset()
 
-        with tf.compat.v1.variable_scope(
-                'CategoricalMLPPolicy/CategoricalMLPModel', reuse=True):
+        with tf.compat.v1.variable_scope('CategoricalMLPPolicy', reuse=True):
             bias = tf.compat.v1.get_variable('mlp/hidden_0/bias')
         # assign it to all one
         bias.load(tf.ones_like(bias).eval())
-        output1 = self.sess.run(
-            [policy.distribution.probs],
-            feed_dict={policy.model.input: [[obs.flatten()]]})
+        output1 = self.sess.run([policy.distribution.probs],
+                                feed_dict={policy.input: [[obs.flatten()]]})
 
         p = pickle.dumps(policy)
 
@@ -89,7 +86,7 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
             policy_pickled = pickle.loads(p)
             output2 = sess.run(
                 [policy_pickled.distribution.probs],
-                feed_dict={policy_pickled.model.input: [[obs.flatten()]]})
+                feed_dict={policy_pickled.input: [[obs.flatten()]]})
             assert np.array_equal(output1, output2)
 
     @pytest.mark.parametrize('obs_dim, action_dim', [

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -87,13 +87,14 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
 
         concat_obs = np.concatenate([obs.flatten(), np.zeros(action_dim)])
         output1 = self.sess.run(
-            [policy.distribution.loc],
-            feed_dict={policy.model.input: [[concat_obs], [concat_obs]]})
-        output2 = self.sess.run(
             [dist_sym.loc],
+            feed_dict={state_input: [[concat_obs], [concat_obs]]})
+        output2 = self.sess.run(
+            [dist_sym2.loc],
             feed_dict={state_input: [[concat_obs], [concat_obs]]})
         assert np.array_equal(output1, output2)
 
@@ -118,12 +119,13 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
 
         output1 = self.sess.run(
-            [policy.distribution.loc],
-            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
-        output2 = self.sess.run(
             [dist_sym.loc],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
+        output2 = self.sess.run(
+            [dist_sym2.loc],
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
@@ -133,31 +135,36 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
                                    state_include_action=False)
         env.reset()
         obs = env.reset()
-        with tf.compat.v1.variable_scope('GaussianGRUPolicy/GaussianGRUModel',
-                                         reuse=True):
+        with tf.compat.v1.variable_scope('GaussianGRUPolicy', reuse=True):
             param = tf.compat.v1.get_variable(
                 'dist_params/log_std_param/parameter')
         # assign it to all one
         param.load(tf.ones_like(param).eval())
 
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym = policy.build(state_input, name='dist_sym').dist
         output1 = self.sess.run(
-            [policy.distribution.loc,
-             policy.distribution.stddev()],
-            feed_dict={policy.model.input: [[obs.flatten()], [obs.flatten()]]})
+            [dist_sym.loc, dist_sym.stddev()],
+            feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
 
         p = pickle.dumps(policy)
 
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
             # yapf: disable
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          policy.input_dim))
+            dist_sym = policy_pickled.build(state_input, name='dist_sym').dist
             output2 = sess.run(
                 [
-                    policy_pickled.distribution.loc,
-                    policy_pickled.distribution.stddev()
+                    dist_sym.loc,
+                    dist_sym.stddev()
                 ],
                 feed_dict={
-                    policy_pickled.model.input: [[obs.flatten()],
-                                                 [obs.flatten()]]
+                    state_input: [[obs.flatten()], [obs.flatten()]]
                 })
             assert np.array_equal(output1, output2)
             # yapf: enable

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -75,6 +75,7 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         ((2, 2), (2, ), 4)
     ])
     # yapf: enable
+    # pylint: disable=no-member
     def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
         policy = GaussianGRUPolicy(env_spec=env.spec,
@@ -106,6 +107,7 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         ((2, 2), (2, ), 4)
     ])
     # yapf: enable
+    # pylint: disable=no-member
     def test_build_state_not_include_action(self, obs_dim, action_dim,
                                             hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
@@ -129,6 +131,7 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
+    # pylint: disable=no-member
     def test_is_pickleable(self):
         env = GarageEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
         policy = GaussianGRUPolicy(env_spec=env.spec,

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy.py
@@ -75,6 +75,7 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         ((2, 2), (2, ), 4)
     ])
     # yapf: enable
+    # pylint: disable=no-member
     def test_build_state_include_action(self, obs_dim, action_dim, hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
         policy = GaussianLSTMPolicy(env_spec=env.spec,
@@ -106,6 +107,7 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         ((2, 2), (2, ), 4)
     ])
     # yapf: enable
+    # pylint: disable=no-member
     def test_build_state_not_include_action(self, obs_dim, action_dim,
                                             hidden_dim):
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))
@@ -129,6 +131,7 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
+    # pylint: disable=no-member
     def test_is_pickleable(self):
         env = GarageEnv(DummyBoxEnv(obs_dim=(1, ), action_dim=(1, )))
         policy = GaussianLSTMPolicy(env_spec=env.spec,

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -58,10 +58,10 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
                                                shape=(None, None,
                                                       policy.input_dim))
         dist_sym = policy.build(state_input, name='dist_sym').dist
-        output1 = self.sess.run(
-            [policy.distribution.loc],
-            feed_dict={policy.model.input: [[obs.flatten()]]})
-        output2 = self.sess.run([dist_sym.loc],
+        dist_sym2 = policy.build(state_input, name='dist_sym2').dist
+        output1 = self.sess.run([dist_sym.loc],
+                                feed_dict={state_input: [[obs.flatten()]]})
+        output2 = self.sess.run([dist_sym2.loc],
                                 feed_dict={state_input: [[obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
@@ -79,26 +79,28 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
 
         obs = env.reset()
 
-        with tf.compat.v1.variable_scope('GaussianMLPPolicy/GaussianMLPModel',
-                                         reuse=True):
+        with tf.compat.v1.variable_scope('GaussianMLPPolicy', reuse=True):
             bias = tf.compat.v1.get_variable(
                 'dist_params/mean_network/hidden_0/bias')
         # assign it to all one
         bias.load(tf.ones_like(bias).eval())
-        output1 = self.sess.run(
-            [policy.distribution.loc,
-             policy.distribution.stddev()],
-            feed_dict={policy.model.input: [[obs.flatten()]]})
+
+        state_input = tf.compat.v1.placeholder(tf.float32,
+                                               shape=(None, None,
+                                                      policy.input_dim))
+        dist_sym = policy.build(state_input, name='dist_sym').dist
+        output1 = self.sess.run([dist_sym.loc, dist_sym.stddev()],
+                                feed_dict={state_input: [[obs.flatten()]]})
 
         p = pickle.dumps(policy)
         with tf.compat.v1.Session(graph=tf.Graph()) as sess:
             policy_pickled = pickle.loads(p)
-            output2 = sess.run(
-                [
-                    policy_pickled.distribution.loc,
-                    policy_pickled.distribution.stddev()
-                ],
-                feed_dict={policy_pickled.model.input: [[obs.flatten()]]})
+            state_input = tf.compat.v1.placeholder(tf.float32,
+                                                   shape=(None, None,
+                                                          policy.input_dim))
+            dist_sym = policy_pickled.build(state_input, name='dist_sym').dist
+            output2 = sess.run([dist_sym.loc, dist_sym.stddev()],
+                               feed_dict={state_input: [[obs.flatten()]]})
             assert np.array_equal(output1, output2)
 
     def test_clone(self):

--- a/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
@@ -91,17 +91,17 @@ class TestGaussianMLPTaskEmbeddingPolicy(TfGraphTestCase):
         obs_input = tf.compat.v1.placeholder(tf.float32, shape=(None, None, 2))
         task_input = tf.compat.v1.placeholder(tf.float32,
                                               shape=(None, None, 2))
-        policy.build(obs_input, task_input)
+        networks = policy.build(obs_input, task_input)
+        dist = networks[0].dist
+        encoder_dist = networks[1].dist
 
-        assert policy.distribution.loc.get_shape().as_list(
-        )[-1] == env.action_space.flat_dim
+        assert dist.loc.get_shape().as_list()[-1] == env.action_space.flat_dim
         assert policy.encoder == encoder
         assert policy.latent_space.flat_dim == latent_dim
         assert policy.task_space.flat_dim == task_num
         assert (policy.augmented_observation_space.flat_dim ==
                 env.observation_space.flat_dim + task_num)
-        assert policy.encoder_distribution.loc.get_shape().as_list(
-        )[-1] == latent_dim
+        assert encoder_dist.loc.get_shape().as_list()[-1] == latent_dim
 
     def test_split_augmented_observation(self):
         obs_dim, task_num = 3, 5

--- a/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_task_embedding_policy.py
@@ -77,6 +77,7 @@ class TestGaussianMLPTaskEmbeddingPolicy(TfGraphTestCase):
         assert latent_info['mean'].shape == (latent_dim, )
         assert latent_info['log_std'].shape == (latent_dim, )
 
+    # pylint: disable=no-member
     def test_auxiliary(self):
         obs_dim, action_dim, task_num, latent_dim = (2, ), (2, ), 2, 2
         env = GarageEnv(DummyBoxEnv(obs_dim=obs_dim, action_dim=action_dim))


### PR DESCRIPTION
This is a proposed change that would make it easier to implement a new policy.

Basically, tf.Model inherits from tf.Module and tf.Policy inherits from tf.Model. This PR
also removed usage of `vectorized`, which is no longer needed.