### PR TITLE
Add progressbar to obtain_evaluation_samples

### DIFF
--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -2,6 +2,7 @@
 from collections import defaultdict
 import time
 
+import click
 from dowel import tabular
 import numpy as np
 
@@ -162,12 +163,13 @@ def obtain_evaluation_episodes(policy,
     episodes = []
     # Use a finite length rollout for evaluation.
 
-    for _ in range(num_eps):
-        eps = rollout(env,
-                      policy,
-                      max_episode_length=max_episode_length,
-                      deterministic=deterministic)
-        episodes.append(eps)
+    with click.progressbar(range(num_eps), label='Evaluating') as pbar:
+        for _ in pbar:
+            eps = rollout(env,
+                          policy,
+                          max_episode_length=max_episode_length,
+                          deterministic=deterministic)
+            episodes.append(eps)
     return EpisodeBatch.from_list(env.spec, episodes)
 
 


### PR DESCRIPTION
Gathering evaluation samples often takes noticeable time, so it's nice to have a progress bar.