### PR TITLE
Update algorithm interface to accept deterministic eval sampling

### DIFF
--- a/src/garage/np/_functions.py
+++ b/src/garage/np/_functions.py
@@ -42,8 +42,8 @@ def obtain_evaluation_episodes(policy,
         max_episode_length (int): Maximum episode length. The episode will
             truncated when length of episode reaches max_episode_length.
         num_eps (int): Number of episodes.
-        deterministic (bool): Whether the a deterministic approach is used
-            in rollout.
+        deterministic (bool): Whether deterministic sampliing is used in
+            evaluation.
 
     Returns:
         EpisodeBatch: Evaluation episodes, representing the best current

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -56,6 +56,11 @@ class DDPG(RLAlgorithm):
         max_action (float): Maximum action magnitude.
         reward_scale (float): Reward scale.
         name (str): Name of the algorithm shown in computation graph.
+        deterministic_eval_sampling (bool) : When using stochastic policies,
+            whether true if deterministic sampling (taking the mean of the
+            distribution output by the stochastic policy) is done and
+            false if random sampling is done (sampling from the output
+            distribution).
 
     """
 
@@ -83,6 +88,7 @@ class DDPG(RLAlgorithm):
             qf_lr=_Default(1e-3),
             clip_pos_returns=False,
             clip_return=np.inf,
+            deterministic_eval_sampling=True,
             max_action=None,
             reward_scale=1.,
             name='DDPG'):
@@ -94,6 +100,7 @@ class DDPG(RLAlgorithm):
         self._name = name
         self._clip_pos_returns = clip_pos_returns
         self._clip_return = clip_return
+        self._deterministic_eval_sampling = deterministic_eval_sampling
 
         self._episode_policy_losses = []
         self._episode_qf_losses = []
@@ -287,7 +294,9 @@ class DDPG(RLAlgorithm):
                         self._min_buffer_size):
                     runner.enable_logging = True
                     eval_episodes = obtain_evaluation_episodes(
-                        self.policy, self._eval_env)
+                        self.policy,
+                        self._eval_env,
+                        deterministic=self._deterministic_eval_sampling)
                     last_returns = log_performance(runner.step_itr,
                                                    eval_episodes,
                                                    discount=self._discount)

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -47,6 +47,11 @@ class DQN(RLAlgorithm):
         double_q (bool): Bool for using double q-network.
         reward_scale (float): Reward scale.
         name (str): Name of the algorithm.
+        deterministic_eval_sampling (bool) : When using stochastic policies,
+            whether true if deterministic sampling (taking the mean of the
+            distribution output by the stochastic policy) is done and
+            false if random sampling is done (sampling from the output
+            distribution).
 
     """
 
@@ -68,6 +73,7 @@ class DQN(RLAlgorithm):
                  target_network_update_freq=5,
                  grad_norm_clipping=None,
                  double_q=False,
+                 deterministic_eval_sampling=True,
                  reward_scale=1.,
                  name='DQN'):
         self._qf_optimizer = qf_optimizer
@@ -76,6 +82,7 @@ class DQN(RLAlgorithm):
         self._target_network_update_freq = target_network_update_freq
         self._grad_norm_clipping = grad_norm_clipping
         self._double_q = double_q
+        self._deterministic_eval_sampling = deterministic_eval_sampling
 
         # clone a target q-function
         self._target_qf = qf.clone('target_qf')
@@ -214,7 +221,9 @@ class DQN(RLAlgorithm):
                         self._min_buffer_size):
                     runner.enable_logging = True
                     eval_episodes = obtain_evaluation_episodes(
-                        self.policy, self._eval_env)
+                        self.policy,
+                        self._eval_env,
+                        deterministic=self._deterministic_eval_sampling)
                     last_returns = log_performance(runner.step_itr,
                                                    eval_episodes,
                                                    discount=self._discount)

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -62,6 +62,12 @@ class TD3(RLAlgorithm):
         exploration_policy_clip (float): Action noise clip.
         actor_update_period (int): Action update period.
         exploration_policy (ExplorationPolicy): Exploration strategy.
+        deterministic_eval_sampling (bool) : When using stochastic policies,
+            whether random true if deterministic sampling (taking the mean of
+            the distribution output by the stochastic policy) is done and
+            false if random sampling is done (sampling from the output
+            distribution).
+
 
     """
 
@@ -95,7 +101,8 @@ class TD3(RLAlgorithm):
             exploration_policy_sigma=0.2,
             actor_update_period=2,
             exploration_policy_clip=0.5,
-            exploration_policy=None):
+            exploration_policy=None,
+            deterministic_eval_sampling=False):
         action_bound = env_spec.action_space.high
         self._max_action = action_bound if max_action is None else max_action
         self._tau = target_update_tau
@@ -104,6 +111,7 @@ class TD3(RLAlgorithm):
         self._name = name
         self._clip_pos_returns = clip_pos_returns
         self._clip_return = clip_return
+        self._deterministic_eval_sampling = deterministic_eval_sampling
 
         self._episode_policy_losses = []
         self._episode_qf_losses = []
@@ -307,7 +315,9 @@ class TD3(RLAlgorithm):
                         self._min_buffer_size):
                     runner.enable_logging = True
                     eval_episodes = obtain_evaluation_episodes(
-                        self.policy, self._eval_env)
+                        self.policy,
+                        self._eval_env,
+                        deterministic=self._deterministic_eval_sampling)
                     last_returns = log_performance(runner.step_itr,
                                                    eval_episodes,
                                                    discount=self._discount)

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -62,7 +62,7 @@ class DDPG(RLAlgorithm):
             clip_return].
         max_action (float): Maximum action magnitude.
         reward_scale (float): Reward scale.
-
+        deterministic_eval_sampling (bool) : When using stochastic policies, whether random true if deterministic sampling (taking the mean of the distribution outputted by the stochastic policy) is done and false if random sampling is done (sampling from the outputted distribution).
     """
 
     def __init__(
@@ -89,6 +89,7 @@ class DDPG(RLAlgorithm):
             qf_lr=_Default(1e-3),
             clip_pos_returns=False,
             clip_return=np.inf,
+            deterministic_eval_sampling=True,
             max_action=None,
             reward_scale=1.):
         action_bound = env_spec.action_space.high
@@ -97,6 +98,7 @@ class DDPG(RLAlgorithm):
         self._qf_weight_decay = qf_weight_decay
         self._clip_pos_returns = clip_pos_returns
         self._clip_return = clip_return
+        self._deterministic_eval_sampling = deterministic_eval_sampling
         self._max_action = action_bound if max_action is None else max_action
 
         self._steps_per_epoch = steps_per_epoch
@@ -159,7 +161,9 @@ class DDPG(RLAlgorithm):
                         self._min_buffer_size):
                     runner.enable_logging = True
                     eval_eps = obtain_evaluation_episodes(
-                        self.policy, self._eval_env)
+                        self.policy,
+                        self._eval_env,
+                        deterministic=self._deterministic_eval_sampling)
                     last_returns = log_performance(runner.step_itr,
                                                    eval_eps,
                                                    discount=self._discount)

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -81,6 +81,11 @@ class SAC(RLAlgorithm):
             for computing eval stats at the end of every epoch.
         eval_env (Environment): environment used for collecting evaluation
             episodes. If None, a copy of the train env is used.
+        deterministic_eval_sampling (bool) : When using stochastic policies,
+            whether true if deterministic sampling (taking the mean of the
+            distribution output by the stochastic policy) is done and
+            false if random sampling is done (sampling from the output
+            distribution).
 
     """
 
@@ -109,6 +114,7 @@ class SAC(RLAlgorithm):
         steps_per_epoch=1,
         num_evaluation_episodes=10,
         eval_env=None,
+        deterministic_eval_sampling=False,
     ):
 
         self._qf1 = qf1
@@ -122,6 +128,7 @@ class SAC(RLAlgorithm):
         self._optimizer = optimizer
         self._num_evaluation_episodes = num_evaluation_episodes
         self._eval_env = eval_env
+        self._deterministic_eval_sampling = deterministic_eval_sampling
 
         self._min_buffer_size = min_buffer_size
         self._steps_per_epoch = steps_per_epoch
@@ -465,7 +472,7 @@ class SAC(RLAlgorithm):
             self.policy,
             self._eval_env,
             num_eps=self._num_evaluation_episodes,
-            deterministic=False)
+            deterministic=self._deterministic_eval_sampling)
         last_return = log_performance(epoch,
                                       eval_episodes,
                                       discount=self._discount)


### PR DESCRIPTION
This PR is related to #1968, fixed the docstring and updated the algorithm interface to accept `deterministic_eval_sampling`