### PR TITLE
Pickling the exploration policy

### DIFF
--- a/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
@@ -43,6 +43,10 @@ def td3_garage_tf(ctxt, env_id, seed):
     deterministic.set_seed(seed)
 
     with TFTrainer(ctxt) as trainer:
+        num_timesteps = (hyper_parameters['n_epochs'] *
+                         hyper_parameters['steps_per_epoch'] *
+                         hyper_parameters['n_exploration_steps'])
+
         env = normalize(GymEnv(env_id))
 
         policy = ContinuousMLPPolicy(
@@ -54,6 +58,7 @@ def td3_garage_tf(ctxt, env_id, seed):
         exploration_policy = AddGaussianNoise(
             env.spec,
             policy,
+            total_timesteps=num_timesteps,
             max_sigma=hyper_parameters['sigma'],
             min_sigma=hyper_parameters['sigma'])
 

--- a/examples/tf/td3_pendulum.py
+++ b/examples/tf/td3_pendulum.py
@@ -34,6 +34,11 @@ def td3_pendulum(ctxt=None, seed=1):
     """
     set_seed(seed)
     with TFTrainer(ctxt) as trainer:
+        n_epochs = 500
+        steps_per_epoch = 20
+        sampler_batch_size = 250
+        num_timesteps = n_epochs * steps_per_epoch * sampler_batch_size
+
         env = GymEnv('InvertedDoublePendulum-v2')
 
         policy = ContinuousMLPPolicy(env_spec=env.spec,
@@ -43,6 +48,7 @@ def td3_pendulum(ctxt=None, seed=1):
 
         exploration_policy = AddGaussianNoise(env.spec,
                                               policy,
+                                              total_timesteps=num_timesteps,
                                               max_sigma=0.1,
                                               min_sigma=0.1)
 
@@ -68,7 +74,7 @@ def td3_pendulum(ctxt=None, seed=1):
                   qf2=qf2,
                   replay_buffer=replay_buffer,
                   target_update_tau=1e-2,
-                  steps_per_epoch=20,
+                  steps_per_epoch=steps_per_epoch,
                   n_train_steps=1,
                   discount=0.99,
                   buffer_batch_size=100,
@@ -78,7 +84,7 @@ def td3_pendulum(ctxt=None, seed=1):
                   qf_optimizer=tf.compat.v1.train.AdamOptimizer)
 
         trainer.setup(td3, env)
-        trainer.train(n_epochs=500, batch_size=250)
+        trainer.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
 
 
 td3_pendulum(seed=1)

--- a/src/garage/np/exploration_policies/add_gaussian_noise.py
+++ b/src/garage/np/exploration_policies/add_gaussian_noise.py
@@ -1,5 +1,6 @@
 """Gaussian exploration strategy."""
 import akro
+from dowel import tabular
 import numpy as np
 
 from garage.np.exploration_policies.exploration_policy import ExplorationPolicy
@@ -100,6 +101,7 @@ class AddGaussianNoise(ExplorationPolicy):
         self._total_env_steps = (self._last_total_env_steps +
                                  np.sum(episode_batch.lengths))
         self._last_total_env_steps = self._total_env_steps
+        tabular.record('AddGaussianNoise/Sigma', self._sigma())
 
     def get_param_values(self):
         """Get parameter values.

--- a/src/garage/np/exploration_policies/add_gaussian_noise.py
+++ b/src/garage/np/exploration_policies/add_gaussian_noise.py
@@ -11,40 +11,34 @@ class AddGaussianNoise(ExplorationPolicy):
     Args:
         env_spec (EnvSpec): Environment spec to explore.
         policy (garage.Policy): Policy to wrap.
+        total_timesteps (int): Total steps in the training, equivalent to
+            max_episode_length * n_epochs.
         max_sigma (float): Action noise standard deviation at the start of
             exploration.
         min_sigma (float): Action noise standard deviation at the end of the
             decay period.
-        decay_period (int): Number of episodes over which to linearly decay
-            sigma from max_sigma to min_sigma.
+        decay_ratio (float): Fraction of total steps for epsilon decay.
 
     """
 
     def __init__(self,
                  env_spec,
                  policy,
+                 total_timesteps,
                  max_sigma=1.0,
                  min_sigma=0.1,
-                 decay_period=1000000):
+                 decay_ratio=1.0):
         assert isinstance(env_spec.action_space, akro.Box)
         assert len(env_spec.action_space.shape) == 1
         super().__init__(policy)
         self._max_sigma = max_sigma
         self._min_sigma = min_sigma
-        self._decay_period = decay_period
+        self._decay_period = int(total_timesteps * decay_ratio)
         self._action_space = env_spec.action_space
-        self._iteration = 0
-
-    def reset(self, dones=None):
-        """Reset the state of the exploration.
-
-        Args:
-            dones (List[bool] or numpy.ndarray or None): Which vectorization
-                states to reset.
-
-        """
-        self._iteration += 1
-        super().reset(dones)
+        self._decrement = (self._max_sigma -
+                           self._min_sigma) / self._decay_period
+        self._total_env_steps = 0
+        self._last_total_env_steps = 0
 
     def get_action(self, observation):
         """Get action from this policy for the input observation.
@@ -58,11 +52,11 @@ class AddGaussianNoise(ExplorationPolicy):
 
         """
         action, agent_info = self.policy.get_action(observation)
-        sigma = self._max_sigma - (self._max_sigma - self._min_sigma) * min(
-            1.0, self._iteration * 1.0 / self._decay_period)
-        return np.clip(action + np.random.normal(size=action.shape) * sigma,
-                       self._action_space.low,
-                       self._action_space.high), agent_info
+        action = np.clip(
+            action + np.random.normal(size=action.shape) * self._sigma(),
+            self._action_space.low, self._action_space.high)
+        self._total_env_steps += 1
+        return action, agent_info
 
     def get_actions(self, observations):
         """Get actions from this policy for the input observation.
@@ -76,8 +70,56 @@ class AddGaussianNoise(ExplorationPolicy):
 
         """
         actions, agent_infos = self.policy.get_actions(observations)
-        sigma = self._max_sigma - (self._max_sigma - self._min_sigma) * min(
-            1.0, self._iteration * 1.0 / self._decay_period)
-        return np.clip(actions + np.random.normal(size=actions.shape) * sigma,
-                       self._action_space.low,
-                       self._action_space.high), agent_infos
+        for itr, _ in enumerate(actions):
+            actions[itr] = np.clip(
+                actions[itr] +
+                np.random.normal(size=actions[itr].shape) * self._sigma(),
+                self._action_space.low, self._action_space.high)
+            self._total_env_steps += 1
+        return actions, agent_infos
+
+    def _sigma(self):
+        """Get the current sigma.
+
+        Returns:
+            double: Sigma.
+
+        """
+        if self._total_env_steps >= self._decay_period:
+            return self._min_sigma
+        return self._max_sigma - self._decrement * self._total_env_steps
+
+    def update(self, episode_batch):
+        """Update the exploration policy using a batch of trajectories.
+
+        Args:
+            episode_batch (EpisodeBatch): A batch of trajectories which
+                were sampled with this policy active.
+
+        """
+        self._total_env_steps = (self._last_total_env_steps +
+                                 np.sum(episode_batch.lengths))
+        self._last_total_env_steps = self._total_env_steps
+
+    def get_param_values(self):
+        """Get parameter values.
+
+        Returns:
+            list or dict: Values of each parameter.
+
+        """
+        return {
+            'total_env_steps': self._total_env_steps,
+            'inner_params': self.policy.get_param_values()
+        }
+
+    def set_param_values(self, params):
+        """Set param values.
+
+        Args:
+            params (np.ndarray): A numpy array of parameter values.
+
+        """
+        self._total_env_steps = params['total_env_steps']
+        self.policy.set_param_values(params['inner_params'])
+        self._last_total_env_steps = self._total_env_steps

--- a/src/garage/np/exploration_policies/epsilon_greedy_policy.py
+++ b/src/garage/np/exploration_policies/epsilon_greedy_policy.py
@@ -42,9 +42,10 @@ class EpsilonGreedyPolicy(ExplorationPolicy):
         self._min_epsilon = min_epsilon
         self._decay_period = int(total_timesteps * decay_ratio)
         self._action_space = env_spec.action_space
-        self._epsilon = self._max_epsilon
         self._decrement = (self._max_epsilon -
                            self._min_epsilon) / self._decay_period
+        self._total_env_steps = 0
+        self._last_total_env_steps = 0
 
     def get_action(self, observation):
         """Get action from this policy for the input observation.
@@ -58,10 +59,9 @@ class EpsilonGreedyPolicy(ExplorationPolicy):
 
         """
         opt_action, _ = self.policy.get_action(observation)
-        self._decay()
-        if np.random.random() < self._epsilon:
+        if np.random.random() < self._epsilon():
             opt_action = self._action_space.sample()
-
+        self._total_env_steps += 1
         return opt_action, dict()
 
     def get_actions(self, observations):
@@ -77,12 +77,54 @@ class EpsilonGreedyPolicy(ExplorationPolicy):
         """
         opt_actions, _ = self.policy.get_actions(observations)
         for itr, _ in enumerate(opt_actions):
-            self._decay()
-            if np.random.random() < self._epsilon:
+            if np.random.random() < self._epsilon():
                 opt_actions[itr] = self._action_space.sample()
+            self._total_env_steps += 1
 
         return opt_actions, dict()
 
-    def _decay(self):
-        if self._epsilon > self._min_epsilon:
-            self._epsilon -= self._decrement
+    def _epsilon(self):
+        """Get the current epsilon.
+
+        Returns:
+            double: Epsilon.
+
+        """
+        if self._total_env_steps >= self._decay_period:
+            return self._min_epsilon
+        return self._max_epsilon - self._decrement * self._total_env_steps
+
+    def update(self, episode_batch):
+        """Update the exploration policy using a batch of trajectories.
+
+        Args:
+            episode_batch (EpisodeBatch): A batch of trajectories which
+                were sampled with this policy active.
+
+        """
+        self._total_env_steps = (self._last_total_env_steps +
+                                 np.sum(episode_batch.lengths))
+        self._last_total_env_steps = self._total_env_steps
+
+    def get_param_values(self):
+        """Get parameter values.
+
+        Returns:
+            list or dict: Values of each parameter.
+
+        """
+        return {
+            'total_env_steps': self._total_env_steps,
+            'inner_params': self.policy.get_param_values()
+        }
+
+    def set_param_values(self, params):
+        """Set param values.
+
+        Args:
+            params (np.ndarray): A numpy array of parameter values.
+
+        """
+        self._total_env_steps = params['total_env_steps']
+        self.policy.set_param_values(params['inner_params'])
+        self._last_total_env_steps = self._total_env_steps

--- a/src/garage/np/exploration_policies/epsilon_greedy_policy.py
+++ b/src/garage/np/exploration_policies/epsilon_greedy_policy.py
@@ -2,6 +2,7 @@
 
 Random exploration according to the value of epsilon.
 """
+from dowel import tabular
 import numpy as np
 
 from garage.np.exploration_policies.exploration_policy import ExplorationPolicy
@@ -105,6 +106,7 @@ class EpsilonGreedyPolicy(ExplorationPolicy):
         self._total_env_steps = (self._last_total_env_steps +
                                  np.sum(episode_batch.lengths))
         self._last_total_env_steps = self._total_env_steps
+        tabular.record('EpsilonGreedyPolicy/Epsilon', self._epsilon())
 
     def get_param_values(self):
         """Get parameter values.

--- a/src/garage/np/exploration_policies/exploration_policy.py
+++ b/src/garage/np/exploration_policies/exploration_policy.py
@@ -51,6 +51,15 @@ class ExplorationPolicy(abc.ABC):
         """
         self.policy.reset(dones)
 
+    def update(self, episode_batch):
+        """Update the exploration policy using a batch of trajectories.
+
+        Args:
+            episode_batch (EpisodeBatch): A batch of trajectories which
+                were sampled with this policy active.
+
+        """
+
     def get_param_values(self):
         """Get parameter values.
 

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -287,6 +287,8 @@ class DDPG(RLAlgorithm):
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
                 trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                if hasattr(self.exploration_policy, 'update'):
+                    self.exploration_policy.update(trainer.step_path)
                 self._train_once(trainer.step_itr, trainer.step_path)
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -210,6 +210,8 @@ class DQN(RLAlgorithm):
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
                 trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                if hasattr(self.exploration_policy, 'update'):
+                    self.exploration_policy.update(trainer.step_path)
                 qf_losses.extend(
                     self._train_once(trainer.step_itr, trainer.step_path))
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -307,6 +307,8 @@ class TD3(RLAlgorithm):
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
                 trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                if hasattr(self.exploration_policy, 'update'):
+                    self.exploration_policy.update(trainer.step_path)
                 self._train_once(trainer.step_itr, trainer.step_path)
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -158,6 +158,8 @@ class DDPG(RLAlgorithm):
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
                 trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                if hasattr(self.exploration_policy, 'update'):
+                    self.exploration_policy.update(trainer.step_path)
                 self.train_once(trainer.step_itr, trainer.step_path)
                 if (cycle == 0 and self.replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):

--- a/src/garage/trainer.py
+++ b/src/garage/trainer.py
@@ -332,7 +332,12 @@ class Trainer:
                 ' or pass `batch_size` to trainer.obtain_samples.')
         episodes = None
         if agent_update is None:
-            agent_update = self._algo.policy.get_param_values()
+            policy = getattr(self._algo, 'exploration_policy', None)
+            if policy is None:
+                # This field should exist, since self.make_sampler would have
+                # failed otherwise.
+                policy = self._algo.policy
+            agent_update = policy.get_param_values()
         episodes = self._sampler.obtain_samples(
             itr, (batch_size or self._train_args.batch_size),
             agent_update=agent_update,

--- a/tests/garage/np/exploration_strategies/test_add_gaussian_noise.py
+++ b/tests/garage/np/exploration_strategies/test_add_gaussian_noise.py
@@ -1,5 +1,5 @@
 """Tests for epsilon greedy policy."""
-import pickle
+import collections
 
 import numpy as np
 import pytest
@@ -41,22 +41,50 @@ def test_params(env):
     policy2 = ConstantPolicy(env.action_space.sample())
     assert (policy1.get_action(None)[0] != policy2.get_action(None)[0]).all()
 
-    exp_policy1 = AddGaussianNoise(env, policy1)
-    exp_policy2 = AddGaussianNoise(env, policy2)
+    exp_policy1 = AddGaussianNoise(env, policy1, 1)
+    exp_policy2 = AddGaussianNoise(env, policy2, 1)
+    exp_policy2.get_action(None)
+
+    assert exp_policy1._sigma() != exp_policy2._sigma()
+
     exp_policy1.set_param_values(exp_policy2.get_param_values())
 
     assert (policy1.get_action(None)[0] == policy2.get_action(None)[0]).all()
+    assert exp_policy1._sigma() == exp_policy2._sigma()
 
 
 def test_decay_period(env):
     policy = ConstantPolicy(env.action_space.sample())
     exp_policy = AddGaussianNoise(env,
                                   policy,
+                                  total_timesteps=2,
                                   max_sigma=1.,
-                                  min_sigma=0.,
-                                  decay_period=2)
+                                  min_sigma=0.)
     assert (exp_policy.get_action(None)[0] != policy.get_action(None)[0]).all()
-    exp_policy.reset()
     assert (exp_policy.get_action(None)[0] != policy.get_action(None)[0]).all()
-    exp_policy.reset()
     assert (exp_policy.get_action(None)[0] == policy.get_action(None)[0]).all()
+
+
+def test_update(env):
+    policy = ConstantPolicy(env.action_space.sample())
+    exp_policy = AddGaussianNoise(env,
+                                  policy,
+                                  total_timesteps=10,
+                                  max_sigma=1.,
+                                  min_sigma=0.)
+    exp_policy.get_action(None)
+    exp_policy.get_action(None)
+
+    DummyBatch = collections.namedtuple('EpisodeBatch', ['lengths'])
+    batch = DummyBatch(np.array([1, 2]))
+
+    # new sigma will be 1 - 0.1 * (1 + 2) = 0.7
+    exp_policy.update(batch)
+    assert np.isclose(exp_policy._sigma(), 0.7)
+
+    exp_policy.get_action(None)
+
+    batch = DummyBatch(np.array([1, 1, 2]))
+    # new sigma will be 0.7 - 0.1 * (1 + 1 + 2) = 0.3
+    exp_policy.update(batch)
+    assert np.isclose(exp_policy._sigma(), 0.3)

--- a/tests/garage/np/exploration_strategies/test_epsilon_greedy_policy.py
+++ b/tests/garage/np/exploration_strategies/test_epsilon_greedy_policy.py
@@ -1,4 +1,5 @@
 """Tests for epsilon greedy policy."""
+import collections
 import pickle
 
 import numpy as np
@@ -21,6 +22,12 @@ class SimplePolicy:
         return np.full(len(observations),
                        self.env_spec.action_space.sample()), dict()
 
+    def get_param_values(self):
+        pass
+
+    def set_param_values(self, params):
+        del params
+
 
 class TestEpsilonGreedyPolicy:
 
@@ -42,20 +49,33 @@ class TestEpsilonGreedyPolicy:
         action, _ = self.epsilon_greedy_policy.get_action(obs)
         assert self.env.action_space.contains(action)
 
-        # epsilon decay by 1 step, new epsilon = 1 - 0.98 = 0.902
+        # epsilon decay by 1 step, new epsilon = 1 - 0.098 = 0.902
         random_rate = np.random.random(
-            100000) < self.epsilon_greedy_policy._epsilon
+            100000) < self.epsilon_greedy_policy._epsilon()
         assert np.isclose([0.902], [sum(random_rate) / 100000], atol=0.01)
 
         actions, _ = self.epsilon_greedy_policy.get_actions([obs] * 5)
 
-        # epsilon decay by 6 steps in total, new epsilon = 1 - 6 * 0.98 = 0.412
+        # epsilon decay by 6 steps in total
+        # new epsilon = 1 - 6 * 0.098 = 0.412
         random_rate = np.random.random(
-            100000) < self.epsilon_greedy_policy._epsilon
+            100000) < self.epsilon_greedy_policy._epsilon()
         assert np.isclose([0.412], [sum(random_rate) / 100000], atol=0.01)
 
         for action in actions:
             assert self.env.action_space.contains(action)
+
+    def test_set_param(self):
+        params = self.epsilon_greedy_policy.get_param_values()
+        params['total_env_steps'] = 6
+        self.epsilon_greedy_policy.set_param_values(params)
+        assert np.isclose(self.epsilon_greedy_policy._epsilon(), 0.412)
+
+    def test_update(self):
+        DummyBatch = collections.namedtuple('EpisodeBatch', ['lengths'])
+        batch = DummyBatch(np.array([1, 2, 3]))
+        self.epsilon_greedy_policy.update(batch)
+        assert np.isclose(self.epsilon_greedy_policy._epsilon(), 0.412)
 
     def test_epsilon_greedy_policy_is_pickleable(self):
         obs, _, _, _ = self.env.step(1)
@@ -64,4 +84,4 @@ class TestEpsilonGreedyPolicy:
 
         h_data = pickle.dumps(self.epsilon_greedy_policy)
         policy = pickle.loads(h_data)
-        assert policy._epsilon == self.epsilon_greedy_policy._epsilon
+        assert policy._epsilon() == self.epsilon_greedy_policy._epsilon()


### PR DESCRIPTION
Add an `update` method to exploration policy to pickle and resume their internal states. This should close https://github.com/rlworkgroup/garage/issues/1399.
Ref: https://github.com/rlworkgroup/garage/commit/9cf85deb52790279afcf8804ea02b0e80c34bea8