### PR TITLE
Disable Ray Dashboard

### DIFF
--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -34,7 +34,8 @@ def trpo_swimmer_ray_sampler(ctxt=None, seed=1):
     ray.init(memory=52428800,
              object_store_memory=78643200,
              ignore_reinit_error=True,
-             log_to_driver=False)
+             log_to_driver=False,
+             include_dashboard=False)
     with TFTrainer(snapshot_config=ctxt) as trainer:
         set_seed(seed)
         env = GymEnv('Swimmer-v2')

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -34,7 +34,8 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
     ray.init(memory=52428800,
              object_store_memory=78643200,
              ignore_reinit_error=True,
-             log_to_driver=False)
+             log_to_driver=False,
+             include_dashboard=False)
     deterministic.set_seed(seed)
     env = GymEnv('InvertedDoublePendulum-v2')
 

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -30,7 +30,9 @@ class RaySampler(Sampler):
     def __init__(self, worker_factory, agents, envs):
         # pylint: disable=super-init-not-called
         if not ray.is_initialized():
-            ray.init(log_to_driver=False)
+            ray.init(log_to_driver=False,
+                     ignore_reinit_error=True,
+                     include_dashboard=False)
         self._sampler_worker = ray.remote(SamplerWorker)
         self._worker_factory = worker_factory
         self._agents = agents

--- a/tests/fixtures/sampler/ray_fixtures.py
+++ b/tests/fixtures/sampler/ray_fixtures.py
@@ -16,7 +16,8 @@ def ray_local_session_fixture():
     if not ray.is_initialized():
         ray.init(local_mode=True,
                  ignore_reinit_error=True,
-                 log_to_driver=False)
+                 log_to_driver=False,
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()
@@ -36,7 +37,8 @@ def ray_session_fixture():
         ray.init(memory=52428800,
                  object_store_memory=78643200,
                  ignore_reinit_error=True,
-                 log_to_driver=False)
+                 log_to_driver=False,
+                 include_dashboard=False)
     yield
     if ray.is_initialized():
         ray.shutdown()


### PR DESCRIPTION
Currently, when we test examples that used the Ray Sampler,
which is every on policy rl algorithm, we shut down the example
after 1 epoch. Because of this, ray.shutdown() is never called
which is necessary for closing ray features such as the ray
dashboard. The dashboard by default tries to attach to the same
port, and so because it hasn't been properly freed after the
example is prematurely shutdown, sometimes the ray sampler
fails to properly init when a new example is started.

To work around this, I have disabled the behavior where the
ray sampler activates its ray dashboard. Users can renable
the dashboard by initing ray inside of their launchers,
like we do in our trpo_swimmer_ray_sampler.py example.

See #1961 for more information