### PR TITLE
Fix LocalRunner always use RLAlgorithm.worker_cls

### DIFF
--- a/src/garage/experiment/local_runner.py
+++ b/src/garage/experiment/local_runner.py
@@ -198,7 +198,6 @@ class LocalRunner:
             sampler_args = {}
         if worker_args is None:
             worker_args = {}
-
         return sampler_cls.from_worker_factory(WorkerFactory(
             seed=seed,
             max_episode_length=max_episode_length,
@@ -214,7 +213,7 @@ class LocalRunner:
               sampler_cls=None,
               sampler_args=None,
               n_workers=psutil.cpu_count(logical=False),
-              worker_class=DefaultWorker,
+              worker_class=None,
               worker_args=None):
         """Set up runner for algorithm and environment.
 
@@ -248,6 +247,8 @@ class LocalRunner:
             sampler_args = {}
         if sampler_cls is None:
             sampler_cls = getattr(algo, 'sampler_cls', None)
+        if worker_class is None:
+            worker_class = getattr(algo, 'worker_cls', DefaultWorker)
         if worker_args is None:
             worker_args = {}
 

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -202,7 +202,7 @@ class SAC(RLAlgorithm):
                                  for step_type in path['step_types']
                              ]).reshape(-1, 1)))
                     path_returns.append(sum(path['rewards']))
-                assert len(path_returns) is len(runner.step_path)
+                assert len(path_returns) == len(runner.step_path)
                 self.episode_rewards.append(np.mean(path_returns))
                 for _ in range(self._gradient_steps):
                     policy_loss, qf1_loss, qf2_loss = self.train_once()


### PR DESCRIPTION
This PR fix a bug related to `LocalRunner` class - our current `LocalRunner` setup will always use `DefaultWorker` as `worker_class` and it will not be updated through setting an attribute `worker_cls` in some algorithms. 