### PR TITLE
Mark test_multiprocessing_sampler flaky

### DIFF
--- a/tests/garage/sampler/test_multiprocessing_sampler.py
+++ b/tests/garage/sampler/test_multiprocessing_sampler.py
@@ -50,6 +50,7 @@ def test_obtain_samples():
     env.close()
 
 
+@pytest.mark.flaky
 @pytest.mark.timeout(10)
 def test_update_envs_env_update():
     max_episode_length = 16
@@ -170,6 +171,7 @@ def test_init_with_crashed_worker():
     env.close()
 
 
+@pytest.mark.flaky
 @pytest.mark.timeout(10)
 def test_pickle():
     max_episode_length = 16


### PR DESCRIPTION
Currently, we just mark it as flaky.