### PR TITLE
Improvements to SAC and MTSAC

### DIFF
--- a/src/garage/torch/algos/mtsac.py
+++ b/src/garage/torch/algos/mtsac.py
@@ -71,6 +71,8 @@ class MTSAC(SAC):
         steps_per_epoch (int): Number of train_once calls per epoch.
         num_evaluation_episodes (int): The number of evaluation episodes used
             for computing eval stats at the end of every epoch.
+        use_deterministic_evaluation (bool): True if the trained policy
+            should be evaluated deterministically.
 
     """
 
@@ -99,29 +101,32 @@ class MTSAC(SAC):
         optimizer=torch.optim.Adam,
         steps_per_epoch=1,
         num_evaluation_episodes=5,
+        use_deterministic_evaluation=True,
     ):
 
-        super().__init__(policy=policy,
-                         qf1=qf1,
-                         qf2=qf2,
-                         replay_buffer=replay_buffer,
-                         env_spec=env_spec,
-                         max_episode_length_eval=max_episode_length_eval,
-                         gradient_steps_per_itr=gradient_steps_per_itr,
-                         fixed_alpha=fixed_alpha,
-                         target_entropy=target_entropy,
-                         initial_log_entropy=initial_log_entropy,
-                         discount=discount,
-                         buffer_batch_size=buffer_batch_size,
-                         min_buffer_size=min_buffer_size,
-                         target_update_tau=target_update_tau,
-                         policy_lr=policy_lr,
-                         qf_lr=qf_lr,
-                         reward_scale=reward_scale,
-                         optimizer=optimizer,
-                         steps_per_epoch=steps_per_epoch,
-                         num_evaluation_episodes=num_evaluation_episodes,
-                         eval_env=eval_env)
+        super().__init__(
+            policy=policy,
+            qf1=qf1,
+            qf2=qf2,
+            replay_buffer=replay_buffer,
+            env_spec=env_spec,
+            max_episode_length_eval=max_episode_length_eval,
+            gradient_steps_per_itr=gradient_steps_per_itr,
+            fixed_alpha=fixed_alpha,
+            target_entropy=target_entropy,
+            initial_log_entropy=initial_log_entropy,
+            discount=discount,
+            buffer_batch_size=buffer_batch_size,
+            min_buffer_size=min_buffer_size,
+            target_update_tau=target_update_tau,
+            policy_lr=policy_lr,
+            qf_lr=qf_lr,
+            reward_scale=reward_scale,
+            optimizer=optimizer,
+            steps_per_epoch=steps_per_epoch,
+            num_evaluation_episodes=num_evaluation_episodes,
+            eval_env=eval_env,
+            use_deterministic_evaluation=use_deterministic_evaluation)
         self._num_tasks = num_tasks
         self._eval_env = eval_env
         self._use_automatic_entropy_tuning = fixed_alpha is None
@@ -203,7 +208,8 @@ class MTSAC(SAC):
                     self.policy,
                     self._eval_env,
                     self._max_episode_length_eval,
-                    num_eps=self._num_evaluation_episodes))
+                    num_eps=self._num_evaluation_episodes,
+                    deterministic=self._use_deterministic_evaluation))
         eval_eps = EpisodeBatch.concatenate(*eval_eps)
         last_return = log_multitask_performance(epoch, eval_eps,
                                                 self._discount)

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -81,34 +81,36 @@ class SAC(RLAlgorithm):
             for computing eval stats at the end of every epoch.
         eval_env (Environment): environment used for collecting evaluation
             episodes. If None, a copy of the train env is used.
+        use_deterministic_evaluation (bool): True if the trained policy
+            should be evaluated deterministically.
 
     """
 
     def __init__(
-        self,
-        env_spec,
-        policy,
-        qf1,
-        qf2,
-        replay_buffer,
-        *,  # Everything after this is numbers.
-        max_episode_length_eval=None,
-        gradient_steps_per_itr,
-        fixed_alpha=None,
-        target_entropy=None,
-        initial_log_entropy=0.,
-        discount=0.99,
-        buffer_batch_size=64,
-        min_buffer_size=int(1e4),
-        target_update_tau=5e-3,
-        policy_lr=3e-4,
-        qf_lr=3e-4,
-        reward_scale=1.0,
-        optimizer=torch.optim.Adam,
-        steps_per_epoch=1,
-        num_evaluation_episodes=10,
-        eval_env=None,
-    ):
+            self,
+            env_spec,
+            policy,
+            qf1,
+            qf2,
+            replay_buffer,
+            *,  # Everything after this is numbers.
+            max_episode_length_eval=None,
+            gradient_steps_per_itr,
+            fixed_alpha=None,
+            target_entropy=None,
+            initial_log_entropy=0.,
+            discount=0.99,
+            buffer_batch_size=64,
+            min_buffer_size=int(1e4),
+            target_update_tau=5e-3,
+            policy_lr=3e-4,
+            qf_lr=3e-4,
+            reward_scale=1.0,
+            optimizer=torch.optim.Adam,
+            steps_per_epoch=1,
+            num_evaluation_episodes=10,
+            eval_env=None,
+            use_deterministic_evaluation=True):
 
         self._qf1 = qf1
         self._qf2 = qf2
@@ -132,6 +134,7 @@ class SAC(RLAlgorithm):
 
         if max_episode_length_eval is not None:
             self._max_episode_length_eval = max_episode_length_eval
+        self._use_deterministic_evaluation = use_deterministic_evaluation
 
         self.policy = policy
         self.env_spec = env_spec
@@ -465,8 +468,9 @@ class SAC(RLAlgorithm):
         eval_episodes = obtain_evaluation_episodes(
             self.policy,
             self._eval_env,
+            self._max_episode_length_eval,
             num_eps=self._num_evaluation_episodes,
-            deterministic=False)
+            deterministic=self._use_deterministic_evaluation)
         last_return = log_performance(epoch,
                                       eval_episodes,
                                       discount=self._discount)


### PR DESCRIPTION
- Add eval sampling to SAC
- add deterministic eval sampling option to SAC and MTSAC constructors
- Add option for deterministic or nondeterministic eval sampling
- Resolve bug that I caught while completing backports
  SAC was not using max_eval_path_length. This has been
  now resolved in 2020.06 as well.