### PR TITLE
Print frozen deps in the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,8 @@ ci-job-verify-envs-pipenv:
 	pipenv graph
 	# pylint will verify all imports work
 	pipenv run pylint --disable=all --enable=import-error garage
+	@echo "Frozen dependencies:"
+	pipenv run pip freeze
 
 ci-deploy-docker: assert-travis
 	echo "${DOCKER_API_KEY}" | docker login -u "${DOCKER_USERNAME}" \


### PR DESCRIPTION
This will make it easy to find a frozen set of dependencies for each release branch, e.g. in case `pip` installs are failing.