### PR TITLE
Pin gym version in benchmarks package

### DIFF
--- a/benchmarks/setup.py
+++ b/benchmarks/setup.py
@@ -12,6 +12,7 @@ REQUIRED = [
     # Please keep alphabetized
     'baselines @ https://{}@api.github.com/repos/openai/baselines/tarball/ea25b9e8b234e6ee1bca43083f8f3cf974143998'.format(GARAGE_GH_TOKEN),  # noqa: E501
     'google-cloud-storage',
+    'gym==0.17.2',
     'matplotlib'
 ]  # yapf: disable
 


### PR DESCRIPTION
openai/baselines depends on gym<16.0 while it is pinned
to 0.17.2 in garage. Installing baselines over garage
leads to installation of gym 0.15.7 which isn't compatible
with cloudpickle 1.3. We do this in our Dockerfile.

This is a temporary fix until we can remove gym dependency
in the main garage package

This might break baselines but since we are not actively
using that, we can deal with that later