### PR TITLE
Only build Docker container for deps changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,15 @@ jobs:
       before_script: skip
       install: skip
       script:
+        # Skip building for PRs and pushes in which no deps change
+        # Nightlies and API builds still always build
+        - >
+          scripts/travisci/check_no_deps_changed.sh &&
+          (
+            [[ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]] ||
+            [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]
+          ) &&
+          travis_terminate 0 || true
         - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
         - make build-ci TAG="${tag}" BUILD_ARGS="--no-cache"
         - make ci-deploy-docker TAG="${tag}"
@@ -87,10 +96,14 @@ jobs:
           tags: true
 
 before_install:
-  # Skip the job for PRs with only documentation changes
+  # Skip the job for PRs and pushes with only documentation changes
+  # Nightlies and API builds always run the job
   - >
     scripts/travisci/check_docs_only.sh &&
-    [[ "${TRAVIS_PULL_REQUEST}" != "false" ]] &&
+    (
+      [[ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]] ||
+      [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]
+    ) &&
     [[ "${SKIP_FOR_DOCS_ONLY}" == "true" ]] &&
     travis_terminate 0 || true
   # Reconfigure docker to be more efficient

--- a/scripts/travisci/check_no_deps_changed.sh
+++ b/scripts/travisci/check_no_deps_changed.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+status=0
+
+function join_by { local d="${1}"; shift; echo -n "${1}"; shift; printf "%s" "${@/#/$d}"; }
+
+deps_files=(
+  '^setup.py$'
+  '^benchmarks/setup.py$'
+  '^Makefile$'
+  '^docker/'
+)
+deps_regex="$(join_by '\|' ${deps_files[@]})"
+
+echo "Checking commit range ${TRAVIS_COMMIT_RANGE}"
+SOURCE="${TRAVIS_COMMIT_RANGE%...*}"
+ORIGIN="${TRAVIS_COMMIT_RANGE#*...}"
+status="$((${status} | ${?}))"
+
+while read commit; do
+  echo "Checking for dependency changes in ${commit}"
+  deps_change="$(git show --name-only --oneline ${commit} \
+    | tail -n +2 \
+    | grep "${deps_regex}" \
+  )"
+  test -z "${deps_change}"
+  pass=$?
+  status="$((${status} | ${pass}))"
+
+  # Print message if it fails
+  if [[ "${pass}" -ne 0 ]]; then
+    echo -e "Found dependency changes in ${commit}"
+    echo -e "Matched with changes in files:\n${deps_change}"
+  fi
+
+done < <(git log --cherry-pick --left-only --pretty="%H" \
+                 "${ORIGIN}...${SOURCE}")
+
+exit "${status}"


### PR DESCRIPTION
Changes TravisCI to only build the Docker container for a PR or push if
it contains changes likely to invalidate the Docker container.

The container always builds on nightly builds or API builds.