### PR TITLE
Make plotting plot the learner in BC

### DIFF
--- a/src/garage/torch/algos/bc.py
+++ b/src/garage/torch/algos/bc.py
@@ -76,13 +76,17 @@ class BC(RLAlgorithm):
         self._batch_size = batch_size
         self._name = name
 
+        # For plotting
+        self.policy = self.learner
+
         # Public fields for sampling.
         self._env_spec = env_spec
+        self.exploration_policy = None
         self.policy = None
         self.max_episode_length = env_spec.max_episode_length
         self.sampler_cls = None
         if isinstance(self._source, Policy):
-            self.policy = self._source
+            self.exploration_policy = self._source
             self.sampler_cls = RaySampler
             self._source = source
         else:


### PR DESCRIPTION
Before, using BC with an expert source policy caused the expert to be shown in the plotter, which was very confusing. This change fixes that, by making the expert the algorithm's `.exploration_policy` and the learner its `.policy`