### PR TITLE
Allow deterministic=False for off-policy

### DIFF
--- a/src/garage/np/_functions.py
+++ b/src/garage/np/_functions.py
@@ -32,7 +32,8 @@ def samples_to_tensors(paths):
 def obtain_evaluation_episodes(policy,
                                env,
                                max_episode_length=1000,
-                               num_eps=100):
+                               num_eps=100,
+                               deterministic=True):
     """Sample the policy for num_eps episodes and return average values.
 
     Args:
@@ -41,6 +42,8 @@ def obtain_evaluation_episodes(policy,
         max_episode_length (int): Maximum episode length. The episode will
             truncated when length of episode reaches max_episode_length.
         num_eps (int): Number of episodes.
+        deterministic (bool): Whether the a deterministic approach is used
+            in rollout.
 
     Returns:
         EpisodeBatch: Evaluation episodes, representing the best current
@@ -54,7 +57,7 @@ def obtain_evaluation_episodes(policy,
         eps = rollout(env,
                       policy,
                       max_episode_length=max_episode_length,
-                      deterministic=True)
+                      deterministic=deterministic)
         episodes.append(eps)
     return EpisodeBatch.from_list(env.spec, episodes)
 

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -462,7 +462,10 @@ class SAC(RLAlgorithm):
 
         """
         eval_episodes = obtain_evaluation_episodes(
-            self.policy, self._eval_env, num_eps=self._num_evaluation_episodes)
+            self.policy,
+            self._eval_env,
+            num_eps=self._num_evaluation_episodes,
+            deterministic=False)
         last_return = log_performance(epoch,
                                       eval_episodes,
                                       discount=self._discount)


### PR DESCRIPTION
This PR allows off-policies like SAC and TD3 to have a non-deterministic rollout. I updated the `obtain_evaluation_episodes` (previously known as `obtain_evaluation_samples`) which now accept also a boolean argument `deterministic` and by default it's true. 