### PR TITLE
Don't push to latest tag on DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,10 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-  # Pull cached docker image
-  - docker pull rlworkgroup/garage-ci:latest
 
 install:
   - tag="rlworkgroup/garage-ci:${TRAVIS_BUILD_NUMBER}"
+  - docker pull "${tag}" || true
   - TAG="${tag}" make build-ci
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ ci-verify-pipenv:
 ci-deploy-docker:
 	echo "${DOCKER_API_KEY}" | docker login -u "${DOCKER_USERNAME}" \
 		--password-stdin
-	docker tag "${TAG}" rlworkgroup/garage-ci:latest
 	docker push rlworkgroup/garage-ci
 
 build-ci: TAG ?= rlworkgroup/garage-ci:latest

--- a/docker/Dockerfile.base.18.04
+++ b/docker/Dockerfile.base.18.04
@@ -64,7 +64,7 @@ RUN wget https://github.com/glfw/glfw/releases/download/3.3/glfw-3.3.zip && \
   make -j"$(nproc)" && \
   make install && \
   cd ../../ && \
-  rm -rf glfw
+  rm -rf glfw-3.3
 
 # MuJoCo 2.0 (for dm_control)
 RUN mkdir -p /root/.mujoco && \

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -3,14 +3,14 @@ services:
   garage-base:
     build:
       cache_from:
-        - rlworkgroup/garage-ci:latest
+        - ${TAG}
       context: ../
       dockerfile: docker/Dockerfile.base.18.04
     image: rlworkgroup/garage-base
   garage-ci-no-files:
     build:
       cache_from:
-        - rlworkgroup/garage-ci:latest
+        - ${TAG}
       context: ../
       dockerfile: docker/Dockerfile.headless
       args:
@@ -19,7 +19,7 @@ services:
   garage-ci:
     build:
       cache_from:
-        - rlworkgroup/garage-ci:latest
+        - ${TAG}
       context: ../
       dockerfile: docker/Dockerfile.runtime
       args:


### PR DESCRIPTION
This commit prevents this release branch from using
garage-ci:latest on DockerHub, since that tag is used
by PRs on master branch, and images from release branches
can negatively affect docker cache.

Effectively duplicates #1635