### PR TITLE
Fix qf_derived_policy variable_scope

### DIFF
--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -30,7 +30,6 @@ class DiscreteQfDerivedPolicy(Module, Policy):
 
     def _initialize(self):
         # pylint: disable=protected-access
-        self._variable_scope = self._qf._variable_scope
         self._f_qval = tf.compat.v1.get_default_session().make_callable(
             self._qf.q_vals, feed_list=[self._qf.input])
 
@@ -77,6 +76,74 @@ class DiscreteQfDerivedPolicy(Module, Policy):
         opt_actions = np.argmax(q_vals, axis=1)
 
         return opt_actions, dict()
+
+    def get_trainable_vars(self):
+        """Get trainable variables.
+
+        Returns:
+            List[tf.Variable]: A list of trainable variables in the current
+                variable scope.
+
+        """
+        return self._qf.get_trainable_vars()
+
+    def get_global_vars(self):
+        """Get global variables.
+
+        Returns:
+            List[tf.Variable]: A list of global variables in the current
+                variable scope.
+
+        """
+        return self._qf.get_global_vars()
+
+    def get_regularizable_vars(self):
+        """Get all network weight variables in the current scope.
+
+        Returns:
+            List[tf.Variable]: A list of network weight variables in the
+                current variable scope.
+
+        """
+        return self._qf.get_regularizable_vars()
+
+    def get_params(self):
+        """Get the trainable variables.
+
+        Returns:
+            List[tf.Variable]: A list of trainable variables in the current
+                variable scope.
+
+        """
+        return self._qf.get_params()
+
+    def get_param_shapes(self):
+        """Get parameter shapes.
+
+        Returns:
+            List[tuple]: A list of variable shapes.
+
+        """
+        return self._qf.get_param_shapes()
+
+    def get_param_values(self):
+        """Get param values.
+
+        Returns:
+            np.ndarray: Values of the parameters evaluated in
+                the current session
+
+        """
+        return self._qf.get_param_values()
+
+    def set_param_values(self, param_values):
+        """Set param values.
+
+        Args:
+            param_values (np.ndarray): A numpy array of parameter values.
+
+        """
+        self._qf.set_param_values(param_values)
 
     @property
     def env_spec(self):

--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -29,10 +29,10 @@ class DiscreteQfDerivedPolicy(Module, Policy):
         self._initialize()
 
     def _initialize(self):
-        with tf.compat.v1.variable_scope(self.name, reuse=False) as vs:
-            self._variable_scope = vs
-            self._f_qval = tf.compat.v1.get_default_session().make_callable(
-                self._qf.q_vals, feed_list=[self._qf.input])
+        # pylint: disable=protected-access
+        self._variable_scope = self._qf._variable_scope
+        self._f_qval = tf.compat.v1.get_default_session().make_callable(
+            self._qf.q_vals, feed_list=[self._qf.input])
 
     def get_action(self, observation):
         """Get action from this policy for the input observation.

--- a/tests/garage/tf/policies/test_qf_derived_policy.py
+++ b/tests/garage/tf/policies/test_qf_derived_policy.py
@@ -29,6 +29,11 @@ class TestQfDerivedPolicy(TfGraphTestCase):
         for action in actions:
             assert self.env.action_space.contains(action)
 
+    def test_get_param(self):
+        with tf.compat.v1.variable_scope('SimpleQFunction', reuse=True):
+            return_var = tf.compat.v1.get_variable('return_var')
+        assert self.policy.get_param_values() == return_var.eval()
+
     def test_is_pickleable(self):
         with tf.compat.v1.variable_scope('SimpleQFunction', reuse=True):
             return_var = tf.compat.v1.get_variable('return_var')


### PR DESCRIPTION
Currently qf_derived_policy has an empty variable_scope, which makes `get_params()` returns an empty list.
This PR fixes the issue by assigning the underlying QFunction variable_scope to its variable_scope.