### PR TITLE
Make snapshot_config optional in benchmarks

### DIFF
--- a/benchmarks/src/garage_benchmarks/benchmark_auto.py
+++ b/benchmarks/src/garage_benchmarks/benchmark_auto.py
@@ -15,26 +15,26 @@ from garage_benchmarks.parameters import MuJoCo1M_ENV_SET
 
 
 @benchmark(plot=False, auto=True)
-def auto_ddpg_benchmarks(snapshot_config):
+def auto_ddpg_benchmarks():
     """Run experiments for DDPG benchmarking."""
     iterate_experiments(ddpg_garage_tf,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
 
 
 @benchmark(plot=False, auto=True)
-def auto_ppo_benchmarks(snapshot_config):
+def auto_ppo_benchmarks():
     """Run experiments for PPO benchmarking."""
     iterate_experiments(ppo_garage_pytorch,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
     iterate_experiments(ppo_garage_tf,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
 
 
 @benchmark(plot=False, auto=True)
-def auto_td3_benchmarks(snapshot_config):
+def auto_td3_benchmarks():
     """Run experiments for TD3 benchmarking."""
     td3_env_ids = [
         env_id for env_id in MuJoCo1M_ENV_SET if env_id != 'Reacher-v2'
@@ -42,26 +42,26 @@ def auto_td3_benchmarks(snapshot_config):
 
     iterate_experiments(td3_garage_tf,
                         td3_env_ids,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
 
 
 @benchmark(plot=False, auto=True)
-def auto_trpo_benchmarks(snapshot_config):
+def auto_trpo_benchmarks():
     """Run experiments for TRPO benchmarking."""
     iterate_experiments(trpo_garage_pytorch,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
     iterate_experiments(trpo_garage_tf,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
 
 
 @benchmark(plot=False, auto=True)
-def auto_vpg_benchmarks(snapshot_config):
+def auto_vpg_benchmarks():
     """Run experiments for VPG benchmarking."""
     iterate_experiments(vpg_garage_pytorch,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})
     iterate_experiments(vpg_garage_tf,
                         MuJoCo1M_ENV_SET,
-                        snapshot_config=snapshot_config)
+                        snapshot_config={'snapshot_mode': 'none'})

--- a/benchmarks/src/garage_benchmarks/helper.py
+++ b/benchmarks/src/garage_benchmarks/helper.py
@@ -80,15 +80,12 @@ def benchmark(exec_func=None, *, plot=True, auto=False):
                 count += 1
             _log_dir = _log_dir + '_' + str(count)
 
-        snapshot_config = {}
-
         if auto:
             _auto = auto
             auto_dir = os.path.join(_log_dir, 'auto')
             os.makedirs(auto_dir)
-            snapshot_config['snapshot_mode'] = 'none'
 
-        exec_func(snapshot_config)
+        exec_func()
 
         if plot:
             plot_dir = os.path.join(_log_dir, 'plot')
@@ -148,7 +145,8 @@ def iterate_experiments(func,
             tf.compat.v1.reset_default_graph()
 
             ctxt = dict(log_dir=sub_log_dir)
-            ctxt.update(snapshot_config)
+            if snapshot_config:
+                ctxt.update(snapshot_config)
             func(ctxt, env_id=env_id, seed=seed)
 
             if _plot is not None or _auto:


### PR DESCRIPTION
PR #2072 added an argument to functions decorated with @benchmark
to pass snapshot_config to auto benchmarks but that broke other
benchmarks that didn't need that argument.

This commit cleans it up by passing snapshot_config directly to
iterate_experiments, since trying to pass it from within decorator
function makes for a confusing API