### PR TITLE
Update torch.full for torch 1.7 support

### DIFF
--- a/src/garage/torch/_functions.py
+++ b/src/garage/torch/_functions.py
@@ -72,7 +72,8 @@ def compute_advantages(discount, gae_lambda, max_episode_length, baselines,
 
     """
     adv_filter = torch.full((1, 1, 1, max_episode_length - 1),
-                            discount * gae_lambda)
+                            discount * gae_lambda,
+                            dtype=torch.float)
     adv_filter = torch.cumprod(F.pad(adv_filter, (1, 0), value=1), dim=-1)
 
     deltas = (rewards + discount * F.pad(baselines, (0, 1))[:, 1:] - baselines)

--- a/tests/garage/torch/modules/test_gaussian_mlp_module.py
+++ b/tests/garage/torch/modules/test_gaussian_mlp_module.py
@@ -56,12 +56,15 @@ def test_std_share_network_output_values(input_dim, output_dim, hidden_sizes):
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = (input_dim *
                     torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -81,13 +84,14 @@ def test_std_share_network_output_values_with_batch(input_dim, output_dim,
 
     exp_mean = torch.full(
         (batch_size, output_dim),
-        input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = (input_dim *
                     torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(
-        torch.full((batch_size, output_dim), exp_variance))
+        torch.full((batch_size, output_dim), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (batch_size, output_dim)
 
 
@@ -107,11 +111,14 @@ def test_std_network_output_values(input_dim, output_dim, hidden_sizes):
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = init_std**2
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -134,12 +141,13 @@ def test_std_network_output_values_with_batch(input_dim, output_dim,
 
     exp_mean = torch.full(
         (batch_size, output_dim),
-        input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = init_std**2
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(
-        torch.full((batch_size, output_dim), exp_variance))
+        torch.full((batch_size, output_dim), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (batch_size, output_dim)
 
 
@@ -162,12 +170,15 @@ def test_std_adaptive_network_output_values(input_dim, output_dim,
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = (input_dim *
                     torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -190,8 +201,10 @@ def test_softplus_std_network_output_values(input_dim, output_dim,
     exp_mean = input_dim * torch.Tensor(hidden_sizes).prod().item()
     exp_variance = torch.Tensor([init_std]).exp().add(1.).log()**2
 
-    assert dist.mean.equal(torch.full((output_dim, ), exp_mean))
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance[0]))
+    assert dist.mean.equal(
+        torch.full((output_dim, ), exp_mean, dtype=torch.float))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -213,7 +226,8 @@ def test_exp_min_std(input_dim, output_dim, hidden_sizes):
 
     exp_variance = min_value**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
@@ -234,7 +248,8 @@ def test_exp_max_std(input_dim, output_dim, hidden_sizes):
 
     exp_variance = max_value**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
@@ -255,7 +270,8 @@ def test_softplus_min_std(input_dim, output_dim, hidden_sizes):
 
     exp_variance = torch.Tensor([min_value]).exp().add(1.).log()**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance[0]))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
@@ -276,8 +292,9 @@ def test_softplus_max_std(input_dim, output_dim, hidden_sizes):
 
     exp_variance = torch.Tensor([max_value]).exp().add(1.).log()**2
 
-    assert torch.equal(dist.variance,
-                       torch.full((output_dim, ), exp_variance[0]))
+    assert torch.equal(
+        dist.variance,
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
 
 
 def test_unknown_std_parameterization():

--- a/tests/garage/torch/modules/test_multi_headed_mlp_module.py
+++ b/tests/garage/torch/modules/test_multi_headed_mlp_module.py
@@ -86,7 +86,8 @@ def test_multi_headed_mlp_module(input_dim, output_dim, hidden_sizes,
     for i, output in enumerate(outputs):
         expected = input_dim * torch.Tensor(hidden_sizes).prod()
         expected *= output_w_init_vals[i]
-        assert torch.equal(output, torch.full((output_dim[i], ), expected))
+        assert torch.equal(
+            output, torch.full((output_dim[i], ), expected, dtype=torch.float))
 
 
 @pytest.mark.parametrize(

--- a/tests/garage/torch/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_gaussian_mlp_policy.py
@@ -40,12 +40,15 @@ class TestGaussianMLPPolicies:
         dist = policy(obs)[0]
 
         expected_mean = torch.full(
-            (act_dim, ), obs_dim * (torch.Tensor(hidden_sizes).prod().item()))
+            (act_dim, ),
+            obs_dim * (torch.Tensor(hidden_sizes).prod().item()),
+            dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_action(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
-        assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
+        assert dist.variance.equal(
+            torch.full((act_dim, ), expected_variance, dtype=torch.float))
         assert action.shape == (act_dim, )
 
     # yapf: disable
@@ -71,12 +74,15 @@ class TestGaussianMLPPolicies:
         dist = policy(torch.from_numpy(obs))[0]
 
         expected_mean = torch.full(
-            (act_dim, ), obs_dim * (torch.Tensor(hidden_sizes).prod().item()))
+            (act_dim, ),
+            obs_dim * (torch.Tensor(hidden_sizes).prod().item()),
+            dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_action(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
-        assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
+        assert dist.variance.equal(
+            torch.full((act_dim, ), expected_variance, dtype=torch.float))
         assert action.shape == (act_dim, )
 
     # yapf: disable
@@ -108,13 +114,16 @@ class TestGaussianMLPPolicies:
 
         expected_mean = torch.full([batch_size, act_dim],
                                    obs_dim *
-                                   (torch.Tensor(hidden_sizes).prod().item()))
+                                   (torch.Tensor(hidden_sizes).prod().item()),
+                                   dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_actions(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
         assert dist.variance.equal(
-            torch.full((batch_size, act_dim), expected_variance))
+            torch.full((batch_size, act_dim),
+                       expected_variance,
+                       dtype=torch.float))
         assert action.shape == (batch_size, act_dim)
 
     # yapf: disable
@@ -146,13 +155,16 @@ class TestGaussianMLPPolicies:
 
         expected_mean = torch.full([batch_size, act_dim],
                                    obs_dim *
-                                   (torch.Tensor(hidden_sizes).prod().item()))
+                                   (torch.Tensor(hidden_sizes).prod().item()),
+                                   dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_actions(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
         assert dist.variance.equal(
-            torch.full((batch_size, act_dim), expected_variance))
+            torch.full((batch_size, act_dim),
+                       expected_variance,
+                       dtype=torch.float))
         assert action.shape == (batch_size, act_dim)
 
     # yapf: disable

--- a/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
@@ -36,7 +36,7 @@ class TestTanhGaussianMLPPolicy:
                                        std_parameterization='exp',
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
-        expected_mean = torch.full((act_dim, ), 1.0)
+        expected_mean = torch.full((act_dim, ), 1.0, dtype=torch.float)
         action, prob = policy.get_action(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.squeeze(0).shape == (act_dim, )
@@ -60,7 +60,7 @@ class TestTanhGaussianMLPPolicy:
                                        std_parameterization='exp',
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
-        expected_mean = torch.full((act_dim, ), 1.0)
+        expected_mean = torch.full((act_dim, ), 1.0, dtype=torch.float)
         action, prob = policy.get_action(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (act_dim, )
@@ -90,7 +90,9 @@ class TestTanhGaussianMLPPolicy:
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
 
-        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        expected_mean = torch.full([batch_size, act_dim],
+                                   1.0,
+                                   dtype=torch.float)
         action, prob = policy.get_actions(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (batch_size, act_dim)
@@ -120,7 +122,9 @@ class TestTanhGaussianMLPPolicy:
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
 
-        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        expected_mean = torch.full([batch_size, act_dim],
+                                   1.0,
+                                   dtype=torch.float)
         action, prob = policy.get_actions(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (batch_size, act_dim)


### PR DESCRIPTION
This PR fix #1823: `torch.full` with no argument `dtype` due to torch 1.7 no longer support 1.6 version. 