### PR TITLE
Fix testing env pickleable

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -43,7 +43,7 @@ def step_env_with_gym_quirks(env, spec, n=10, render=True,
     if serialize_env:
         # Roundtrip serialization
         round_trip = pickle.loads(pickle.dumps(env))
-        assert round_trip.env.spec == env.env.spec
+        assert round_trip.env.spec.id == env.env.spec.id
         env = round_trip
 
     env.reset()
@@ -63,7 +63,7 @@ def step_env_with_gym_quirks(env, spec, n=10, render=True,
     if serialize_env:
         # Roundtrip serialization
         round_trip = pickle.loads(pickle.dumps(env))
-        assert round_trip.env.spec == env.env.spec
+        assert round_trip.env.spec.id == env.env.spec.id
 
 
 def convolve(_input, filter_weights, filter_bias, strides, filters,


### PR DESCRIPTION
Fix comparing env spec by only comparing the name of the env. This is a temporary solution. In ideal solution, we should also compare the action_space, observation_space, max_episode_steps. However, one environment, `KellyCoinflipGeneralized-v0` will generate a different actions space each time constructed by `gym.make()`.