### PR TITLE
Set docker memory limit to 6.5gb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" scripts/travisci/check_precommit.sh
 
 
@@ -106,7 +106,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           '[ ! -f ${MJKEY_PATH} ] || mv ${MJKEY_PATH} ${MJKEY_PATH}.bak &&
@@ -147,7 +147,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           '[ ! -f ${MJKEY_PATH} ] || mv ${MJKEY_PATH} ${MJKEY_PATH}.bak
@@ -187,7 +187,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           'pytest --cov=garage --cov-report=xml -m "mujoco and not flaky" --durations=20 &&
@@ -226,7 +226,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           'pytest --cov=garage --cov-report=xml -m "mujoco_long and not flaky" --durations=20 &&
@@ -266,7 +266,7 @@ jobs:
             -e GITHUB_SHA \
             -e GITHUB_RUN_ID \
             --memory 6500m \
-            --memory-swap 7500m \
+            --memory-swap 6500m \
             "${DOCKER_TAG}" pytest -v -m nightly
 
 
@@ -299,7 +299,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           'CONDA_ROOT=$HOME/miniconda \
@@ -349,7 +349,7 @@ jobs:
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
           --memory 6500m \
-          --memory-swap 7500m \
+          --memory-swap 6500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
           "export PATH=\$PATH_NO_VENV && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" scripts/travisci/check_precommit.sh
 
@@ -105,7 +105,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
@@ -146,7 +146,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
@@ -186,7 +186,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
@@ -225,7 +225,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
@@ -265,7 +265,7 @@ jobs:
             -e GITHUB_HEAD_REF \
             -e GITHUB_SHA \
             -e GITHUB_RUN_ID \
-            --memory 7500m \
+            --memory 6500m \
             --memory-swap 7500m \
             "${DOCKER_TAG}" pytest -v -m nightly
 
@@ -298,7 +298,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \
@@ -348,7 +348,7 @@ jobs:
           -e GITHUB_HEAD_REF \
           -e GITHUB_SHA \
           -e GITHUB_RUN_ID \
-          --memory 7500m \
+          --memory 6500m \
           --memory-swap 7500m \
           "${DOCKER_TAG}" \
           /bin/bash -c \


### PR DESCRIPTION
Github Actions runners have 7gb of ram