### PR TITLE
Allow setting total_env_steps

### DIFF
--- a/src/garage/trainer.py
+++ b/src/garage/trainer.py
@@ -645,6 +645,16 @@ class Trainer:
         """
         return self._stats.total_env_steps
 
+    @total_env_steps.setter
+    def total_env_steps(self, value):
+        """Total environment steps collected.
+
+        Args:
+            value (int): Total environment steps collected.
+
+        """
+        self._stats.total_env_steps = value
+
 
 class NotSetupError(Exception):
     """Raise when an experiment is about to run without setup."""


### PR DESCRIPTION
This is needed to allow the Trainer not to know about the Samplers directly
See issue #2120