### PR TITLE
Add StepType and remove terminal

### DIFF
--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,6 +1,10 @@
 """Garage Base."""
 # yapf: disable
-from garage._dtypes import InOutSpec, TimeStep, TimeStepBatch, TrajectoryBatch
+from garage._dtypes import (InOutSpec,
+                            StepType,
+                            TimeStep,
+                            TimeStepBatch,
+                            TrajectoryBatch)
 from garage._environment import Environment
 from garage._functions import (_Default,
                                log_multitask_performance,
@@ -13,5 +17,5 @@ from garage.experiment.experiment import wrap_experiment
 __all__ = [
     '_Default', 'make_optimizer', 'wrap_experiment', 'TimeStep',
     'TrajectoryBatch', 'log_multitask_performance', 'log_performance',
-    'InOutSpec', 'TimeStepBatch', 'Environment'
+    'InOutSpec', 'TimeStepBatch', 'Environment', 'StepType'
 ]

--- a/src/garage/replay_buffer/path_buffer.py
+++ b/src/garage/replay_buffer/path_buffer.py
@@ -3,6 +3,8 @@ import collections
 
 import numpy as np
 
+from garage import StepType
+
 
 class PathBuffer:
     """A replay buffer that stores and can sample whole paths.
@@ -36,13 +38,17 @@ class PathBuffer:
         env_spec = trajectories.env_spec
         obs_space = env_spec.observation_space
         for traj in trajectories.split():
+            terminals = np.array([
+                step_type == StepType.TERMINAL for step_type in traj.step_types
+            ],
+                                 dtype=bool)
             path = {
                 'observations': obs_space.flatten_n(traj.observations),
                 'next_observations':
                 obs_space.flatten_n(traj.next_observations),
                 'actions': env_spec.action_space.flatten_n(traj.actions),
                 'rewards': traj.rewards.reshape(-1, 1),
-                'terminals': traj.terminals.reshape(-1, 1),
+                'terminals': terminals.reshape(-1, 1),
             }
             self.add_path(path)
 

--- a/src/garage/sampler/_dtypes.py
+++ b/src/garage/sampler/_dtypes.py
@@ -3,7 +3,7 @@ import collections
 
 import numpy as np
 
-from garage import TrajectoryBatch
+from garage import StepType, TrajectoryBatch
 
 
 class InProgressTrajectory:
@@ -27,7 +27,7 @@ class InProgressTrajectory:
         self.observations = [initial_observation]
         self.actions = []
         self.rewards = []
-        self.terminals = []
+        self.step_types = []
         self.agent_infos = collections.defaultdict(list)
         self.env_infos = collections.defaultdict(list)
 
@@ -50,7 +50,13 @@ class InProgressTrajectory:
             self.agent_infos[k].append(v)
         for k, v in env_info.items():
             self.env_infos[k].append(v)
-        self.terminals.append(d)
+        # Temporary solution
+        # When env returns a TimeStep in future, this should append the
+        # step type. Now only StepType.TERMINAL is added.
+        if d:
+            self.step_types.append(StepType.TERMINAL)
+        else:
+            self.step_types.append(StepType.MID)
         return next_o
 
     def to_batch(self):
@@ -75,7 +81,8 @@ class InProgressTrajectory:
                                last_observations=np.asarray([self.last_obs]),
                                actions=np.asarray(self.actions),
                                rewards=np.asarray(self.rewards),
-                               terminals=np.asarray(self.terminals),
+                               step_types=np.asarray(self.step_types,
+                                                     dtype=StepType),
                                env_infos=env_infos,
                                agent_infos=agent_infos,
                                lengths=np.asarray([len(self.rewards)],

--- a/src/garage/sampler/fragment_worker.py
+++ b/src/garage/sampler/fragment_worker.py
@@ -3,7 +3,7 @@ import copy
 
 import numpy as np
 
-from garage import TrajectoryBatch
+from garage import StepType, TrajectoryBatch
 from garage.sampler import _apply_env_update, InProgressTrajectory
 from garage.sampler.default_worker import DefaultWorker
 
@@ -108,7 +108,7 @@ class FragmentWorker(DefaultWorker):
                 frag.step(action, agent_info)
                 self._path_lengths[i] += 1
             if (self._path_lengths[i] >= self._max_episode_length
-                    or frag.terminals[-1]):
+                    or frag.step_types[-1] == StepType.TERMINAL):
                 self._path_lengths[i] = 0
                 complete_frag = frag.to_batch()
                 self._complete_fragments.append(complete_frag)

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -7,7 +7,7 @@ from dowel import logger, tabular
 import numpy as np
 import tensorflow as tf
 
-from garage import log_performance, make_optimizer, TrajectoryBatch
+from garage import log_performance, make_optimizer, StepType, TrajectoryBatch
 from garage.misc import tensor_utils as np_tensor_utils
 from garage.np.algos import RLAlgorithm
 from garage.sampler import RaySampler
@@ -209,7 +209,10 @@ class NPO(RLAlgorithm):
                 rewards=path['rewards'],
                 env_infos=path['env_infos'],
                 agent_infos=path['agent_infos'],
-                dones=path['dones']) for path in paths
+                dones=np.array([
+                    step_type == StepType.TERMINAL
+                    for step_type in path['step_types']
+                ])) for path in paths
         ]
 
         if hasattr(self._baseline, 'predict_n'):

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -1,4 +1,5 @@
 """Relative Entropy Policy Search implementation in Tensorflow."""
+# yapf: disable
 import collections
 
 from dowel import logger, tabular
@@ -6,13 +7,19 @@ import numpy as np
 import scipy.optimize
 import tensorflow as tf
 
-from garage import _Default, log_performance, make_optimizer, TrajectoryBatch
+from garage import (_Default,
+                    log_performance,
+                    make_optimizer,
+                    StepType,
+                    TrajectoryBatch)
 from garage.np.algos import RLAlgorithm
 from garage.sampler import RaySampler
 from garage.tf import paths_to_tensors
 from garage.tf.misc import tensor_utils
 from garage.tf.misc.tensor_utils import flatten_inputs, graph_inputs
 from garage.tf.optimizers import LbfgsOptimizer
+
+# yapf: disable
 
 
 # pylint: disable=differing-param-doc, differing-type-doc
@@ -170,7 +177,10 @@ class REPS(RLAlgorithm):  # noqa: D416
                 rewards=path['rewards'],
                 env_infos=path['env_infos'],
                 agent_infos=path['agent_infos'],
-                dones=path['dones']) for path in paths
+                dones=np.array([
+                    step_type == StepType.TERMINAL
+                    for step_type in path['step_types']
+                ])) for path in paths
         ]
 
         if hasattr(self._baseline, 'predict_n'):

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from garage import log_performance
+from garage import log_performance, StepType
 from garage.np import obtain_evaluation_samples
 from garage.np.algos import RLAlgorithm
 from garage.sampler import FragmentWorker, RaySampler
@@ -197,7 +197,10 @@ class SAC(RLAlgorithm):
                              action=path['actions'],
                              reward=path['rewards'].reshape(-1, 1),
                              next_observation=path['next_observations'],
-                             terminal=path['dones'].reshape(-1, 1)))
+                             terminal=np.array([
+                                 step_type == StepType.TERMINAL
+                                 for step_type in path['step_types']
+                             ]).reshape(-1, 1)))
                     path_returns.append(sum(path['rewards']))
                 assert len(path_returns) is len(runner.step_path)
                 self.episode_rewards.append(np.mean(path_returns))

--- a/tests/garage/sampler/test_fragment_worker.py
+++ b/tests/garage/sampler/test_fragment_worker.py
@@ -6,7 +6,7 @@ import pprint
 import numpy as np
 import pytest
 
-from garage import TrajectoryBatch
+from garage import StepType, TrajectoryBatch
 from garage.envs import GarageEnv, GridWorldEnv
 from garage.np.policies import ScriptedPolicy
 from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
@@ -70,7 +70,7 @@ def slice_trajectories(trajectories, slice_size):
                 last_observations=last_obs,
                 actions=traj.actions[indices],
                 rewards=traj.rewards[indices],
-                terminals=traj.terminals[indices],
+                step_types=traj.step_types[indices],
                 env_infos={k: v[indices]
                            for (k, v) in traj.env_infos},
                 agent_infos={k: v[indices]
@@ -95,7 +95,8 @@ def test_rollout(env, policy, timesteps_per_call):
         traj = worker.rollout()
         assert sum(traj.lengths) == timesteps_per_call * N_TRAJ
         if timesteps_per_call * i < 4:
-            assert sum(traj.terminals) == 0
+            assert not any(step_type == StepType.TERMINAL
+                           for step_type in traj.step_types)
     worker.shutdown()
 
 

--- a/tests/garage/test_dtypes.py
+++ b/tests/garage/test_dtypes.py
@@ -370,6 +370,24 @@ def test_step_type_dtype_mismatch_time_step(sample_data):
         del s
 
 
+def test_step_type_property_time_step(sample_data):
+    sample_data['step_type'] = StepType.FIRST
+    s = TimeStep(**sample_data)
+    assert s.first
+
+    sample_data['step_type'] = StepType.MID
+    s = TimeStep(**sample_data)
+    assert s.mid
+
+    sample_data['step_type'] = StepType.TERMINAL
+    s = TimeStep(**sample_data)
+    assert s.terminal and s.last
+
+    sample_data['step_type'] = StepType.TIMEOUT
+    s = TimeStep(**sample_data)
+    assert s.timeout and s.last
+
+
 @pytest.fixture
 def batch_data():
     # spaces
@@ -420,6 +438,13 @@ def test_new_ts_batch(batch_data):
     assert s.env_infos is batch_data['env_infos']
     assert s.agent_infos is batch_data['agent_infos']
     assert s.step_types is batch_data['step_types']
+
+
+def test_invalid_inferred_batch_size(batch_data):
+    with pytest.raises(ValueError, match='batch dimension of rewards'):
+        batch_data['rewards'] = []
+        s = TimeStepBatch(**batch_data)
+        del s
 
 
 def test_observations_env_spec_mismatch_batch(batch_data):

--- a/tests/garage/test_functions.py
+++ b/tests/garage/test_functions.py
@@ -16,6 +16,7 @@ from garage import (_Default,
                     log_multitask_performance,
                     log_performance,
                     make_optimizer,
+                    StepType,
                     TrajectoryBatch)
 from garage.envs import EnvSpec
 
@@ -39,8 +40,12 @@ def test_log_performance():
             0.17657714, 0.04783857, 0.73904013, 0.41364329, 0.52235551,
             0.24203526, 0.43328910
         ]),
-        terminals=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1],
-                           dtype=bool),
+        step_types=np.array(
+            [StepType.FIRST] + [StepType.MID] * (lengths[0] - 2) +
+            [StepType.TERMINAL] + [StepType.FIRST] + [StepType.MID] *
+            (lengths[1] - 2) + [StepType.TERMINAL] + [StepType.FIRST] +
+            [StepType.FIRST],
+            dtype=StepType),
         env_infos={
             'success':
             np.array([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],
@@ -85,8 +90,7 @@ def test_log_multitask_performance_task_name():
             0.17657714, 0.04783857, 0.73904013, 0.41364329, 0.52235551,
             0.24203526, 0.43328910
         ]),
-        terminals=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1],
-                           dtype=bool),
+        step_types=np.array([StepType.MID] * sum(lengths), dtype=StepType),
         env_infos={
             'success':
             np.array([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],
@@ -132,8 +136,7 @@ def test_log_multitask_performance_task_id():
             0.17657714, 0.04783857, 0.73904013, 0.41364329, 0.52235551,
             0.24203526, 0.43328910
         ]),
-        terminals=np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1],
-                           dtype=bool),
+        step_types=np.array([StepType.MID] * sum(lengths), dtype=StepType),
         env_infos={
             'success':
             np.array([0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1],

--- a/tests/garage/torch/policies/test_context_conditioned_policy.py
+++ b/tests/garage/torch/policies/test_context_conditioned_policy.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from torch.nn import functional as F  # NOQA
 
-from garage import TimeStep
+from garage import StepType, TimeStep
 from garage.envs import EnvSpec, GarageEnv
 from garage.torch.embeddings import MLPEncoder
 from garage.torch.policies import (ContextConditionedPolicy,
@@ -81,9 +81,9 @@ class TestContextConditionedPolicy:
                      next_observation=np.ones(self.obs_dim),
                      action=np.ones(self.action_dim),
                      reward=1.0,
-                     terminal=False,
                      env_info={},
-                     agent_info={})
+                     agent_info={},
+                     step_type=StepType.FIRST)
         updates = 10
         for _ in range(updates):
             self.module.update_context(s)


### PR DESCRIPTION
This PR comes with [#1775 ](https://github.com/rlworkgroup/garage/pull/1775)
1. Add Enum `StepType`
2. Remove `terminal` from time step, since it can be inferred from `StepType.TERMINAL`. In the new API, `reset()` and `step()` returns a `TimeStep`. Downstream consumers of `TimeStep` will need to check `TimeStep.step_type` for terminal. 
3. Similarly, `terminals` is removed from `TimeStepBatch` and `TrajectoryBatch`.
4. Consumers can tell if a `TimeStep` is a `TERMINAL`, `TIMEOUT` or simply the last (i.e. `TERMINAL` or `TIMEOUT) with its helper functions.

Will add usage implementation & test once the changes of TimeStep itself are approved.