### PR TITLE
Remove unnecessary list comprehensions from VPG

### DIFF
--- a/examples/tf/rl2_ppo_metaworld_ml10.py
+++ b/examples/tf/rl2_ppo_metaworld_ml10.py
@@ -7,8 +7,7 @@ import metaworld
 
 from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv
-from garage.experiment import (MetaEvaluator,
-                               MetaWorldTaskSampler,
+from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline

--- a/examples/tf/rl2_ppo_metaworld_ml1_push.py
+++ b/examples/tf/rl2_ppo_metaworld_ml1_push.py
@@ -7,8 +7,7 @@ import metaworld
 
 from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv
-from garage.experiment import (MetaEvaluator,
-                               MetaWorldTaskSampler,
+from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline

--- a/examples/tf/rl2_ppo_metaworld_ml45.py
+++ b/examples/tf/rl2_ppo_metaworld_ml45.py
@@ -7,8 +7,7 @@ import metaworld
 
 from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv
-from garage.experiment import (MetaEvaluator,
-                               MetaWorldTaskSampler,
+from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline

--- a/examples/torch/maml_trpo_metaworld_ml10.py
+++ b/examples/torch/maml_trpo_metaworld_ml10.py
@@ -8,8 +8,7 @@ import torch
 
 from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv
-from garage.experiment import (MetaEvaluator,
-                               MetaWorldTaskSampler,
+from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.torch.algos import MAMLTRPO

--- a/examples/torch/maml_trpo_metaworld_ml45.py
+++ b/examples/torch/maml_trpo_metaworld_ml45.py
@@ -8,8 +8,7 @@ import torch
 
 from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
-from garage.experiment import (MetaEvaluator,
-                               MetaWorldTaskSampler,
+from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.torch.algos import MAMLTRPO

--- a/src/garage/experiment/__init__.py
+++ b/src/garage/experiment/__init__.py
@@ -5,8 +5,7 @@ from garage.experiment.snapshotter import SnapshotConfig, Snapshotter
 from garage.experiment.task_sampler import (ConstructEnvsSampler,
                                             EnvPoolSampler,
                                             MetaWorldTaskSampler,
-                                            SetTaskSampler,
-                                            TaskSampler)
+                                            SetTaskSampler, TaskSampler)
 
 # yapf: enable
 

--- a/src/garage/experiment/task_sampler.py
+++ b/src/garage/experiment/task_sampler.py
@@ -7,8 +7,7 @@ import math
 import numpy as np
 
 from garage.envs import GymEnv, TaskNameWrapper, TaskOnehotWrapper
-from garage.sampler.env_update import (ExistingEnvUpdate,
-                                       NewEnvUpdate,
+from garage.sampler.env_update import (ExistingEnvUpdate, NewEnvUpdate,
                                        SetTaskUpdate)
 
 # yapf: enable

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -6,9 +6,7 @@ from dowel import logger, tabular
 import numpy as np
 import torch
 
-from garage import (_Default,
-                    log_performance,
-                    make_optimizer,
+from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes)
 from garage.np.algos import RLAlgorithm
 from garage.sampler import FragmentWorker, LocalSampler

--- a/src/garage/torch/algos/maml.py
+++ b/src/garage/torch/algos/maml.py
@@ -7,9 +7,7 @@ from dowel import tabular
 import numpy as np
 import torch
 
-from garage import (_Default,
-                    EpisodeBatch,
-                    log_multitask_performance,
+from garage import (_Default, EpisodeBatch, log_multitask_performance,
                     make_optimizer)
 from garage.np import discount_cumsum
 from garage.sampler import RaySampler

--- a/src/garage/torch/algos/mtsac.py
+++ b/src/garage/torch/algos/mtsac.py
@@ -3,8 +3,7 @@
 import numpy as np
 import torch
 
-from garage import (EpisodeBatch,
-                    log_multitask_performance,
+from garage import (EpisodeBatch, log_multitask_performance,
                     obtain_evaluation_episodes)
 from garage.torch import global_device
 from garage.torch.algos import SAC

--- a/tests/garage/tf/algos/test_rl2trpo.py
+++ b/tests/garage/tf/algos/test_rl2trpo.py
@@ -12,8 +12,7 @@ from garage.sampler import LocalSampler
 from garage.tf.algos import RL2TRPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
-                                  FiniteDifferenceHVP,
-                                  PenaltyLBFGSOptimizer)
+                                  FiniteDifferenceHVP, PenaltyLBFGSOptimizer)
 from garage.tf.policies import GaussianGRUPolicy
 from garage.trainer import TFTrainer
 

--- a/tests/garage/tf/policies/test_discrete_qf_argmax_policy.py
+++ b/tests/garage/tf/policies/test_discrete_qf_argmax_policy.py
@@ -10,8 +10,7 @@ from garage.tf.q_functions import DiscreteCNNQFunction
 
 # yapf: disable
 from tests.fixtures import TfGraphTestCase
-from tests.fixtures.envs.dummy import (DummyDictEnv,
-                                       DummyDiscreteEnv,
+from tests.fixtures.envs.dummy import (DummyDictEnv, DummyDiscreteEnv,
                                        DummyDiscretePixelEnvBaselines)
 from tests.fixtures.q_functions import SimpleQFunction
 


### PR DESCRIPTION
Part of #1110

The `train_once` function now takes an `EpisodeBatch` rather than an `EpisodeBatch` that's been converted to a `list(dict)` with `.to_list()`. Unfortunately, the algorithm requires the observations/rewards/returns to be padded to `max_episode_length` for certain operations, so I had to use `.to_list()` inside the algo.

Also fixed a small `__init__` arg bug in `RaySampler`