### PR TITLE
GarageEnv wraps BulletEnv

### DIFF
--- a/src/garage/envs/bullet/__init__.py
+++ b/src/garage/envs/bullet/__init__.py
@@ -11,3 +11,36 @@ except Exception as e:
 from garage.envs.bullet.bullet_env import BulletEnv
 
 __all__ = ['BulletEnv']
+
+
+def _get_bullet_env_list():
+    """Return a complete list of Bullet Gym environments.
+
+    Returns:
+        list: a list of bullet environment id (str)
+    """
+    envs = [env.replace('- ', '') for env in pybullet_envs.getList()]
+    # Hardcoded missing environment names from pybullet_envs.getList()
+    envs.extend([
+        'MinitaurExtendedEnv-v0', 'MinitaurReactiveEnv-v0',
+        'MinitaurBallGymEnv-v0', 'MinitaurTrottingEnv-v0',
+        'MinitaurStandGymEnv-v0', 'MinitaurAlternatingLegsEnv-v0',
+        'MinitaurFourLegStandEnv-v0', 'KukaDiverseObjectGrasping-v0'
+    ])
+    return envs
+
+
+def _get_unsupported_env_list():
+    """Return a list of unsupported Bullet Gym environments.
+
+    See https://github.com/rlworkgroup/garage/issues/1668
+
+    Returns:
+        list: a list of bullet environment id (str)
+    """
+    return [
+        'MinitaurExtendedEnv-v0', 'MinitaurReactiveEnv-v0',
+        'MinitaurBallGymEnv-v0', 'MinitaurTrottingEnv-v0',
+        'MinitaurStandGymEnv-v0', 'MinitaurAlternatingLegsEnv-v0',
+        'MinitaurFourLegStandEnv-v0', 'KukaDiverseObjectGrasping-v0'
+    ]

--- a/src/garage/envs/bullet/bullet_env.py
+++ b/src/garage/envs/bullet/bullet_env.py
@@ -1,15 +1,125 @@
 """Wrappers for py_bullet environments."""
 import inspect
 
+import akro
+import gym
 from pybullet_envs.bullet.minitaur_duck_gym_env import MinitaurBulletDuckEnv
 from pybullet_envs.bullet.minitaur_gym_env import MinitaurBulletEnv
 from pybullet_envs.env_bases import MJCFBaseBulletEnv
 
-from garage.envs import GarageEnv
+from garage.envs.env_spec import EnvSpec
 
 
-class BulletEnv(GarageEnv):
+class BulletEnv(gym.Wrapper):
     """Binding for py_bullet environments."""
+
+    def __init__(self, env=None, env_name='', is_image=False):
+        """Returns a Garage wrapper class for bullet-based gym.Env.
+
+        Args:
+            env (gym.wrappers.time_limit): A gym.wrappers.time_limit.TimeLimit
+                object wrapping a gym.Env created via gym.make().
+            env_name (str): If the env_name is speficied, a gym environment
+                with that name will be created. If such an environment does not
+                exist, a `gym.error` is thrown.
+            is_image (bool): True if observations contain pixel values,
+                false otherwise. Setting this to true converts a gym.Spaces.Box
+                obs space to an akro.Image and normalizes pixel values.
+
+        """
+        if not env:
+            # 'RacecarZedBulletEnv-v0' environment enables rendering by
+            # default, while pybullet allows only one GUI connection at a time.
+            # Setting renders to False avoids potential error when multiple
+            # of these envs are tested at the same time.
+            if env_name == 'RacecarZedBulletEnv-v0':
+                env = gym.make(env_name, renders=False)
+            else:
+                env = gym.make(env_name)
+
+        # Needed for deserialization
+        self._env = env
+        self._env_name = env_name
+
+        super().__init__(env)
+        self.action_space = akro.from_gym(self.env.action_space)
+        self.observation_space = akro.from_gym(self.env.observation_space,
+                                               is_image=is_image)
+        self._spec = EnvSpec(action_space=self.action_space,
+                             observation_space=self.observation_space)
+
+    @property
+    def spec(self):
+        """Return the environment specification.
+
+        This property needs to exist, since it's defined as a property in
+        gym.Wrapper in a way that makes it difficult to overwrite.
+
+        Returns:
+            garage.envs.env_spec.EnvSpec: The envionrment specification.
+
+        """
+        return self._spec
+
+    def close(self):
+        """Close the wrapped env."""
+        #  RacecarZedBulletEnv-v0 environment doesn't disconnect from bullet
+        #  server in its close() method.
+        #  Note that disconnect() disconnects the environment from the physics
+        #  server, whereas the GUI window will not be destroyed.
+        #  The expected behavior
+        if self.env.env.spec.id == 'RacecarZedBulletEnv-v0':
+            # pylint: disable=protected-access
+            if self.env.env._p.isConnected():
+                self.env.env._p.disconnect()
+        self.env.close()
+
+    def reset(self, **kwargs):
+        """Call reset on wrapped env.
+
+        This method is necessary to suppress a deprecated warning
+        thrown by gym.Wrapper.
+
+        Args:
+            kwargs: Keyword args
+
+        Returns:
+            object: The initial observation.
+
+        """
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        """Call step on wrapped env.
+
+        This method is necessary to suppress a deprecated warning
+        thrown by gym.Wrapper.
+
+        Args:
+            action (np.ndarray): An action provided by the agent.
+
+        Returns:
+            np.ndarray: Agent's observation of the current environment
+            float: Amount of reward returned after previous action
+            bool: Whether the episode has ended, in which case further step()
+                calls will return undefined results
+            dict: Contains auxiliary diagnostic information (helpful for
+                debugging, and sometimes learning)
+
+        """
+        observation, reward, done, info = self.env.step(action)
+        # gym envs that are wrapped in TimeLimit wrapper modify
+        # the done/termination signal to be true whenever a time
+        # limit expiration occurs. The following statement sets
+        # the done signal to be True only if caused by an
+        # environment termination, and not a time limit
+        # termination. The time limit termination signal
+        # will be saved inside env_infos as
+        # 'GarageEnv.TimeLimitTerminated'
+        if 'TimeLimit.truncated' in info:
+            info['GarageEnv.TimeLimitTerminated'] = done  # done = True always
+            done = not info['TimeLimit.truncated']
+        return observation, reward, done, info
 
     def __getstate__(self):
         """See `Object.__getstate__.
@@ -37,10 +147,20 @@ class BulletEnv(GarageEnv):
                 args['robot'] = env.robot
                 param_names.remove('robot')
 
-        # Create param name -> param value mapping
+        # Create param name -> param value mapping for the wrapped environment
         args = {key: env.__dict__['_' + key] for key in param_names}
-        args['class_type'] = type(env)
-        args['_env_name'] = self._env_name
+
+        # Only one local in-process GUI connection is allowed. Thus pickled
+        # BulletEnv shouldn't enable rendering. New BulletEnv will connect in
+        # DIRECT mode.
+        for key in args.keys():
+            if 'render' in key:
+                args[key] = False
+
+        # Add BulletEnv class specific params
+        # env id is saved to help gym.make() in __setstate__
+        args['id'] = env.spec.id
+        args['env_name'] = self._env_name
 
         return args
 
@@ -53,11 +173,11 @@ class BulletEnv(GarageEnv):
             state (dict): The instance’s __init__() arguments.
 
         """
-        class_type = state['class_type']
-        env_name = state['_env_name']
-        # Create a new class instance via constructor arguments
-        del state['class_type']
-        del state['_env_name']
-        env = class_type(**state)
+        env_id = state['id']
+        env_name = state['env_name']
+        # Create a environment via constructor arguments
+        del state['id']
+        del state['env_name']
+        env = gym.make(env_id, **state)
 
         self.__init__(env, env_name)

--- a/src/garage/envs/bullet/bullet_env.py
+++ b/src/garage/envs/bullet/bullet_env.py
@@ -115,9 +115,9 @@ class BulletEnv(gym.Wrapper):
         # environment termination, and not a time limit
         # termination. The time limit termination signal
         # will be saved inside env_infos as
-        # 'GarageEnv.TimeLimitTerminated'
+        # 'BulletEnv.TimeLimitTerminated'
         if 'TimeLimit.truncated' in info:
-            info['GarageEnv.TimeLimitTerminated'] = done  # done = True always
+            info['BulletEnv.TimeLimitTerminated'] = done  # done = True always
             done = not info['TimeLimit.truncated']
         return observation, reward, done, info
 

--- a/src/garage/envs/garage_env.py
+++ b/src/garage/envs/garage_env.py
@@ -5,6 +5,7 @@ import copy
 import akro
 import gym
 
+from garage.envs.bullet import _get_bullet_env_list, BulletEnv
 from garage.envs.env_spec import EnvSpec
 
 # The gym environments using one of the packages in the following lists as
@@ -35,18 +36,59 @@ class GarageEnv(gym.Wrapper):
     convert action_space and observation_space from gym.Spaces to
     akro.spaces.
 
-    Args:
-        env (gym.Env): An env that will be wrapped
-        env_name (str): If the env_name is speficied, a gym environment
-            with that name will be created. If such an environment does not
-            exist, a `gym.error` is thrown.
-        is_image (bool): True if observations contain pixel values,
-            false otherwise. Setting this to true converts a gym.Spaces.Box
-            obs space to an akro.Image and normalizes pixel values.
-
+    GarageEnv handles all environments created by gym.make().
+    It returns a different wrapper class instance if the input environment
+    requires special handling.
+    Current supported wrapper classes are:
+        garage.envs.bullet.BulletEnv for Bullet-based gym environments.
+    See __new__() for details.
     """
 
+    def __new__(cls, *args, **kwargs):
+        """Returns environment specific wrapper based on input environment type.
+
+        Args:
+            args: positional arguments
+            kwargs: keyword arguments
+
+        Returns:
+             garage.envs.bullet.BulletEnv: if the environment is a bullet-based
+                environment. Else returns a garage.envs.GarageEnv
+        """
+        # Determine if the input env is a bullet-based gym environment
+        env = None
+        if 'env' in kwargs:  # env passed as a keyword arg
+            env = kwargs['env']
+        elif len(args) > 1 and args[0]:  # env passed as a positional arg
+            env = args[0]
+        if env and any(env.env.spec.id == name
+                       for name in _get_bullet_env_list()):
+            return BulletEnv(env)
+
+        env_name = ''
+        if 'env_name' in kwargs:  # env_name as a keyword arg
+            env_name = kwargs['env_name']
+        elif len(args) > 2 and args[1] != '':  # env_name as a positional arg
+            env_name = args[1]
+        if env_name != '' and any(env_name == name
+                                  for name in _get_bullet_env_list()):
+            return BulletEnv(gym.make(env_name))
+
+        return super(GarageEnv, cls).__new__(cls)
+
     def __init__(self, env=None, env_name='', is_image=False):
+        """Initializes a GarageEnv.
+
+        Args:
+            env (gym.wrappers.time_limit): A gym.wrappers.time_limit.TimeLimit
+                object wrapping a gym.Env created via gym.make().
+            env_name (str): If the env_name is speficied, a gym environment
+                with that name will be created. If such an environment does not
+                exist, a `gym.error` is thrown.
+            is_image (bool): True if observations contain pixel values,
+                false otherwise. Setting this to true converts a gym.Spaces.Box
+                obs space to an akro.Image and normalizes pixel values.
+        """
         # Needed for deserialization
         self._env_name = env_name
         self._env = env
@@ -59,8 +101,8 @@ class GarageEnv(gym.Wrapper):
         self.action_space = akro.from_gym(self.env.action_space)
         self.observation_space = akro.from_gym(self.env.observation_space,
                                                is_image=is_image)
-        self.__spec = EnvSpec(action_space=self.action_space,
-                              observation_space=self.observation_space)
+        self._spec = EnvSpec(action_space=self.action_space,
+                             observation_space=self.observation_space)
 
     @property
     def spec(self):
@@ -73,7 +115,7 @@ class GarageEnv(gym.Wrapper):
             garage.envs.env_spec.EnvSpec: The envionrment specification.
 
         """
-        return self.__spec
+        return self._spec
 
     def close(self):
         """Close the wrapped env."""
@@ -140,12 +182,12 @@ class GarageEnv(gym.Wrapper):
         thrown by gym.Wrapper.
 
         Args:
-            action (object): An action provided by the agent.
+            action (np.ndarray): An action provided by the agent.
 
         Returns:
-            object: Agent's observation of the current environment
-            float : Amount of reward returned after previous action
-            bool : Whether the episode has ended, in which case further step()
+            np.ndarray: Agent's observation of the current environment
+            float: Amount of reward returned after previous action
+            bool: Whether the episode has ended, in which case further step()
                 calls will return undefined results
             dict: Contains auxiliary diagnostic information (helpful for
                 debugging, and sometimes learning)

--- a/src/garage/envs/garage_env.py
+++ b/src/garage/envs/garage_env.py
@@ -4,6 +4,7 @@ import copy
 
 import akro
 import gym
+from gym.wrappers.time_limit import TimeLimit
 
 from garage.envs.bullet import _get_bullet_env_list, BulletEnv
 from garage.envs.env_spec import EnvSpec
@@ -59,7 +60,9 @@ class GarageEnv(gym.Wrapper):
         env = None
         if 'env' in kwargs:  # env passed as a keyword arg
             env = kwargs['env']
-        elif len(args) > 1 and args[0]:  # env passed as a positional arg
+        elif len(args) >= 1 and isinstance(args[0], TimeLimit):
+            # env passed as a positional arg
+            # only checks env created by gym.make(), which has type TimeLimit
             env = args[0]
         if env and any(env.env.spec.id == name
                        for name in _get_bullet_env_list()):
@@ -68,7 +71,8 @@ class GarageEnv(gym.Wrapper):
         env_name = ''
         if 'env_name' in kwargs:  # env_name as a keyword arg
             env_name = kwargs['env_name']
-        elif len(args) > 2 and args[1] != '':  # env_name as a positional arg
+        elif len(args) >= 2:
+            # env_name as a positional arg
             env_name = args[1]
         if env_name != '' and any(env_name == name
                                   for name in _get_bullet_env_list()):

--- a/tests/garage/envs/bullet/test_bullet_env.py
+++ b/tests/garage/envs/bullet/test_bullet_env.py
@@ -82,3 +82,19 @@ def test_pickle_creates_new_server(env_ids):
 
         for env in envs:
             env.close()
+
+
+def test_time_limit_env():
+    """Test BulletEnv emits done signal when time limit expiration occurs.
+
+    MinitaurBulletEnv-v0 has max_episode_steps=1000, thus
+    info['BulletEnv.TimeLimitTerminated'] is expected to be True after 1000
+    steps.
+
+    """
+    env = BulletEnv(env_name='MinitaurBulletEnv-v0')
+    env.reset()
+    for _ in range(1000):
+        _, _, done, info = env.step(env.spec.action_space.sample())
+    assert not done and info['TimeLimit.truncated']
+    assert info['BulletEnv.TimeLimitTerminated']

--- a/tests/garage/envs/bullet/test_bullet_env.py
+++ b/tests/garage/envs/bullet/test_bullet_env.py
@@ -1,7 +1,6 @@
 """Test module for BulletEnv"""
 import pickle
 
-import gym
 import pybullet_envs
 from pybullet_utils.bullet_client import BulletClient
 import pytest
@@ -22,10 +21,7 @@ def test_can_step(env_ids):
             # unconditionally, which globally resets other simulations. So
             # only one Kuka environment is tested.
             continue
-        if env_id == 'RacecarZedBulletEnv-v0':
-            env = BulletEnv(gym.make(env_id, renders=False))
-        else:
-            env = BulletEnv(gym.make(env_id))
+        env = BulletEnv(env_name=env_id)
         ob_space = env.observation_space
         act_space = env.action_space
         env.reset()
@@ -41,33 +37,28 @@ def test_can_step(env_ids):
 
 @pytest.mark.parametrize('env_ids', [pybullet_envs.getList()])
 def test_pickleable(env_ids):
-    """Test Bullet environments are pickleable"""
+    """Test Bullet environments are pickle-able"""
     for env_id in env_ids:
         # extract id string
         env_id = env_id.replace('- ', '')
-        if env_id == 'RacecarZedBulletEnv-v0':
-            env = BulletEnv(gym.make(env_id, renders=False))
-        else:
-            env = BulletEnv(gym.make(env_id))
+        env = BulletEnv(env_name=env_id)
         round_trip = pickle.loads(pickle.dumps(env))
         assert round_trip
+        env.close()
 
 
 @pytest.mark.parametrize('env_ids', [pybullet_envs.getList()])
 def test_pickle_creates_new_server(env_ids):
-    """Test pickleing a Bullet environment creates a new connection.
+    """Test pickling a Bullet environment creates a new connection.
 
-    If all pickleing create new connections, no repetition of client id
+    If all pickling create new connections, no repetition of client id
     should be found.
     """
     n_env = 4
     for env_id in env_ids:
         # extract id string
         env_id = env_id.replace('- ', '')
-        if env_id == 'RacecarZedBulletEnv-v0':
-            bullet_env = BulletEnv(gym.make(env_id, renders=False))
-        else:
-            bullet_env = BulletEnv(gym.make(env_id))
+        bullet_env = BulletEnv(env_name=env_id)
         envs = [pickle.loads(pickle.dumps(bullet_env)) for _ in range(n_env)]
         id_set = set()
 
@@ -88,3 +79,6 @@ def test_pickle_creates_new_server(env_ids):
                 # Some environments have _p as the pybullet module, and they
                 # don't store client id, so can't check here
                 pass
+
+        for env in envs:
+            env.close()

--- a/tests/garage/envs/test_garage_env.py
+++ b/tests/garage/envs/test_garage_env.py
@@ -1,6 +1,8 @@
+import gym
 import pytest
 
 from garage.envs import EnvSpec, GarageEnv
+from garage.envs.bullet import BulletEnv
 
 
 class TestGarageEnv:
@@ -32,3 +34,13 @@ class TestGarageEnv:
                 garage_env.spec.action_space.sample())
         assert not done and info['TimeLimit.truncated']
         assert info['GarageEnv.TimeLimitTerminated']
+
+    def test_return_bullet_env(self):
+        env = GarageEnv(env=gym.make('CartPoleBulletEnv-v1'))
+        assert isinstance(env, BulletEnv)
+        env = GarageEnv(env_name='CartPoleBulletEnv-v1')
+        assert isinstance(env, BulletEnv)
+        env = GarageEnv(gym.make('CartPoleBulletEnv-v1'))
+        assert isinstance(env, BulletEnv)
+        env = GarageEnv(None, 'CartPoleBulletEnv-v1')
+        assert isinstance(env, BulletEnv)

--- a/tests/garage/tf/envs/test_base.py
+++ b/tests/garage/tf/envs/test_base.py
@@ -4,6 +4,7 @@ import gym
 import pytest
 
 from garage.envs import GarageEnv
+from garage.envs.bullet import _get_unsupported_env_list
 from tests.helpers import step_env_with_gym_quirks
 
 
@@ -20,6 +21,8 @@ class TestGarageEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
+        if any(name == spec.id for name in _get_unsupported_env_list()):
+            pytest.skip('Skip unsupported Bullet environments')
         env = GarageEnv(spec.make())
         step_env_with_gym_quirks(env, spec)
 
@@ -29,6 +32,8 @@ class TestGarageEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
+        if any(name == spec.id for name in _get_unsupported_env_list()):
+            pytest.skip('Skip unsupported Bullet environments')
         env = GarageEnv(env_name=spec.id)
         step_env_with_gym_quirks(env,
                                  spec,


### PR DESCRIPTION
1. Make `GarageEnv` capable of handling all environments created by `gym.make()`.
Now `GarageEnv.__new__()` checks the input environment type and returns a `BulletEnv` if the environment is bullet-based.
User can use `GarageEnv` to work with bullet-based environments, instead of importing `BulletEnv` -> Increases user-interface simplicity.

2. Change `BulletEnv` pickle appraoch
A new environment should be created via `gym.make()` rather than its class constructor; otherwise the environment won't be wrapped with `TimeLimit`.