### PR TITLE
Support all registered bullet gym envs

### DIFF
--- a/src/garage/envs/bullet/__init__.py
+++ b/src/garage/envs/bullet/__init__.py
@@ -11,19 +11,3 @@ except Exception as e:
 from garage.envs.bullet.bullet_env import BulletEnv
 
 __all__ = ['BulletEnv']
-
-
-def _get_unsupported_env_list():
-    """Return a list of unsupported Bullet Gym environments.
-
-    See https://github.com/rlworkgroup/garage/issues/1668
-
-    Returns:
-        list: a list of bullet environment id (str)
-    """
-    return [
-        'MinitaurExtendedEnv-v0', 'MinitaurReactiveEnv-v0',
-        'MinitaurBallGymEnv-v0', 'MinitaurTrottingEnv-v0',
-        'MinitaurStandGymEnv-v0', 'MinitaurAlternatingLegsEnv-v0',
-        'MinitaurFourLegStandEnv-v0', 'KukaDiverseObjectGrasping-v0'
-    ]

--- a/src/garage/envs/bullet/bullet_env.py
+++ b/src/garage/envs/bullet/bullet_env.py
@@ -106,7 +106,10 @@ class BulletEnv(GymEnv):
                 param_names.remove('robot')
 
         # Create param name -> param value mapping for the wrapped environment
-        args = {key: env.__dict__['_' + key] for key in param_names}
+        args = {
+            key: env.__dict__['_' + key]
+            for key in param_names if '_' + key in env.__dict__
+        }
 
         # Only one local in-process GUI connection is allowed. Thus pickled
         # BulletEnv shouldn't enable rendering. New BulletEnv will connect in
@@ -119,6 +122,11 @@ class BulletEnv(GymEnv):
         # env id is saved to help gym.make() in __setstate__
         args['id'] = env.spec.id
         args['max_episode_length'] = self._max_episode_length
+
+        if 'args' in args:
+            del args['args']
+        if 'kwargs' in args:
+            del args['kwargs']
 
         return args
 

--- a/src/garage/envs/bullet/bullet_env.py
+++ b/src/garage/envs/bullet/bullet_env.py
@@ -123,8 +123,6 @@ class BulletEnv(GymEnv):
         args['id'] = env.spec.id
         args['max_episode_length'] = self._max_episode_length
 
-        if 'args' in args:
-            del args['args']
         if 'kwargs' in args:
             del args['kwargs']
 

--- a/src/garage/envs/gym_env.py
+++ b/src/garage/envs/gym_env.py
@@ -131,6 +131,7 @@ class GymEnv(Environment):
             RuntimeError: if the environment is wrapped by a TimeLimit and its
                 max_episode_steps is not equal to its spec's time limit value.
         """
+        self._env = None
         if isinstance(env, str):
             self._env = gym.make(env)
         elif isinstance(env, gym.Env):

--- a/tests/garage/envs/bullet/test_bullet_env.py
+++ b/tests/garage/envs/bullet/test_bullet_env.py
@@ -5,7 +5,7 @@ import pybullet_envs
 from pybullet_utils.bullet_client import BulletClient
 import pytest
 
-from garage.envs.bullet import _get_unsupported_env_list, BulletEnv
+from garage.envs.bullet import BulletEnv
 
 from tests.helpers import step_env
 
@@ -17,13 +17,11 @@ def test_can_step(env_ids):
     for env_id in env_ids:
         # extract id string
         env_id = env_id.replace('- ', '')
-        if env_id == 'KukaCamBulletEnv-v0':
-            # Kuka environments calls py_bullet.resetSimulation() in reset()
+        if env_id in ('KukaCamBulletEnv-v0', 'KukaDiverseObjectGrasping-v0'):
+            # Kuka environments calls pybullet.resetSimulation() in reset()
             # unconditionally, which globally resets other simulations. So
             # only one Kuka environment is tested.
             continue
-        if env_id in _get_unsupported_env_list():
-            pytest.skip('Skip unsupported Bullet environments')
         env = BulletEnv(env_id)
         ob_space = env.observation_space
         act_space = env.action_space
@@ -44,8 +42,6 @@ def test_pickleable(env_ids):
     for env_id in env_ids:
         # extract id string
         env_id = env_id.replace('- ', '')
-        if env_id in _get_unsupported_env_list():
-            pytest.skip('Skip unsupported Bullet environments')
         env = BulletEnv(env_id)
         round_trip = pickle.loads(pickle.dumps(env))
         assert round_trip
@@ -63,8 +59,6 @@ def test_pickle_creates_new_server(env_ids):
     for env_id in env_ids:
         # extract id string
         env_id = env_id.replace('- ', '')
-        if env_id in _get_unsupported_env_list():
-            pytest.skip('Skip unsupported Bullet environments')
         bullet_env = BulletEnv(env_id)
         envs = [pickle.loads(pickle.dumps(bullet_env)) for _ in range(n_env)]
         id_set = set()

--- a/tests/garage/tf/envs/test_gym_base.py
+++ b/tests/garage/tf/envs/test_gym_base.py
@@ -10,24 +10,22 @@ from tests.helpers import step_env_with_gym_quirks
 
 class TestGymEnv:
 
-    def test_is_pickleable(self):
-        env = GymEnv('CartPole-v1')
-        round_trip = pickle.loads(pickle.dumps(env))
-        assert round_trip
-
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
     def test_all_gym_envs(self, spec):
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
+        if spec._env_name.startswith('CarRacing'):
+            pytest.skip(
+                'CarRacing-* envs bundled in atari-py 0.2.x don\'t load')
         if 'Kuka' in spec.id:
             # Kuka environments calls py_bullet.resetSimulation() in reset()
             # unconditionally, which globally resets other simulations. So
             # only one Kuka environment can be tested.
             pytest.skip('Skip Kuka Bullet environments')
         env = GymEnv(spec.id)
-        step_env_with_gym_quirks(env, spec)
+        step_env_with_gym_quirks(env, spec, visualize=False)
 
     @pytest.mark.nightly
     @pytest.mark.parametrize('spec', list(gym.envs.registry.all()))
@@ -41,8 +39,5 @@ class TestGymEnv:
             # only one Kuka environment can be tested.
             pytest.skip('Skip Kuka Bullet environments')
         env = GymEnv(spec.id)
-        step_env_with_gym_quirks(env,
-                                 spec,
-                                 n=1,
-                                 visualize=True,
-                                 serialize_env=True)
+        round_trip = pickle.loads(pickle.dumps(env))
+        assert round_trip

--- a/tests/garage/tf/envs/test_gym_base.py
+++ b/tests/garage/tf/envs/test_gym_base.py
@@ -4,7 +4,6 @@ import gym
 import pytest
 
 from garage.envs import GymEnv
-from garage.envs.bullet import _get_unsupported_env_list
 
 from tests.helpers import step_env_with_gym_quirks
 
@@ -22,8 +21,6 @@ class TestGymEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        if spec.id in _get_unsupported_env_list():
-            pytest.skip('Skip unsupported Bullet environments')
         if 'Kuka' in spec.id:
             # Kuka environments calls py_bullet.resetSimulation() in reset()
             # unconditionally, which globally resets other simulations. So
@@ -38,8 +35,6 @@ class TestGymEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        if spec.id in _get_unsupported_env_list():
-            pytest.skip('Skip unsupported Bullet environments')
         if 'Kuka' in spec.id:
             # Kuka environments calls py_bullet.resetSimulation() in reset()
             # unconditionally, which globally resets other simulations. So


### PR DESCRIPTION
Logics for skipping unsupported bullet gym environments can be removed once upstream fixes to pybullet is merged.