### PR TITLE
Narrow mujoco-py constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ EXTRAS['gym'] = [
 ]
 
 EXTRAS['mujoco'] = [
-    'mujoco-py<=2.0.2.8',
+    'mujoco-py>=2.0,<=2.0.2.8',
     f'gym[all]=={GYM_VERSION}',
 ]
 


### PR DESCRIPTION
#1996 removed the `>=2.0` constraint, which is important.