### PR TITLE
Backport 2020.06 for torch support 1.7

### DIFF
--- a/src/garage/torch/_functions.py
+++ b/src/garage/torch/_functions.py
@@ -68,7 +68,8 @@ def compute_advantages(discount, gae_lambda, max_path_length, baselines,
 
     """
     adv_filter = torch.full((1, 1, 1, max_path_length - 1),
-                            discount * gae_lambda)
+                            discount * gae_lambda,
+                            dtype=torch.float)
     adv_filter = torch.cumprod(F.pad(adv_filter, (1, 0), value=1), dim=-1)
 
     deltas = (rewards + discount * F.pad(baselines, (0, 1))[:, 1:] - baselines)

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -99,4 +99,4 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
                     policy_pickled.distribution.stddev()
                 ],
                 feed_dict={policy_pickled.model.input: [[obs.flatten()]]})
-            assert np.array_equal(output1, output2)
+            assert np.array_equal(output2, output1)

--- a/tests/garage/torch/modules/test_gaussian_mlp_module.py
+++ b/tests/garage/torch/modules/test_gaussian_mlp_module.py
@@ -40,51 +40,53 @@ different_std_settings = [(1, 1, (1, ), (1, )), (1, 2, (2, ), (2, )),
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_std_share_network_output_values(input_dim, output_dim, hidden_sizes):
-    module = GaussianMLPTwoHeadedModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPTwoHeadedModule(input_dim=input_dim,
+                                        output_dim=output_dim,
+                                        hidden_sizes=hidden_sizes,
+                                        hidden_nonlinearity=None,
+                                        std_parameterization='exp',
+                                        hidden_w_init=nn.init.ones_,
+                                        output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_std_share_network_output_values_with_batch(input_dim, output_dim,
                                                     hidden_sizes):
-    module = GaussianMLPTwoHeadedModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPTwoHeadedModule(input_dim=input_dim,
+                                        output_dim=output_dim,
+                                        hidden_sizes=hidden_sizes,
+                                        hidden_nonlinearity=None,
+                                        std_parameterization='exp',
+                                        hidden_w_init=nn.init.ones_,
+                                        output_w_init=nn.init.ones_)
 
     batch_size = 5
     dist = module(torch.ones([batch_size, input_dim]))
 
     exp_mean = torch.full(
         (batch_size, output_dim),
-        input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(
-        torch.full((batch_size, output_dim), exp_variance))
+        torch.full((batch_size, output_dim), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (batch_size, output_dim)
 
 
@@ -92,24 +94,26 @@ def test_std_share_network_output_values_with_batch(input_dim, output_dim,
 def test_std_network_output_values(input_dim, output_dim, hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = init_std**2
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -118,27 +122,27 @@ def test_std_network_output_values_with_batch(input_dim, output_dim,
                                               hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     batch_size = 5
     dist = module(torch.ones([batch_size, input_dim]))
 
     exp_mean = torch.full(
         (batch_size, output_dim),
-        input_dim * (torch.Tensor(hidden_sizes).prod().item()))
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
     exp_variance = init_std**2
 
     assert dist.mean.equal(exp_mean)
     assert dist.variance.equal(
-        torch.full((batch_size, output_dim), exp_variance))
+        torch.full((batch_size, output_dim), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (batch_size, output_dim)
 
 
@@ -147,27 +151,29 @@ def test_std_network_output_values_with_batch(input_dim, output_dim,
     different_std_settings)
 def test_std_adaptive_network_output_values(input_dim, output_dim,
                                             hidden_sizes, std_hidden_sizes):
-    module = GaussianMLPIndependentStdModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        std_hidden_sizes=std_hidden_sizes,
-        hidden_nonlinearity=None,
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_,
-        std_hidden_nonlinearity=None,
-        std_hidden_w_init=nn.init.ones_,
-        std_output_w_init=nn.init.ones_)
+    module = GaussianMLPIndependentStdModule(input_dim=input_dim,
+                                             output_dim=output_dim,
+                                             hidden_sizes=hidden_sizes,
+                                             std_hidden_sizes=std_hidden_sizes,
+                                             hidden_nonlinearity=None,
+                                             hidden_w_init=nn.init.ones_,
+                                             output_w_init=nn.init.ones_,
+                                             std_hidden_nonlinearity=None,
+                                             std_hidden_w_init=nn.init.ones_,
+                                             std_output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = torch.full(
-        (output_dim, ), input_dim * (torch.Tensor(hidden_sizes).prod().item()))
-    exp_variance = (
-        input_dim * torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
+        (output_dim, ),
+        input_dim * (torch.Tensor(hidden_sizes).prod().item()),
+        dtype=torch.float)
+    exp_variance = (input_dim *
+                    torch.Tensor(hidden_sizes).prod()).exp().pow(2).item()
 
     assert dist.mean.equal(exp_mean)
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -176,23 +182,24 @@ def test_softplus_std_network_output_values(input_dim, output_dim,
                                             hidden_sizes):
     init_std = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=init_std,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=init_std,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_mean = input_dim * torch.Tensor(hidden_sizes).prod().item()
     exp_variance = torch.Tensor([init_std]).exp().add(1.).log()**2
 
-    assert dist.mean.equal(torch.full((output_dim, ), exp_mean))
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance[0]))
+    assert dist.mean.equal(
+        torch.full((output_dim, ), exp_mean, dtype=torch.float))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
     assert dist.rsample().shape == (output_dim, )
 
 
@@ -200,92 +207,93 @@ def test_softplus_std_network_output_values(input_dim, output_dim,
 def test_exp_min_std(input_dim, output_dim, hidden_sizes):
     min_value = 10.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=1.,
-        min_std=min_value,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=1.,
+                               min_std=min_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
     exp_variance = min_value**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_exp_max_std(input_dim, output_dim, hidden_sizes):
     max_value = 1.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=10.,
-        max_std=max_value,
-        hidden_nonlinearity=None,
-        std_parameterization='exp',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=10.,
+                               max_std=max_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='exp',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
     exp_variance = max_value**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance, dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_softplus_min_std(input_dim, output_dim, hidden_sizes):
     min_value = 2.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=1.,
-        min_std=min_value,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.zeros_,
-        output_w_init=nn.init.zeros_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=1.,
+                               min_std=min_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.zeros_,
+                               output_w_init=nn.init.zeros_)
 
     dist = module(torch.ones(input_dim))
 
     exp_variance = torch.Tensor([min_value]).exp().add(1.).log()**2
 
-    assert dist.variance.equal(torch.full((output_dim, ), exp_variance[0]))
+    assert dist.variance.equal(
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
 
 
 @pytest.mark.parametrize('input_dim, output_dim, hidden_sizes', plain_settings)
 def test_softplus_max_std(input_dim, output_dim, hidden_sizes):
     max_value = 1.
 
-    module = GaussianMLPModule(
-        input_dim=input_dim,
-        output_dim=output_dim,
-        hidden_sizes=hidden_sizes,
-        init_std=10,
-        max_std=max_value,
-        hidden_nonlinearity=None,
-        std_parameterization='softplus',
-        hidden_w_init=nn.init.ones_,
-        output_w_init=nn.init.ones_)
+    module = GaussianMLPModule(input_dim=input_dim,
+                               output_dim=output_dim,
+                               hidden_sizes=hidden_sizes,
+                               init_std=10,
+                               max_std=max_value,
+                               hidden_nonlinearity=None,
+                               std_parameterization='softplus',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_)
 
     dist = module(torch.ones(input_dim))
 
     exp_variance = torch.Tensor([max_value]).exp().add(1.).log()**2
 
-    assert torch.equal(dist.variance,
-                       torch.full((output_dim, ), exp_variance[0]))
+    assert torch.equal(
+        dist.variance,
+        torch.full((output_dim, ), exp_variance[0], dtype=torch.float))
 
 
 def test_unknown_std_parameterization():
     with pytest.raises(NotImplementedError):
-        GaussianMLPModule(
-            input_dim=1, output_dim=1, std_parameterization='unknown')
+        GaussianMLPModule(input_dim=1,
+                          output_dim=1,
+                          std_parameterization='unknown')

--- a/tests/garage/torch/modules/test_multi_headed_mlp_module.py
+++ b/tests/garage/torch/modules/test_multi_headed_mlp_module.py
@@ -86,7 +86,8 @@ def test_multi_headed_mlp_module(input_dim, output_dim, hidden_sizes,
     for i, output in enumerate(outputs):
         expected = input_dim * torch.Tensor(hidden_sizes).prod()
         expected *= output_w_init_vals[i]
-        assert torch.equal(output, torch.full((output_dim[i], ), expected))
+        assert torch.equal(
+            output, torch.full((output_dim[i], ), expected, dtype=torch.float))
 
 
 @pytest.mark.parametrize(

--- a/tests/garage/torch/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_gaussian_mlp_policy.py
@@ -36,12 +36,15 @@ class TestGaussianMLPPolicies:
         dist = policy(obs)[0]
 
         expected_mean = torch.full(
-            (act_dim, ), obs_dim * (torch.Tensor(hidden_sizes).prod().item()))
+            (act_dim, ),
+            obs_dim * (torch.Tensor(hidden_sizes).prod().item()),
+            dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_action(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
-        assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
+        assert dist.variance.equal(
+            torch.full((act_dim, ), expected_variance, dtype=torch.float))
         assert action.shape == (act_dim, )
 
     # yapf: disable
@@ -67,12 +70,15 @@ class TestGaussianMLPPolicies:
         dist = policy(torch.from_numpy(obs))[0]
 
         expected_mean = torch.full(
-            (act_dim, ), obs_dim * (torch.Tensor(hidden_sizes).prod().item()))
+            (act_dim, ),
+            obs_dim * (torch.Tensor(hidden_sizes).prod().item()),
+            dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_action(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
-        assert dist.variance.equal(torch.full((act_dim, ), expected_variance))
+        assert dist.variance.equal(
+            torch.full((act_dim, ), expected_variance, dtype=torch.float))
         assert action.shape == (act_dim, )
 
     # yapf: disable
@@ -104,13 +110,16 @@ class TestGaussianMLPPolicies:
 
         expected_mean = torch.full([batch_size, act_dim],
                                    obs_dim *
-                                   (torch.Tensor(hidden_sizes).prod().item()))
+                                   (torch.Tensor(hidden_sizes).prod().item()),
+                                   dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_actions(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
         assert dist.variance.equal(
-            torch.full((batch_size, act_dim), expected_variance))
+            torch.full((batch_size, act_dim),
+                       expected_variance,
+                       dtype=torch.float))
         assert action.shape == (batch_size, act_dim)
 
     # yapf: disable
@@ -142,13 +151,16 @@ class TestGaussianMLPPolicies:
 
         expected_mean = torch.full([batch_size, act_dim],
                                    obs_dim *
-                                   (torch.Tensor(hidden_sizes).prod().item()))
+                                   (torch.Tensor(hidden_sizes).prod().item()),
+                                   dtype=torch.float)
         expected_variance = init_std**2
         action, prob = policy.get_actions(obs)
 
         assert np.array_equal(prob['mean'], expected_mean.numpy())
         assert dist.variance.equal(
-            torch.full((batch_size, act_dim), expected_variance))
+            torch.full((batch_size, act_dim),
+                       expected_variance,
+                       dtype=torch.float))
         assert action.shape == (batch_size, act_dim)
 
     # yapf: disable

--- a/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
@@ -32,7 +32,7 @@ class TestTanhGaussianMLPPolicy:
                                        std_parameterization='exp',
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
-        expected_mean = torch.full((act_dim, ), 1.0)
+        expected_mean = torch.full((act_dim, ), 1.0, dtype=torch.float)
         action, prob = policy.get_action(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.squeeze(0).shape == (act_dim, )
@@ -56,7 +56,7 @@ class TestTanhGaussianMLPPolicy:
                                        std_parameterization='exp',
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
-        expected_mean = torch.full((act_dim, ), 1.0)
+        expected_mean = torch.full((act_dim, ), 1.0, dtype=torch.float)
         action, prob = policy.get_action(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (act_dim, )
@@ -86,7 +86,9 @@ class TestTanhGaussianMLPPolicy:
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
 
-        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        expected_mean = torch.full([batch_size, act_dim],
+                                   1.0,
+                                   dtype=torch.float)
         action, prob = policy.get_actions(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (batch_size, act_dim)
@@ -116,7 +118,9 @@ class TestTanhGaussianMLPPolicy:
                                        hidden_w_init=nn.init.ones_,
                                        output_w_init=nn.init.ones_)
 
-        expected_mean = torch.full([batch_size, act_dim], 1.0)
+        expected_mean = torch.full([batch_size, act_dim],
+                                   1.0,
+                                   dtype=torch.float)
         action, prob = policy.get_actions(obs)
         assert np.allclose(prob['mean'], expected_mean.numpy(), rtol=1e-3)
         assert action.shape == (batch_size, act_dim)


### PR DESCRIPTION
This PR fix #1823 (Backport 2020.06): torch.full with no argument dtype due to torch 1.7 no longer support 1.6 version.