### PR TITLE
Export task samplers in garage.experiment

### DIFF
--- a/src/garage/experiment/__init__.py
+++ b/src/garage/experiment/__init__.py
@@ -1,9 +1,15 @@
 """Experiment functions."""
+# yapf: disable
 from garage.experiment.local_runner import LocalRunner
 from garage.experiment.local_tf_runner import LocalTFRunner
 from garage.experiment.meta_evaluator import MetaEvaluator
 from garage.experiment.snapshotter import SnapshotConfig, Snapshotter
-from garage.experiment.task_sampler import TaskSampler
+from garage.experiment.task_sampler import (ConstructEnvsSampler,
+                                            EnvPoolSampler,
+                                            SetTaskSampler,
+                                            TaskSampler)
+
+# yapf: enable
 
 __all__ = [
     'LocalRunner',
@@ -12,4 +18,7 @@ __all__ = [
     'Snapshotter',
     'SnapshotConfig',
     'TaskSampler',
+    'ConstructEnvsSampler',
+    'EnvPoolSampler',
+    'SetTaskSampler',
 ]


### PR DESCRIPTION
This ensures that they will appear in the API docs.

Fixes #1768