### PR TITLE
Use EpisodeBatch in Torch SAC

### DIFF
--- a/src/garage/torch/algos/mtsac.py
+++ b/src/garage/torch/algos/mtsac.py
@@ -174,7 +174,7 @@ class MTSAC(SAC):
             torch.Tensor: log_alpha. shape is (1, self.buffer_batch_size)
 
         """
-        obs = samples_data['observation']
+        obs = samples_data['observations']
         log_alpha = self._log_alpha
         one_hots = obs[:, -self._num_tasks:]
         if (log_alpha.shape[0] != one_hots.shape[1]

--- a/tests/garage/torch/algos/test_mtsac.py
+++ b/tests/garage/torch/algos/test_mtsac.py
@@ -65,7 +65,7 @@ def test_mtsac_get_log_alpha(monkeypatch):
     monkeypatch.setattr(mtsac, '_log_alpha', torch.Tensor([1., 2.]))
     for i, _ in enumerate(env_names):
         obs = torch.Tensor([env.reset()[0]] * buffer_batch_size)
-        log_alpha = mtsac._get_log_alpha(dict(observation=obs))
+        log_alpha = mtsac._get_log_alpha(dict(observations=obs))
         assert (log_alpha == torch.Tensor([i + 1, i + 1])).all().item()
         assert log_alpha.size() == torch.Size([mtsac._buffer_batch_size])
 
@@ -121,7 +121,7 @@ def test_mtsac_get_log_alpha_incorrect_num_tasks(monkeypatch):
                     'The correct number of tasks?')
     obs = torch.Tensor([env.reset()[0]] * buffer_batch_size)
     with pytest.raises(ValueError, match=error_string):
-        mtsac._get_log_alpha(dict(observation=obs))
+        mtsac._get_log_alpha(dict(observations=obs))
 
 
 @pytest.mark.mujoco

--- a/tests/garage/torch/algos/test_sac.py
+++ b/tests/garage/torch/algos/test_sac.py
@@ -103,11 +103,11 @@ def testCriticLoss():
     terminals = torch.Tensor([[0.], [0.]])
     next_observations = torch.FloatTensor([[5, 6], [7, 8]])
     samples_data = {
-        'observation': observations,
-        'action': actions,
-        'reward': rewards,
-        'terminal': terminals,
-        'next_observation': next_observations
+        'observations': observations,
+        'actions': actions,
+        'rewards': rewards,
+        'terminals': terminals,
+        'next_observations': next_observations
     }
     td_targets = [7.3, 19.1]
     pred_td_targets = [7., 10.]
@@ -140,7 +140,7 @@ def testActorLoss():
     observations = torch.Tensor([[1., 2.], [3., 4.]])
     action_dists = policy(observations)[0]
     actions = torch.Tensor(action_dists.rsample_with_pre_tanh_value())
-    samples_data = dict(observation=observations)
+    samples_data = dict(observations=observations)
     log_pi = action_dists.log_prob(actions)
     expected_loss = (2 * 10 - (2 + 1) - (4 + 1)) / 2
     loss = sac._actor_objective(samples_data, actions, log_pi)


### PR DESCRIPTION
Part of #1110

I think this really should use `TimeStepBatch`, but as far as I can tell, the `trainer` doesn't have a way of retrieving one of those. It only deals in `EpisodeBatch` or the `list(dict)` type that's scattered everywhere.