### PR TITLE
Don't push to latest tag on DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,8 @@ before_install:
 
 install:
   # Pull cached docker image
-  - docker pull rlworkgroup/garage-ci:latest
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
+  - docker pull ${tag}
   - make build-ci TAG="${tag}"
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -113,13 +113,12 @@ ci-job-verify-envs-pipenv:
 ci-deploy-docker: assert-travis
 	echo "${DOCKER_API_KEY}" | docker login -u "${DOCKER_USERNAME}" \
 		--password-stdin
-	docker tag "${TAG}" rlworkgroup/garage-ci:latest
 	docker push rlworkgroup/garage-ci
 
 build-ci: TAG ?= rlworkgroup/garage-ci:latest
 build-ci: docker/Dockerfile
 	docker build \
-		--cache-from rlworkgroup/garage-ci:latest \
+		--cache-from ${TAG} \
 		-f docker/Dockerfile \
 		--target garage-dev-18.04 \
 		-t ${TAG} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN wget https://github.com/glfw/glfw/releases/download/3.3/glfw-3.3.zip && \
   make -j"$(nproc)" && \
   make install && \
   cd ../../ && \
-  rm -rf glfw
+  rm -rf glfw-3.3
 
 ARG user=garage-user
 ARG uid=999
@@ -99,15 +99,13 @@ RUN python3.5 -m venv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 
 # Prevent pip from complaining about available upgrades inside virtualenv
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --upgrade pip setuptools wheel && \
+  rm -r $HOME/.cache/pip
 
 # We need a MuJoCo key to install mujoco_py
 # In this step only the presence of the file mjkey.txt is required, so we only
 # create an empty file
 RUN touch $HOME/.mujoco/mjkey.txt
-RUN pip install garage && \
-    pip install garage[all] && \
-    rm -r $HOME/.cache/pip
 
 COPY --chown=$user:$user docker/entrypoint-runtime.sh $HOME/code/garage/docker/entrypoint-runtime.sh
 ENTRYPOINT ["code/garage/docker/entrypoint-runtime.sh"]
@@ -164,15 +162,14 @@ COPY --chown=$user:$user .pre-commit-config.yaml $HOME/code/garage
 RUN git init && \
   pip install pre-commit && \
   pre-commit install && \
-  pre-commit install-hooks
+  pre-commit install-hooks && \
+  rm -r $HOME/.cache/pip
 
 # Install deps (but not the code)
-# Note that we don't delete the pip cache for dev builds
-RUN rm -rf $VIRTUAL_ENV && \
-  python3.5 -m venv $VIRTUAL_ENV && \
-  pip install --upgrade pip setuptools wheel && \
+RUN pip install --upgrade pip setuptools wheel && \
   pip install .[all,dev] && \
-  rm $HOME/.mujoco/mjkey.txt
+  rm $HOME/.mujoco/mjkey.txt && \
+  rm -r $HOME/.cache/pip
 
 # Add code stub last (ensures code changes have the shortest builds)
 COPY --chown=$user:$user . $HOME/code/garage


### PR DESCRIPTION
This commit prevents this release branch from using
garage-ci:latest on DockerHub, since that tag is used
by PRs on master branch, and images from release branches
can negatively affect docker cache.

Also, backports #1576