### PR TITLE
Add torch DiscreteCNNModule & DiscreteCNNQFunction

### DIFF
--- a/src/garage/torch/modules/__init__.py
+++ b/src/garage/torch/modules/__init__.py
@@ -1,5 +1,6 @@
 """PyTorch Modules."""
 # yapf: disable
+# isort:skip_file
 from garage.torch.modules.categorical_cnn_module import CategoricalCNNModule
 from garage.torch.modules.cnn_module import CNNModule
 from garage.torch.modules.gaussian_mlp_module import (
@@ -9,12 +10,14 @@ from garage.torch.modules.gaussian_mlp_module import (
 from garage.torch.modules.gaussian_mlp_module import GaussianMLPModule
 from garage.torch.modules.mlp_module import MLPModule
 from garage.torch.modules.multi_headed_mlp_module import MultiHeadedMLPModule
-
+# DiscreteCNNModule must go after MLPModule
+from garage.torch.modules.discrete_cnn_module import DiscreteCNNModule
 # yapf: enable
 
 __all__ = [
     'CategoricalCNNModule',
     'CNNModule',
+    'DiscreteCNNModule',
     'MLPModule',
     'MultiHeadedMLPModule',
     'GaussianMLPModule',

--- a/src/garage/torch/modules/cnn_module.py
+++ b/src/garage/torch/modules/cnn_module.py
@@ -1,11 +1,14 @@
 """CNN Module."""
 import copy
 
+import torch
 from torch import nn
 
 from garage.torch import flatten_to_single_vector, NonLinearity
 
 
+# pytorch v1.6 issue, see https://github.com/pytorch/pytorch/issues/42305
+# pylint: disable=abstract-method
 # pylint: disable=unused-argument
 class CNNModule(nn.Module):
     """Convolutional neural network (CNN) model in pytorch.
@@ -55,7 +58,7 @@ class CNNModule(nn.Module):
                  input_var,
                  hidden_channels,
                  kernel_sizes,
-                 strides=1,
+                 strides,
                  hidden_nonlinearity=nn.ReLU,
                  hidden_w_init=nn.init.xavier_uniform_,
                  hidden_b_init=nn.init.zeros_,
@@ -67,6 +70,9 @@ class CNNModule(nn.Module):
                  layer_normalization=False,
                  n_layers=None,
                  is_image=True):
+        if len(strides) != len(hidden_channels):
+            raise ValueError('Strides and hidden_channels must have the same'
+                             ' number of dimensions')
         super().__init__()
         self._hidden_channels = hidden_channels
         self._kernel_sizes = kernel_sizes
@@ -125,7 +131,7 @@ class CNNModule(nn.Module):
 
         """
         if self._is_image:
-            input_val /= 255.0
+            input_val = torch.div(input_val, 255.0)
         x = input_val
         for layer in self._cnn_layers:
             x = layer(x)

--- a/src/garage/torch/modules/discrete_cnn_module.py
+++ b/src/garage/torch/modules/discrete_cnn_module.py
@@ -1,0 +1,140 @@
+"""Discrete CNN Q Function."""
+import torch
+from torch import nn
+
+from garage.torch.modules import CNNModule, MLPModule
+
+
+# pytorch v1.6 issue, see https://github.com/pytorch/pytorch/issues/42305
+# pylint: disable=abstract-method
+class DiscreteCNNModule(nn.Module):
+    """Discrete CNN Module.
+
+    A CNN followed by one or more fully connected layers with a set number
+    of discrete outputs.
+
+    Args:
+        input_shape (tuple[int]): Shape of the input. Based on 'NCHW' data
+            format: [batch_size, channel, height, width].
+        output_dim (int): Output dimension of the fully-connected layer.
+        kernel_sizes (tuple[int]): Dimension of the conv filters.
+            For example, (3, 5) means there are two convolutional layers.
+            The filter for first layer is of dimension (3 x 3)
+            and the second one is of dimension (5 x 5).
+        strides (tuple[int]): The stride of the sliding window. For example,
+            (1, 2) means there are two convolutional layers. The stride of the
+            filter for first layer is 1 and that of the second layer is 2.
+        hidden_channels (tuple[int]): Number of output channels for CNN.
+            For example, (3, 32) means there are two convolutional layers.
+            The filter for the first conv layer outputs 3 channels
+            and the second one outputs 32 channels.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        mlp_hidden_nonlinearity (callable): Activation function for
+            intermediate dense layer(s) in the MLP. It should return
+            a torch.Tensor. Set it to None to maintain a linear activation.
+        cnn_hidden_nonlinearity (callable): Activation function for
+            intermediate CNN layer(s). It should return a torch.Tensor.
+            Set it to None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            torch.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            torch.Tensor.
+        paddings (tuple[int]):  Zero-padding added to both sides of the input
+        padding_mode (str): The type of padding algorithm to use,
+            either 'SAME' or 'VALID'.
+        max_pool (bool): Bool for using max-pooling or not.
+        pool_shape (tuple[int]): Dimension of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers are of the same
+            shape (2, 2).
+        pool_stride (tuple[int]): The strides of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers have
+            strides (2, 2).
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a torch.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            torch.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            torch.Tensor.
+        layer_normalization (bool): Bool for using layer normalization or not.
+        is_image (bool): If true, the inputs are normalized by dividing by 255.
+    """
+
+    def __init__(self,
+                 input_shape,
+                 output_dim,
+                 kernel_sizes,
+                 hidden_channels,
+                 strides,
+                 hidden_sizes=(32, 32),
+                 cnn_hidden_nonlinearity=nn.ReLU,
+                 mlp_hidden_nonlinearity=nn.ReLU,
+                 hidden_w_init=nn.init.xavier_uniform_,
+                 hidden_b_init=nn.init.zeros_,
+                 paddings=0,
+                 padding_mode='zeros',
+                 max_pool=False,
+                 pool_shape=None,
+                 pool_stride=1,
+                 output_nonlinearity=None,
+                 output_w_init=nn.init.xavier_uniform_,
+                 output_b_init=nn.init.zeros_,
+                 layer_normalization=False,
+                 is_image=True):
+
+        super().__init__()
+
+        input_var = torch.zeros(input_shape)
+        cnn_module = CNNModule(input_var=input_var,
+                               kernel_sizes=kernel_sizes,
+                               strides=strides,
+                               hidden_w_init=hidden_w_init,
+                               hidden_b_init=hidden_b_init,
+                               hidden_channels=hidden_channels,
+                               hidden_nonlinearity=cnn_hidden_nonlinearity,
+                               paddings=paddings,
+                               padding_mode=padding_mode,
+                               max_pool=max_pool,
+                               layer_normalization=layer_normalization,
+                               pool_shape=pool_shape,
+                               pool_stride=pool_stride,
+                               is_image=is_image)
+
+        with torch.no_grad():
+            cnn_out = cnn_module(input_var)
+        flat_dim = torch.flatten(cnn_out, start_dim=1).shape[1]
+        mlp_module = MLPModule(flat_dim,
+                               output_dim,
+                               hidden_sizes,
+                               hidden_nonlinearity=mlp_hidden_nonlinearity,
+                               hidden_w_init=hidden_w_init,
+                               hidden_b_init=hidden_b_init,
+                               output_nonlinearity=output_nonlinearity,
+                               output_w_init=output_w_init,
+                               output_b_init=output_b_init,
+                               layer_normalization=layer_normalization)
+
+        if mlp_hidden_nonlinearity is None:
+            self._module = nn.Sequential(cnn_module, nn.Flatten(), mlp_module)
+        else:
+            self._module = nn.Sequential(cnn_module, mlp_hidden_nonlinearity(),
+                                         nn.Flatten(), mlp_module)
+
+    def forward(self, inputs):
+        """Forward method.
+
+        Args:
+            inputs (torch.Tensor): Inputs to the model of shape
+                (input_shape*).
+
+        Returns:
+            torch.Tensor: Output tensor of shape :math:`(N, output_dim)`.
+
+        """
+        return self._module(inputs)

--- a/src/garage/torch/q_functions/__init__.py
+++ b/src/garage/torch/q_functions/__init__.py
@@ -1,5 +1,7 @@
 """PyTorch Q-functions."""
 from garage.torch.q_functions.continuous_mlp_q_function import (
     ContinuousMLPQFunction)
+from garage.torch.q_functions.discrete_cnn_q_function import (
+    DiscreteCNNQFunction)
 
-__all__ = ['ContinuousMLPQFunction']
+__all__ = ['ContinuousMLPQFunction', 'DiscreteCNNQFunction']

--- a/src/garage/torch/q_functions/discrete_cnn_q_function.py
+++ b/src/garage/torch/q_functions/discrete_cnn_q_function.py
@@ -1,0 +1,112 @@
+"""Discrete CNN Q Function."""
+import torch
+from torch import nn
+
+from garage.torch.modules import DiscreteCNNModule
+
+
+# pytorch v1.6 issue, see https://github.com/pytorch/pytorch/issues/42305
+# pylint: disable=abstract-method
+class DiscreteCNNQFunction(DiscreteCNNModule):
+    """Discrete CNN Q Function.
+
+    A Q network that estimates Q values of all possible discrete actions.
+    It is constructed using a CNN followed by one or more fully-connected
+    layers.
+
+    Args:
+        env_spec (EnvSpec): Environment specification.
+        kernel_sizes (tuple[int]): Dimension of the conv filters.
+            For example, (3, 5) means there are two convolutional layers.
+            The filter for first layer is of dimension (3 x 3)
+            and the second one is of dimension (5 x 5).
+        strides (tuple[int]): The stride of the sliding window. For example,
+            (1, 2) means there are two convolutional layers. The stride of the
+            filter for first layer is 1 and that of the second layer is 2.
+        hidden_channels (tuple[int]): Number of output channels for CNN.
+            For example, (3, 32) means there are two convolutional layers.
+            The filter for the first conv layer outputs 3 channels
+            and the second one outputs 32 channels.
+        minibatch_size (int): Size of the optimization minibatch.
+        hidden_sizes (list[int]): Output dimension of dense layer(s) for
+            the MLP for mean. For example, (32, 32) means the MLP consists
+            of two hidden layers, each with 32 hidden units.
+        mlp_hidden_nonlinearity (callable): Activation function for
+            intermediate dense layer(s) in the MLP. It should return
+            a torch.Tensor. Set it to None to maintain a linear activation.
+        cnn_hidden_nonlinearity (callable): Activation function for
+            intermediate CNN layer(s). It should return a torch.Tensor.
+            Set it to None to maintain a linear activation.
+        hidden_w_init (callable): Initializer function for the weight
+            of intermediate dense layer(s). The function should return a
+            torch.Tensor.
+        hidden_b_init (callable): Initializer function for the bias
+            of intermediate dense layer(s). The function should return a
+            torch.Tensor.
+        paddings (tuple[int]):  Zero-padding added to both sides of the input
+        padding_mode (str): The type of padding algorithm to use,
+            either 'SAME' or 'VALID'.
+        max_pool (bool): Bool for using max-pooling or not.
+        pool_shape (tuple[int]): Dimension of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers are of the same
+            shape (2, 2).
+        pool_stride (tuple[int]): The strides of the pooling layer(s). For
+            example, (2, 2) means that all the pooling layers have
+            strides (2, 2).
+        output_nonlinearity (callable): Activation function for output dense
+            layer. It should return a torch.Tensor. Set it to None to
+            maintain a linear activation.
+        output_w_init (callable): Initializer function for the weight
+            of output dense layer(s). The function should return a
+            torch.Tensor.
+        output_b_init (callable): Initializer function for the bias
+            of output dense layer(s). The function should return a
+            torch.Tensor.
+        layer_normalization (bool): Bool for using layer normalization or not.
+        is_image (bool): If true, the inputs are normalized by dividing by 255.
+    """
+
+    def __init__(self,
+                 env_spec,
+                 kernel_sizes,
+                 hidden_channels,
+                 strides,
+                 minibatch_size,
+                 hidden_sizes=(32, 32),
+                 cnn_hidden_nonlinearity=torch.relu,
+                 mlp_hidden_nonlinearity=torch.relu,
+                 hidden_w_init=nn.init.xavier_uniform_,
+                 hidden_b_init=nn.init.zeros_,
+                 paddings=0,
+                 padding_mode='zeros',
+                 max_pool=False,
+                 pool_shape=None,
+                 pool_stride=1,
+                 output_nonlinearity=None,
+                 output_w_init=nn.init.xavier_uniform_,
+                 output_b_init=nn.init.zeros_,
+                 layer_normalization=False,
+                 is_image=True):
+
+        input_shape = (minibatch_size, ) + env_spec.observation_space.shape
+        output_dim = env_spec.action_space.flat_dim
+        super().__init__(input_shape=input_shape,
+                         output_dim=output_dim,
+                         kernel_sizes=kernel_sizes,
+                         strides=strides,
+                         hidden_sizes=hidden_sizes,
+                         hidden_channels=hidden_channels,
+                         cnn_hidden_nonlinearity=cnn_hidden_nonlinearity,
+                         mlp_hidden_nonlinearity=mlp_hidden_nonlinearity,
+                         hidden_w_init=hidden_w_init,
+                         hidden_b_init=hidden_b_init,
+                         paddings=paddings,
+                         padding_mode=padding_mode,
+                         max_pool=max_pool,
+                         pool_shape=pool_shape,
+                         pool_stride=pool_stride,
+                         output_nonlinearity=output_nonlinearity,
+                         output_w_init=output_w_init,
+                         output_b_init=output_b_init,
+                         layer_normalization=layer_normalization,
+                         is_image=is_image)

--- a/tests/garage/torch/modules/test_discrete_cnn_module.py
+++ b/tests/garage/torch/modules/test_discrete_cnn_module.py
@@ -1,0 +1,119 @@
+"""Test DiscreteCNNModule."""
+import pickle
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from garage.torch.modules import CNNModule, DiscreteCNNModule, MLPModule
+
+
+@pytest.mark.parametrize(
+    'output_dim, kernel_sizes, hidden_channels, strides, paddings', [
+        (1, (1, ), (32, ), (1, ), (0, )),
+        (2, (3, ), (32, ), (1, ), (0, )),
+        (5, (3, ), (32, ), (2, ), (0, )),
+        (5, (5, ), (12, ), (1, ), (2, )),
+        (5, (1, 1), (32, 64), (1, 1), (0, 0)),
+        (10, (3, 3), (32, 64), (1, 1), (0, 0)),
+        (10, (3, 3), (32, 64), (2, 2), (0, 0)),
+    ])
+def test_output_values(output_dim, kernel_sizes, hidden_channels, strides,
+                       paddings):
+
+    batch_size = 64
+    input_width = 32
+    input_height = 32
+    in_channel = 3
+    input_shape = (batch_size, in_channel, input_height, input_width)
+    obs = torch.rand(input_shape)
+
+    module = DiscreteCNNModule(input_shape=input_shape,
+                               output_dim=output_dim,
+                               hidden_channels=hidden_channels,
+                               hidden_sizes=hidden_channels,
+                               kernel_sizes=kernel_sizes,
+                               strides=strides,
+                               paddings=paddings,
+                               padding_mode='zeros',
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_,
+                               is_image=False)
+
+    cnn = CNNModule(input_var=obs,
+                    hidden_channels=hidden_channels,
+                    kernel_sizes=kernel_sizes,
+                    strides=strides,
+                    paddings=paddings,
+                    padding_mode='zeros',
+                    hidden_w_init=nn.init.ones_,
+                    is_image=False)
+    flat_dim = torch.flatten(cnn(obs).detach(), start_dim=1).shape[1]
+
+    mlp = MLPModule(
+        flat_dim,
+        output_dim,
+        hidden_channels,
+        hidden_w_init=nn.init.ones_,
+        output_w_init=nn.init.ones_,
+    )
+
+    cnn_out = cnn(obs)
+    output = mlp(torch.flatten(cnn_out, start_dim=1))
+
+    assert torch.all(torch.eq(output.detach(), module(obs).detach()))
+
+
+@pytest.mark.parametrize('output_dim, hidden_channels, kernel_sizes, strides',
+                         [(1, (32, ), (1, ), (1, ))])
+def test_without_nonlinearity(output_dim, hidden_channels, kernel_sizes,
+                              strides):
+    batch_size = 64
+    input_width = 32
+    input_height = 32
+    in_channel = 3
+    input_shape = (batch_size, in_channel, input_height, input_width)
+
+    module = DiscreteCNNModule(input_shape=input_shape,
+                               output_dim=output_dim,
+                               hidden_channels=hidden_channels,
+                               hidden_sizes=hidden_channels,
+                               kernel_sizes=kernel_sizes,
+                               strides=strides,
+                               mlp_hidden_nonlinearity=None,
+                               cnn_hidden_nonlinearity=None,
+                               hidden_w_init=nn.init.ones_,
+                               output_w_init=nn.init.ones_,
+                               is_image=False)
+
+    assert len(module._module) == 3
+
+
+@pytest.mark.parametrize('output_dim, hidden_channels, kernel_sizes, strides',
+                         [(1, (32, ), (1, ), (1, )), (5, (32, ), (3, ), (1, )),
+                          (2, (32, ), (3, ), (1, )),
+                          (3, (32, 64), (1, 1), (1, 1)),
+                          (4, (32, 64), (3, 3), (1, 1))])
+def test_is_pickleable(output_dim, hidden_channels, kernel_sizes, strides):
+    batch_size = 64
+    input_width = 32
+    input_height = 32
+    in_channel = 3
+    input_shape = (batch_size, in_channel, input_height, input_width)
+    input_a = torch.ones(input_shape)
+
+    model = DiscreteCNNModule(input_shape=input_shape,
+                              output_dim=output_dim,
+                              hidden_channels=hidden_channels,
+                              kernel_sizes=kernel_sizes,
+                              mlp_hidden_nonlinearity=nn.ReLU,
+                              cnn_hidden_nonlinearity=nn.ReLU,
+                              strides=strides)
+    output1 = model(input_a)
+
+    h = pickle.dumps(model)
+    model_pickled = pickle.loads(h)
+    output2 = model_pickled(input_a)
+
+    assert np.array_equal(torch.all(torch.eq(output1, output2)), True)

--- a/tests/garage/torch/q_functions/test_discrete_cnn_q_function.py
+++ b/tests/garage/torch/q_functions/test_discrete_cnn_q_function.py
@@ -1,0 +1,74 @@
+import pickle
+
+import pytest
+import torch
+from torch import nn
+
+from garage.envs import GymEnv
+from garage.torch.q_functions import DiscreteCNNQFunction
+
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+
+# yapf: disable
+@pytest.mark.parametrize('batch_size, hidden_channels, kernel_sizes, '
+                         'strides',
+                         [(1, (32, ), (1, ), (1, )),
+                          (3, (32, ), (3, ), (1, )),
+                          (9, (32, ), (3, ), (1, )),
+                          (15, (32, 64), (1, 1), (1, 1)),
+                          (22, (32, 64), (3, 3), (1, 1))])
+# yapf: enable
+def test_forward(batch_size, hidden_channels, kernel_sizes, strides):
+    env_spec = GymEnv(DummyBoxEnv(obs_dim=(3, 10, 10))).spec
+    obs_dim = env_spec.observation_space.shape
+    obs = torch.zeros((batch_size, ) + obs_dim, dtype=torch.float32)
+
+    qf = DiscreteCNNQFunction(env_spec=env_spec,
+                              kernel_sizes=kernel_sizes,
+                              strides=strides,
+                              minibatch_size=batch_size,
+                              mlp_hidden_nonlinearity=None,
+                              cnn_hidden_nonlinearity=None,
+                              hidden_channels=hidden_channels,
+                              hidden_sizes=hidden_channels,
+                              hidden_w_init=nn.init.ones_,
+                              output_w_init=nn.init.ones_,
+                              is_image=False)
+
+    output = qf(obs)
+    expected_output = torch.zeros(output.shape)
+
+    assert output.shape == (batch_size, env_spec.action_space.flat_dim)
+    assert torch.eq(output, expected_output).all()
+
+
+# yapf: disable
+@pytest.mark.parametrize('batch_size, hidden_channels, '
+                         'kernel_sizes, strides',
+                         [(1, (32, ), (1, ), (1, )),
+                          (15, (32, 64), (1, 1), (1, 1))])
+# yapf: enable
+def test_is_pickleable(batch_size, hidden_channels, kernel_sizes, strides):
+    env_spec = GymEnv(DummyBoxEnv(obs_dim=(3, 10, 10))).spec
+    obs_dim = env_spec.observation_space.shape
+    obs = torch.ones((batch_size, ) + obs_dim, dtype=torch.float32)
+
+    qf = DiscreteCNNQFunction(env_spec=env_spec,
+                              kernel_sizes=kernel_sizes,
+                              strides=strides,
+                              minibatch_size=batch_size,
+                              mlp_hidden_nonlinearity=None,
+                              cnn_hidden_nonlinearity=None,
+                              hidden_channels=hidden_channels,
+                              hidden_sizes=hidden_channels,
+                              hidden_w_init=nn.init.ones_,
+                              output_w_init=nn.init.ones_,
+                              is_image=False)
+
+    output1 = qf(obs)
+    p = pickle.dumps(qf)
+    qf_pickled = pickle.loads(p)
+    output2 = qf_pickled(obs)
+
+    assert torch.eq(output1, output2).all()


### PR DESCRIPTION
Adds the mentioned primitives to torch. This also prevents `CNNModule` from mutating the input tensor when normalizing images, which it was previously doing.