### PR TITLE
a policy simulation script that works with snapshotted policies

### DIFF
--- a/examples/simulate_policy.py
+++ b/examples/simulate_policy.py
@@ -1,0 +1,19 @@
+# Load the policy and the env in which it was trained
+from garage.experiment import Snapshotter
+import tensorflow as tf # optional, only for TensorFlow as we need a tf.Session
+import fire
+
+def run_rollouts(file, animated=True):
+    snapshotter = Snapshotter()
+    with tf.compat.v1.Session(): # optional, only for TensorFlow
+        data = snapshotter.load(file)
+    policy = data['algo'].policy
+    env = data['env']
+
+    # See what the trained policy can accomplish
+    from garage.sampler.utils import rollout
+    path = rollout(env, policy, animated=animated)
+    print(path)
+
+if __name__ == '__main__':
+    fire.Fire(run_rollouts)


### PR DESCRIPTION
The examples/sim_policy.py script didn't work with the torch training example script I ran, so I created a sim_policy script using code from the docs that works for snapshotted policies. 