### PR TITLE
Record total_env_steps in samplers

### DIFF
--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -40,6 +40,7 @@ class RaySampler(Sampler):
         self._all_workers = defaultdict(None)
         self._workers_started = False
         self.start_worker()
+        self.total_env_steps = 0
 
     @classmethod
     def from_worker_factory(cls, worker_factory, agents, envs):
@@ -170,7 +171,9 @@ class RaySampler(Sampler):
                     batches.append(episode_batch)
                     pbar.update(num_returned_samples)
 
-        return EpisodeBatch.concatenate(*batches)
+        samples = EpisodeBatch.concatenate(*batches)
+        self.total_env_steps += sum(samples.lengths)
+        return samples
 
     def obtain_exact_episodes(self,
                               n_eps_per_worker,
@@ -247,7 +250,9 @@ class RaySampler(Sampler):
             itertools.chain(
                 *[episodes[i] for i in range(self._worker_factory.n_workers)]))
 
-        return EpisodeBatch.concatenate(*ordered_episodes)
+        samples = EpisodeBatch.concatenate(*ordered_episodes)
+        self.total_env_steps += sum(samples.lengths)
+        return samples
 
     def shutdown_worker(self):
         """Shuts down the worker."""


### PR DESCRIPTION
This change makes it practical to use a Sampler that the Trainer isn't aware of.
See issue #2120