### PR TITLE
Fix rl2 nightly test timeout

### DIFF
--- a/tests/integration_tests/test_examples.py
+++ b/tests/integration_tests/test_examples.py
@@ -378,7 +378,7 @@ def test_maml_vpg():
 
 @pytest.mark.nightly
 @pytest.mark.no_cover
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(600)
 def test_rl2_ppo_metaworld_ml1_push():
     """Test rl2_ppo_metaworld_ml1_push.py."""
     assert subprocess.run([


### PR DESCRIPTION
Unfortunately there's no way to be sure this fixed the timeout without running the nightly CI on this change.

If it still times out, we will have to disable this test.