### PR TITLE
Fix EnvStep comparison and tests

### DIFF
--- a/examples/tf/rl2_ppo_metaworld_ml10.py
+++ b/examples/tf/rl2_ppo_metaworld_ml10.py
@@ -5,6 +5,7 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
+from garage.envs import GymEnv
 from garage.experiment import LocalTFRunner, task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
@@ -39,7 +40,7 @@ def rl2_ppo_metaworld_ml10(ctxt, seed, max_episode_length, meta_batch_size,
     set_seed(seed)
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         ml10_train_envs = [
-            RL2Env(mwb.ML10.from_task(task_name))
+            RL2Env(GymEnv(mwb.ML10.from_task(task_name)))
             for task_name in mwb.ML10.get_train_tasks().all_task_names
         ]
         tasks = task_sampler.EnvPoolSampler(ml10_train_envs)

--- a/examples/tf/rl2_ppo_metaworld_ml10_meta_test.py
+++ b/examples/tf/rl2_ppo_metaworld_ml10_meta_test.py
@@ -5,6 +5,7 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
+from garage.envs import GymEnv
 from garage.experiment import LocalTFRunner, task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.experiment.meta_evaluator import MetaEvaluator
@@ -41,14 +42,14 @@ def rl2_ppo_metaworld_ml10_meta_test(ctxt, seed, max_episode_length,
     set_seed(seed)
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         ml10_train_envs = [
-            RL2Env(mwb.ML10.from_task(task_name))
+            RL2Env(GymEnv(mwb.ML10.from_task(task_name)))
             for task_name in mwb.ML10.get_train_tasks().all_task_names
         ]
         tasks = task_sampler.EnvPoolSampler(ml10_train_envs)
         tasks.grow_pool(meta_batch_size)
 
         ml10_test_envs = [
-            RL2Env(mwb.ML10.from_task(task_name))
+            RL2Env(GymEnv(mwb.ML10.from_task(task_name)))
             for task_name in mwb.ML10.get_test_tasks().all_task_names
         ]
         test_tasks = task_sampler.EnvPoolSampler(ml10_test_envs)

--- a/examples/tf/rl2_ppo_metaworld_ml45.py
+++ b/examples/tf/rl2_ppo_metaworld_ml45.py
@@ -5,6 +5,7 @@ import click
 import metaworld.benchmarks as mwb
 
 from garage import wrap_experiment
+from garage.envs import GymEnv
 from garage.experiment import LocalTFRunner, task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
@@ -40,7 +41,7 @@ def rl2_ppo_metaworld_ml45(ctxt, seed, max_episode_length, meta_batch_size,
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         ml45_train_tasks = mwb.ML45.get_train_tasks()
         ml45_train_envs = [
-            RL2Env(mwb.ML45.from_task(task_name))
+            RL2Env(GymEnv(mwb.ML45.from_task(task_name)))
             for task_name in ml45_train_tasks.all_task_names
         ]
         tasks = task_sampler.EnvPoolSampler(ml45_train_envs)

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -34,8 +34,7 @@ def trpo_swimmer_ray_sampler(ctxt=None, seed=1):
     ray.init(memory=52428800,
              object_store_memory=78643200,
              ignore_reinit_error=True,
-             log_to_driver=False,
-             include_dashboard=False)
+             log_to_driver=False)
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         set_seed(seed)
         env = GymEnv('Swimmer-v2')

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -33,8 +33,7 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
     ray.init(memory=52428800,
              object_store_memory=78643200,
              ignore_reinit_error=True,
-             log_to_driver=False,
-             include_dashboard=False)
+             log_to_driver=False)
     deterministic.set_seed(seed)
     env = GymEnv('InvertedDoublePendulum-v2')
 

--- a/src/garage/_environment.py
+++ b/src/garage/_environment.py
@@ -74,6 +74,19 @@ class EnvSpec(InOutSpec):
         """
         return self._max_episode_length
 
+    def __eq__(self, other):
+        """See :meth:`object.__eq__`.
+
+        Args:
+            other (EnvSpec): :class:`~EnvSpec` to compare with.
+
+        Returns:
+            bool: Whether these :class:`~EnvSpec` instances are equal.
+        """
+        return (self.observation_space == other.observation_space
+                and self.action_space == other.action_space
+                and self.max_episode_length == other.max_episode_length)
+
 
 class EnvStep(
         collections.namedtuple('EnvStep', [

--- a/src/garage/envs/gym_env.py
+++ b/src/garage/envs/gym_env.py
@@ -44,6 +44,8 @@ def _get_time_limit(env, max_episode_length):
     if hasattr(env, 'spec') and env.spec and hasattr(env.spec,
                                                      'max_episode_steps'):
         spec_steps = env.spec.max_episode_steps
+    elif hasattr(env, '_max_episode_steps'):
+        spec_steps = getattr(env, '_max_episode_steps')
 
     if spec_steps:
         if max_episode_length is not None and max_episode_length != spec_steps:

--- a/tests/fixtures/sampler/ray_fixtures.py
+++ b/tests/fixtures/sampler/ray_fixtures.py
@@ -16,8 +16,7 @@ def ray_local_session_fixture():
     if not ray.is_initialized():
         ray.init(local_mode=True,
                  ignore_reinit_error=True,
-                 log_to_driver=False,
-                 include_dashboard=False)
+                 log_to_driver=False)
     yield
     if ray.is_initialized():
         ray.shutdown()
@@ -37,8 +36,7 @@ def ray_session_fixture():
         ray.init(memory=52428800,
                  object_store_memory=78643200,
                  ignore_reinit_error=True,
-                 log_to_driver=False,
-                 include_dashboard=False)
+                 log_to_driver=False)
     yield
     if ray.is_initialized():
         ray.shutdown()

--- a/tests/garage/tf/envs/test_gym_base.py
+++ b/tests/garage/tf/envs/test_gym_base.py
@@ -22,8 +22,13 @@ class TestGymEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        if any(name == spec.id for name in _get_unsupported_env_list()):
+        if spec.id in _get_unsupported_env_list():
             pytest.skip('Skip unsupported Bullet environments')
+        if 'Kuka' in spec.id:
+            # Kuka environments calls py_bullet.resetSimulation() in reset()
+            # unconditionally, which globally resets other simulations. So
+            # only one Kuka environment can be tested.
+            pytest.skip('Skip Kuka Bullet environments')
         env = GymEnv(spec.id)
         step_env_with_gym_quirks(env, spec)
 
@@ -33,8 +38,13 @@ class TestGymEnv:
         if spec._env_name.startswith('Defender'):
             pytest.skip(
                 'Defender-* envs bundled in atari-py 0.2.x don\'t load')
-        if any(name == spec.id for name in _get_unsupported_env_list()):
+        if spec.id in _get_unsupported_env_list():
             pytest.skip('Skip unsupported Bullet environments')
+        if 'Kuka' in spec.id:
+            # Kuka environments calls py_bullet.resetSimulation() in reset()
+            # unconditionally, which globally resets other simulations. So
+            # only one Kuka environment can be tested.
+            pytest.skip('Skip Kuka Bullet environments')
         env = GymEnv(spec.id)
         step_env_with_gym_quirks(env,
                                  spec,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,5 @@
 """helper functions for tests and benchmarks."""
-import pickle
-
+import cloudpickle
 import numpy as np
 import pytest
 
@@ -33,10 +32,10 @@ def step_env_with_gym_quirks(env,
                              n=10,
                              visualize=True,
                              serialize_env=False):
-    """Step env gym helper.
+    """Step env helper.
 
     Args:
-        env (GymEnv): Input environment.
+        env (Environment): Input environment.
         spec (EnvSpec): The environment specification.
         n (int): Steps.
         visualize (bool): Whether to visualize the environment.
@@ -45,8 +44,8 @@ def step_env_with_gym_quirks(env,
     """
     if serialize_env:
         # Roundtrip serialization
-        round_trip = pickle.loads(pickle.dumps(env))
-        assert round_trip.env.spec == env.env.spec
+        round_trip = cloudpickle.loads(cloudpickle.dumps(env))
+        assert round_trip.spec == env.spec
         env = round_trip
 
     env.reset()
@@ -62,11 +61,6 @@ def step_env_with_gym_quirks(env,
             break
 
     env.close()
-
-    if serialize_env:
-        # Roundtrip serialization
-        round_trip = pickle.loads(pickle.dumps(env))
-        assert round_trip.env.spec == env.env.spec
 
 
 def convolve(_input, filter_weights, filter_bias, strides, filters,


### PR DESCRIPTION
1. Add EnvSpec Comparison logic so it works with `roundtrip.spec == env.spec` evaluation.
2. Fix GymEnv's get time limit logic - `gym.TimeLimit` doesn't have `spec` populated, so in this case we should look at `_max_episode_steps` directly.
3. Fix some example usages.

Closes [#1896 ](https://github.com/rlworkgroup/garage/issues/1896)