### PR TITLE
Specify cloudpickle version for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ REQUIRED = [
     # Please keep alphabetized
     'akro',
     'click>=2.0',
-    'cloudpickle',
+    'cloudpickle<1.5',
     'cma==2.7.0',
     'dowel==0.0.3',
     'gym[atari,box2d,classic_control]' + GYM_VERSION,


### PR DESCRIPTION
Latest release of `cloudpickle` moves `CloudPickler`  from `cloudpickle.cloudpickle` to `cloudpickle.cloudpickle_fast`, which is incompatible with current versions of `tensorflow_probability`, which calls `from cloudpickle.cloudpickle import CloudPickler`.

Restrict `cloudpickle` version to ensure package compatibility.