### PR TITLE
Remove "Subpackages" heading from API Reference

### DIFF
--- a/docs/autoapi_templates/python/module.rst
+++ b/docs/autoapi_templates/python/module.rst
@@ -70,8 +70,8 @@ Functions
 {% block subpackages %}
 {% set visible_subpackages = obj.subpackages|selectattr("display")|list %}
 {% if visible_subpackages %}
-Subpackages
------------
+{# Subpackages
+----------- #}
 .. toctree::
    :titlesonly:
    :maxdepth: 1


### PR DESCRIPTION
This just makes it harder to browse, especially for tf/torch.