### PR TITLE
Skip bullet envs in test_base

### DIFF
--- a/src/garage/envs/bullet/__init__.py
+++ b/src/garage/envs/bullet/__init__.py
@@ -11,3 +11,20 @@ except Exception as e:
 from garage.envs.bullet.bullet_env import BulletEnv
 
 __all__ = ['BulletEnv']
+
+
+def get_bullet_env_list():
+    """Return a complete list of Bullet Gym environments.
+
+    Returns:
+        list: a list of bullet environment names (str)
+    """
+    envs = [env.replace('- ', '') for env in pybullet_envs.getList()]
+    # Hardcoded missing environment names from pybullet_envs.getList()
+    envs.extend([
+        'MinitaurExtendedEnv-v0', 'MinitaurReactiveEnv-v0',
+        'MinitaurBallGymEnv-v0', 'MinitaurTrottingEnv-v0',
+        'MinitaurStandGymEnv-v0', 'MinitaurAlternatingLegsEnv-v0',
+        'MinitaurFourLegStandEnv-v0', 'KukaDiverseObjectGrasping-v0'
+    ])
+    return envs

--- a/tests/garage/tf/envs/test_base.py
+++ b/tests/garage/tf/envs/test_base.py
@@ -1,6 +1,7 @@
 import pickle
 
 import gym
+import pybullet_envs
 import pytest
 
 from garage.envs import GarageEnv
@@ -17,18 +18,30 @@ class TestGarageEnv:
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs(self, spec):
+        bullet_envs = [
+            env.replace('- ', '') for env in pybullet_envs.getList()
+        ]
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
+        elif spec._env_name in bullet_envs:
+            pytest.skip('Bullet environments will be loaded differently via '
+                        'BulletEnv()')
         env = GarageEnv(spec.make())
         step_env_with_gym_quirks(env, spec)
 
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs_pickleable(self, spec):
+        bullet_envs = [
+            env.replace('- ', '') for env in pybullet_envs.getList()
+        ]
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
+        elif spec._env_name in bullet_envs:
+            pytest.skip('Bullet environments will be loaded differently via '
+                        'BulletEnv()')
         env = GarageEnv(env_name=spec.id)
         step_env_with_gym_quirks(env,
                                  spec,

--- a/tests/garage/tf/envs/test_base.py
+++ b/tests/garage/tf/envs/test_base.py
@@ -1,10 +1,10 @@
 import pickle
 
 import gym
-import pybullet_envs
 import pytest
 
 from garage.envs import GarageEnv
+from garage.envs.bullet import get_bullet_env_list
 from tests.helpers import step_env_with_gym_quirks
 
 
@@ -18,30 +18,24 @@ class TestGarageEnv:
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs(self, spec):
-        bullet_envs = [
-            env.replace('- ', '') for env in pybullet_envs.getList()
-        ]
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        elif spec._env_name in bullet_envs:
-            pytest.skip('Bullet environments will be loaded differently via '
-                        'BulletEnv()')
+        if any(name[:name.find('-v')] == spec._env_name
+               for name in get_bullet_env_list()):
+            pytest.skip('Bullet environments not supported with GarageEnv yet')
         env = GarageEnv(spec.make())
         step_env_with_gym_quirks(env, spec)
 
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs_pickleable(self, spec):
-        bullet_envs = [
-            env.replace('- ', '') for env in pybullet_envs.getList()
-        ]
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        elif spec._env_name in bullet_envs:
-            pytest.skip('Bullet environments will be loaded differently via '
-                        'BulletEnv()')
+        if any(name[:name.find('-v')] == spec._env_name
+               for name in get_bullet_env_list()):
+            pytest.skip('Bullet environments not supported with GarageEnv yet')
         env = GarageEnv(env_name=spec.id)
         step_env_with_gym_quirks(env,
                                  spec,


### PR DESCRIPTION
Fix broken CI by skipping bullet environment checks in `test_base.py`.

Now `GarageEnv` can't handle bullet environment pickle logic, so skip bullet environment related tests. Bullet environments are already tested in [`test_bullet_env.py`](https://github.com/rlworkgroup/garage/blob/master/tests/garage/envs/bullet/test_bullet_env.py).

This is only a temporary fix. Future PRs will make GarageEnv silently wrap bullet environments with BulletEnv, and make GarageEnv works for all gym.make() instances.

Note: `garage.env.bullet` is imported to _explicitly_ add bullet environments to gym registry. Without this import, bullet environments won't be added to gym registry unless [`test_bullet_env.py`](https://github.com/rlworkgroup/garage/blob/master/tests/garage/envs/bullet/test_bullet_env.py#L5) is tested at the same time. This ensures consistent test input of `test_base.py`.

