### PR TITLE
Pin mujoco-py to fix gcc error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ EXTRAS['gym'] = [
 ]
 
 EXTRAS['mujoco'] = [
-    'mujoco-py==2.0.2.8',
+    'mujoco-py<=2.0.2.8',
     f'gym[all]=={GYM_VERSION}',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ EXTRAS['gym'] = [
 ]
 
 EXTRAS['mujoco'] = [
-    'mujoco-py<2.1,>=2.0',
+    'mujoco-py==2.0.2.8',
     f'gym[all]=={GYM_VERSION}',
 ]
 


### PR DESCRIPTION
The latest mujoco-py is broken because of gcc related bug. Currently we just pin its version to 2.0.2.8. This should close #1989. 