### PR TITLE
Use cudnn7-runtime for run-nvidia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-headless: assert-docker-version docker/Dockerfile
 		${BUILD_ARGS} .
 
 build-nvidia: TAG ?= rlworkgroup/garage-nvidia:latest
-build-nvidia: PARENT_IMAGE ?= nvidia/cuda:10.2-runtime-ubuntu18.04
+build-nvidia: PARENT_IMAGE ?= nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
 build-nvidia: assert-docker-version docker/Dockerfile
 	docker build \
 		-f docker/Dockerfile \

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -22,6 +22,6 @@ elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage-nvidia" ]]; then
 		-f "../$DOCKERFILE_PATH" \
 		--target garage-nvidia-18.04 \
 		-t "$IMAGE_NAME" \
-		--build-arg PARENT_IMAGE="nvidia/cuda:10.2-runtime-ubuntu18.04" \
+		--build-arg PARENT_IMAGE="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04" \
 		..
 fi

--- a/docs/user/docker.md
+++ b/docs/user/docker.md
@@ -108,7 +108,7 @@ make run-headless BUILD_ARGS="--build-arg MY_VAR=123" RUN_ARGS="-e MY_VAR=123"
 
 ## NVIDIA image
 
-The garage NVIDIA images come with CUDA 10.2.
+The garage NVIDIA images come with CUDA 10.2 and cuDNN (required for tensorflow).
 
 ### Prerequisites for NVIDIA image
 
@@ -165,14 +165,14 @@ make run-nvidia GPUS="device=0,2"
 
 ### Using a different driver version
 
-The garage-nvidia docker image uses `nvidia/cuda:10.2-runtime-ubuntu18.04` as
-the parent image which requires NVIDIA driver version 440.33+. If you need
+The garage-nvidia docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
+as the parent image which requires NVIDIA driver version 440.33+. If you need
 to use garage with a different driver version, you might be able to build the
 garage-nvidia image from scratch using a different parent image using the
 variable `PARENT_IMAGE`.
 
 ```
-make run-nvidia PARENT_IMAGE="nvidia/cuda:10.1-runtime-ubuntu18.04"
+make run-nvidia PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04"
 ```
 
 You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub.docker.com/r/nvidia/cuda/tags)


### PR DESCRIPTION
This is needed to make TF work in Docker+CUDA

TODO
* [x] Change docker/hooks
* [x] Update docs
* [ ] Document testing procedure which would have caught this? (#1829 opened for this)