### PR TITLE
Backport #1812 to release 2020.06

### DIFF
--- a/docs/user/implement_algo.md
+++ b/docs/user/implement_algo.md
@@ -1,0 +1,657 @@
+# Implement a New Algorithm
+
+In this section, we will describe how to implement an RL algorithm using garage.
+Note that this section assumes some level of familiarity with reinforcement
+learning. For a more gentle introduction to the field of reinforcement learning
+as a whole, we recommend consulting [OpenAI's Spinning Up](https://spinningup.openai.com/en/latest/user/introduction.html).
+
+```eval_rst
+We will start by introducing the core :code:`RLAlgorithm` API used in garage,
+then show how to implement the classical REINFORCE :cite:`williams1992simple`
+algorithm, also known as the "vanilla" policy gradient (VPG).
+```
+
+## Algorithm API
+
+All RL algorithms used with garage implement a small interface that allows
+accessing important services such as snapshotting, "plotting" (visualization of
+the current policy in the environment), and resume.
+
+The interface requires a single method, `train(runner)`, which takes a
+`garage.experiment.LocalRunner`. The interface is defined in
+`garage.np.algos.RLAlgorithm`, but inheriting from this class isn't necessary.
+
+Some additional functionality (such as sampling and plotting) require additional
+fields to exist.
+
+```eval_rst
+.. literalinclude:: ../../src/garage/np/algos/rl_algorithm.py
+```
+
+In order to implement snapshotting and resume, instances of `RLAlgorithm`
+are also expected to support the Python standard library's [pickle interface](https://docs.python.org/3/library/pickle.html#pickling-class-instances).
+Garage primitives such as environments, policies, Q functions, and value
+functions already implement this interface, so no work is typically required to
+implement it.
+
+## Basic Setup
+
+Garage components are fairly weakly coupled, meaning that different parts can
+be used independently. However, for this purpose of this tutorial we'll use the
+parts together in the way that's generally recommended.
+
+At the core of garage is the assumption that the algorithm runs a series of
+"epochs", which are a unit of time small enough that most services, such as
+logging, will only have new results once per epoch.
+
+The current epoch is controlled by the algorithm using
+`LocalRunner.step_epochs()`.
+
+```py
+class MyAlgorithm:
+
+    def train(self, runner):
+        epoch_stepper = runner.step_epochs()
+        print('It is epoch 0')
+        next(epoch_stepper)
+        print('It is epoch 1')
+        next(epoch_stepper)
+        print('It is epoch 2')
+```
+
+In practice, it's used in a loop like this:
+
+```py
+class MyAlgorithm:
+
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            print('It is epoch', epoch)
+```
+
+Each time the epoch is stepped, various "services" update. For example, logs
+are synchronized, snapshotting (for later resuming) may occur, the plotter will
+update, etc.
+
+When an experiment is resumed, the epoch `train` will be called again, but the
+first epoch yielded by `step_epochs` will be the one after the snapshot.
+
+In order to use the `LocalRunner`, we'll need a set up log directory. This can
+be done manually, but for this tutorial we'll use the `wrap_experiment` function
+to do that for us.
+
+We'll also want an environment to test our algorithm with.
+
+```py
+from garage import wrap_experiment
+<<<<<<< HEAD
+from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GarageEnv
+>>>>>>> a1877525... Flatten observations if necessary
+from garage.experiment import LocalRunner
+
+@wrap_experiment
+def debug_my_algorithm(ctxt):
+    runner = LocalRunner(ctxt)
+<<<<<<< HEAD
+    env = PointEnv()
+=======
+    env = GarageEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
+    algo = MyAlgorithm()
+    runner.setup(algo, env)
+    runner.train(n_epochs=3)
+
+debug_my_algorithm()
+```
+
+With the above file and the `MyAlgorithm` definition above, it should be
+possible to run `MyAlgorithm`, and get it to print an output like the following:
+
+```sh
+2020-07-22 23:32:34 | [debug_my_algorithm] Logging to /home/ruofu/garage/data/local/experiment/debug_my_algorithm
+2020-07-22 23:32:34 | [debug_my_algorithm] Obtaining samples...
+It is epoch 0
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #0 | Saving snapshot...
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #0 | Saved
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #0 | Time 0.01 s
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #0 | EpochTime 0.01 s
+-------------  -
+TotalEnvSteps  0
+-------------  -
+It is epoch 1
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #1 | Saving snapshot...
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #1 | Saved
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #1 | Time 0.01 s
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #1 | EpochTime 0.00 s
+-------------  -
+TotalEnvSteps  0
+-------------  -
+It is epoch 2
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #2 | Saving snapshot...
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #2 | Saved
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #2 | Time 0.02 s
+2020-07-22 23:32:34 | [debug_my_algorithm] epoch #2 | EpochTime 0.01 s
+-------------  -
+TotalEnvSteps  0
+-------------  -
+```
+
+Now that we have the basics out of the way, we can start actually doing some
+reinforcement learning.
+
+## Gathering Samples
+
+In the above section, we set up an algorithm, but never actually explored the
+environment at all, as can be seen by `TotalEnvSteps` always being zero.
+
+In order to collect samples from the environment, we can set the `sampler_cls`
+and `policy` fields on our algorithm, and call `runner.obtain_samples()`. We'll
+also need to seed the random number generators used for the experiment.
+
+```py
+from garage.samplers import LocalSampler
+
+class SimpleVPG:
+
+    sampler_cls = LocalSampler
+
+    def __init__(self, env_spec, policy):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.max_episode_length = 200
+
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            samples = runner.obtain_samples(epoch)
+
+from garage import wrap_experiment
+<<<<<<< HEAD
+from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GarageEnv
+>>>>>>> a1877525... Flatten observations if necessary
+from garage.experiment import LocalRunner
+from garage.experiment.deterministic import set_seed
+from garage.torch.policies import GaussianMLPPolicy
+
+@wrap_experiment
+def debug_my_algorithm(ctxt):
+    set_seed(100)
+    runner = LocalRunner(ctxt)
+<<<<<<< HEAD
+    env = PointEnv()
+=======
+    env = GarageEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
+    policy = GaussianMLPPolicy(env.spec)
+    algo = SimpleVPG(policy)
+    runner.setup(algo, env)
+    runner.train(n_epochs=500, batch_size=4000)
+
+debug_my_algorithm()
+```
+
+## Training the Policy with Samples
+
+```eval_rst
+Of course, we'll need to actually use the resulting samples to train our
+policy with PyTorch, TensorFlow or NumPy. In this tutorial, we'll implement an
+extremely simple form of REINFORCE :cite:`williams1992simple` (a.k.a. Vanilla
+Policy Gradient) using PyTorch and TensorFlow. We will also implement a simple
+Cross Entropy Method (CEM) :cite:`rubinstein2004cross` using NumPy.
+```
+
+### PyTorch
+
+```py
+import torch
+import numpy as np
+
+from garage.samplers import LocalSampler
+from garage.misc import tensor_utils
+
+class SimpleVPG:
+
+    sampler_cls = LocalSampler
+
+    def __init__(self, env_spec, policy):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.max_episode_length = 200
+        self._discount = 0.99
+        self._policy_opt = torch.optim.Adam(self.policy.parameters(), lr=1e-3)
+
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            samples = runner.obtain_samples(epoch)
+            self._train_once(samples)
+
+    def _train_once(self, samples):
+        losses = []
+        self._policy_opt.zero_grad()
+        for path in samples:
+            returns_numpy = tensor_utils.discount_cumsum(
+                path['rewards'], self._discount)
+            returns = torch.Tensor(returns_numpy.copy())
+            obs = torch.Tensor(path['observations'])
+            actions = torch.Tensor(path['actions'])
+            dist = self.policy(obs)[0]
+            log_likelihoods = dist.log_prob(actions)
+            loss = (-log_likelihoods * returns).mean()
+            loss.backward()
+            losses.append(loss.item())
+        self._policy_opt.step()
+        return np.mean(losses)
+```
+
+That lets us train a policy, but it doesn't let us confirm that it actually works.
+We can add a little logging to the `train()` method.
+
+```py
+from garage import log_performance, EpisodeBatch
+
+...
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            samples = runner.obtain_samples(epoch)
+            log_performance(
+                epoch,
+                EpisodeBatch.from_episode_list(self.env_spec, samples),
+                self._discount)
+            self._train_once(samples)
+```
+
+For completeness, the full experiment file ([`example/torch/tutorial_vpg.py`](https://github.com/rlworkgroup/garage/blob/master/examples/torch/tutorial_vpg.py))
+is repeated below:
+
+```eval_rst
+.. literalinclude:: ../../examples/torch/tutorial_vpg.py
+```
+
+Running the experiment file should print outputs like the following. The policy
+should solve the `PointEnv` after 100 epochs (i.e. the `Evaluation/SuccessRate`
+reaches 1).
+
+```sh
+2020-07-24 15:30:32 | [tutorial_vpg] Logging to /home/ruofu/garage/data/local/experiment/tutorial_vpg
+Sampling  [####################################]  100%
+2020-07-24 15:30:36 | [tutorial_vpg] epoch #0 | Saving snapshot...
+2020-07-24 15:30:36 | [tutorial_vpg] epoch #0 | Saved
+2020-07-24 15:30:36 | [tutorial_vpg] epoch #0 | Time 3.65 s
+2020-07-24 15:30:36 | [tutorial_vpg] epoch #0 | EpochTime 3.65 s
+----------------------------------  -----------
+Evaluation/AverageDiscountedReturn   -78.1057
+Evaluation/AverageReturn            -180.404
+Evaluation/Iteration                   0
+Evaluation/MaxReturn                 -36.996
+Evaluation/MinReturn                -625.757
+Evaluation/NumEpisodes                26
+Evaluation/StdReturn                 143.39
+Evaluation/SuccessRate                 0.384615
+Evaluation/TerminationRate             0.384615
+TotalEnvSteps                       4085
+----------------------------------  -----------
+2020-07-24 15:30:37 | [tutorial_vpg] epoch #1 | Saving snapshot...
+2020-07-24 15:30:37 | [tutorial_vpg] epoch #1 | Saved
+2020-07-24 15:30:37 | [tutorial_vpg] epoch #1 | Time 4.21 s
+2020-07-24 15:30:37 | [tutorial_vpg] epoch #1 | EpochTime 0.55 s
+----------------------------------  -----------
+Evaluation/AverageDiscountedReturn   -77.1423
+Evaluation/AverageReturn            -186.052
+Evaluation/Iteration                   1
+Evaluation/MaxReturn                 -19.9412
+Evaluation/MinReturn                -458.353
+Evaluation/NumEpisodes                28
+Evaluation/StdReturn                 134.528
+Evaluation/SuccessRate                 0.428571
+Evaluation/TerminationRate             0.428571
+TotalEnvSteps                       8202
+----------------------------------  -----------
+...
+```
+
+As `PointEnv` currently not supports visualization, If you want to visualize the
+policy when training, you can solve an Gym environment, for example
+`LunarLanderContinuous-v2`, and set `plot` to `True` in `runner.train()`:
+
+```py
+...
+@wrap_experiment
+def tutorial_vpg(ctxt=None):
+    set_seed(100)
+    runner = LocalRunner(ctxt)
+<<<<<<< HEAD
+    env = GarageEnv('LunarLanderContinuous-v2')
+=======
+    env = GarageEnv(env_name='LunarLanderContinuous-v2')
+>>>>>>> a1877525... Flatten observations if necessary
+    policy = GaussianMLPPolicy(env.spec)
+    algo = SimpleVPG(env.spec, policy)
+    runner.setup(algo, env)
+    runner.train(n_epochs=500, batch_size=4000, plot=True)
+...
+```
+
+### TensorFlow
+
+Before the training part, TensorFlow version is almost the same as PyTorch's,
+except for the replacement of `LocalRunner` with `LocalTFRunner`.
+
+```py
+...
+from garage import wrap_experiment
+<<<<<<< HEAD
+from garage.envs import PointEnv
+=======
+from garage.envs import PointEnv, GarageEnv
+>>>>>>> a1877525... Flatten observations if necessary
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.tf.policies import GaussianMLPPolicy
+
+@wrap_experiment
+def tutorial_vpg(ctxt=None):
+    set_seed(100)
+    with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
+        env = PointEnv()
+=======
+        env = GarageEnv(PointEnv())
+>>>>>>> a1877525... Flatten observations if necessary
+        policy = GaussianMLPPolicy(env.spec)
+        algo = SimpleVPG(env.spec, policy)
+        runner.setup(algo, env)
+        runner.train(n_epochs=500, batch_size=4000)
+...
+```
+
+Different from PyTorch's version, we need to build the computation graph before
+training the policy in TensorFlow.
+
+```py
+import tensorflow as tf
+...
+
+class SimpleVPG:
+
+    sampler_cls = LocalSampler
+
+    def __init__(self, env_spec, policy):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.max_episode_length = 200
+        self._discount = 0.99
+        self.init_opt()
+
+    def init_opt(self):
+        observation_dim = self.policy.observation_space.flat_dim
+        action_dim = self.policy.action_space.flat_dim
+        with tf.name_scope('inputs'):
+            self._observation = tf.compat.v1.placeholder(
+                tf.float32, shape=[None, observation_dim], name='observation')
+            self._action = tf.compat.v1.placeholder(tf.float32,
+                                                    shape=[None, action_dim],
+                                                    name='action')
+            self._returns = tf.compat.v1.placeholder(tf.float32,
+                                                     shape=[None],
+                                                     name='return')
+        policy_dist = self.policy.build(self._observation, name='policy').dist
+        with tf.name_scope('loss'):
+            ll = policy_dist.log_prob(self._action, name='log_likelihood')
+            loss = -tf.reduce_mean(ll * self._returns)
+        with tf.name_scope('train'):
+            self._train_op = tf.compat.v1.train.AdamOptimizer(1e-3).minimize(
+                loss)
+```
+
+The `train()` method is the same, while int the `_train_once()` method, we feed
+the inputs with sample data.
+
+```py
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            samples = runner.obtain_samples(epoch)
+            log_performance(
+                epoch,
+                EpisodeBatch.from_list(self.env_spec, samples),
+                self._discount)
+            self._train_once(samples)
+
+    def _train_once(self, samples):
+        obs = np.concatenate([path['observations'] for path in samples])
+        actions = np.concatenate([path['actions'] for path in samples])
+        returns = []
+        for path in samples:
+            returns.append(
+                tensor_utils.discount_cumsum(path['rewards'], self._discount))
+        returns = np.concatenate(returns)
+        sess = tf.compat.v1.get_default_session()
+        sess.run(self._train_op,
+                 feed_dict={
+                     self._observation: obs,
+                     self._action: actions,
+                     self._returns: returns,
+                 })
+        return np.mean(returns)
+```
+
+As it is mentioned above, to support snapshot and resume, we need to implement
+all things pickling. However, we use instance variables (e.g. `self._action`)
+to save unpickled `tf.Tensor` in the class. So we need to define `__getstate__`
+and `__setstate__` like:
+
+```py
+   def __getstate__(self):
+        data = self.__dict__.copy()
+        del data['_observation']
+        del data['_action']
+        del data['_returns']
+        del data['_train_op']
+        return data
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.init_opt()
+```
+
+For completeness, the full experiment file ([`example/tf/tutorial_vpg.py`](https://github.com/rlworkgroup/garage/blob/master/examples/tf/tutorial_vpg.py))
+is repeated below:
+
+```eval_rst
+.. literalinclude:: ../../examples/tf/tutorial_vpg.py
+```
+
+Similar to the PyTorch's version, Running the experiment file should print
+outputs like the following. The policy should solve the `PointEnv` after 100
+epochs (i.e. the `Evaluation/SuccessRate` reaches 1).
+
+```sh
+2020-07-24 15:31:44 | [tutorial_vpg] Logging to /home/ruofu/garage/data/local/experiment/tutorial_vpg_1
+2020-07-24 15:31:45 | [tutorial_vpg] Obtaining samples...
+Sampling  [####################################]  100%
+2020-07-24 15:31:50 | [tutorial_vpg] epoch #0 | Saving snapshot...
+2020-07-24 15:31:51 | [tutorial_vpg] epoch #0 | Saved
+2020-07-24 15:31:51 | [tutorial_vpg] epoch #0 | Time 5.25 s
+2020-07-24 15:31:51 | [tutorial_vpg] epoch #0 | EpochTime 5.25 s
+----------------------------------  ----------
+Evaluation/AverageDiscountedReturn   -376.475
+Evaluation/AverageReturn            -1035.36
+Evaluation/Iteration                    0
+Evaluation/MaxReturn                 -969.42
+Evaluation/MinReturn                -1090.39
+Evaluation/NumEpisodes                 20
+Evaluation/StdReturn                   35.3741
+Evaluation/SuccessRate                  0
+Evaluation/TerminationRate              0
+TotalEnvSteps                        4000
+----------------------------------  ----------
+Sampling  [####################################]  100%
+2020-07-24 15:31:53 | [tutorial_vpg] epoch #1 | Saving snapshot...
+2020-07-24 15:31:53 | [tutorial_vpg] epoch #1 | Saved
+2020-07-24 15:31:53 | [tutorial_vpg] epoch #1 | Time 7.42 s
+2020-07-24 15:31:53 | [tutorial_vpg] epoch #1 | EpochTime 2.16 s
+----------------------------------  ----------
+Evaluation/AverageDiscountedReturn   -376.199
+Evaluation/AverageReturn            -1044.4
+Evaluation/Iteration                    1
+Evaluation/MaxReturn                 -865.945
+Evaluation/MinReturn                -1154.95
+Evaluation/NumEpisodes                 20
+Evaluation/StdReturn                   69.6729
+Evaluation/SuccessRate                  0
+Evaluation/TerminationRate              0
+TotalEnvSteps                        8000
+----------------------------------  ----------
+...
+```
+
+### NumPy
+
+We will implement [CEM](https://github.com/rlworkgroup/garage/blob/master/src/garage/np/algos/cem.py)
+with NumPy, and train the `CategoricalMLPPolicy` to solve `CartPole-v1`. The
+experiment function is similar to that of TensorFlow:
+
+```py
+from garage import wrap_experiment
+from garage.envs import GarageEnv
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.tf.policies import CategoricalMLPPolicy
+
+@wrap_experiment
+def tutorial_cem(ctxt=None):
+    set_seed(100)
+    with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
+        env = GarageEnv('CartPole-v1')
+=======
+        env = GarageEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
+        policy = CategoricalMLPPolicy(env.spec)
+        algo = SimpleCEM(env.spec, policy)
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=1000)
+```
+
+When training the policy, we use `policy.get_param_values()` method to get the
+initial parameters of the policy, and use `policy.set_param_values()` to update
+parameters of the policy.
+
+```py
+import numpy as np
+from garage.misc import tensor_utils
+from garage.sampler import LocalSampler
+
+class SimpleCEM:
+    sampler_cls = LocalSampler
+
+    def __init__(self, env_spec, policy):
+        self.env_spec = env_spec
+        self.policy = policy
+        self.max_episode_length = 200
+        self._discount = 0.99
+        self._extra_std = 1
+        self._extra_decay_time = 100
+        self._n_samples = 20
+        self._n_best = 1
+        self._cur_std = 1
+        self._cur_mean = self.policy.get_param_values()
+        self._all_avg_returns = []
+        self._all_params = [self._cur_mean.copy()]
+        self._cur_params = None
+
+    def train(self, runner):
+        for epoch in runner.step_epochs():
+            samples = runner.obtain_samples(epoch)
+            log_performance(
+                epoch,
+                EpisodeBatch.from_list(self.env_spec, samples),
+                self._discount)
+            self._train_once(epoch, samples)
+
+    def _train_once(self, epoch, paths):
+        returns = []
+        for path in paths:
+            returns.append(
+                tensor_utils.discount_cumsum(path['rewards'], self._discount))
+        avg_return = np.mean(np.concatenate(returns))
+        self._all_avg_returns.append(avg_return)
+        if (epoch + 1) % self._n_samples == 0:
+            avg_rtns = np.array(self._all_avg_returns)
+            best_inds = np.argsort(-avg_rtns)[:self._n_best]
+            best_params = np.array(self._all_params)[best_inds]
+            self._cur_mean = best_params.mean(axis=0)
+            self._cur_std = best_params.std(axis=0)
+            self.policy.set_param_values(self._cur_mean)
+            avg_return = max(self._all_avg_returns)
+            self._all_avg_returns.clear()
+            self._all_params.clear()
+        self._cur_params = self._sample_params(epoch)
+        self._all_params.append(self._cur_params.copy())
+        self.policy.set_param_values(self._cur_params)
+        return avg_return
+
+    def _sample_params(self, epoch):
+        extra_var_mult = max(1.0 - epoch / self._extra_decay_time, 0)
+        sample_std = np.sqrt(
+            np.square(self._cur_std) +
+            np.square(self._extra_std) * extra_var_mult)
+        return np.random.standard_normal(len(
+            self._cur_mean)) * sample_std + self._cur_mean
+```
+
+You can see the full experiment file [here](https://github.com/rlworkgroup/garage/blob/master/examples/np/tutorial_cem.py).
+Running the experiment file should print outputs like the following. If you want
+to visualize the policy when training, you can set `plot` to `True` in
+`runner.train()` as mentioned before in PyTorch section.
+
+```sh
+2020-07-24 15:33:49 | [tutorial_cem] Logging to /home/ruofu/garage/data/local/experiment/tutorial_cem
+2020-07-24 15:33:50 | [tutorial_cem] Obtaining samples...
+Sampling  [####################################]  100%
+2020-07-24 15:33:54 | [tutorial_cem] epoch #0 | Saving snapshot...
+2020-07-24 15:33:54 | [tutorial_cem] epoch #0 | Saved
+2020-07-24 15:33:54 | [tutorial_cem] epoch #0 | Time 3.52 s
+2020-07-24 15:33:54 | [tutorial_cem] epoch #0 | EpochTime 3.52 s
+----------------------------------  ---------
+Evaluation/AverageDiscountedReturn    20.0163
+Evaluation/AverageReturn              22.5333
+Evaluation/Iteration                   0
+Evaluation/MaxReturn                  52
+Evaluation/MinReturn                  10
+Evaluation/NumEpisodes                45
+Evaluation/StdReturn                   7.9822
+Evaluation/TerminationRate             1
+TotalEnvSteps                       1014
+----------------------------------  ---------
+2020-07-24 15:33:54 | [tutorial_cem] epoch #1 | Saving snapshot...
+2020-07-24 15:33:54 | [tutorial_cem] epoch #1 | Saved
+2020-07-24 15:33:54 | [tutorial_cem] epoch #1 | Time 4.03 s
+2020-07-24 15:33:54 | [tutorial_cem] epoch #1 | EpochTime 0.50 s
+----------------------------------  ----------
+Evaluation/AverageDiscountedReturn    15.7595
+Evaluation/AverageReturn              17.1017
+Evaluation/Iteration                   1
+Evaluation/MaxReturn                  24
+Evaluation/MinReturn                  13
+Evaluation/NumEpisodes                59
+Evaluation/StdReturn                   2.75985
+Evaluation/TerminationRate             1
+TotalEnvSteps                       2023
+----------------------------------  ----------
+...
+```
+
+## References
+
+```eval_rst
+.. bibliography:: references.bib
+   :style: unsrt
+   :filter: docname in docnames
+```
+
+----
+
+*This page was authored by K.R. Zentner ([@krzentner](https://github.com/krzentner)) and Ruofu Wang ([@yeukfu](https://github.com/yeukfu)).*

--- a/docs/user/meta_multi_task_rl_exp.md
+++ b/docs/user/meta_multi_task_rl_exp.md
@@ -1,0 +1,321 @@
+# Run Meta-/Multi-Task RL Experiments
+
+This guide will walk you through how to run meta-/ multi-task RL experiments in garage.
+
+Similar to running all other experiments in garage, running meta-/ multi-task RL experiments generally involves steps such as:
+
+- Defining the experiement with the `wrap_experiment` decorator
+- Constructing a `LocalRunner`
+- Constructing an environment
+- Constructing policy/ algorithm object(s)
+
+In meta-/multi-task RL experiment, it revolves around solving multiple tasks and hence the construction of multiple/specific environment(s). Belows are a few environment wrappers commonly used in garage for meta-/multi-task RL learning:
+
+- `MultiEnvWrapper`: a wrapper for mulitiple environments
+- `RL2Env`: a specific wrapper for RL2 environment
+
+Also, it's worth noting that [MetaWorld](https://github.com/rlworkgroup/metaworld) provides a variety of benchmarked robotics tasks and can be extensively used in garage.
+
+## Meta-RL experiments
+
+The garage repository contains several meta-RL experiment examples. We will take a look at `te_ppo_metaworld_ml1_push.py` as below:
+
+```py
+from metaworld.benchmarks import ML1
+import tensorflow as tf
+
+from garage import wrap_experiment
+from garage.envs import GarageEnv, normalize
+from garage.envs.multi_env_wrapper import MultiEnvWrapper
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.np.baselines import LinearMultiFeatureBaseline
+from garage.sampler import LocalSampler
+from garage.tf.algos import TEPPO
+from garage.tf.algos.te import TaskEmbeddingWorker
+from garage.tf.embeddings import GaussianMLPEncoder
+from garage.tf.policies import GaussianMLPTaskEmbeddingPolicy
+
+@wrap_experiment
+def te_ppo_ml1_push(ctxt, seed, n_epochs, batch_size_per_task):
+    """Train Task Embedding PPO with PointEnv.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+        n_epochs (int): Total number of epochs for training.
+        batch_size_per_task (int): Batch size of samples for each task.
+
+    """
+    set_seed(seed)
+<<<<<<< HEAD
+    envs = [normalize(GarageEnv(ML1.get_train_tasks('push-v1')))]
+=======
+    envs = [GarageEnv(normalize(ML1.get_train_tasks('push-v1')))]
+>>>>>>> a1877525... Flatten observations if necessary
+    env = MultiEnvWrapper(envs, mode='del-onehot')
+
+    latent_length = 2
+    inference_window = 6
+    batch_size = batch_size_per_task
+    policy_ent_coeff = 2e-2
+    encoder_ent_coeff = 2e-4
+    inference_ce_coeff = 5e-2
+    max_episode_length = 100
+    embedding_init_std = 0.1
+    embedding_max_std = 0.2
+    embedding_min_std = 1e-6
+    policy_init_std = 1.0
+    policy_max_std = None
+    policy_min_std = None
+
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
+
+        task_embed_spec = TEPPO.get_encoder_spec(env.task_space,
+                                                 latent_dim=latent_length)
+
+        task_encoder = GaussianMLPEncoder(
+            name='embedding',
+            embedding_spec=task_embed_spec,
+            hidden_sizes=(20, 20),
+            std_share_network=True,
+            init_std=embedding_init_std,
+            max_std=embedding_max_std,
+            output_nonlinearity=tf.nn.tanh,
+            min_std=embedding_min_std,
+        )
+
+        traj_embed_spec = TEPPO.get_infer_spec(
+            env.spec,
+            latent_dim=latent_length,
+            inference_window_size=inference_window)
+
+        inference = GaussianMLPEncoder(
+            name='inference',
+            embedding_spec=traj_embed_spec,
+            hidden_sizes=(20, 10),
+            std_share_network=True,
+            init_std=2.0,
+            output_nonlinearity=tf.nn.tanh,
+            min_std=embedding_min_std,
+        )
+
+        policy = GaussianMLPTaskEmbeddingPolicy(
+            name='policy',
+            env_spec=env.spec,
+            encoder=task_encoder,
+            hidden_sizes=(32, 16),
+            std_share_network=True,
+            max_std=policy_max_std,
+            init_std=policy_init_std,
+            min_std=policy_min_std,
+        )
+
+        baseline = LinearMultiFeatureBaseline(
+            env_spec=env.spec, features=['observations', 'tasks', 'latents'])
+
+        algo = TEPPO(env_spec=env.spec,
+                     policy=policy,
+                     baseline=baseline,
+                     inference=inference,
+                     max_episode_length=max_episode_length,
+                     discount=0.99,
+                     lr_clip_range=0.2,
+                     policy_ent_coeff=policy_ent_coeff,
+                     encoder_ent_coeff=encoder_ent_coeff,
+                     inference_ce_coeff=inference_ce_coeff,
+                     use_softplus_entropy=True,
+                     optimizer_args=dict(
+                         batch_size=32,
+                         max_epochs=10,
+                         learning_rate=1e-3,
+                     ),
+                     inference_optimizer_args=dict(
+                         batch_size=32,
+                         max_epochs=10,
+                     ),
+                     center_adv=True,
+                     stop_ce_gradient=True)
+
+        runner.setup(algo,
+                     env,
+                     sampler_cls=LocalSampler,
+                     sampler_args=None,
+                     worker_class=TaskEmbeddingWorker)
+        runner.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
+
+
+te_ppo_ml1_push()
+```
+
+Note that `envs` are a list of `env` created from `ML1-reach-v1` environment in `metaworld.benchmarks`.
+
+To handle multiple environments, `envs` object can be passed to `MultiEnvWrapper` along with several other arguments such as `sample_strategy`, `mode`, `env_names`.
+
+In this example, we assume one-hot task id is appened to observation and to exclude that, the call to `MultiEnvWrapper(envs)` is replaced with `MultiEnvWrapper(envs, mode='del-onehot')`.
+
+## Multi-task RL experiments
+
+When performing a multi-task RL experiment, we can use multi-task learning environment such as `MT50`, `MT10` etc. We will take a look at `te_ppo_metaworld_mt50.py` as below:
+
+```py
+from garage import wrap_experiment
+from garage.envs import GarageEnv, normalize
+from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.np.baselines import LinearMultiFeatureBaseline
+from garage.sampler import LocalSampler
+from garage.tf.algos import TEPPO
+from garage.tf.algos.te import TaskEmbeddingWorker
+from garage.tf.embeddings import GaussianMLPEncoder
+from garage.tf.policies import GaussianMLPTaskEmbeddingPolicy
+
+@wrap_experiment
+def te_ppo_mt50(ctxt, seed, n_epochs, batch_size_per_task):
+    """Train Task Embedding PPO with PointEnv.
+
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+        n_epochs (int): Total number of epochs for training.
+        batch_size_per_task (int): Batch size of samples for each task.
+
+    """
+    set_seed(seed)
+    tasks = MT50.get_train_tasks().all_task_names
+<<<<<<< HEAD
+    envs = [GarageEnv(normalize(MT50.from_task(task))) for task in tasks]
+=======
+    envs = [normalize(GarageEnv(MT50.from_task(task))) for task in tasks]
+>>>>>>> a1877525... Flatten observations if necessary
+    env = MultiEnvWrapper(envs,
+                          sample_strategy=round_robin_strategy,
+                          mode='del-onehot')
+
+    latent_length = 6
+    inference_window = 6
+    batch_size = batch_size_per_task * len(tasks)
+    policy_ent_coeff = 2e-2
+    encoder_ent_coeff = 2e-4
+    inference_ce_coeff = 5e-2
+    max_episode_length = 100
+    embedding_init_std = 0.1
+    embedding_max_std = 0.2
+    embedding_min_std = 1e-6
+    policy_init_std = 1.0
+    policy_max_std = None
+    policy_min_std = None
+
+    with LocalTFRunner(snapshot_config=ctxt) as runner:
+
+        task_embed_spec = TEPPO.get_encoder_spec(env.task_space,
+                                                 latent_dim=latent_length)
+
+        task_encoder = GaussianMLPEncoder(
+            name='embedding',
+            embedding_spec=task_embed_spec,
+            hidden_sizes=(20, 20),
+            std_share_network=True,
+            init_std=embedding_init_std,
+            max_std=embedding_max_std,
+            output_nonlinearity=tf.nn.tanh,
+            min_std=embedding_min_std,
+        )
+
+        traj_embed_spec = TEPPO.get_infer_spec(
+            env.spec,
+            latent_dim=latent_length,
+            inference_window_size=inference_window)
+
+        inference = GaussianMLPEncoder(
+            name='inference',
+            embedding_spec=traj_embed_spec,
+            hidden_sizes=(20, 10),
+            std_share_network=True,
+            init_std=2.0,
+            output_nonlinearity=tf.nn.tanh,
+            min_std=embedding_min_std,
+        )
+
+        policy = GaussianMLPTaskEmbeddingPolicy(
+            name='policy',
+            env_spec=env.spec,
+            encoder=task_encoder,
+            hidden_sizes=(32, 16),
+            std_share_network=True,
+            max_std=policy_max_std,
+            init_std=policy_init_std,
+            min_std=policy_min_std,
+        )
+
+        baseline = LinearMultiFeatureBaseline(
+            env_spec=env.spec, features=['observations', 'tasks', 'latents'])
+
+        algo = TEPPO(env_spec=env.spec,
+                     policy=policy,
+                     baseline=baseline,
+                     inference=inference,
+                     max_episode_length=max_episode_length,
+                     discount=0.99,
+                     lr_clip_range=0.2,
+                     policy_ent_coeff=policy_ent_coeff,
+                     encoder_ent_coeff=encoder_ent_coeff,
+                     inference_ce_coeff=inference_ce_coeff,
+                     use_softplus_entropy=True,
+                     optimizer_args=dict(
+                         batch_size=32,
+                         max_epochs=10,
+                         learning_rate=1e-3,
+                     ),
+                     inference_optimizer_args=dict(
+                         batch_size=32,
+                         max_epochs=10,
+                     ),
+                     center_adv=True,
+                     stop_ce_gradient=True)
+
+        runner.setup(algo,
+                     env,
+                     sampler_cls=LocalSampler,
+                     sampler_args=None,
+                     worker_class=TaskEmbeddingWorker)
+        runner.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
+
+
+te_ppo_mt50()
+
+```
+
+In this example, to sample tasks from `MT50` environments in a round robin fashion, the call to `MultiEnvWrapper` becomes `MultiEnvWrapper(envs , sample_strategy=round_robin_strategy, mode='del-onehot')`.
+
+## Garage's meta-/ multi-task RL benchmark
+
+Garage benchmarks the following meta-/ multi RL experiements:
+
+```eval_rst
++---------------+-------------+------------+--------------------+
+| Algorithm     | Observation | Action     | Environment Set    |
++===============+=============+============+====================+
+| Meta-RL       | Non-Pixel   | Discrete   | *ML_ENV_SET        |
++---------------+-------------+------------+--------------------+
+| Multi-Task RL | Non-Pixel   | Discrete   | *MT_ENV_SET        |
++---------------+-------------+------------+--------------------+
+```
+
+```py
+*ML_ENV_SET = ['ML1-push-v1' ,  'ML1-reach-v1' ,  'ML1-pick-place-v1' ,  'ML10' ,  'ML45']
+
+*MT
+_ENV_SET = ['ML1-push-v1' ,  'ML1-reach-v1' ,  'ML1-pick-place-v1' ,  'MT10' ,  'MT50' ]
+```
+
+See [`docs/benchmarking.md`](https://garage.readthedocs.io/en/latest/user/benchmarking.html) for a more detailed explaination on garage's benchmarking.
+
+----
+
+*This page was authored by Iris Liu ([@irisliucy](https://github.com/irisliucy)).*

--- a/docs/user/training_a_policy.md
+++ b/docs/user/training_a_policy.md
@@ -1,0 +1,212 @@
+# Train a Policy to Solve an Environment
+
+This page will guide you how to train a policy to solve an environment.
+
+## Define the Experiment
+
+In garage, we train a policy in an experiment, which is a function wrapped by a
+decorator called `wrap_experiment`. Below is an simple example.
+`wrap_experiment` could have some arguments. You can see the [experiments doc](experiments)
+for details of running experiments.
+
+```py
+@wrap_experiment
+def my_first_experiment():
+    ...
+```
+
+### Construct a LocalRunner
+
+Within the experiment, we need a `LocalRunner` to set up important state (such
+as a TensorFlow Session) for training a policy. To construct a `LocalRunner`, an
+experiment context called `ctxt` is needed. This is used to create the
+snapshotter, and we can set it `None` here to make it simple.
+
+Garage supports both PyTorch and TensorFlow. If you use TensorFlow, you should
+use `LocalTFRunner`.
+
+Besides, in order to produce determinism, you can set a seed for the random
+number generator.
+
+```py
+@wrap_experiment
+def my_first_experiment(ctxt=None, seed=1):
+    set_seed(seed)
+    # PyTorch
+    runner = LocalRunner(ctxt)
+    ...
+    # TensorFlow
+    with LocalTFRunner(ctxt) as runner:
+        ...
+```
+
+### Construct an Environment
+
+Garage supports many environments. You can also implement your own environment
+like [this](implement_env). In this example, we choose `CartPole-V1`
+environment.
+
+```py
+<<<<<<< HEAD
+env = GarageEnv('CartPole-v1')
+=======
+env = GarageEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
+```
+
+### Construct a Policy and an Algorithm
+
+Construct your policy and choose an algorithm to train it. Here, we use
+`CategoricalMLPPolicy` and `TRPO`, you can also implement your own algorithm
+like [this](implement_algo). The policy should be compatible with the
+environment's observations and action space (CNN for image observations,
+discrete policy for discrete action spaces, etc). The action space of
+`CartPole-V1` is discrete so we choose a discrete policy here.
+
+```py
+policy = CategoricalMLPPolicy(name='policy',
+                              env_spec=env.spec,
+                              hidden_sizes=(32, 32))
+
+baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+algo = TRPO(env_spec=env.spec,
+            policy=policy,
+            baseline=baseline,
+            max_episode_length=100,
+            discount=0.99,
+            max_kl_step=0.01)
+```
+
+### Tell `LocalRunner` How to Train the Policy
+
+The final step is calling `runner.setup` and `runner.train` to co-ordinate
+training the policy.
+
+```py
+runner.setup(algo, env)
+runner.train(n_epochs=100, batch_size=4000)
+```
+
+## Run the Experiment
+
+To run the experiment, simply call the experiment function you just defined.
+
+```py
+my_first_experiment()
+my_first_experiment(seed=3)  # changes the seed to 3
+```
+
+Often these will appear at the end of your launcher script, but your experiment
+functions are regular Python functions, and can be imported anywhere.
+
+See below for a full example.
+
+## Example: Train TRPO to Solve `CartPole-v1`
+
+In the above steps, we construct the required components to train a
+`CategoricalMLPPolicy` with `TRPO` to solve `CartPole-v1` and wrap all into an
+experiment function. You can find the full example in [`examples/tf/trpo_cartpole.py`](https://github.com/rlworkgroup/garage/blob/master/examples/tf/trpo_cartpole.py),
+which is also pasted below:
+
+```py
+from garage import wrap_experiment
+from garage.envs import GarageEnv
+from garage.experiment import LocalTFRunner
+from garage.experiment.deterministic import set_seed
+from garage.np.baselines import LinearFeatureBaseline
+from garage.tf.algos import TRPO
+from garage.tf.policies import CategoricalMLPPolicy
+
+
+@wrap_experiment
+def trpo_cartpole(ctxt=None, seed=1):
+    """Train TRPO with CartPole-v1 environment.
+
+    Args:
+        ctxt (gExperimentContext): The experiment configuration used by
+            LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+
+    """
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
+<<<<<<< HEAD
+        env = GarageEnv('CartPole-v1')
+=======
+        env = GarageEnv(env_name='CartPole-v1')
+>>>>>>> a1877525... Flatten observations if necessary
+
+        policy = CategoricalMLPPolicy(name='policy',
+                                      env_spec=env.spec,
+                                      hidden_sizes=(32, 32))
+
+        baseline = LinearFeatureBaseline(env_spec=env.spec)
+
+        algo = TRPO(env_spec=env.spec,
+                    policy=policy,
+                    baseline=baseline,
+                    max_episode_length=100,
+                    discount=0.99,
+                    max_kl_step=0.01)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=100, batch_size=4000)
+
+
+trpo_cartpole()
+```
+
+Running the above should produce output like:
+
+```sh
+2020-06-25 14:03:46 | [trpo_cartpole] Logging to /home/ruofu/garage/data/local/experiment/trpo_cartpole_4
+2020-06-25 14:03:48 | [trpo_cartpole] Obtaining samples...
+Sampling  [####################################]  100%
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Logging diagnostics...
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Optimizing policy...
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Computing loss before
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Computing KL before
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Optimizing
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | Start CG optimization:
+#parameters: 1282, #inputs: 186, #subsample_inputs: 186
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | computing loss before
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | computing gradient
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | gradient computed
+2020-06-25 14:03:52 | [trpo_cartpole] epoch #0 | computing descent direction
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | descent direction computed
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | backtrack iters: 10
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | optimization finished
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Computing KL after
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Computing loss after
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Fitting baseline...
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Saving snapshot...
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Saved
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | Time 4.66 s
+2020-06-25 14:03:53 | [trpo_cartpole] epoch #0 | EpochTime 4.66 s
+---------------------------------------  --------------
+Evaluation/AverageDiscountedReturn         19.045
+Evaluation/AverageReturn                   21.5054
+Evaluation/TerminationRate                  1
+Evaluation/Iteration                        0
+Evaluation/MaxReturn                       58
+Evaluation/MinReturn                        8
+Evaluation/NumEpisodes                    186
+Evaluation/StdReturn                       10.0511
+Extras/EpisodeRewardMean                   22.22
+LinearFeatureBaseline/ExplainedVariance     4.14581e-08
+TotalEnvSteps                            4000
+policy/Entropy                              3.22253
+policy/KL                                   9.75289e-05
+policy/KLBefore                             0
+policy/LossAfter                           -0.5136
+policy/LossBefore                          -0.513123
+policy/Perplexity                          25.0916
+policy/dLoss                                0.000476599
+---------------------------------------  --------------
+```
+
+----
+
+*This page was authored by Ruofu Wang ([@yeukfu](https://github.com/yeukfu)).*

--- a/docs/user/use_pretrained_network_to_start_new_experiment.md
+++ b/docs/user/use_pretrained_network_to_start_new_experiment.md
@@ -1,0 +1,182 @@
+# Use a pre-trained network to start a new experiment
+
+In this section you will learn how to load a pre-trained network and use it in
+new experiments. In general, this process involves loading a snapshot, extracting
+the component that you wish to reuse, and including that component in the new
+experiment.
+
+We'll cover two examples in particular:
+
+- How to use a trained policy as an expert in Behavioral Cloning
+- How to reuse a trained Q function in DQN
+
+Before attempting either of these, you'll need a saved experiment snapshot. [This page](https://garage.readthedocs.io/en/latest/user/save_load_resume_exp.html)
+will show you how to get one.
+
+## Example: Use a pre-trained policy as a BC expert
+
+There are two steps involved. First, we must load the pre-trained policy. Assuming
+that it was trained with garage, details on extracting a policy from a saved experiment
+can be found [here](https://garage.readthedocs.io/en/latest/user/reuse_garage_policy.html).
+Next, we setup a new experiment and pass the policy as the `source` argument of
+the `BC` constructor:
+
+```python
+# Load the policy
+from garage.experiment import Snapshotter
+snapshotter = Snapshotter()
+snapshot = snapshotter.load('path/to/snapshot/dir')
+
+expert = snapshot['algo'].policy
+env = snapshot['env']  # We assume env is the same
+
+# Setup new experiment
+from garage import wrap_experiment
+from garage.experiment import LocalRunner
+from garage.torch.algos import BC
+from garage.torch.policies import GaussianMLPPolicy
+
+@wrap_experiment
+def bc_with_pretrained_expert(ctxt=None):
+    runner = LocalRunner(ctxt)
+    policy = GaussianMLPPolicy(env.spec, [8, 8])
+    batch_size = 1000
+    algo = BC(env.spec,
+              policy,
+              batch_size=batch_size,
+              source=expert,
+              max_path_length=200,
+              policy_lr=1e-2,
+              loss='log_prob')
+    runner.setup(algo, env)
+    runner.train(100, batch_size=batch_size)
+
+
+bc_with_pretrained_expert()
+```
+
+Please refer to [this page](https://garage.readthedocs.io/en/latest/user/algo_bc.html)
+for more information on garage's implementation of Behavioral Cloning. If your expert
+policy wasn't trained with garage, you can wrap it in garage's `Policy` API
+(`garage.torch.policies.Policy`) before passing it to `BC`.
+
+## Example: Use a pre-trained Q function in a new DQN experiment
+
+Garage's DQN module accepts a Q function in its constructor: `DQN(env_space=env.spec, policy=policy, qf=qf, ...)`
+To use a pre-trained Q function, we simply load one and pass it in, rather than
+creating a new one. Since there is a relatively large number of constructs that
+go into creating a DQN, we suggest you use the [Pong example code](https://github.com/rlworkgroup/garage/blob/master/examples/tf/dqn_pong.py)
+as a starting point. You'll have to modify lines 68-75 (`qf = DiscreteCNNQFunction(...)`)
+as shown below:
+
+```python
+import click
+import gym
+
+from garage import wrap_experiment
+from garage.envs import GarageEnv
+<<<<<<< HEAD
+from garage.envs.wrappers import ClipReward
+from garage.envs.wrappers import EpisodicLife
+from garage.envs.wrappers import FireReset
+from garage.envs.wrappers import Grayscale
+from garage.envs.wrappers import MaxAndSkip
+from garage.envs.wrappers import Noop
+from garage.envs.wrappers import Resize
+from garage.envs.wrappers import StackFrames
+=======
+from garage.envs.wrappers.clip_reward import ClipReward
+from garage.envs.wrappers.episodic_life import EpisodicLife
+from garage.envs.wrappers.fire_reset import FireReset
+from garage.envs.wrappers.grayscale import Grayscale
+from garage.envs.wrappers.max_and_skip import MaxAndSkip
+from garage.envs.wrappers.noop import Noop
+from garage.envs.wrappers.resize import Resize
+from garage.envs.wrappers.stack_frames import StackFrames
+>>>>>>> a1877525... Flatten observations if necessary
+from garage.experiment import LocalTFRunner, Snapshotter  # Add this import!
+from garage.experiment.deterministic import set_seed
+from garage.np.exploration_policies import EpsilonGreedyPolicy
+from garage.replay_buffer import PathBuffer
+from garage.tf.algos import DQN
+from garage.tf.policies import DiscreteQfDerivedPolicy
+
+
+@click.command()
+@click.option('--buffer_size', type=int, default=int(5e4))
+@click.option('--max_episode_length', type=int, default=500)
+@wrap_experiment
+def dqn_pong(ctxt=None, seed=1, buffer_size=int(5e4), max_episode_length=500):
+    """Train DQN on PongNoFrameskip-v4 environment.
+    Args:
+        ctxt (garage.experiment.ExperimentContext): The experiment
+            configuration used by LocalRunner to create the snapshotter.
+        seed (int): Used to seed the random number generator to produce
+            determinism.
+        buffer_size (int): Number of timesteps to store in replay buffer.
+        max_episode_length (int): Maximum length of a path after which a path
+            is considered complete. This is used during testing to minimize
+            the memory required to store a single path.
+    """
+    set_seed(seed)
+    with LocalTFRunner(ctxt) as runner:
+        n_epochs = 100
+        steps_per_epoch = 20
+        sampler_batch_size = 500
+        num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
+
+        env = gym.make('PongNoFrameskip-v4')
+        env = Noop(env, noop_max=30)
+        env = MaxAndSkip(env, skip=4)
+        env = EpisodicLife(env)
+        if 'FIRE' in env.unwrapped.get_action_meanings():
+            env = FireReset(env)
+        env = Grayscale(env)
+        env = Resize(env, 84, 84)
+        env = ClipReward(env)
+        env = StackFrames(env, 4)
+
+        env = GarageEnv(env, is_image=True)
+
+        replay_buffer = PathBuffer(capacity_in_transitions=buffer_size)
+
+        # MARK: begin modifications to existing example
+        snapshotter = Snapshotter()
+        snapshot = snapshotter.load('path/to/previous/run/snapshot/dir')
+        qf = snapshot['algo']._qf
+        # MARK: end modifications to existing example
+
+        policy = DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
+        exploration_policy = EpsilonGreedyPolicy(env_spec=env.spec,
+                                                 policy=policy,
+                                                 total_timesteps=num_timesteps,
+                                                 max_epsilon=1.0,
+                                                 min_epsilon=0.02,
+                                                 decay_ratio=0.1)
+
+        algo = DQN(env_spec=env.spec,
+                   policy=policy,
+                   qf=qf,
+                   exploration_policy=exploration_policy,
+                   replay_buffer=replay_buffer,
+                   qf_lr=1e-4,
+                   discount=0.99,
+                   min_buffer_size=int(1e4),
+                   max_episode_length=max_episode_length,
+                   double_q=False,
+                   n_train_steps=500,
+                   steps_per_epoch=steps_per_epoch,
+                   target_network_update_freq=2,
+                   buffer_batch_size=32)
+
+        runner.setup(algo, env)
+        runner.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
+
+
+dqn_pong()
+```
+
+----
+
+_This page was authored by Hayden Shively
+([@haydenshively](https://github.com/haydenshively))_

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -36,7 +36,7 @@ def trpo_swimmer_ray_sampler(ctxt=None, seed=1):
              object_store_memory=78643200,
              ignore_reinit_error=True,
              log_to_driver=False,
-             include_webui=False)
+             include_dashboard=False)
     with LocalTFRunner(snapshot_config=ctxt) as runner:
         set_seed(seed)
         env = GarageEnv(gym.make('Swimmer-v2'))

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -34,7 +34,7 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
              object_store_memory=78643200,
              ignore_reinit_error=True,
              log_to_driver=False,
-             include_webui=False)
+             include_dashboard=False)
     deterministic.set_seed(seed)
     env = GarageEnv(env_name='InvertedDoublePendulum-v2')
 

--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -59,7 +59,6 @@ def rollout(env,
     if animated:
         env.render()
     while path_length < (max_path_length or np.inf):
-        o = env.observation_space.flatten(o)
         a, agent_info = agent.get_action(o)
         if deterministic and 'mean' in agent_info:
             a = agent_info['mean']

--- a/src/garage/tf/policies/categorical_gru_policy.py
+++ b/src/garage/tf/policies/categorical_gru_policy.py
@@ -241,6 +241,8 @@ class CategoricalGRUPolicy(StochasticPolicy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/categorical_lstm_policy.py
+++ b/src/garage/tf/policies/categorical_lstm_policy.py
@@ -270,6 +270,8 @@ class CategoricalLSTMPolicy(StochasticPolicy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/categorical_mlp_policy.py
+++ b/src/garage/tf/policies/categorical_mlp_policy.py
@@ -162,8 +162,8 @@ class CategoricalMLPPolicy(StochasticPolicy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
-        sample, prob = self._f_prob(np.expand_dims([observation], 1))
-        return np.squeeze(sample[0]), dict(prob=np.squeeze(prob, axis=1)[0])
+        actions, agent_infos = self.get_actions([observation])
+        return actions, {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Return multiple actions.
@@ -176,9 +176,8 @@ class CategoricalMLPPolicy(StochasticPolicy):
             dict(numpy.ndarray): Distribution parameters.
 
         """
-        # Flatten the observation, will be removed soon
-        # Flattening should be done in sampler
-        observations = self.observation_space.flatten_n(observations)
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         samples, probs = self._f_prob(np.expand_dims(observations, 1))
         return np.squeeze(samples), dict(prob=np.squeeze(probs, axis=1))
 

--- a/src/garage/tf/policies/continuous_mlp_policy.py
+++ b/src/garage/tf/policies/continuous_mlp_policy.py
@@ -4,6 +4,7 @@ A continuous MLP network can be used as policy method in different RL
 algorithms. It accepts an observation of the environment and predicts a
 continuous action.
 """
+import numpy as np
 import tensorflow as tf
 
 from garage.experiment import deterministic
@@ -124,9 +125,9 @@ class ContinuousMLPPolicy(Policy):
             dict: Empty dict since this policy does not model a distribution.
 
         """
-        action = self._f_prob([observation])
-        action = self.action_space.unflatten(action)
-        return action, dict()
+        actions, agent_infos = self.get_actions([observation])
+        action = actions[0]
+        return action, {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get multiple actions from this policy for the input observations.
@@ -139,6 +140,8 @@ class ContinuousMLPPolicy(Policy):
             dict: Empty dict since this policy does not model a distribution.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         actions = self._f_prob(observations)
         actions = self.action_space.unflatten_n(actions)
         return actions, dict()

--- a/src/garage/tf/policies/gaussian_gru_policy.py
+++ b/src/garage/tf/policies/gaussian_gru_policy.py
@@ -268,6 +268,8 @@ class GaussianGRUPolicy(StochasticPolicy):
                 self._state_include_action is True.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/gaussian_lstm_policy.py
+++ b/src/garage/tf/policies/gaussian_lstm_policy.py
@@ -297,6 +297,8 @@ class GaussianLSTMPolicy(StochasticPolicy):
                 self._state_include_action is True.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         if self._state_include_action:
             assert self._prev_actions is not None
             all_input = np.concatenate([observations, self._prev_actions],

--- a/src/garage/tf/policies/gaussian_mlp_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_policy.py
@@ -210,11 +210,8 @@ class GaussianMLPPolicy(StochasticPolicy):
                 distribution.
 
         """
-        sample, mean, log_std = self._f_dist(np.expand_dims([observation], 1))
-        sample = self.action_space.unflatten(np.squeeze(sample, 1)[0])
-        mean = self.action_space.unflatten(np.squeeze(mean, 1)[0])
-        log_std = self.action_space.unflatten(np.squeeze(log_std, 1)[0])
-        return sample, dict(mean=mean, log_std=log_std)
+        actions, agent_infos = self.get_actions([observation])
+        return actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get multiple actions from this policy for the input observations.
@@ -233,6 +230,8 @@ class GaussianMLPPolicy(StochasticPolicy):
                 distribution.
 
         """
+        if not isinstance(observations[0], np.ndarray):
+            observations = self.observation_space.flatten_n(observations)
         samples, means, log_stds = self._f_dist(np.expand_dims(
             observations, 1))
         samples = self.action_space.unflatten_n(np.squeeze(samples, 1))

--- a/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
+++ b/src/garage/tf/policies/gaussian_mlp_task_embedding_policy.py
@@ -90,6 +90,7 @@ class GaussianMLPTaskEmbeddingPolicy(TaskEmbeddingPolicy):
                  std_parameterization='exp',
                  layer_normalization=False):
         assert isinstance(env_spec.action_space, akro.Box)
+        assert not isinstance(env_spec.observation_space, akro.Dict)
         super().__init__(name, env_spec, encoder)
         self._hidden_sizes = hidden_sizes
         self._hidden_nonlinearity = hidden_nonlinearity
@@ -237,8 +238,8 @@ class GaussianMLPTaskEmbeddingPolicy(TaskEmbeddingPolicy):
                     A is the dimension of action.
 
         """
-        obs, task = self.split_augmented_observation(observation)
-        return self.get_action_given_task(obs, task)
+        actions, agent_infos = self.get_actions([observation])
+        return actions[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         """Get actions sampled from the policy.

--- a/src/garage/torch/policies/stochastic_policy.py
+++ b/src/garage/torch/policies/stochastic_policy.py
@@ -1,6 +1,8 @@
 """Base Stochastic Policy."""
 import abc
 
+import akro
+import numpy as np
 import torch
 
 from garage.torch import global_device
@@ -27,16 +29,16 @@ class StochasticPolicy(Policy, abc.ABC):
                         values of the distribution.
 
         """
+        if not isinstance(observation, np.ndarray) and not isinstance(
+                observation, torch.Tensor):
+            observation = self._env_spec.observation_space.flatten(observation)
         with torch.no_grad():
             if not isinstance(observation, torch.Tensor):
                 observation = torch.as_tensor(observation).float().to(
                     global_device())
             observation = observation.unsqueeze(0)
-            dist, info = self.forward(observation)
-            return dist.sample().squeeze(0).cpu().numpy(), {
-                k: v.squeeze(0).detach().cpu().numpy()
-                for (k, v) in info.items()
-            }
+            action, agent_infos = self.get_actions(observation)
+            return action[0], {k: v[0] for k, v in agent_infos.items()}
 
     def get_actions(self, observations):
         r"""Get actions given observations.
@@ -55,6 +57,24 @@ class StochasticPolicy(Policy, abc.ABC):
                         values of the distribution.
 
         """
+        if not isinstance(observations[0], np.ndarray) and not isinstance(
+                observations[0], torch.Tensor):
+            observations = self._env_spec.observation_space.flatten_n(
+                observations)
+
+        # frequently users like to pass lists of torch tensors or lists of
+        # numpy arrays. This handles those conversions.
+        if isinstance(observations, list):
+            if isinstance(observations[0], np.ndarray):
+                observations = np.stack(observations)
+            elif isinstance(observations[0], torch.Tensor):
+                observations = torch.stack(observations)
+
+        if isinstance(self._env_spec.observation_space, akro.Image) and \
+                len(observations.shape) < \
+                len(self._env_spec.observation_space.shape):
+            observations = self._env_spec.observation_space.unflatten_n(
+                observations)
         with torch.no_grad():
             if not isinstance(observations, torch.Tensor):
                 observations = torch.as_tensor(observations).float().to(

--- a/tests/fixtures/envs/dummy/dummy_dict_env.py
+++ b/tests/fixtures/envs/dummy/dummy_dict_env.py
@@ -1,5 +1,6 @@
 """Dummy akro.Dict environment for testing purpose."""
 import akro
+import gym
 import numpy as np
 
 from garage.envs import EnvSpec
@@ -11,11 +12,19 @@ class DummyDictEnv(DummyEnv):
 
     Args:
         random (bool): If observations are randomly generated or not.
+        obs_space_type (str): The type of the inner spaces of the
+            dict observation space.
+        act_space_type (str): The type of action space to mock.
 
     """
 
-    def __init__(self, random=True):
+    def __init__(self, random=True, obs_space_type='box',
+                 act_space_type='box'):
+        assert obs_space_type in ['box', 'image', 'discrete']
+        assert act_space_type in ['box', 'discrete']
         super().__init__(random)
+        self.obs_space_type = obs_space_type
+        self.act_space_type = act_space_type
         self.spec = EnvSpec(action_space=self.action_space,
                             observation_space=self.observation_space)
 
@@ -27,15 +36,34 @@ class DummyDictEnv(DummyEnv):
             akro.Dict: Observation space.
 
         """
-
-        return akro.Dict({
-            'achieved_goal':
-            akro.Box(low=-200., high=200., shape=(3, ), dtype=np.float32),
-            'desired_goal':
-            akro.Box(low=-200., high=200., shape=(3, ), dtype=np.float32),
-            'observation':
-            akro.Box(low=-200., high=200., shape=(25, ), dtype=np.float32)
-        })
+        if self.obs_space_type == 'box':
+            return gym.spaces.Dict({
+                'achieved_goal':
+                gym.spaces.Box(low=-200.,
+                               high=200.,
+                               shape=(3, ),
+                               dtype=np.float32),
+                'desired_goal':
+                gym.spaces.Box(low=-200.,
+                               high=200.,
+                               shape=(3, ),
+                               dtype=np.float32),
+                'observation':
+                gym.spaces.Box(low=-200.,
+                               high=200.,
+                               shape=(25, ),
+                               dtype=np.float32)
+            })
+        elif self.obs_space_type == 'image':
+            return gym.spaces.Dict({
+                'dummy':
+                gym.spaces.Box(low=0,
+                               high=255,
+                               shape=(100, 100, 3),
+                               dtype=np.uint8),
+            })
+        else:
+            return gym.spaces.Dict({'dummy': gym.spaces.Discrete(5)})
 
     @property
     def action_space(self):
@@ -45,7 +73,10 @@ class DummyDictEnv(DummyEnv):
             akro.Box: Action space.
 
         """
-        return akro.Box(low=-5.0, high=5.0, shape=(1, ), dtype=np.float32)
+        if self.act_space_type == 'box':
+            return akro.Box(low=-5.0, high=5.0, shape=(1, ), dtype=np.float32)
+        else:
+            return akro.Discrete(5)
 
     def reset(self):
         """Reset the environment.

--- a/tests/fixtures/q_functions/simple_q_function.py
+++ b/tests/fixtures/q_functions/simple_q_function.py
@@ -16,7 +16,9 @@ class SimpleQFunction(QFunction):
 
     def __init__(self, env_spec, name='SimpleQFunction'):
         super().__init__(name)
-        self.obs_dim = env_spec.observation_space.shape
+        # avnish
+        # self.obs_dim = env_spec.observation_space.shape
+        self.obs_dim = (env_spec.observation_space.flat_dim, )
         action_dim = env_spec.observation_space.flat_dim
         self.model = SimpleMLPModel(output_dim=action_dim)
 

--- a/tests/fixtures/sampler/ray_fixtures.py
+++ b/tests/fixtures/sampler/ray_fixtures.py
@@ -17,7 +17,7 @@ def ray_local_session_fixture():
         ray.init(local_mode=True,
                  ignore_reinit_error=True,
                  log_to_driver=False,
-                 include_webui=False)
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()
@@ -38,7 +38,7 @@ def ray_session_fixture():
                  object_store_memory=78643200,
                  ignore_reinit_error=True,
                  log_to_driver=False,
-                 include_webui=False)
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()

--- a/tests/garage/replay_buffer/test_her_replay_buffer.py
+++ b/tests/garage/replay_buffer/test_her_replay_buffer.py
@@ -3,6 +3,7 @@ import pickle
 import numpy as np
 import pytest
 
+from garage.envs import GarageEnv
 from garage.replay_buffer import HERReplayBuffer
 from tests.fixtures.envs.dummy import DummyDictEnv
 
@@ -10,7 +11,7 @@ from tests.fixtures.envs.dummy import DummyDictEnv
 class TestHerReplayBuffer:
 
     def setup_method(self):
-        self.env = DummyDictEnv()
+        self.env = GarageEnv(DummyDictEnv())
         self.obs = self.env.reset()
         self._replay_k = 4
         self.replay_buffer = HERReplayBuffer(env_spec=self.env.spec,

--- a/tests/garage/sampler/test_utils.py
+++ b/tests/garage/sampler/test_utils.py
@@ -27,11 +27,6 @@ class TestRollout:
         # dummy is the env_info_key
         assert path['env_infos']['dummy'].shape[0] == 3
 
-    def test_does_flatten(self):
-        path = utils.rollout(self.env, self.policy, max_path_length=5)
-        assert path['observations'][0].shape == (16, )
-        assert path['actions'][0].shape == (2, 2)
-
     def test_deterministic_action(self):
         path = utils.rollout(self.env,
                              self.policy,

--- a/tests/garage/tf/policies/test_categorical_gru_policy.py
+++ b/tests/garage/tf/policies/test_categorical_gru_policy.py
@@ -6,9 +6,14 @@ import tensorflow as tf
 
 from garage.envs import GarageEnv
 from garage.tf.policies import CategoricalGRUPolicy
-from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+# yapf: disable
+from tests.fixtures import TfGraphTestCase  # noqa: I202
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestCategoricalGRUPolicy(TfGraphTestCase):
@@ -98,25 +103,34 @@ class TestCategoricalGRUPolicy(TfGraphTestCase):
             feed_dict={state_input: [[obs.flatten()], [obs.flatten()]]})
         assert np.array_equal(output1, output2)
 
-    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim', [
-        ((1, ), 1, 4),
-        ((2, ), 2, 4),
-        ((1, 1), 1, 4),
-        ((2, 2), 2, 4),
+    @pytest.mark.parametrize('obs_dim, action_dim, hidden_dim, obs_type', [
+        ((1, ), 1, 4, 'discrete'),
+        ((2, ), 2, 4, 'discrete'),
+        ((1, 1), 1, 4, 'discrete'),
+        ((2, 2), 2, 4, 'discrete'),
+        ((1, ), 1, 4, 'dict'),
     ])
-    def test_get_action(self, obs_dim, action_dim, hidden_dim):
-        env = GarageEnv(
-            DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+    def test_get_action(self, obs_dim, action_dim, hidden_dim, obs_type):
+        assert obs_type in ['discrete', 'dict']
+        if obs_type == 'discrete':
+            env = GarageEnv(
+                DummyDiscreteEnv(obs_dim=obs_dim, action_dim=action_dim))
+        else:
+            env = GarageEnv(
+                DummyDictEnv(obs_space_type='box', act_space_type='discrete'))
         policy = CategoricalGRUPolicy(env_spec=env.spec,
                                       hidden_dim=hidden_dim,
                                       state_include_action=False)
         policy.reset(do_resets=None)
         obs = env.reset()
 
-        action, _ = policy.get_action(obs.flatten())
+        if obs_type == 'discrete':
+            obs = obs.flatten()
+
+        action, _ = policy.get_action(obs)
         assert env.action_space.contains(action)
 
-        actions, _ = policy.get_actions([obs.flatten()])
+        actions, _ = policy.get_actions([obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_gru_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_gru_policy.py
@@ -6,9 +6,14 @@ import tensorflow as tf
 
 from garage.envs import GarageEnv
 from garage.tf.policies import GaussianGRUPolicy
-from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+# yapf: disable
+from tests.fixtures import TfGraphTestCase  # noqa: I202
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianGRUPolicy(TfGraphTestCase):
@@ -64,6 +69,22 @@ class TestGaussianGRUPolicy(TfGraphTestCase):
         assert env.action_space.contains(action)
 
         actions, _ = policy.get_actions([obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianGRUPolicy(env_spec=env.spec,
+                                   hidden_dim=4,
+                                   state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_lstm_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_lstm_policy.py
@@ -6,9 +6,14 @@ import tensorflow as tf
 
 from garage.envs import GarageEnv
 from garage.tf.policies import GaussianLSTMPolicy
-from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+# yapf: disable
+from tests.fixtures import TfGraphTestCase  # noqa: I202
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianLSTMPolicy(TfGraphTestCase):
@@ -40,6 +45,22 @@ class TestGaussianLSTMPolicy(TfGraphTestCase):
         policy.reset()
 
         actions, _ = policy.get_actions([obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianLSTMPolicy(env_spec=env.spec,
+                                    hidden_dim=4,
+                                    state_include_action=False)
+        policy.reset(do_resets=None)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/tf/policies/test_gaussian_mlp_policy.py
@@ -6,9 +6,14 @@ import tensorflow as tf
 
 from garage.envs import GarageEnv
 from garage.tf.policies import GaussianMLPPolicy
-from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyBoxEnv
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+
+# yapf: disable
+from tests.fixtures import TfGraphTestCase  # noqa: I202
+from tests.fixtures.envs.dummy import (DummyBoxEnv,
+                                       DummyDictEnv,
+                                       DummyDiscreteEnv)
+
+# yapf: enable
 
 
 class TestGaussianMLPPolicy(TfGraphTestCase):
@@ -38,6 +43,19 @@ class TestGaussianMLPPolicy(TfGraphTestCase):
         actions, _ = policy.get_actions(
             [obs.flatten(), obs.flatten(),
              obs.flatten()])
+        for action in actions:
+            assert env.action_space.contains(action)
+
+    def test_get_action_dict_space(self):
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianMLPPolicy(env_spec=env.spec)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.contains(action)
+
+        actions, _ = policy.get_actions([obs, obs])
         for action in actions:
             assert env.action_space.contains(action)
 

--- a/tests/garage/tf/policies/test_qf_derived_policy.py
+++ b/tests/garage/tf/policies/test_qf_derived_policy.py
@@ -1,12 +1,21 @@
 import pickle
 
+import pytest
 import tensorflow as tf
 
 from garage.envs import GarageEnv
+from garage.envs.wrappers import AtariEnv
 from garage.tf.policies import DiscreteQfDerivedPolicy
-from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import DummyDiscreteEnv
+from garage.tf.q_functions import DiscreteCNNQFunction
+
+# yapf: disable
+from tests.fixtures import TfGraphTestCase  # noqa: I202
+from tests.fixtures.envs.dummy import (DummyDictEnv,
+                                       DummyDiscreteEnv,
+                                       DummyDiscretePixelEnvBaselines)
 from tests.fixtures.q_functions import SimpleQFunction
+
+# yapf: enable
 
 
 class TestQfDerivedPolicy(TfGraphTestCase):
@@ -42,3 +51,43 @@ class TestQfDerivedPolicy(TfGraphTestCase):
             policy_pickled = pickle.loads(p)
             action2, _ = policy_pickled.get_action(obs)
             assert action1 == action2
+
+    def test_does_not_support_dict_obs_space(self):
+        """Test that policy raises error if passed a dict obs space."""
+        env = GarageEnv(DummyDictEnv(act_space_type='discrete'))
+        with pytest.raises(ValueError):
+            qf = SimpleQFunction(env.spec,
+                                 name='does_not_support_dict_obs_space')
+            DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
+
+    def test_invalid_action_spaces(self):
+        """Test that policy raises error if passed a dict obs space."""
+        env = GarageEnv(DummyDictEnv(act_space_type='box'))
+        with pytest.raises(ValueError):
+            qf = SimpleQFunction(env.spec)
+            DiscreteQfDerivedPolicy(env_spec=env.spec, qf=qf)
+
+
+class TestQfDerivedPolicyImageObs(TfGraphTestCase):
+
+    def setup_method(self):
+        super().setup_method()
+        self.env = GarageEnv(AtariEnv(DummyDiscretePixelEnvBaselines()),
+                             is_image=True)
+        self.qf = DiscreteCNNQFunction(env_spec=self.env.spec,
+                                       filters=((1, (1, 1)), ),
+                                       strides=(1, ),
+                                       dueling=False)
+        self.policy = DiscreteQfDerivedPolicy(env_spec=self.env.spec,
+                                              qf=self.qf)
+        self.sess.run(tf.compat.v1.global_variables_initializer())
+        self.env.reset()
+
+    def test_obs_unflattened(self):
+        """Test if a flattened image obs is passed to get_action
+           then it is unflattened.
+        """
+        obs = self.env.observation_space.sample()
+        action, _ = self.policy.get_action(
+            self.env.observation_space.flatten(obs))
+        self.env.step(action)

--- a/tests/garage/torch/policies/test_context_conditioned_policy.py
+++ b/tests/garage/torch/policies/test_context_conditioned_policy.py
@@ -32,9 +32,8 @@ class TestContextConditionedPolicy:
             (self.env_spec.observation_space, latent_space))
         augmented_env_spec = EnvSpec(augmented_obs_space,
                                      self.env_spec.action_space)
-
-        self.obs_dim = int(np.prod(self.env_spec.observation_space.shape))
-        self.action_dim = int(np.prod(self.env_spec.action_space.shape))
+        self.obs_dim = self.env_spec.observation_space.flat_dim
+        self.action_dim = self.env_spec.action_space.flat_dim
         reward_dim = 1
         self.encoder_input_dim = self.obs_dim + self.action_dim + reward_dim
         encoder_output_dim = self.latent_dim * 2

--- a/tests/garage/torch/policies/test_deterministic_mlp_policy.py
+++ b/tests/garage/torch/policies/test_deterministic_mlp_policy.py
@@ -7,7 +7,11 @@ from torch import nn
 
 from garage.envs import GarageEnv
 from garage.torch.policies import DeterministicMLPPolicy
-from tests.fixtures.envs.dummy import DummyBoxEnv
+
+# yapf: Disable
+from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDictEnv  # noqa: I202
+
+# yapf: Enable
 
 
 class TestDeterministicMLPPolicies:
@@ -20,7 +24,7 @@ class TestDeterministicMLPPolicies:
         obs_dim = env_spec.observation_space.flat_dim
         act_dim = env_spec.action_space.flat_dim
         obs = torch.ones([1, obs_dim], dtype=torch.float32)
-
+        obs_np = np.ones([1, obs_dim], dtype=np.float32)
         policy = DeterministicMLPPolicy(env_spec=env_spec,
                                         hidden_nonlinearity=None,
                                         hidden_sizes=hidden_sizes,
@@ -31,6 +35,7 @@ class TestDeterministicMLPPolicies:
                                   fill_value=obs_dim * np.prod(hidden_sizes),
                                   dtype=np.float32)
         assert np.array_equal(policy.get_action(obs)[0], expected_output)
+        assert np.array_equal(policy.get_action(obs_np)[0], expected_output)
 
     # yapf: disable
     @pytest.mark.parametrize('batch_size, hidden_sizes', [
@@ -46,7 +51,8 @@ class TestDeterministicMLPPolicies:
         obs_dim = env_spec.observation_space.flat_dim
         act_dim = env_spec.action_space.flat_dim
         obs = torch.ones([batch_size, obs_dim], dtype=torch.float32)
-
+        obs_np = np.ones([obs_dim], dtype=np.float32)
+        obs_torch = torch.Tensor(obs_np)
         policy = DeterministicMLPPolicy(env_spec=env_spec,
                                         hidden_nonlinearity=None,
                                         hidden_sizes=hidden_sizes,
@@ -57,6 +63,10 @@ class TestDeterministicMLPPolicies:
                                   fill_value=obs_dim * np.prod(hidden_sizes),
                                   dtype=np.float32)
         assert np.array_equal(policy.get_actions(obs)[0], expected_output)
+        assert np.array_equal(
+            policy.get_actions([obs_torch] * batch_size)[0], expected_output)
+        assert np.array_equal(
+            policy.get_actions([obs_np] * batch_size)[0], expected_output)
 
     # yapf: disable
     @pytest.mark.parametrize('batch_size, hidden_sizes', [
@@ -84,3 +94,21 @@ class TestDeterministicMLPPolicies:
         policy_pickled = pickle.loads(p)
         output2 = policy_pickled.get_actions(obs)[0]
         assert np.array_equal(output1, output2)
+
+    def test_get_action_dict_space(self):
+        """Test if observations from dict obs spaces are properly flattened."""
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = DeterministicMLPPolicy(env_spec=env.spec,
+                                        hidden_nonlinearity=None,
+                                        hidden_sizes=(1, ),
+                                        hidden_w_init=nn.init.ones_,
+                                        output_w_init=nn.init.ones_)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.shape == action.shape
+
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape

--- a/tests/garage/torch/policies/test_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_gaussian_mlp_policy.py
@@ -8,7 +8,11 @@ from torch import nn
 
 from garage.envs import GarageEnv
 from garage.torch.policies import GaussianMLPPolicy
-from tests.fixtures.envs.dummy import DummyBoxEnv
+
+# yapf: Disable
+from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDictEnv  # noqa: I202
+
+# yapf: Enable
 
 
 class TestGaussianMLPPolicies:
@@ -195,3 +199,24 @@ class TestGaussianMLPPolicies:
 
         assert np.array_equal(output1_prob['mean'], output2_prob['mean'])
         assert output1_action.shape == output2_action.shape
+
+    def test_get_action_dict_space(self):
+        """Test if observations from dict obs spaces are properly flattened."""
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = GaussianMLPPolicy(env_spec=env.spec,
+                                   hidden_nonlinearity=None,
+                                   hidden_sizes=(1, ),
+                                   hidden_w_init=nn.init.ones_,
+                                   output_w_init=nn.init.ones_)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.shape == action.shape
+
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape

--- a/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
+++ b/tests/garage/torch/policies/test_tanh_gaussian_mlp_policy.py
@@ -8,7 +8,11 @@ from torch import nn
 
 from garage.envs import GarageEnv
 from garage.torch.policies import TanhGaussianMLPPolicy
-from tests.fixtures.envs.dummy import DummyBoxEnv
+
+# yapf: Disable
+from tests.fixtures.envs.dummy import DummyBoxEnv, DummyDictEnv  # noqa: I202
+
+# yapf: Enable
 
 
 class TestTanhGaussianMLPPolicy:
@@ -177,3 +181,21 @@ class TestTanhGaussianMLPPolicy:
         else:
             policy.to(None)
             assert str(next(policy.parameters()).device) == 'cpu'
+
+    def test_get_action_dict_space(self):
+        """Test if observations from dict obs spaces are properly flattened."""
+        env = GarageEnv(
+            DummyDictEnv(obs_space_type='box', act_space_type='box'))
+        policy = TanhGaussianMLPPolicy(env_spec=env.spec,
+                                       hidden_nonlinearity=None,
+                                       hidden_sizes=(1, ),
+                                       hidden_w_init=nn.init.ones_,
+                                       output_w_init=nn.init.ones_)
+        obs = env.reset()
+
+        action, _ = policy.get_action(obs)
+        assert env.action_space.shape == action.shape
+
+        actions, _ = policy.get_actions(np.array([obs, obs]))
+        for action in actions:
+            assert env.action_space.shape == action.shape

--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -18,6 +18,7 @@ NON_ALGO_EXAMPLES = [
 LONG_RUNNING_EXAMPLES = [
     EXAMPLES_ROOT_DIR / 'tf/ppo_memorize_digits.py',
     EXAMPLES_ROOT_DIR / 'tf/dqn_pong.py',
+    EXAMPLES_ROOT_DIR / 'tf/her_ddpg_fetchreach.py',
     EXAMPLES_ROOT_DIR / 'tf/trpo_cubecrash.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_ppo_half_cheetah_dir.py',
     EXAMPLES_ROOT_DIR / 'torch/maml_trpo_half_cheetah_dir.py',
@@ -73,9 +74,6 @@ def test_algo_examples(filepath):
         filepath (str): path string of example
 
     """
-    if filepath == str(EXAMPLES_ROOT_DIR / 'tf/her_ddpg_fetchreach.py'):
-        pytest.skip('Temporarily skipped because it is broken')
-
     env = os.environ.copy()
     env['GARAGE_EXAMPLE_TEST_N_EPOCHS'] = '1'
     # Don't use check=True, since that causes subprocess to throw an error


### PR DESCRIPTION
* Flatten observations if necessary

This commit takes care to convert observations that belong to
spaces that aren't box spaces into observations that would
come from box spaces via akro observation space flattening.

It is really a temporary change. The better solution would be
to modify our GymEnv/GarageEnv and BulletEnv Wrappers to flatten
observations spaces that aren't box spaces.

This is a smaller change, however, the HER replay buffer would
need to be rewritten, which is a much larger change/refactor.

I have refrained from modifying the primitives that belong to
multi task and metalearning algorithms specifically.

Additionally, this change updates usages of ray to reflect
the update in parameter names from ray 0.8.6->0.8.7
