### PR TITLE
Address TF/ DDPG low return

### DIFF
--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -9,6 +9,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
+from garage.np.policies import UniformRandomPolicy
 from garage.replay_buffer import HERReplayBuffer
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
@@ -43,6 +44,8 @@ def her_ddpg_fetchreach(ctxt=None, seed=1):
                                                        policy,
                                                        sigma=0.2)
 
+        uniform_random_policy = UniformRandomPolicy(env.spec)
+
         qf = ContinuousMLPQFunction(
             env_spec=env.spec,
             name='QFunction',
@@ -68,6 +71,7 @@ def her_ddpg_fetchreach(ctxt=None, seed=1):
             n_train_steps=40,
             discount=0.95,
             exploration_policy=exploration_policy,
+            uniform_random_policy=uniform_random_policy,
             policy_optimizer=tf.compat.v1.train.AdamOptimizer,
             qf_optimizer=tf.compat.v1.train.AdamOptimizer,
             buffer_batch_size=256,


### PR DESCRIPTION
This PR addresses #1077 from with the following investigation directions. 

Investigation of low performance of TF/ DDPG: 
- [x]  Add noise to the actions (no noise added to testing).


- [x] Add warm-up period `start_steps=1000`(Select action randomly before the first 1000 time steps, afterwards select action based on policy; update the policy after the warm-up period).

- [ ] Use gaussian noise instead of OU noise (The original paper proposed OU noise but in recent papers such as TD3/  D4PG, there is no performance benefit for OU noise).
