### PR TITLE
Update MTSAC examples and MW version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ EXTRAS['dev'] = [
     'flake8',
     'flake8-docstrings>=1.5.0',
     'flake8-import-order',
-    f'metaworld @ https://{GARAGE_GH_TOKEN}@api.github.com/repos/rlworkgroup/metaworld/tarball/9b773d0db1e7af65466c362fdb9603aaffe5b978',  # noqa: E501
+    f'metaworld @ https://{GARAGE_GH_TOKEN}@api.github.com/repos/rlworkgroup/metaworld/tarball/0875192baaa91c43523708f55866d98eaf3facaf',  # noqa: E501
     'isort>=4.3.21,<5.0.0',
     'pep8-naming==0.7.0',
     'pre-commit',


### PR DESCRIPTION
- update metaworld version to commit that
  standardizes max path length to 200
- apply reward normalization to training
  environments so that reward scales are between
  -1 and 1 in MTSAC examples
- update MTSAC MT50 hyperparameters
- reduce environment vectorization to reduce memory
  consumption of environments.

I'm re-benchmarking MTSAC over here:
https://tensorboard.dev/experiment/mG9aeJvIR4aLCDcgoDf82A/