### PR TITLE
Add episode_info to TimeStep, TimeStepBatch, and EpisodeBatch

### DIFF
--- a/src/garage/_dtypes.py
+++ b/src/garage/_dtypes.py
@@ -5,7 +5,8 @@ import enum
 import akro
 import numpy as np
 
-from garage.np import concat_tensor_dict_list, slice_nested_dict
+from garage.np import (concat_tensor_dict_list, slice_nested_dict,
+                       stack_tensor_dict_list)
 
 # pylint: disable=too-many-lines
 
@@ -13,6 +14,7 @@ from garage.np import concat_tensor_dict_list, slice_nested_dict
 class EpisodeBatch(
         collections.namedtuple('EpisodeBatch', [
             'env_spec',
+            'episode_infos',
             'observations',
             'last_observations',
             'actions',
@@ -49,6 +51,11 @@ class EpisodeBatch(
     Attributes:
         env_spec (EnvSpec): Specification for the environment from
             which this data was sampled.
+        episode_infos (dict[str, np.ndarray]): A dict of numpy arrays
+            containing the episode-level information of each episode. Each
+            value of this dict should be a numpy array of shape :math:`(N,
+            S^*)`. For example, in goal-conditioned reinforcement learning this
+            could contain the goal state for each episode.
         observations (numpy.ndarray): A numpy array of shape
             :math:`(N \bullet [T], O^*)` containing the (possibly
             multi-dimensional) observations for all time steps in this batch.
@@ -64,13 +71,15 @@ class EpisodeBatch(
         rewards (numpy.ndarray): A numpy array of shape
             :math:`(N \bullet [T])` containing the rewards for all time steps
             in this batch.
-        env_infos (dict): A dict of numpy arrays arbitrary environment state
-            information. Each value of this dict should be a numpy array of
-            shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
-        agent_infos (numpy.ndarray): A dict of numpy arrays arbitrary agent
-            state information. Each value of this dict should be a numpy array
-            of shape :math:`(N \bullet [T])` or :math:`(N \bullet [T], S^*)`.
-            For example, this may contain the hidden states from an RNN policy.
+        env_infos (dict[str, np.ndarray]): A dict of numpy arrays arbitrary
+            environment state information. Each value of this dict should be
+            a numpy array of shape :math:`(N \bullet [T])` or :math:`(N \bullet
+            [T], S^*)`.
+        agent_infos (dict[str, np.ndarray]): A dict of numpy arrays arbitrary
+            agent state information. Each value of this dict should be a numpy
+            array of shape :math:`(N \bullet [T])` or :math:`(N \bullet [T],
+            S^*)`.  For example, this may contain the hidden states from an RNN
+            policy.
         step_types (numpy.ndarray): A numpy array of `StepType with shape
             :math:`(N,)` containing the time step types for all transitions in
             this batch.
@@ -85,8 +94,8 @@ class EpisodeBatch(
     """
     __slots__ = ()
 
-    def __new__(cls, env_spec, observations, last_observations, actions,
-                rewards, env_infos, agent_infos, step_types,
+    def __new__(cls, env_spec, episode_infos, observations, last_observations,
+                actions, rewards, env_infos, agent_infos, step_types,
                 lengths):  # noqa: D102
         # pylint: disable=too-many-branches
 
@@ -230,9 +239,23 @@ class EpisodeBatch(
                 'step_types tensor must be dtype `StepType`, but got tensor '
                 'of dtype {} instead.'.format(step_types.dtype))
 
-        return super().__new__(EpisodeBatch, env_spec, observations,
-                               last_observations, actions, rewards, env_infos,
-                               agent_infos, step_types, lengths)
+        # episode_infos
+        for key, val in episode_infos.items():
+            if not isinstance(val, (dict, np.ndarray)):
+                raise ValueError(
+                    'Each entry in episode_infos must be a numpy array,'
+                    'but got key {} with value type {} instead.'.format(
+                        key, type(val)))
+            if (isinstance(val, np.ndarray) and val.shape[0] != len(lengths)):
+                raise ValueError(
+                    'Each entry in episode_infos must have a batch dimension '
+                    'of length {}, but got key {} with batch size {} instead.'.
+                    format(len(lengths), key, val.shape[0]))
+
+        return super().__new__(EpisodeBatch, env_spec, episode_infos,
+                               observations, last_observations, actions,
+                               rewards, env_infos, agent_infos, step_types,
+                               lengths)
 
     @classmethod
     def concatenate(cls, *batches):
@@ -251,6 +274,10 @@ class EpisodeBatch(
                     batches[0].env_infos.keys()))
                 assert (set(b.agent_infos.keys()) == set(
                     batches[0].agent_infos.keys()))
+        episode_infos = {
+            k: np.concatenate([b.episode_infos[k] for b in batches])
+            for k in batches[0].episode_infos.keys()
+        }
         env_infos = {
             k: np.concatenate([b.env_infos[k] for b in batches])
             for k in batches[0].env_infos.keys()
@@ -259,7 +286,12 @@ class EpisodeBatch(
             k: np.concatenate([b.agent_infos[k] for b in batches])
             for k in batches[0].agent_infos.keys()
         }
+        episode_infos = {
+            k: np.concatenate([b.episode_infos[k] for b in batches])
+            for k in batches[0].episode_infos.keys()
+        }
         return cls(
+            episode_infos=episode_infos,
             env_spec=batches[0].env_spec,
             observations=np.concatenate(
                 [batch.observations for batch in batches]),
@@ -288,6 +320,7 @@ class EpisodeBatch(
             stop = start + length
             eps = EpisodeBatch(
                 env_spec=self.env_spec,
+                episode_infos=slice_nested_dict(self.episode_infos, i, i + 1),
                 observations=self.observations[start:stop],
                 last_observations=np.asarray([self.last_observations[i]]),
                 actions=self.actions[start:stop],
@@ -298,6 +331,7 @@ class EpisodeBatch(
                 lengths=np.asarray([length]))
             episodes.append(eps)
             start = stop
+
         return episodes
 
     def to_list(self):
@@ -324,6 +358,8 @@ class EpisodeBatch(
                 * step_types (numpy.ndarray): A numpy array of `StepType with
                     shape (T,) containing the time step types for all
                     transitions in this batch.
+                * episode_infos (dict[str, np.ndarray]): Dictionary of stacked,
+                    non-flattened `episode_info` arrays.
 
         """
         start = 0
@@ -331,6 +367,9 @@ class EpisodeBatch(
         for i, length in enumerate(self.lengths):
             stop = start + length
             episodes.append({
+                'episode_infos':
+                {k: v[i:i + 1]
+                 for (k, v) in self.episode_infos.items()},
                 'observations':
                 self.observations[start:stop],
                 'next_observations':
@@ -360,6 +399,8 @@ class EpisodeBatch(
             env_spec (EnvSpec): Specification for the environment from which
                 this data was sampled.
             paths (list[dict[str, np.ndarray or dict[str, np.ndarray]]]): Keys:
+                * episode_infos (dict[str, np.ndarray]): Dictionary of stacked,
+                    non-flattened `episode_info` arrays, each of shape (S^*).
                 * observations (np.ndarray): Non-flattened array of
                     observations. Typically has shape (T, S^*) (the unflattened
                     state space of the current environment). observations[i]
@@ -385,7 +426,6 @@ class EpisodeBatch(
                 * step_types (numpy.ndarray): A numpy array of `StepType with
                     shape (T,) containing the time step types for all
                     transitions in this batch.
-
         """
         lengths = np.asarray([len(p['rewards']) for p in paths])
         if all(
@@ -406,6 +446,8 @@ class EpisodeBatch(
                     [p['observations'][-1] for p in paths])
 
         stacked_paths = concat_tensor_dict_list(paths)
+        episode_infos = stack_tensor_dict_list(
+            [path['episode_infos'] for path in paths])
 
         # Temporary solution. This logic is not needed if algorithms process
         # step_types instead of dones directly.
@@ -419,6 +461,7 @@ class EpisodeBatch(
             del stacked_paths['dones']
 
         return cls(env_spec=env_spec,
+                   episode_infos=episode_infos,
                    observations=observations,
                    last_observations=last_observations,
                    actions=stacked_paths['actions'],
@@ -624,8 +667,8 @@ class StepType(enum.IntEnum):
 
 class TimeStep(
         collections.namedtuple('TimeStep', [
-            'env_spec', 'observation', 'action', 'reward', 'next_observation',
-            'env_info', 'agent_info', 'step_type'
+            'env_spec', 'episode_info', 'observation', 'action', 'reward',
+            'next_observation', 'env_info', 'agent_info', 'step_type'
         ])):
     # pylint: disable=missing-return-doc, missing-return-type-doc, missing-param-doc, missing-type-doc  # noqa: E501
     r"""A tuple representing a single TimeStep.
@@ -637,24 +680,28 @@ class TimeStep(
     Attributes:
         env_spec (EnvSpec): Specification for the environment from which this
             data was sampled.
+        episode_info (dict[str, np.ndarray]): A dict of numpy arrays of shape
+            :math:`(S*^,)` containing episode-level information of each
+            episode.  For example, in goal-conditioned reinforcement learning
+            this could contain the goal state for each episode.
         observation (numpy.ndarray): A numpy array of shape :math:`(O^*)`
-            containing the observation for the this time step in the
+            containing the observation for this time step in the
             environment. These must conform to
             :obj:`EnvStep.observation_space`.
             The observation before applying the action.
             `None` if `step_type` is `StepType.FIRST`, i.e. at the start of a
             sequence.
         action (numpy.ndarray): A numpy array of shape :math:`(A^*)`
-            containing the action for the this time step. These must conform
+            containing the action for this time step. These must conform
             to :obj:`EnvStep.action_space`.
             `None` if `step_type` is `StepType.FIRST`, i.e. at the start of a
             sequence.
         reward (float): A float representing the reward for taking the action
-            given the observation, at the this time step.
+            given the observation, at this time step.
             `None` if `step_type` is `StepType.FIRST`, i.e. at the start of a
             sequence.
         next_observation (numpy.ndarray): A numpy array of shape :math:`(O^*)`
-            containing the observation for the this time step in the
+            containing the observation for this time step in the
             environment. These must conform to
             :obj:`EnvStep.observation_space`.
             The observation after applying the action.
@@ -695,15 +742,16 @@ class TimeStep(
             is StepType.TIMEOUT
 
     @classmethod
-    def from_env_step(cls, env_step, last_observation, agent_info):
+    def from_env_step(cls, env_step, last_observation, agent_info,
+                      episode_info):
         """Create a TimeStep from a EnvStep.
 
         Args:
             env_step (EnvStep): the env step returned by the environment.
             last_observation (numpy.ndarray): A numpy array of shape
-                :math:`(O^*)` containing the observation for the this time
+                :math:`(O^*)` containing the observation for this time
                 step in the environment. These must conform to
-                :obj:`EnvStep.observation_space`.
+                :attr:`EnvStep.observation_space`.
                 The observation before applying the action.
             agent_info (dict):  A dict of arbitrary agent state information.
 
@@ -712,6 +760,7 @@ class TimeStep(
             agent info.
         """
         return cls(env_spec=env_step.env_spec,
+                   episode_info=episode_info,
                    observation=last_observation,
                    action=env_step.action,
                    reward=env_step.reward,
@@ -757,7 +806,7 @@ class InOutSpec:
 
 class TimeStepBatch(
         collections.namedtuple('TimeStepBatch', [
-            'env_spec', 'observations', 'actions', 'rewards',
+            'env_spec', 'episode_infos', 'observations', 'actions', 'rewards',
             'next_observations', 'env_infos', 'agent_infos', 'step_types'
         ])):
     # pylint: disable=missing-param-doc, missing-type-doc
@@ -768,6 +817,11 @@ class TimeStepBatch(
     Attributes:
         env_spec (EnvSpec): Specification for the environment from
             which this data was sampled.
+        episode_infos (dict[str, np.ndarray]): A dict of numpy arrays
+            containing the episode-level information of each episode. Each
+            value of this dict should be a numpy array of shape :math:`(N,
+            S^*)`. For example, in goal-conditioned reinforcement learning this
+            could contain the goal state for each episode.
         observations (numpy.ndarray): Non-flattened array of observations.
             Typically has shape (batch_size, S^*) (the unflattened state space
             of the current environment).
@@ -793,7 +847,7 @@ class TimeStepBatch(
     """
     __slots__ = ()
 
-    def __new__(cls, env_spec, observations, actions, rewards,
+    def __new__(cls, env_spec, episode_infos, observations, actions, rewards,
                 next_observations, env_infos, agent_infos,
                 step_types):  # noqa: D102
         # pylint: disable=missing-return-doc, missing-return-type-doc,
@@ -930,9 +984,26 @@ class TimeStepBatch(
                     'length {}, but got key {} with batch size {} instead.'.
                     format(inferred_batch_size, key, val.shape[0]))
 
-        return super().__new__(TimeStepBatch, env_spec, observations, actions,
-                               rewards, next_observations, env_infos,
-                               agent_infos, step_types)
+        # episode_infos
+        for key, val in episode_infos.items():
+            if not isinstance(val, (dict, np.ndarray)):
+                raise ValueError(
+                    'Each entry in episode_infos must be a numpy array, '
+                    'but got key {} with value type {} instead.'.format(
+                        key, type(val)))
+
+            if (isinstance(val, np.ndarray)
+                    and val.shape[0] != inferred_batch_size):
+                raise ValueError(
+                    'Each entry in episode_infos must have a batch '
+                    'dimension of '
+                    'length {}, but got key {} with batch size {} instead.'.
+                    format(inferred_batch_size, key, val.shape[0]))
+
+        return super().__new__(TimeStepBatch, env_spec, episode_infos,
+                               observations, actions, rewards,
+                               next_observations, env_infos, agent_infos,
+                               step_types)
 
     @classmethod
     def concatenate(cls, *batches):
@@ -951,7 +1022,10 @@ class TimeStepBatch(
         if len(batches) < 1:
             raise ValueError('Please provide at least one TimeStepBatch to '
                              'concatenate')
-
+        episode_infos = {
+            k: np.concatenate([b.episode_infos[k] for b in batches])
+            for k in batches[0].episode_infos.keys()
+        }
         env_infos = {
             k: np.concatenate([b.env_infos[k] for b in batches])
             for k in batches[0].env_infos.keys()
@@ -960,8 +1034,10 @@ class TimeStepBatch(
             k: np.concatenate([b.agent_infos[k] for b in batches])
             for k in batches[0].agent_infos.keys()
         }
+
         return cls(
             env_spec=batches[0].env_spec,
+            episode_infos=episode_infos,
             observations=np.concatenate(
                 [batch.observations for batch in batches]),
             actions=np.concatenate([batch.actions for batch in batches]),
@@ -986,6 +1062,10 @@ class TimeStepBatch(
 
         for i in range(len(self.rewards)):
             time_step = TimeStepBatch(
+                episode_infos={
+                    k: np.asarray([v[i]])
+                    for (k, v) in self.episode_infos.items()
+                },
                 env_spec=self.env_spec,
                 observations=np.asarray([self.observations[i]]),
                 actions=np.asarray([self.actions[i]]),
@@ -1012,6 +1092,12 @@ class TimeStepBatch(
 
         Returns:
             list[dict[str, np.ndarray or dict[str, np.ndarray]]]: Keys:
+                episode_infos (dict[str, np.ndarray]): A dict of numpy arrays
+                    containing the episode-level information of each episode.
+                    Each value of this dict should be a numpy array of shape
+                    :math:`(S^*,)`. For example, in goal-conditioned
+                    reinforcement learning this could contain the goal state
+                    for each episode.
                 observations (numpy.ndarray): Non-flattened array of
                     observations.
                     Typically has shape (batch_size, S^*) (the unflattened
@@ -1035,11 +1121,14 @@ class TimeStepBatch(
                 step_types (numpy.ndarray): A numpy array of `StepType with
                         shape (batch_size,) containing the time step types for
                         all transitions in this batch.
-
         """
         samples = []
         for i in range(len(self.rewards)):
             samples.append({
+                'episode_infos': {
+                    k: np.asarray([v[i]])
+                    for (k, v) in self.episode_infos.items()
+                },
                 'observations':
                 np.asarray([self.observations[i]]),
                 'actions':
@@ -1055,7 +1144,7 @@ class TimeStepBatch(
                 {k: np.asarray([v[i]])
                  for (k, v) in self.agent_infos.items()},
                 'step_types':
-                np.asarray([self.step_types[i]]),
+                np.asarray([self.step_types[i]])
             })
         return samples
 
@@ -1079,6 +1168,12 @@ class TimeStepBatch(
                 this data was sampled.
             ts_samples (list[dict[str, np.ndarray or dict[str, np.ndarray]]]):
                 keys:
+                * episode_infos (dict[str, np.ndarray]): A dict of numpy arrays
+                    containing the episode-level information of each episode.
+                    Each value of this dict should be a numpy array of shape
+                    :math:`(N, S^*)`. For example, in goal-conditioned
+                    reinforcement learning this could contain the goal state
+                    for each episode.
                 * observations (numpy.ndarray): Non-flattened array of
                     observations.
                     Typically has shape (batch_size, S^*) (the unflattened
@@ -1101,7 +1196,6 @@ class TimeStepBatch(
                 shape (batch_size,) containing the time step types for all
                     transitions in this batch.
 
-
         Returns:
             TimeStepBatch: The concatenation of samples.
 
@@ -1113,7 +1207,8 @@ class TimeStepBatch(
             raise ValueError('Please provide at least one dict')
 
         ts_batches = [
-            TimeStepBatch(env_spec=env_spec,
+            TimeStepBatch(episode_infos=sample['episode_infos'],
+                          env_spec=env_spec,
                           observations=sample['observations'],
                           actions=sample['actions'],
                           rewards=sample['rewards'],
@@ -1137,12 +1232,23 @@ class TimeStepBatch(
             TimeStepBatch: The converted batch.
 
         """
+        episode_infos = dict()
+        for i in range(len(batch.lengths)):
+            for k, v in batch.episode_infos.items():
+                for _ in range(batch.lengths[i]):
+                    episode_infos.setdefault(k, []).append(v[i])
+
+        for k, v in batch.episode_infos.items():
+            episode_infos[k] = np.asarray(episode_infos[k])
+
         next_observations = np.concatenate(
             tuple([
                 np.concatenate((eps.observations[1:], eps.last_observations))
                 for eps in batch.split()
             ]))
-        return cls(env_spec=batch.env_spec,
+
+        return cls(episode_infos=episode_infos,
+                   env_spec=batch.env_spec,
                    observations=batch.observations,
                    actions=batch.actions,
                    rewards=batch.rewards.reshape(-1, 1),

--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -109,7 +109,7 @@ def rollout(env,
     env_steps = []
     agent_infos = []
     observations = []
-    last_obs = env.reset()[0]
+    last_obs, episode_infos = env.reset()
     agent.reset()
     episode_length = 0
     if animated:
@@ -130,6 +130,7 @@ def rollout(env,
         last_obs = es.observation
 
     return dict(
+        episode_infos=episode_infos,
         observations=np.array(observations),
         actions=np.array([es.action for es in env_steps]),
         rewards=np.array([es.reward for es in env_steps]),

--- a/src/garage/envs/point_env.py
+++ b/src/garage/envs/point_env.py
@@ -95,7 +95,7 @@ class PointEnv(Environment):
         first_obs = np.concatenate([self._point, (dist, )])
         self._step_cnt = 0
 
-        return first_obs, dict()
+        return first_obs, dict(goal=self._goal)
 
     def step(self, action):
         """Step the environment.

--- a/src/garage/np/policies/fixed_policy.py
+++ b/src/garage/np/policies/fixed_policy.py
@@ -1,4 +1,6 @@
 """Policy that performs a fixed sequence of actions."""
+import numpy as np
+
 from garage.np.policies.policy import Policy
 
 
@@ -97,7 +99,10 @@ class FixedPolicy(Policy):
         if len(observations) != 1:
             raise ValueError('FixedPolicy does not support more than one '
                              'observation at a time.')
-        return self.get_action(observations[0])
+        action, agent_info = self.get_action(observations[0])
+        return np.array(
+            [action]), {k: np.array([v])
+                        for (k, v) in agent_info.items()}
 
     @property
     def env_spec(self):

--- a/src/garage/replay_buffer/path_buffer.py
+++ b/src/garage/replay_buffer/path_buffer.py
@@ -141,6 +141,7 @@ class PathBuffer:
         ],
                               dtype=StepType)
         return TimeStepBatch(env_spec=self._env_spec,
+                             episode_infos={},
                              observations=samples['observations'],
                              actions=samples['actions'],
                              rewards=samples['rewards'],

--- a/src/garage/sampler/fragment_worker.py
+++ b/src/garage/sampler/fragment_worker.py
@@ -130,7 +130,8 @@ class FragmentWorker(DefaultWorker):
             if len(frag.rewards) > 0:
                 complete_frag = frag.to_batch()
                 self._complete_fragments.append(complete_frag)
-                self._fragments[i] = InProgressEpisode(frag.env, frag.last_obs)
+                self._fragments[i] = InProgressEpisode(frag.env, frag.last_obs,
+                                                       frag.episode_info)
         assert len(self._complete_fragments) > 0
         result = EpisodeBatch.concatenate(*self._complete_fragments)
         self._complete_fragments = []

--- a/src/garage/sampler/utils.py
+++ b/src/garage/sampler/utils.py
@@ -1,0 +1,133 @@
+"""Utility functions related to sampling."""
+
+import numpy as np
+
+from garage.np import stack_tensor_dict_list, truncate_tensor_dict
+
+
+def rollout(env,
+            agent,
+            *,
+            max_episode_length=np.inf,
+            animated=False,
+            speedup=1,
+            deterministic=False):
+    """Sample a single episode of the agent in the environment.
+
+    Args:
+        agent (Policy): Agent used to select actions.
+        env (Environment): Environment to perform actions in.
+        max_episode_length (int): If the episode reaches this many timesteps,
+            it is truncated.
+        animated (bool): If true, render the environment after each step.
+        speedup (float): Factor by which to decrease the wait time between
+            rendered steps. Only relevant, if animated == true.
+        deterministic (bool): If true, use the mean action returned by the
+            stochastic policy instead of sampling from the returned action
+            distribution.
+
+    Returns:
+        dict[str, np.ndarray or dict]: Dictionary, with keys:
+            * observations(np.array): Flattened array of observations.
+                There should be one more of these than actions. Note that
+                observations[i] (for i < len(observations) - 1) was used by the
+                agent to choose actions[i]. Should have shape (T + 1, S^*) (the
+                unflattened state space of the current environment).
+            * actions(np.array): Non-flattened array of actions. Should have
+                shape (T, S^*) (the unflattened action space of the current
+                environment).
+            * rewards(np.array): Array of rewards of shape (T,) (1D array of
+                length timesteps).
+            * agent_infos(Dict[str, np.array]): Dictionary of stacked,
+                non-flattened `agent_info` arrays.
+            * env_infos(Dict[str, np.array]): Dictionary of stacked,
+                non-flattened `env_info` arrays.
+            * episode_infos(Dict[str, np.array]): Dictionary of stacked,
+                non-flattened `episode_info` arrays.
+            * dones(np.array): Array of termination signals.
+
+    """
+    del speedup
+    env_steps = []
+    agent_infos = []
+    observations = []
+    episode_infos = []
+    last_obs, episode_info = env.reset()
+    agent.reset()
+    episode_length = 0
+    if animated:
+        env.visualize()
+    while episode_length < (max_episode_length or np.inf):
+        a, agent_info = agent.get_action(last_obs)
+        if deterministic and 'mean' in agent_info:
+            a = agent_info['mean']
+        es = env.step(a)
+        env_steps.append(es)
+        observations.append(last_obs)
+        agent_infos.append(agent_info)
+        episode_infos.append(episode_info)
+        episode_length += 1
+        if es.last:
+            break
+        last_obs = es.observation
+
+    return dict(
+        observations=np.array(observations),
+        actions=np.array([es.action for es in env_steps]),
+        rewards=np.array([es.reward for es in env_steps]),
+        agent_infos=stack_tensor_dict_list(agent_infos),
+        env_infos=stack_tensor_dict_list([es.env_info for es in env_steps]),
+        episode_infos=stack_tensor_dict_list(episode_infos),
+        dones=np.array([es.terminal for es in env_steps]),
+    )
+
+
+def truncate_paths(paths, max_samples):
+    """Truncate the paths so that the total number of samples is max_samples.
+
+    This is done by removing extra paths at the end of
+    the list, and make the last path shorter if necessary
+
+    Args:
+        paths (list[dict[str, np.ndarray]]): Samples, items with keys:
+            * observations (np.ndarray): Enviroment observations
+            * actions (np.ndarray): Agent actions
+            * rewards (np.ndarray): Environment rewards
+            * env_infos (dict): Environment state information
+            * agent_infos (dict): Agent state information
+        max_samples(int) : Maximum number of samples allowed.
+
+    Returns:
+        list[dict[str, np.ndarray]]: A list of paths, truncated so that the
+            number of samples adds up to max-samples
+
+    Raises:
+        ValueError: If key a other than 'observations', 'actions', 'rewards',
+            'env_infos' and 'agent_infos' is found.
+
+    """
+    # chop samples collected by extra paths
+    # make a copy
+    valid_keys = {
+        'observations', 'actions', 'rewards', 'env_infos', 'agent_infos'
+    }
+    paths = list(paths)
+    total_n_samples = sum(len(path['rewards']) for path in paths)
+    while paths and total_n_samples - len(paths[-1]['rewards']) >= max_samples:
+        total_n_samples -= len(paths.pop(-1)['rewards'])
+    if paths:
+        last_path = paths.pop(-1)
+        truncated_last_path = dict()
+        truncated_len = len(
+            last_path['rewards']) - (total_n_samples - max_samples)
+        for k, v in last_path.items():
+            if k in ['observations', 'actions', 'rewards']:
+                truncated_last_path[k] = v[:truncated_len]
+            elif k in ['env_infos', 'agent_infos']:
+                truncated_last_path[k] = truncate_tensor_dict(v, truncated_len)
+            else:
+                raise ValueError(
+                    'Unexpected key {} found in path. Valid keys: {}'.format(
+                        k, valid_keys))
+        paths.append(truncated_last_path)
+    return paths

--- a/src/garage/tf/algos/rl2.py
+++ b/src/garage/tf/algos/rl2.py
@@ -482,6 +482,10 @@ class RL2(MetaRLAlgorithm, abc.ABC):
             k: np.concatenate([b.agent_infos[k] for b in episode_list])
             for k in episode_list[0].agent_infos.keys()
         }
+        episode_infos = {
+            k: np.concatenate([b.episode_infos[k] for b in episode_list])
+            for k in episode_list[0].episode_infos.keys()
+        }
         actions = np.concatenate([
             self._env_spec.action_space.flatten_n(ep.actions)
             for ep in episode_list
@@ -489,6 +493,7 @@ class RL2(MetaRLAlgorithm, abc.ABC):
 
         return EpisodeBatch(
             env_spec=episode_list[0].env_spec,
+            episode_infos=episode_infos,
             observations=np.concatenate(
                 [ep.observations for ep in episode_list]),
             last_observations=episode_list[-1].last_observations,

--- a/src/garage/tf/algos/te.py
+++ b/src/garage/tf/algos/te.py
@@ -120,12 +120,16 @@ class TaskEmbeddingWorker(DefaultWorker):
         self._agent_infos = defaultdict(list)
         latent_infos = self._latent_infos
         self._latent_infos = defaultdict(list)
+        episode_infos = self._episode_infos
+        self._episode_infos = defaultdict(list)
         for k, v in latent_infos.items():
             latent_infos[k] = np.asarray(v)
         for k, v in agent_infos.items():
             agent_infos[k] = np.asarray(v)
         for k, v in env_infos.items():
             env_infos[k] = np.asarray(v)
+        for k, v in episode_infos.items():
+            episode_infos[k] = np.asarray(v)
         env_infos['task_onehot'] = np.asarray(tasks)
         agent_infos['latent'] = np.asarray(latents)
         for k, v in latent_infos.items():
@@ -134,6 +138,7 @@ class TaskEmbeddingWorker(DefaultWorker):
         self._lengths = []
 
         return EpisodeBatch(env_spec=self.env.spec,
+                            episode_infos=episode_infos,
                             observations=np.asarray(observations),
                             last_observations=np.asarray(last_observations),
                             actions=np.asarray(actions),

--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -716,6 +716,7 @@ class PEARLWorker(DefaultWorker):
                  accum_context=False):
         self._deterministic = deterministic
         self._accum_context = accum_context
+        self._episode_info = None
         super().__init__(seed=seed,
                          max_episode_length=max_episode_length,
                          worker_number=worker_number)
@@ -723,7 +724,7 @@ class PEARLWorker(DefaultWorker):
     def start_episode(self):
         """Begin a new episode."""
         self._eps_length = 0
-        self._prev_obs = self.env.reset()[0]
+        self._prev_obs, self._episode_info = self.env.reset()
 
     def step_episode(self):
         """Take a single time-step in the current episode.
@@ -748,7 +749,8 @@ class PEARLWorker(DefaultWorker):
             if self._accum_context:
                 s = TimeStep.from_env_step(env_step=es,
                                            last_observation=self._prev_obs,
-                                           agent_info=agent_info)
+                                           agent_info=agent_info,
+                                           episode_info=self._episode_info)
                 self.agent.update_context(s)
             if not es.last:
                 self._prev_obs = es.observation

--- a/tests/garage/replay_buffer/test_path_buffer.py
+++ b/tests/garage/replay_buffer/test_path_buffer.py
@@ -41,8 +41,13 @@ def eps_data():
                           [StepType.TERMINAL])
     step_types = np.array(step_types, dtype=StepType)
 
+    # episode_infos
+    episode_infos = dict()
+    episode_infos['task_one_hot'] = np.stack([[1, 1]] * len(lens))
+
     return {
         'env_spec': env_spec,
+        'episode_infos': episode_infos,
         'observations': obs,
         'last_observations': last_obs,
         'actions': act,

--- a/tests/garage/test_functions.py
+++ b/tests/garage/test_functions.py
@@ -12,14 +12,8 @@ import pytest
 import tensorflow as tf
 import torch
 
-from garage import (_Default,
-                    EnvSpec,
-                    EpisodeBatch,
-                    log_multitask_performance,
-                    log_performance,
-                    make_optimizer,
-                    rollout,
-                    StepType)
+from garage import (_Default, EnvSpec, EpisodeBatch, log_multitask_performance,
+                    log_performance, make_optimizer, rollout, StepType)
 from garage.envs import GymEnv
 
 from tests.fixtures import TfGraphTestCase
@@ -79,6 +73,7 @@ def test_log_performance():
                      dtype=bool)
         },
         agent_infos={},
+        episode_infos={},
         lengths=lengths)
 
     log_file = tempfile.NamedTemporaryFile()
@@ -126,6 +121,7 @@ def test_log_multitask_performance_task_name():
             np.array(['env1'] * 10 + ['env2'] * 5 + ['env1'] + ['env3'])
         },
         agent_infos={},
+        episode_infos={},
         lengths=lengths)
 
     log_file = tempfile.NamedTemporaryFile()
@@ -172,6 +168,7 @@ def test_log_multitask_performance_task_id():
             np.array([1] * 10 + [3] * 5 + [1] + [4])
         },
         agent_infos={},
+        episode_infos={},
         lengths=lengths)
 
     log_file = tempfile.NamedTemporaryFile()

--- a/tests/garage/torch/policies/test_context_conditioned_policy.py
+++ b/tests/garage/torch/policies/test_context_conditioned_policy.py
@@ -82,6 +82,7 @@ class TestContextConditionedPolicy:
                      reward=1.0,
                      env_info={},
                      agent_info={},
+                     episode_info={},
                      step_type=StepType.FIRST)
         updates = 10
         for _ in range(updates):


### PR DESCRIPTION
Fixing issue #1845, allowing for `episode_info` (returned by `env.reset()`) to be used/passed around in these dtypes. 