### PR TITLE
Suppress physics errors in dm_control tests

### DIFF
--- a/tests/garage/envs/dm_control/test_dm_control_env.py
+++ b/tests/garage/envs/dm_control/test_dm_control_env.py
@@ -25,7 +25,7 @@ class TestDmControlEnv:
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with dm_control.mujoco.Physics.suppress_physics_errors():
+        with env.physics.suppress_physics_errors():
             step_env(env, render=False)
         env.close()
 
@@ -42,7 +42,7 @@ class TestDmControlEnv:
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with dm_control.mujoco.Physics.suppress_physics_errors():
+        with env.physics.suppress_physics_errors():
             step_env(env, render=False)
         env.close()
 
@@ -53,7 +53,7 @@ class TestDmControlEnv:
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with dm_control.mujoco.Physics.suppress_physics_errors():
+        with env.physics.suppress_physics_errors():
             step_env(env, render=False)
         round_trip.close()
         env.close()
@@ -67,7 +67,7 @@ class TestDmControlEnv:
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with dm_control.mujoco.Physics.suppress_physics_errors():
+        with env.physics.suppress_physics_errors():
             step_env(env, render=False)
         round_trip.close()
         env.close()

--- a/tests/garage/envs/dm_control/test_dm_control_env.py
+++ b/tests/garage/envs/dm_control/test_dm_control_env.py
@@ -2,6 +2,7 @@ import collections
 from copy import copy
 import pickle
 
+import dm_control.mujoco
 import dm_control.suite
 import pytest
 
@@ -23,7 +24,9 @@ class TestDmControlEnv:
         a = act_space.sample()
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
-        step_env(env, render=False)
+        # Sometimes random actions lead to physics errors
+        with dm_control.mujoco.Physics.suppress_physics_errors():
+            step_env(env, render=False)
         env.close()
 
     @pytest.mark.nightly
@@ -38,7 +41,9 @@ class TestDmControlEnv:
         a = act_space.sample()
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
-        step_env(env, render=False)
+        # Sometimes random actions lead to physics errors
+        with dm_control.mujoco.Physics.suppress_physics_errors():
+            step_env(env, render=False)
         env.close()
 
     def test_pickleable(self):
@@ -47,7 +52,9 @@ class TestDmControlEnv:
         round_trip = pickle.loads(pickle.dumps(env))
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
-        step_env(round_trip, render=False)
+        # Sometimes random actions lead to physics errors
+        with dm_control.mujoco.Physics.suppress_physics_errors():
+            step_env(env, render=False)
         round_trip.close()
         env.close()
 
@@ -59,7 +66,9 @@ class TestDmControlEnv:
         round_trip = pickle.loads(pickle.dumps(env))
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
-        step_env(round_trip, render=False)
+        # Sometimes random actions lead to physics errors
+        with dm_control.mujoco.Physics.suppress_physics_errors():
+            step_env(env, render=False)
         round_trip.close()
         env.close()
 

--- a/tests/garage/envs/dm_control/test_dm_control_env.py
+++ b/tests/garage/envs/dm_control/test_dm_control_env.py
@@ -25,7 +25,7 @@ class TestDmControlEnv:
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with env.physics.suppress_physics_errors():
+        with env._env.physics.suppress_physics_errors():
             step_env(env, render=False)
         env.close()
 
@@ -42,7 +42,7 @@ class TestDmControlEnv:
         assert act_space.contains(a)
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with env.physics.suppress_physics_errors():
+        with env._env.physics.suppress_physics_errors():
             step_env(env, render=False)
         env.close()
 
@@ -53,7 +53,7 @@ class TestDmControlEnv:
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with env.physics.suppress_physics_errors():
+        with env._env.physics.suppress_physics_errors():
             step_env(env, render=False)
         round_trip.close()
         env.close()
@@ -67,7 +67,7 @@ class TestDmControlEnv:
         assert round_trip
         # Skip rendering because it causes TravisCI to run out of memory
         # Sometimes random actions lead to physics errors
-        with env.physics.suppress_physics_errors():
+        with env._env.physics.suppress_physics_errors():
             step_env(env, render=False)
         round_trip.close()
         env.close()


### PR DESCRIPTION
This is intended to unflake the CI.

See failure at https://travis-ci.com/github/rlworkgroup/garage/jobs/370193879#L1713