### PR TITLE
Flatten observations in the policy if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,7 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `garage.np.OffPolicyRLAlgorithm` ([#1552](https://github.com/rlworkgroup/garage/pull/1552))
 
 ### Fixed
-- Bug where `GarageEnv` did not pickle ([#1029](https://github.com/rlworkgroup/garage/pull/1029))
+- Bug where `GymEnv` did not pickle ([#1029](https://github.com/rlworkgroup/garage/pull/1029))
 - Bug where `VecEnvExecutor` conflated terminal state and time limit signal (
   [#1178](https://github.com/rlworkgroup/garage/pull/1178),
   [#1570](https://github.com/rlworkgroup/garage/pull/1570))

--- a/docs/user/implement_algo.md
+++ b/docs/user/implement_algo.md
@@ -84,13 +84,21 @@ We'll also want an environment to test our algorithm with.
 
 ```py
 from garage import wrap_experiment
+<<<<<<< HEAD
 from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GymEnv
+>>>>>>> a1877525... Flatten observations if necessary
 from garage.experiment import LocalRunner
 
 @wrap_experiment
 def debug_my_algorithm(ctxt):
     runner = LocalRunner(ctxt)
+<<<<<<< HEAD
     env = PointEnv()
+=======
+    env = GymEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
     algo = MyAlgorithm()
     runner.setup(algo, env)
     runner.train(n_epochs=3)
@@ -159,7 +167,11 @@ class SimpleVPG:
             samples = runner.obtain_samples(epoch)
 
 from garage import wrap_experiment
+<<<<<<< HEAD
 from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GymEnv
+>>>>>>> a1877525... Flatten observations if necessary
 from garage.experiment import LocalRunner
 from garage.experiment.deterministic import set_seed
 from garage.torch.policies import GaussianMLPPolicy
@@ -168,7 +180,11 @@ from garage.torch.policies import GaussianMLPPolicy
 def debug_my_algorithm(ctxt):
     set_seed(100)
     runner = LocalRunner(ctxt)
+<<<<<<< HEAD
     env = PointEnv()
+=======
+    env = GymEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
     policy = GaussianMLPPolicy(env.spec)
     algo = SimpleVPG(policy)
     runner.setup(algo, env)
@@ -306,7 +322,11 @@ policy when training, you can solve an Gym environment, for example
 def tutorial_vpg(ctxt=None):
     set_seed(100)
     runner = LocalRunner(ctxt)
+<<<<<<< HEAD
     env = GymEnv('LunarLanderContinuous-v2')
+=======
+    env = GymEnv(env_name='LunarLanderContinuous-v2')
+>>>>>>> a1877525... Flatten observations if necessary
     policy = GaussianMLPPolicy(env.spec)
     algo = SimpleVPG(env.spec, policy)
     runner.setup(algo, env)
@@ -322,7 +342,11 @@ except for the replacement of `LocalRunner` with `LocalTFRunner`.
 ```py
 ...
 from garage import wrap_experiment
+<<<<<<< HEAD
 from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GymEnv
+>>>>>>> a1877525... Flatten observations if necessary
 from garage.experiment import LocalTFRunner
 from garage.experiment.deterministic import set_seed
 from garage.tf.policies import GaussianMLPPolicy
@@ -331,7 +355,11 @@ from garage.tf.policies import GaussianMLPPolicy
 def tutorial_vpg(ctxt=None):
     set_seed(100)
     with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
         env = PointEnv()
+=======
+        env = GymEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
         policy = GaussianMLPPolicy(env.spec)
         algo = SimpleVPG(env.spec, policy)
         runner.setup(algo, env)
@@ -496,7 +524,11 @@ from garage.tf.policies import CategoricalMLPPolicy
 def tutorial_cem(ctxt=None):
     set_seed(100)
     with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
         env = GymEnv('CartPole-v1')
+=======
+        env = GymEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
         policy = CategoricalMLPPolicy(env.spec)
         algo = SimpleCEM(env.spec, policy)
         runner.setup(algo, env)

--- a/docs/user/meta_multi_task_rl_exp.md
+++ b/docs/user/meta_multi_task_rl_exp.md
@@ -50,7 +50,11 @@ def te_ppo_ml1_push(ctxt, seed, n_epochs, batch_size_per_task):
 
     """
     set_seed(seed)
+<<<<<<< HEAD
     envs = [normalize(GymEnv(ML1.get_train_tasks('push-v1')))]
+=======
+    envs = [GymEnv(normalize(ML1.get_train_tasks('push-v1')))]
+>>>>>>> a1877525... Flatten observations if necessary
     env = MultiEnvWrapper(envs, mode='del-onehot')
 
     latent_length = 2
@@ -184,7 +188,11 @@ def te_ppo_mt50(ctxt, seed, n_epochs, batch_size_per_task):
     """
     set_seed(seed)
     tasks = MT50.get_train_tasks().all_task_names
+<<<<<<< HEAD
     envs = [GymEnv(normalize(MT50.from_task(task))) for task in tasks]
+=======
+    envs = [normalize(GymEnv(MT50.from_task(task))) for task in tasks]
+>>>>>>> a1877525... Flatten observations if necessary
     env = MultiEnvWrapper(envs,
                           sample_strategy=round_robin_strategy,
                           mode='del-onehot')

--- a/docs/user/training_a_policy.md
+++ b/docs/user/training_a_policy.md
@@ -47,7 +47,11 @@ like [this](implement_env). In this example, we choose `CartPole-V1`
 environment.
 
 ```py
+<<<<<<< HEAD
 env = GymEnv('CartPole-v1')
+=======
+env = GymEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
 ```
 
 ### Construct a Policy and an Algorithm
@@ -128,7 +132,11 @@ def trpo_cartpole(ctxt=None, seed=1):
     """
     set_seed(seed)
     with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
         env = GymEnv('CartPole-v1')
+=======
+        env = GymEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
 
         policy = CategoricalMLPPolicy(name='policy',
                                       env_spec=env.spec,

--- a/docs/user/use_pretrained_network_to_start_new_experiment.md
+++ b/docs/user/use_pretrained_network_to_start_new_experiment.md
@@ -75,6 +75,7 @@ import gym
 
 from garage import wrap_experiment
 from garage.envs import GymEnv
+<<<<<<< HEAD
 from garage.envs.wrappers import ClipReward
 from garage.envs.wrappers import EpisodicLife
 from garage.envs.wrappers import FireReset
@@ -83,6 +84,16 @@ from garage.envs.wrappers import MaxAndSkip
 from garage.envs.wrappers import Noop
 from garage.envs.wrappers import Resize
 from garage.envs.wrappers import StackFrames
+=======
+from garage.envs.wrappers.clip_reward import ClipReward
+from garage.envs.wrappers.episodic_life import EpisodicLife
+from garage.envs.wrappers.fire_reset import FireReset
+from garage.envs.wrappers.grayscale import Grayscale
+from garage.envs.wrappers.max_and_skip import MaxAndSkip
+from garage.envs.wrappers.noop import Noop
+from garage.envs.wrappers.resize import Resize
+from garage.envs.wrappers.stack_frames import StackFrames
+>>>>>>> a1877525... Flatten observations if necessary
 from garage.experiment import LocalTFRunner, Snapshotter  # Add this import!
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy

--- a/examples/jupyter/custom_env.ipynb
+++ b/examples/jupyter/custom_env.ipynb
@@ -359,7 +359,11 @@
     "        return obs\n",
     "      \n",
     "env = NpWrapper(env)\n",
+<<<<<<< HEAD
     "env = normalize(GymEnv(env))"
+=======
+    "env = GymEnv(normalize(env))"
+>>>>>>> a1877525... Flatten observations if necessary
    ]
   },
   {

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -35,7 +35,7 @@ def trpo_swimmer_ray_sampler(ctxt=None, seed=1):
              object_store_memory=78643200,
              ignore_reinit_error=True,
              log_to_driver=False,
-             include_webui=False)
+             include_dashboard=False)
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         set_seed(seed)
         env = GymEnv('Swimmer-v2')

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -34,7 +34,7 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
              object_store_memory=78643200,
              ignore_reinit_error=True,
              log_to_driver=False,
-             include_webui=False)
+             include_dashboard=False)
     deterministic.set_seed(seed)
     env = GymEnv('InvertedDoublePendulum-v2')
 

--- a/src/garage/np/policies/__init__.py
+++ b/src/garage/np/policies/__init__.py
@@ -4,4 +4,8 @@ from garage.np.policies.fixed_policy import FixedPolicy
 from garage.np.policies.policy import Policy
 from garage.np.policies.scripted_policy import ScriptedPolicy
 
-__all__ = ['FixedPolicy', 'Policy', 'ScriptedPolicy']
+__all__ = [
+    'FixedPolicy',
+    'Policy',
+    'ScriptedPolicy',
+]

--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -55,7 +55,6 @@ def rollout(env,
     if animated:
         env.visualize()
     while episode_length < (max_episode_length or np.inf):
-        last_obs = env.observation_space.flatten(last_obs)
         a, agent_info = agent.get_action(last_obs)
         if deterministic and 'mean' in agent_info:
             a = agent_info['mean']

--- a/src/garage/tf/policies/categorical_cnn_policy.py
+++ b/src/garage/tf/policies/categorical_cnn_policy.py
@@ -81,6 +81,9 @@ class CategoricalCNNPolicy(CategoricalCNNModel, Policy):
         assert isinstance(env_spec.action_space, akro.Discrete), (
             'CategoricalCNNPolicy only works with akro.Discrete action '
             'space.')
+        if isinstance(env_spec.observation_space, akro.Dict):
+            raise ValueError('CNN policies do not support'
+                             'with akro.Dict observation spaces.')
 
         self._env_spec = env_spec
         self._obs_dim = env_spec.observation_space.shape
@@ -152,8 +155,8 @@ class CategoricalCNNPolicy(CategoricalCNNModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
-        sample, prob = self._f_prob(np.expand_dims([observation], 1))
-        return np.squeeze(sample), dict(prob=np.squeeze(prob, axis=1)[0])
+        sample, prob = self.get_actions([observation])
+        return sample, {k: v[0] for k, v in prob.items()}
 
     def get_actions(self, observations):
         """Return multiple actions.
@@ -166,6 +169,11 @@ class CategoricalCNNPolicy(CategoricalCNNModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
+        if isinstance(self.env_spec.observation_space, akro.Image) and \
+                len(observations[0].shape) < \
+                len(self.env_spec.observation_space.shape):
+            observations = self.env_spec.observation_space.unflatten_n(
+                observations)
         samples, probs = self._f_prob(np.expand_dims(observations, 1))
         return np.squeeze(samples), dict(prob=np.squeeze(probs, axis=1))
 

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -229,6 +229,8 @@ class CategoricalGRUPolicy(CategoricalGRUModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -258,6 +258,8 @@ class CategoricalLSTMPolicy(CategoricalLSTMModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -124,8 +124,8 @@ class CategoricalMLPPolicy(CategoricalMLPModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
-        sample, prob = self._f_prob(np.expand_dims([observation], 1))
-        return np.squeeze(sample[0]), dict(prob=np.squeeze(prob, axis=1)[0])
+        actions, agent_infos = self.get_actions([observation])
+        return actions, {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Return multiple actions.
@@ -138,9 +138,8 @@ class CategoricalMLPPolicy(CategoricalMLPModel, Policy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
-        # Flatten the observation, will be removed soon
-        # Flattening should be done in sampler
-        observations = self.observation_space.flatten_n(observations)
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         samples, probs = self._f_prob(np.expand_dims(observations, 1))
         return np.squeeze(samples), dict(prob=np.squeeze(probs, axis=1))
 

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -4,6 +4,7 @@ A continuous MLP network can be used as policy method in different RL
 algorithms. It accepts an observation of the environment and predicts a
 continuous action.
 """
+import numpy as np
 import tensorflow as tf
 
 from garage.experiment import deterministic
@@ -122,9 +123,9 @@ class ContinuousMLPPolicy(MLPModel, Policy):
             dict: Empty dict since this policy does not model a distribution.
 
         """
-        action = self._f_prob([observation])
-        action = self.action_space.unflatten(action)
-        return action, dict()
+        actions, agent_infos = self.get_actions([observation])
+        action = actions[0]
+        return action, {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get multiple actions from this policy for the input observations.
@@ -137,6 +138,8 @@ class ContinuousMLPPolicy(MLPModel, Policy):
             dict: Empty dict since this policy does not model a distribution.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         actions = self._f_prob(observations)
         actions = self.action_space.unflatten_n(actions)
         return actions, dict()

--- a/src/garage/tf/policies/discrete_qf_derived_policy.py
+++ b/src/garage/tf/policies/discrete_qf_derived_policy.py
@@ -21,7 +21,12 @@ class DiscreteQfDerivedPolicy(Module, Policy):
     """
 
     def __init__(self, env_spec, qf, name='DiscreteQfDerivedPolicy'):
-        assert isinstance(env_spec.action_space, akro.Discrete)
+        assert isinstance(env_spec.action_space, akro.Discrete), (
+            'DiscreteQfDerivedPolicy only supports akro.Discrete action spaces'
+        )
+        if isinstance(env_spec.observation_space, akro.Dict):
+            raise ValueError('CNN policies do not support'
+                             'with akro.Dict observation spaces.')
         super().__init__(name)
         self._env_spec = env_spec
         self._qf = qf
@@ -45,15 +50,8 @@ class DiscreteQfDerivedPolicy(Module, Policy):
                 dict since there is no parameterization.
 
         """
-        if isinstance(self.env_spec.observation_space, akro.Image) and \
-                len(observation.shape) < \
-                len(self.env_spec.observation_space.shape):
-            observation = self.env_spec.observation_space.unflatten(
-                observation)
-        q_vals = self._f_qval([observation])
-        opt_action = np.argmax(q_vals)
-
-        return opt_action, dict()
+        opt_actions, agent_infos = self.get_actions([observation])
+        return opt_actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get actions from this policy for the input observations.

--- a/src/garage/tf/policies/gaussian_gru_policy.py
+++ b/src/garage/tf/policies/gaussian_gru_policy.py
@@ -257,6 +257,8 @@ class GaussianGRUPolicy(GaussianGRUModel, Policy):
                 self._state_include_action is True.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/gaussian_lstm_policy.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy.py
@@ -285,6 +285,8 @@ class GaussianLSTMPolicy(GaussianLSTMModel, Policy):
                 self._state_include_action is True.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/gaussian_mlp_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy.py
@@ -182,11 +182,8 @@ class GaussianMLPPolicy(GaussianMLPModel, Policy):
                 distribution.
 
         """
-        sample, mean, log_std = self._f_dist(np.expand_dims([observation], 1))
-        sample = self.action_space.unflatten(np.squeeze(sample, 1)[0])
-        mean = self.action_space.unflatten(np.squeeze(mean, 1)[0])
-        log_std = self.action_space.unflatten(np.squeeze(log_std, 1)[0])
-        return sample, dict(mean=mean, log_std=log_std)
+        actions, agent_infos = self.get_actions([observation])
+        return actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get multiple actions from this policy for the input observations.
@@ -205,6 +202,8 @@ class GaussianMLPPolicy(GaussianMLPModel, Policy):
                 distribution.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         samples, means, log_stds = self._f_dist(np.expand_dims(
             observations, 1))
         samples = self.action_space.unflatten_n(np.squeeze(samples, 1))

--- a/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
@@ -91,7 +91,7 @@ class GaussianMLPTaskEmbeddingPolicy(GaussianMLPModel, TaskEmbeddingPolicy):
                  std_parameterization='exp',
                  layer_normalization=False):
         assert isinstance(env_spec.action_space, akro.Box)
-
+        assert not isinstance(env_spec.observation_space, akro.Dict)
         self._env_spec = env_spec
         self._name = name
         self._encoder = encoder
@@ -232,8 +232,8 @@ class GaussianMLPTaskEmbeddingPolicy(GaussianMLPModel, TaskEmbeddingPolicy):
                     A is the dimension of action.
 
         """
-        obs, task = self.split_augmented_observation(observation)
-        return self.get_action_given_task(obs, task)
+        actions, agent_infos = self.get_actions([observation])
+        return actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get actions sampled from the policy.

--- a/src/garage/torch/policies/categorical_cnn_policy.py
+++ b/src/garage/torch/policies/categorical_cnn_policy.py
@@ -84,13 +84,16 @@ class CategoricalCNNPolicy(StochasticPolicy):
                  name='CategoricalCNNPolicy'):
 
         if not isinstance(env.spec.action_space, akro.Discrete):
-            raise ValueError('CategoricalMLPPolicy only works'
+            raise ValueError('CategoricalMLPPolicy only works '
                              'with akro.Discrete action space.')
+        if isinstance(env.spec.observation_space, akro.Dict):
+            raise ValueError('CNN policies do not support '
+                             'with akro.Dict observation spaces.')
 
         super().__init__(env.spec, name)
         self._env = env
         self._obs_dim = self._env.spec.observation_space.shape
-        self._action_dim = self._env.spec.action_space.n
+        self._action_dim = self._env.spec.action_space.flat_dim
         self._kernel_sizes = kernel_sizes
         self._strides = strides
         self._hidden_nonlinearity = hidden_nonlinearity

--- a/src/garage/torch/policies/deterministic_mlp_policy.py
+++ b/src/garage/torch/policies/deterministic_mlp_policy.py
@@ -3,6 +3,8 @@
 A neural network can be used as policy method in different RL algorithms.
 It accepts an observation of the environment and predicts an action.
 """
+import akro
+import numpy as np
 import torch
 
 from garage.torch.modules import MLPModule
@@ -59,9 +61,13 @@ class DeterministicMLPPolicy(Policy):
                     * np.ndarray[float]: Log of standard deviation of the
                         distribution
         """
+        if not isinstance(observation, np.ndarray) and not isinstance(
+                observation, torch.Tensor):
+            observation = self._env_spec.observation_space.flatten(observation)
         with torch.no_grad():
-            x = self(torch.Tensor(observation).unsqueeze(0))
-            return x.squeeze(0).numpy(), dict()
+            observation = torch.Tensor(observation).unsqueeze(0)
+            action, agent_infos = self.get_actions(observation)
+            return action[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get actions given observations.
@@ -77,6 +83,23 @@ class DeterministicMLPPolicy(Policy):
                     * np.ndarray[float]: Log of standard deviation of the
                         distribution
         """
+        if not isinstance(observations[0], np.ndarray) and not isinstance(
+                observations[0], torch.Tensor):
+            observations = self._env_spec.observation_space.flatten_n(
+                observations)
+        # frequently users like to pass lists of torch tensors or lists of
+        # numpy arrays. This handles those conversions.
+        if isinstance(observations, list):
+            if isinstance(observations[0], np.ndarray):
+                observations = np.stack(observations)
+            elif isinstance(observations[0], torch.Tensor):
+                observations = torch.stack(observations)
+
+        if isinstance(self._env_spec.observation_space, akro.Image) and \
+                len(observations.shape) < \
+                len(self._env_spec.observation_space.shape):
+            observations = self._env_spec.observation_space.unflatten_n(
+                observations)
         with torch.no_grad():
             x = self(torch.Tensor(observations))
             return x.numpy(), dict()

--- a/src/garage/torch/policies/stochastic_policy.py
+++ b/src/garage/torch/policies/stochastic_policy.py
@@ -2,6 +2,7 @@
 import abc
 
 import akro
+import numpy as np
 import torch
 
 from garage.torch import global_device
@@ -27,18 +28,16 @@ class StochasticPolicy(Policy, abc.ABC):
                     * np.ndarray[float]: Standard deviation of logarithmic
                         values of the distribution.
         """
+        if not isinstance(observation, np.ndarray) and not isinstance(
+                observation, torch.Tensor):
+            observation = self._env_spec.observation_space.flatten(observation)
         with torch.no_grad():
             if not isinstance(observation, torch.Tensor):
                 observation = torch.as_tensor(observation).float().to(
                     global_device())
-            if isinstance(self._env_spec.observation_space, akro.Image):
-                observation /= 255.0  # scale image
             observation = observation.unsqueeze(0)
-            dist, info = self.forward(observation)
-            return dist.sample().squeeze(0).cpu().numpy(), {
-                k: v.squeeze(0).detach().cpu().numpy()
-                for (k, v) in info.items()
-            }
+            action, agent_infos = self.get_actions(observation)
+            return action[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         r"""Get actions given observations.
@@ -56,6 +55,24 @@ class StochasticPolicy(Policy, abc.ABC):
                     * np.ndarray[float]: Standard deviation of logarithmic
                         values of the distribution.
         """
+        if not isinstance(observations[0], np.ndarray) and not isinstance(
+                observations[0], torch.Tensor):
+            observations = self._env_spec.observation_space.flatten_n(
+                observations)
+
+        # frequently users like to pass lists of torch tensors or lists of
+        # numpy arrays. This handles those conversions.
+        if isinstance(observations, list):
+            if isinstance(observations[0], np.ndarray):
+                observations = np.stack(observations)
+            elif isinstance(observations[0], torch.Tensor):
+                observations = torch.stack(observations)
+
+        if isinstance(self._env_spec.observation_space, akro.Image) and \
+                len(observations.shape) < \
+                len(self._env_spec.observation_space.shape):
+            observations = self._env_spec.observation_space.unflatten_n(
+                observations)
         with torch.no_grad():
             if not isinstance(observations, torch.Tensor):
                 observations = torch.as_tensor(observations).float().to(

--- a/tests/fixtures/q_functions/simple_q_function.py
+++ b/tests/fixtures/q_functions/simple_q_function.py
@@ -14,7 +14,7 @@ class SimpleQFunction(SimpleMLPModel):
     """
 
     def __init__(self, env_spec, name='SimpleQFunction'):
-        self.obs_dim = env_spec.observation_space.shape
+        self.obs_dim = (env_spec.observation_space.flat_dim, )
         action_dim = env_spec.observation_space.flat_dim
         super().__init__(output_dim=action_dim, name=name)
 

--- a/tests/fixtures/sampler/ray_fixtures.py
+++ b/tests/fixtures/sampler/ray_fixtures.py
@@ -17,7 +17,7 @@ def ray_local_session_fixture():
         ray.init(local_mode=True,
                  ignore_reinit_error=True,
                  log_to_driver=False,
-                 include_webui=False)
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()
@@ -38,7 +38,7 @@ def ray_session_fixture():
                  object_store_memory=78643200,
                  ignore_reinit_error=True,
                  log_to_driver=False,
-                 include_webui=False)
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()

--- a/tests/garage/replay_buffer/test_her_replay_buffer.py
+++ b/tests/garage/replay_buffer/test_her_replay_buffer.py
@@ -3,6 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
+from garage.envs import GymEnv
 from garage.replay_buffer import HERReplayBuffer
 
 from tests.fixtures.envs.dummy import DummyDictEnv
@@ -11,8 +12,8 @@ from tests.fixtures.envs.dummy import DummyDictEnv
 class TestHerReplayBuffer:
 
     def setup_method(self):
-        self.env = DummyDictEnv()
-        self.obs = self.env.reset()
+        self.env = GymEnv(DummyDictEnv())
+        self.obs = self.env.reset()[0]
         self._replay_k = 4
         self.replay_buffer = HERReplayBuffer(env_spec=self.env.spec,
                                              capacity_in_transitions=10,

--- a/tests/garage/sampler/test_utils.py
+++ b/tests/garage/sampler/test_utils.py
@@ -23,11 +23,6 @@ class TestRollout:
         assert path['agent_infos']['dummy'].shape[0] == 3
         assert path['env_infos']['dummy'].shape[0] == 3
 
-    def test_does_flatten(self):
-        path = utils.rollout(self.env, self.policy, max_episode_length=5)
-        assert path['observations'][0].shape == (16, )
-        assert path['actions'][0].shape == (2, 2)
-
     def test_deterministic_action(self):
         path = utils.rollout(self.env,
                              self.policy,

--- a/tests/garage/tf/policies/test_categorical_cnn_policy.py
+++ b/tests/garage/tf/policies/test_categorical_cnn_policy.py
@@ -9,7 +9,7 @@ from garage.envs import GymEnv
 from garage.tf.policies import CategoricalCNNPolicy
 
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyDiscretePixelEnv
+from tests.fixtures.envs.dummy import DummyDictEnv, DummyDiscretePixelEnv
 
 
 class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
@@ -116,3 +116,40 @@ class TestCategoricalCNNPolicyWithModel(TfGraphTestCase):
         for cloned_param, param in zip(policy_clone.parameters.values(),
                                        policy.parameters.values()):
             assert np.array_equal(cloned_param, param)
+
+    @pytest.mark.parametrize('filters, strides, padding, hidden_sizes', [
+        (((3, (32, 32)), ), (1, ), 'VALID', (4, )),
+    ])
+    def test_does_not_support_dict_obs_space(self, filters, strides, padding,
+                                             hidden_sizes):
+        """Test that policy raises error if passed a dict obs space."""
+        env = GymEnv(DummyDictEnv(act_space_type='discrete'))
+        with pytest.raises(ValueError):
+            CategoricalCNNPolicy(env_spec=env.spec,
+                                 filters=filters,
+                                 strides=strides,
+                                 padding=padding,
+                                 hidden_sizes=hidden_sizes)
+
+
+class TestCategoricalCNNPolicyImageObs(TfGraphTestCase):
+
+    def setup_method(self):
+        super().setup_method()
+        self.env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
+        self.sess.run(tf.compat.v1.global_variables_initializer())
+        self.env.reset()
+
+    @pytest.mark.parametrize('filters, strides, padding, hidden_sizes', [
+        (((3, (32, 32)), ), (1, ), 'VALID', (4, )),
+    ])
+    def test_obs_unflattened(self, filters, strides, padding, hidden_sizes):
+        self.policy = CategoricalCNNPolicy(env_spec=self.env.spec,
+                                           filters=filters,
+                                           strides=strides,
+                                           padding=padding,
+                                           hidden_sizes=hidden_sizes)
+        obs = self.env.observation_space.sample()
+        action, _ = self.policy.get_action(
+            self.env.observation_space.flatten(obs))
+        self.env.step(action)

--- a/tests/garage/tf/policies/test_categorical_gru_policy.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import CategoricalGRUPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestCategoricalGRUPolicy(TfGraphTestCase):
@@ -99,24 +104,34 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
-    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
-        ((1, ), 1, 4),
-        ((2, ), 2, 4),
-        ((1, 1), 1, 4),
-        ((2, 2), 2, 4),
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim, obs_type', [
+        ((1, ), 1, 4, 'discrete'),
+        ((2, ), 2, 4, 'discrete'),
+        ((1, 1), 1, 4, 'discrete'),
+        ((2, 2), 2, 4, 'discrete'),
+        ((1, ), 1, 4, 'dict'),
     ])
-    def test_get_action(self, obs_dim, action_dim, hidden_dim):
-        env = GymEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+    def test_get_action(self, obs_dim, action_dim, hidden_dim, obs_type):
+        assert obs_type in ['discrete', 'dict']
+        if obs_type == 'discrete':
+            env = GymEnv(
+                DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        else:
+            env = GymEnv(
+                DummyDictEnv(obs_space_type='box', act_space_type='discrete'))
         policy = CategoricalGRUPolicy(env_spec=env.spec,
                                       hidden_dim=hidden_dim,
                                       state_include_action=False)
         policy.reset(do_resets=None)
         obs = env.reset()[0]
 
-        action, _ = policy.get_action(obs.flatten())
+        if obs_type == 'discrete':
+            obs = obs.flatten()
+
+        action, _ = policy.get_action(obs)
         assert env.action_space.contains(action)
 
-        actions, _ = policy.get_actions([obs.flatten()])
+        actions, _ = policy.get_actions([obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_categorical_lstm_policy.py
+++ b/tests/garage/tf/policies/test_categorical_lstm_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import CategoricalLSTMPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestCategoricalLSTMPolicy(TfGraphTestCase):
@@ -18,26 +23,35 @@ class TestCategoricalLSTMPolicy(TfGraphTestCase):
         with pytest.raises(ValueError):
             CategoricalLSTMPolicy(env_spec=env.spec)
 
-    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
-        ((1, ), 1, 4),
-        ((2, ), 2, 4),
-        ((1, 1), 1, 4),
-        ((2, 2), 2, 4),
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim, obs_type', [
+        ((1, ), 1, 4, 'discrete'),
+        ((2, ), 2, 4, 'discrete'),
+        ((1, 1), 1, 4, 'discrete'),
+        ((2, 2), 2, 4, 'discrete'),
+        ((1, ), 1, 4, 'dict'),
     ])
     def test_get_action_state_include_action(self, obs_dim, action_dim,
-                                             hidden_dim):
-        env = GymEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+                                             hidden_dim, obs_type):
+        assert obs_type in ['discrete', 'dict']
+        if obs_type == 'discrete':
+            env = GymEnv(
+                DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        else:
+            env = GymEnv(
+                DummyDictEnv(obs_space_type='box', act_space_type='discrete'))
         policy = CategoricalLSTMPolicy(env_spec=env.spec,
                                        hidden_dim=hidden_dim,
                                        state_include_action=True)
 
         policy.reset()
         obs = env.reset()[0]
+        if obs_type == 'discrete':
+            obs = obs.flatten()
 
-        action, _ = policy.get_action(obs.flatten())
+        action, _ = policy.get_action(obs)
         assert env.action_space.contains(action)
 
-        actions, _ = policy.get_actions([obs.flatten()])
+        actions, _ = policy.get_actions([obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_categorical_mlp_policy.py
+++ b/tests/garage/tf/policies/test_categorical_mlp_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import CategoricalMLPPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestCategoricalMLPPolicy(TfGraphTestCase):
@@ -18,23 +23,29 @@ class TestCategoricalMLPPolicy(TfGraphTestCase):
         with pytest.raises(ValueError):
             CategoricalMLPPolicy(env_spec=env.spec)
 
-    @pytest.mark.parametrize('obs_dim, action_dim', [
-        ((1, ), 1),
-        ((2, ), 2),
-        ((1, 1), 1),
-        ((2, 2), 2),
+    @pytest.mark.parametrize('obs_dim, action_dim, obs_type', [
+        ((1, ), 1, 'discrete'),
+        ((2, ), 2, 'discrete'),
+        ((1, 1), 1, 'discrete'),
+        ((2, 2), 2, 'discrete'),
+        ((1, ), 1, 'dict'),
     ])
-    def test_get_action(self, obs_dim, action_dim):
-        env = GymEnv(DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+    def test_get_action(self, obs_dim, action_dim, obs_type):
+        assert obs_type in ['discrete', 'dict']
+        if obs_type == 'discrete':
+            env = GymEnv(
+                DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        else:
+            env = GymEnv(
+                DummyDictEnv(obs_space_type='box', act_space_type='discrete'))
         policy = CategoricalMLPPolicy(env_spec=env.spec)
         obs = env.reset()[0]
-
-        action, _ = policy.get_action(obs.flatten())
+        if obs_type == 'discrete':
+            obs = obs.flatten()
+        action, _ = policy.get_action(obs)
         assert env.action_space.contains(action)
 
-        actions, _ = policy.get_actions(
-            [obs.flatten(), obs.flatten(),
-             obs.flatten()])
+        actions, _ = policy.get_actions([obs, obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import GaussianGRUPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianGRUPolicy(TfGraphTestCase):
@@ -64,6 +69,21 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         assert env.action_space.contains(action)
 
         actions, _ = policy.get_actions([obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GymEnv(DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianGRUPolicy(env_spec=env.spec,
+                                   hidden_dim=4,
+                                   state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()[0]
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import GaussianLSTMPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianLSTMPolicy(TfGraphTestCase):
@@ -40,6 +45,21 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         policy.reset()
 
         actions, _ = policy.get_actions([obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GymEnv(DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianLSTMPolicy(env_spec=env.spec,
+                                    hidden_dim=4,
+                                    state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()[0]
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -7,8 +7,13 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.tf.policies import GaussianMLPPolicy
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianMLPPolicy(TfGraphTestCase):
@@ -38,6 +43,18 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
         actions, _ = policy.get_actions(
             [obs.flatten(), obs.flatten(),
              obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GymEnv(DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianMLPPolicy(env_spec=env.spec)
+        obs = env.reset()[0]
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_qf_derived_policy.py
+++ b/tests/garage/tf/policies/test_qf_derived_policy.py
@@ -1,13 +1,21 @@
 import pickle
 
+import pytest
 import tensorflow as tf
 
 from garage.envs import GymEnv
+from garage.envs.wrappers import AtariEnv
 from garage.tf.policies import DiscreteQfDerivedPolicy
+from garage.tf.q_functions import DiscreteCNNQFunction
 
+# yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+from tests.fixtures.envs.dummy import (DummyDictEnv,
+                                       DummyDiscreteEnv,
+                                       DummyDiscretePixelEnvBaselines)
 from tests.fixtures.q_functions import SimpleQFunction
+
+# yapf: enable
 
 
 class TestQfDerivedPolicy(TfGraphTestCase):
@@ -47,3 +55,43 @@ class TestQfDerivedPolicy(TfGraphTestCase):
             policy_pickled = pickle.loads(p)
             action2, _ = policy_pickled.get_action(obs)
             assert action1 == action2
+
+    def test_does_not_support_dict_obs_space(self):
+        """Test that policy raises error if passed a dict obs space."""
+        env = GymEnv(DummyDictEnv(act_space_type='discrete'))
+        with pytest.raises(ValueError):
+            qf = SimpleQFunction(env.spec,
+                                 name='does_not_support_dict_obs_space')
+            DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
+
+    def test_invalid_action_spaces(self):
+        """Test that policy raises error if passed a dict obs space."""
+        env = GymEnv(DummyDictEnv(act_space_type='box'))
+        with pytest.raises(ValueError):
+            qf = SimpleQFunction(env.spec)
+            DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
+
+
+class TestQfDerivedPolicyImageObs(TfGraphTestCase):
+
+    def setup_method(self):
+        super().setup_method()
+        self.env = GymEnv(AtariEnv(DummyDiscretePixelEnvBaselines()),
+                          is_image=True)
+        self.qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                       filters=((1, (1, 1)), ),
+                                       strides=(1, ),
+                                       dueling=False)
+        self.policy = DiscreteQfDerivedPolicy(env_spec=self.env.spec,
+                                              qf=self.qf)
+        self.sess.run(tf.compat.v1.global_variables_initializer())
+        self.env.reset()
+
+    def test_obs_unflattened(self):
+        """Test if a flattened image obs is passed to get_action
+           then it is unflattened.
+        """
+        obs = self.env.observation_space.sample()
+        action, _ = self.policy.get_action(
+            self.env.observation_space.flatten(obs))
+        self.env.step(action)

--- a/tests/garage/torch/policies/test_context_conditioned_policy.py
+++ b/tests/garage/torch/policies/test_context_conditioned_policy.py
@@ -32,9 +32,8 @@ class TestContextConditionedPolicy:
             (self.env_spec.observation_space, latent_space))
         augmented_env_spec = EnvSpec(augmented_obs_space,
                                      self.env_spec.action_space)
-
-        self.obs_dim = int(np.prod(self.env_spec.observation_space.shape))
-        self.action_dim = int(np.prod(self.env_spec.action_space.shape))
+        self.obs_dim = self.env_spec.observation_space.flat_dim
+        self.action_dim = self.env_spec.action_space.flat_dim
         reward_dim = 1
         self.encoder_input_dim = self.obs_dim + self.action_dim + reward_dim
         encoder_output_dim = self.latent_dim * 2

--- a/tests/garage/torch/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_gaussian_mlp_policy.py
@@ -9,7 +9,10 @@ from torch import nn
 from garage.envs import GymEnv
 from garage.torch.policies import GaussianMLPPolicy
 
-from tests.fixtures.envs.dummy import DummyBoxEnv
+# yapf: Disable
+from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDictEnv
+
+# yapf: Enable
 
 
 class TestGaussianMLPPolicies:
@@ -184,3 +187,23 @@ class TestGaussianMLPPolicies:
 
         assert np.array_equal(output1_prob['mean'], output2_prob['mean'])
         assert output1_action.shape == output2_action.shape
+
+    def test_get_action_dict_space(self):
+        """Test if observations from dict obs spaces are properly flattened."""
+        env = GymEnv(DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianMLPPolicy(env_spec=env.spec,
+                                   hidden_nonlinearity=None,
+                                   hidden_sizes=(1, ),
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+        obs = env.reset()[0]
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.shape == action.shape
+
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape

--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -18,6 +18,7 @@ NON_ALGO_EXAMPLES = [
 LONG_RUNNING_EXAMPLES = [
     EXAMPLES_ROOT_DIR / 'tf/ppo_memorize_digits.py',
     EXAMPLES_ROOT_DIR / 'tf/dqn_pong.py',
+    EXAMPLES_ROOT_DIR / 'tf/her_ddpg_fetchreach.py',
     EXAMPLES_ROOT_DIR / 'tf/trpo_cubecrash.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_ppo_half_cheetah_dir.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_trpo_half_cheetah_dir.py',
@@ -73,9 +74,6 @@ def test_algo_examples(filepath):
         filepath (str): path string of example
 
     """
-    if filepath == str(EXAMPLES_ROOT_DIR / 'tf/her_ddpg_fetchreach.py'):
-        pytest.skip('Temporarily skipped because it is broken')
-
     env = os.environ.copy()
     env['GARAGE_EXAMPLE_TEST_N_EPOCHS'] = '1'
     # Don't use check=True, since that causes subprocess to throw an error


### PR DESCRIPTION
The current behavior of garage is for samplers,
algorithms, and users to flatten their observations
before feeding them into policies. This is because
garage policies flatten their observation spaces
and expect observations from that flattened observation
space.

The proposed change is to flatten observations inside of
the policies if needed. Observations should be flattened
only if they arent numpy arrays, because numpy arrays are
the type of observation that would be returned by a flattened
observation box space.

This makes ddpg-fetch-her work, however some additional changes
were needed to make it work. For example, the timelimit terminated
fetch environment only inserts timelimit truncated signals
if the environment has reached a timelimit. This doesn't work
when considering trajectory batches, which require that the
same number of keys are in every observation in a trajectory.
To get around this, if there is no time limit termination,
a time limit termination False signal is inserted.

Something that I need help on is how to document observations when they aren't 
numpy arrays. For example, if they come from dict spaces, they are dictionary observations.