### PR TITLE
Add doctest for ci and doctest sample files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ docs:
 
 ci-job-precommit: assert-docker
 	scripts/travisci/check_precommit.sh
-	@pushd docs && make doctest && popd
-	echo " "
+	@pushd docs && make doctest clean && popd
 
 ci-job-normal: assert-docker
 	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ docs:
 
 ci-job-precommit: assert-docker
 	scripts/travisci/check_precommit.sh
+	@pushd docs && make doctest && popd
+	echo " "
 
 ci-job-normal: assert-docker
 	[ ! -f $(MJKEY_PATH) ] || mv $(MJKEY_PATH) $(MJKEY_PATH).bak

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,8 @@ SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 APIDOCDIR     = _apidoc
+AUTOAPIDIR    = _autoapi
+DATADIR       = data
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -52,6 +54,8 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(APIDOCDIR)/*
+	rm -rf $(AUTOAPIDIR)/*
+	rm -rf $(DATADIR)/*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,6 @@ SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
-APIDOCDIR     = _apidoc
 AUTOAPIDIR    = _autoapi
 DATADIR       = data
 
@@ -178,7 +177,6 @@ linkcheck:
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	rm -rf data/local/
 	@echo
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,7 +53,6 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf $(APIDOCDIR)/*
 	rm -rf $(AUTOAPIDIR)/*
 	rm -rf $(DATADIR)/*
 
@@ -179,6 +178,8 @@ linkcheck:
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	rm -rf data/local/
+	@echo
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -334,6 +334,8 @@ todo_include_todos = True
 doctest_global_setup = '''
 try:
     import numpy as np
+    import akro
+    import gym
 except ImportError:
     np = None
 '''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,6 +329,15 @@ todo_include_todos = True
 #     'dm_control', 'glfw', 'mujoco_py', 'ray', 'torch', 'torchvision'
 # ]
 
+# -- Options for doctest extension --------------------------------------------
+#Global library imports for doctest
+doctest_global_setup = '''
+try:
+    import numpy as np
+except ImportError:
+    np = None
+'''
+trim_doctest_flags = True
 # -- Options for autoapi extension --------------------------------------------
 autoapi_root = '_autoapi'
 autoapi_dirs = ['../src']

--- a/docs/user/experiments.rst
+++ b/docs/user/experiments.rst
@@ -29,7 +29,7 @@ Finally, the launcher calls :code:`runner.setup` and :code:`runner.train` which 
 The garage repository contains several example experiment launchers. A fairly
 simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
 
-.. code-block:: python
+.. testcode::
 
   from garage import wrap_experiment
   from garage.envs import GarageEnv
@@ -74,6 +74,15 @@ simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
 
   trpo_cartpole()
 
+.. testoutput::
+   :hide:
+
+   ...
+
+.. testcleanup::
+
+	import shutil
+	shutil.rmtree('data/local/')
 
 Running the above should produce output like:
 
@@ -217,7 +226,7 @@ In order to enable the GPU for PyTorch, add the following code snippets to the e
   import torch
   from garage.torch import set_gpu_mode
 
-  ...
+  # ...
 
     if torch.cuda.is_available():
         set_gpu_mode(True)

--- a/docs/user/experiments.rst
+++ b/docs/user/experiments.rst
@@ -79,11 +79,6 @@ simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
 
    ...
 
-.. testcleanup::
-
-	import shutil
-	shutil.rmtree('data/local/')
-
 Running the above should produce output like:
 
 .. code-block:: text

--- a/docs/user/implement_algo.rst
+++ b/docs/user/implement_algo.rst
@@ -272,7 +272,7 @@ We can add a little logging to the :code:`train()` method.
 
     # ...
 
-		def train(self, runner):
+        def train(self, runner):
             for epoch in runner.step_epochs():
                 samples = runner.obtain_samples(epoch)
                 log_performance(epoch,

--- a/docs/user/implement_algo.rst
+++ b/docs/user/implement_algo.rst
@@ -73,7 +73,7 @@ logging, will only have new results once per epoch.
 The current epoch is constrolled by the algorithm using
 :code:`LocalRunner.step_epochs()`.
 
-.. code-block:: python
+.. testcode::
 
     class MyAlgorithm:
 
@@ -88,7 +88,7 @@ The current epoch is constrolled by the algorithm using
 In practice, it's used in a loop like this:
 
 
-.. code-block:: python
+.. testcode::
 
     class MyAlgorithm:
 
@@ -111,13 +111,13 @@ This can be done manually, but for this tutorial we'll use the
 
 We'll also want an environment to test our algorithm with.
 
-.. code-block:: python
+.. testcode::
 
     from garage import wrap_experiment
     from garage.envs import PointEnv
     from garage.experiment import LocalRunner
 
-    @wrap_experiment(log_dir='my_algorithm_logs', use_existing_dir=True)
+    @wrap_experiment(use_existing_dir=True)
     def debug_my_algorithm(ctxt):
         runner = LocalRunner(ctxt)
         env = PointEnv()
@@ -127,6 +127,15 @@ We'll also want an environment to test our algorithm with.
 
     debug_my_algorithm()
 
+.. testoutput::
+   :hide:
+
+   ...
+
+.. testcleanup::
+
+	import shutil
+	shutil.rmtree('data/local/')
 
 With the above file and the :code:`MyAlgorithm` definition above, it should be
 possible to run :code:`MyAlgorithm`, and get it to print an output like the
@@ -134,7 +143,7 @@ following:
 
 .. code-block:: text
 
-  2020-05-18 14:11:49 | [debug_my_algorithm] Logging to my_algorithm_logs
+  2020-05-18 14:11:49 | [debug_my_algorithm] Logging to /data/local/experiment/debug_my_algorithm
   2020-05-18 14:11:49 | [debug_my_algorithm] Obtaining samples...
   It is epoch 0
   2020-05-18 14:11:49 | [debug_my_algorithm] epoch #0 | Saving snapshot...
@@ -266,9 +275,9 @@ We can add a little logging to the :code:`train()` method.
 
     from garage import log_performance, TrajectoryBatch
 
-    ...
+    # ...
 
-        def train(self, runner):
+		def train(self, runner):
             for epoch in runner.step_epochs():
                 samples = runner.obtain_samples(epoch)
                 log_performance(epoch,

--- a/docs/user/implement_algo.rst
+++ b/docs/user/implement_algo.rst
@@ -132,11 +132,6 @@ We'll also want an environment to test our algorithm with.
 
    ...
 
-.. testcleanup::
-
-	import shutil
-	shutil.rmtree('data/local/')
-
 With the above file and the :code:`MyAlgorithm` definition above, it should be
 possible to run :code:`MyAlgorithm`, and get it to print an output like the
 following:

--- a/docs/user/implement_env.rst
+++ b/docs/user/implement_env.rst
@@ -81,9 +81,15 @@ For each environment, we will need to specify the set of valid observations and 
 set of valid actions. This is done by implementing the following
 property methods:
 
-.. code-block:: python
+.. testsetup::
 
-    class PointEnv(Env):
+    import akro
+    import gym
+    import numpy as np
+
+.. testcode::
+
+    class PointEnv(gym.Env):
 
         # ...
 
@@ -107,7 +113,7 @@ simple, we will just sample the coordinates from a uniform distribution. The
 method should also return the initial observation. In our case, it will be the
 same as its state.
 
-.. code-block:: python
+.. testcode::
 
     class PointEnv(gym.Env):
 
@@ -126,9 +132,9 @@ extra keyword arguments (whose values should be vectors only) for diagnostic pur
 The procedure that interfaces with the environment is responsible for calling
 :code:`reset` after seeing that the episode is terminated.
 
-.. code-block:: python
+.. testcode::
 
-    class PointEnv(Env):
+    class PointEnv(gym.Env):
 
         # ...
 
@@ -143,14 +149,14 @@ The procedure that interfaces with the environment is responsible for calling
 Finally, we can implement some plotting to visualize what the MDP is doing. For
 simplicity, let's just print the current state of the MDP on the terminal:
 
-.. code-block:: python
+.. testcode::
 
     class PointEnv(gym.Env):
 
         # ...
 
         def render(self):
-            print 'current state:', self._state
+            print ('current state:', self._state)
 
 And we're done! We can now simulate the environment using the following diagnostic
 script:

--- a/docs/user/implement_env.rst
+++ b/docs/user/implement_env.rst
@@ -81,12 +81,6 @@ For each environment, we will need to specify the set of valid observations and 
 set of valid actions. This is done by implementing the following
 property methods:
 
-.. testsetup::
-
-    import akro
-    import gym
-    import numpy as np
-
 .. testcode::
 
     class PointEnv(gym.Env):

--- a/src/garage/misc/tensor_utils.py
+++ b/src/garage/misc/tensor_utils.py
@@ -1,4 +1,4 @@
-"""Utiliy functions for tensors."""
+"""Utility functions for tensors."""
 import numpy as np
 import scipy.signal
 
@@ -16,6 +16,7 @@ def discount_cumsum(x, discount):
 
     Returns:
         np.ndarrary: Discounted cumulative sum.
+
 
     """
     return scipy.signal.lfilter([1], [1, float(-discount)], x[::-1],
@@ -61,6 +62,15 @@ def flatten_tensors(tensors):
 
     Returns:
         numpy.ndarray: Flattened tensors.
+
+    Example:
+
+    .. testsetup::
+
+        from garage.misc.tensor_utils import flatten_tensors
+
+    >>> flatten_tensors([np.ndarray([1]), np.ndarray([1])])
+    array(...)
 
     """
     if tensors:


### PR DESCRIPTION
This PR adds doctest to target `make ci-job-precommit` and adds sample doctest blocks to all currently runnable code blocks in `docs/user` and one example of a doctest-able docstring in `tensor_utils.py`. 