### PR TITLE
Fix a typo to allow evaluating algos deterministically

### DIFF
--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -61,7 +61,7 @@ def rollout(env,
     while path_length < (max_path_length or np.inf):
         o = env.observation_space.flatten(o)
         a, agent_info = agent.get_action(o)
-        if deterministic and 'mean' in agent_infos:
+        if deterministic and 'mean' in agent_info:
             a = agent_info['mean']
         next_o, r, d, env_info = env.step(a)
         observations.append(o)

--- a/tests/fixtures/policies/dummy_policy.py
+++ b/tests/fixtures/policies/dummy_policy.py
@@ -17,6 +17,7 @@ class DummyPolicy(Policy):
             self,
             env_spec,
     ):
+        # pylint: disable=super-init-not-called
         self._env_spec = env_spec
         self._param = []
         self._param_values = np.random.uniform(-1, 1, 1000)
@@ -32,7 +33,7 @@ class DummyPolicy(Policy):
             dict: Distribution parameters.
 
         """
-        return self.action_space.sample(), dict(dummy='dummy')
+        return self.action_space.sample(), dict(dummy='dummy', mean=0.)
 
     def get_actions(self, observations):
         """Get multiple actions from this policy for the input observations.

--- a/tests/fixtures/policies/dummy_policy.py
+++ b/tests/fixtures/policies/dummy_policy.py
@@ -13,10 +13,7 @@ class DummyPolicy(Policy):
 
     """
 
-    def __init__(
-            self,
-            env_spec,
-    ):
+    def __init__(self, env_spec):
         # pylint: disable=super-init-not-called
         self._env_spec = env_spec
         self._param = []

--- a/tests/garage/sampler/test_utils.py
+++ b/tests/garage/sampler/test_utils.py
@@ -32,6 +32,13 @@ class TestRollout:
         assert path['observations'][0].shape == (16, )
         assert path['actions'][0].shape == (2, 2)
 
+    def test_deterministic_action(self):
+        path = utils.rollout(self.env,
+                             self.policy,
+                             max_path_length=5,
+                             deterministic=True)
+        assert (path['actions'] == 0.).all()
+
 
 class TestTruncatePaths:
 


### PR DESCRIPTION
When running some experiments with SAC I have discovered that my algorithm does not act deterministically during the evaluation (i.e. the action is sampled from the policy distribution instead of taking the mean/mode of the distribution). The code for [obtaining evaluation samples](https://github.com/rlworkgroup/garage/blob/master/src/garage/np/_functions.py#L32) uses the `rollout` function from [sampler.utils](https://github.com/rlworkgroup/garage/blob/master/src/garage/sampler/utils.py#L10) with the argument `deterministic=True`.

The rollout function is then supposed to look into `agent_info` dictionary and use the `mean` value stored there. Unfortunately, currently in the code it looks into the `agent_infos` (with `s` at the end), which is a list containing `agent_info` dictionaries and as such obviously does not contain the `mean` key. This means that the stochastic, sampled action is used instead. My pull request solves this issue by fixing the typo.

Technical sidenote - maybe there should be an exception raised if `deterministic=True` and there is no `mean` key in the dict?