### PR TITLE
Make gym dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ REQUIRED = [
     'cloudpickle==1.3',
     'cma==2.7.0',
     'dowel==0.0.3',
-    f'gym[atari,box2d,classic_control]=={GYM_VERSION}',
     'numpy>=1.14.5',
     'psutil',
     'python-dateutil',
@@ -30,6 +29,10 @@ REQUIRED = [
 
 # Dependencies for optional features
 EXTRAS = {}
+
+EXTRAS['gym'] = [
+    f'gym[atari,box2d,classic_control]=={GYM_VERSION}',
+]
 
 EXTRAS['mujoco'] = [
     'mujoco-py<2.1,>=2.0',

--- a/src/garage/_environment.py
+++ b/src/garage/_environment.py
@@ -403,7 +403,7 @@ class Wrapper(Environment):
 
     @property
     def spec(self):
-        """EnvSpec: The envionrment specification."""
+        """EnvSpec: The environment specification."""
         return self._env.spec
 
     @property

--- a/src/garage/np/exploration_policies/add_gaussian_noise.py
+++ b/src/garage/np/exploration_policies/add_gaussian_noise.py
@@ -1,5 +1,5 @@
 """Gaussian exploration strategy."""
-import gym
+import akro
 import numpy as np
 
 from garage.np.exploration_policies.exploration_policy import ExplorationPolicy
@@ -26,7 +26,7 @@ class AddGaussianNoise(ExplorationPolicy):
                  max_sigma=1.0,
                  min_sigma=0.1,
                  decay_period=1000000):
-        assert isinstance(env_spec.action_space, gym.spaces.Box)
+        assert isinstance(env_spec.action_space, akro.Space)
         assert len(env_spec.action_space.shape) == 1
         super().__init__(policy)
         self._max_sigma = max_sigma

--- a/src/garage/np/exploration_policies/add_gaussian_noise.py
+++ b/src/garage/np/exploration_policies/add_gaussian_noise.py
@@ -26,7 +26,7 @@ class AddGaussianNoise(ExplorationPolicy):
                  max_sigma=1.0,
                  min_sigma=0.1,
                  decay_period=1000000):
-        assert isinstance(env_spec.action_space, akro.Space)
+        assert isinstance(env_spec.action_space, akro.Box)
         assert len(env_spec.action_space.shape) == 1
         super().__init__(policy)
         self._max_sigma = max_sigma

--- a/src/garage/tf/plotter/plotter.py
+++ b/src/garage/tf/plotter/plotter.py
@@ -30,11 +30,11 @@ class Plotter:
     Usually, this class is used by sending plot=True to LocalRunner.train().
 
     Args:
-        env (gym.Env): Environment from which to visualize episodes. This will
-        be used without copying in the current process but in a separate
-        thread, so it should be given a unique copy (in particular, do not pass
-        the training environment here, then try to pickle it, or you will
-        occasionally get crashes).
+        env (garage.Environment): Environment from which to visualize episodes.
+            This will be used without copying in the current process but in a
+            separate thread, so it should be given a unique copy (in
+            particular, do not pass the training environment here, then try to
+            pickle it, or you will occasionally get crashes).
         policy (garage.tf.Policy): Policy used to visualize episodes.
         sess (tf.Session): The TensorFlow session to use.
         graph (tf.Graph): The TensorFlow graph to use.

--- a/src/garage/torch/_functions.py
+++ b/src/garage/torch/_functions.py
@@ -11,10 +11,12 @@ This collection of functions can be used to manage the following:
 """
 import copy
 
-import gym
+import akro
 import torch
 from torch import nn
 import torch.nn.functional as F
+
+from garage import Wrapper
 
 _USE_GPU = False
 _DEVICE = None
@@ -336,34 +338,56 @@ class NonLinearity(nn.Module):
         return repr(self.module)
 
 
-class TransposeImage(gym.ObservationWrapper):
-    """Transpose observation space for image observation in PyTorch."""
+class TransposeImage(Wrapper):
+    """Transpose observation space for image observation in PyTorch.
 
-    def __init__(self, env=None):
-        """Transpose image observation space.
-
-        Reshape the input observation shape from (H, W, C) into (C, H, W)
+    Reshape the input observation shape from (H, W, C) into (C, H, W)
         in pytorch format.
+    """
+
+    @property
+    def observation_space(self):
+        """akro.Space: The observation space specification."""
+        obs_shape = self._env.observation_space
+        return akro.Box(self._env.observation_space.low[0, 0, 0],
+                        self._env.observation_space.high[0, 0, 0],
+                        [obs_shape[2], obs_shape[1], obs_shape[0]],
+                        dtype=self._env.observation_space.dtype)
+
+    @property
+    def spec(self):
+        """EnvSpec: The environment specification."""
+        env_spec = copy.deepcopy(self._env.spec)
+        env_spec.observation_space = self.observation_space
+        return env_spec
+
+    def step(self, action):
+        """Step the wrapped env.
 
         Args:
-            env (Environment): environment.
-        """
-        super().__init__(env)
-        obs_shape = self.observation_space.shape
-        self.observation_space = gym.spaces.Box(
-            self.observation_space.low[0, 0, 0],
-            self.observation_space.high[0, 0, 0],
-            [obs_shape[2], obs_shape[1], obs_shape[0]],
-            dtype=self.observation_space.dtype)
-
-    def observation(self, observation):
-        """Transpose image observation.
-
-        Args:
-            observation (tensor): observation.
+            action (np.ndarray): An action provided by the agent.
 
         Returns:
-            torch.Tensor: transposed observation.
+            EnvStep: The environment step resulting from the action.
+
         """
-        # Observation is of type Tensor
-        return observation.transpose(2, 0, 1)
+        env_step = self._env.step(action)
+        env_step.observation = env_step.observation.transpose(2, 0, 1)
+        return env_step
+
+    def reset(self):
+        """Reset the wrapped env.
+
+        Returns:
+            numpy.ndarray: The first observation conforming to
+                `observation_space`.
+            dict: The episode-level information.
+                Note that this is not part of `env_info` provided in `step()`.
+                It contains information of he entire episode， which could be
+                needed to determine the first action (e.g. in the case of
+                goal-conditioned or MTRL.)
+
+        """
+        env_init = self._env.reset()
+        env_init[0] = env_init[0].transpose(2, 0, 1)
+        return env_init

--- a/tests/fixtures/envs/dummy/dummy_box_env.py
+++ b/tests/fixtures/envs/dummy/dummy_box_env.py
@@ -1,5 +1,5 @@
-"""Dummy gym.spaces.Box environment for testing purpose."""
-import gym
+"""Dummy akro.Box environment for testing purpose."""
+import akro
 import numpy as np
 
 from tests.fixtures.envs.dummy import DummyEnv
@@ -26,10 +26,7 @@ class DummyBoxEnv(DummyEnv):
             gym.spaces: The observation space of the environment.
 
         """
-        return gym.spaces.Box(low=-1,
-                              high=1,
-                              shape=self._obs_dim,
-                              dtype=np.float32)
+        return akro.Box(low=-1, high=1, shape=self._obs_dim, dtype=np.float32)
 
     @property
     def action_space(self):
@@ -39,10 +36,10 @@ class DummyBoxEnv(DummyEnv):
             gym.spaces: The action space of the environment.
 
         """
-        return gym.spaces.Box(low=-5.0,
-                              high=5.0,
-                              shape=self._action_dim,
-                              dtype=np.float32)
+        return akro.Box(low=-5.0,
+                        high=5.0,
+                        shape=self._action_dim,
+                        dtype=np.float32)
 
     def reset(self):
         """Reset the environment.

--- a/tests/garage/test_environment.py
+++ b/tests/garage/test_environment.py
@@ -1,6 +1,5 @@
 import akro
 import cloudpickle
-import gym
 import numpy as np
 import pytest
 
@@ -19,11 +18,8 @@ def test_env_spec_pickleable():
 @pytest.fixture
 def sample_data():
     # spaces
-    obs_space = gym.spaces.Box(low=1,
-                               high=10,
-                               shape=(4, 3, 2),
-                               dtype=np.float32)
-    act_space = gym.spaces.MultiDiscrete([2, 5])
+    obs_space = akro.Box(low=1, high=10, shape=(4, 3, 2), dtype=np.float32)
+    act_space = akro.Discrete(5)
     env_spec = EnvSpec(obs_space, act_space)
 
     # generate data

--- a/tests/garage/torch/policies/test_categorical_cnn_policy.py
+++ b/tests/garage/torch/policies/test_categorical_cnn_policy.py
@@ -35,7 +35,7 @@ class TestCategoricalCNNPolicy:
     def test_get_action(self, hidden_channels, kernel_sizes, strides,
                         hidden_sizes):
         """Test get_action function."""
-        env = DummyDiscretePixelEnv()
+        env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
         env = self._initialize_obs_env(env)
         policy = CategoricalCNNPolicy(env=env,
                                       kernel_sizes=kernel_sizes,
@@ -43,7 +43,7 @@ class TestCategoricalCNNPolicy:
                                       strides=strides,
                                       hidden_sizes=hidden_sizes)
         env.reset()
-        obs, _, _, _ = env.step(1)
+        obs = env.step(1).observation
         action, _ = policy.get_action(obs)
         assert env.action_space.contains(action)
 
@@ -56,8 +56,8 @@ class TestCategoricalCNNPolicy:
     def test_get_action_img_obs(self, hidden_channels, kernel_sizes, strides,
                                 hidden_sizes):
         """Test get_action function with akro.Image observation space."""
-        env = GymEnv(self._initialize_obs_env(DummyDiscretePixelEnv()),
-                     is_image=True)
+        env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
+        env = self._initialize_obs_env(env)
         policy = CategoricalCNNPolicy(env=env,
                                       kernel_sizes=kernel_sizes,
                                       hidden_channels=hidden_channels,
@@ -78,7 +78,7 @@ class TestCategoricalCNNPolicy:
     def test_get_actions(self, hidden_channels, kernel_sizes, strides,
                          hidden_sizes):
         """Test get_actions function with akro.Image observation space."""
-        env = DummyDiscretePixelEnv()
+        env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
         env = self._initialize_obs_env(env)
         policy = CategoricalCNNPolicy(env=env,
                                       kernel_sizes=kernel_sizes,
@@ -86,7 +86,7 @@ class TestCategoricalCNNPolicy:
                                       strides=strides,
                                       hidden_sizes=hidden_sizes)
         env.reset()
-        obs, _, _, _ = env.step(1)
+        obs = env.step(1).observation
 
         actions, _ = policy.get_actions([obs, obs, obs])
         for action in actions:
@@ -105,7 +105,7 @@ class TestCategoricalCNNPolicy:
     def test_is_pickleable(self, hidden_channels, kernel_sizes, strides,
                            hidden_sizes):
         """Test if policy is pickable."""
-        env = DummyDiscretePixelEnv()
+        env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
         env = self._initialize_obs_env(env)
         policy = CategoricalCNNPolicy(env=env,
                                       kernel_sizes=kernel_sizes,
@@ -113,7 +113,7 @@ class TestCategoricalCNNPolicy:
                                       strides=strides,
                                       hidden_sizes=hidden_sizes)
         env.reset()
-        obs, _, _, _ = env.step(1)
+        obs = env.step(1).observation
 
         output_action_1, _ = policy.get_action(obs)
 
@@ -154,8 +154,8 @@ class TestCategoricalCNNPolicy:
         """Test if a flattened image obs is passed to get_action
            then it is unflattened.
         """
-        env = GymEnv(self._initialize_obs_env(DummyDiscretePixelEnv()),
-                     is_image=True)
+        env = GymEnv(DummyDiscretePixelEnv(), is_image=True)
+        env = self._initialize_obs_env(env)
         env.reset()
         policy = CategoricalCNNPolicy(env=env,
                                       kernel_sizes=kernel_sizes,


### PR DESCRIPTION
Should close #1276. I'll put up a PR that removes gym from akro soon

Note that gym is still present in the `garage.envs` folder and many tests