### PR TITLE
Make TanhNormal.log_prob(1.0) != -inf

### DIFF
--- a/src/garage/torch/distributions/tanh_normal.py
+++ b/src/garage/torch/distributions/tanh_normal.py
@@ -49,7 +49,8 @@ class TanhNormal(torch.distributions.Distribution):
         """
         # pylint: disable=arguments-differ
         if pre_tanh_value is None:
-            pre_tanh_value = torch.log((1 + value) / (1 - value)) / 2
+            pre_tanh_value = torch.log(
+                (1 + epsilon + value) / (1 + epsilon - value)) / 2
         norm_lp = self._normal.log_prob(pre_tanh_value)
         ret = (norm_lp - torch.sum(
             torch.log(self._clip_but_pass_gradient((1. - value**2)) + epsilon),

--- a/tests/garage/torch/distributions/test_tanh_normal_dist.py
+++ b/tests/garage/torch/distributions/test_tanh_normal_dist.py
@@ -48,7 +48,7 @@ class TestBenchmarkTanhNormalDistribution:
         log_prob = dist.log_prob(action, pre_tanh_action)
         log_prob_approx = dist.log_prob(action)
         assert torch.allclose(log_prob, torch.Tensor([-0.2798519]))
-        assert torch.allclose(log_prob_approx, torch.Tensor([-0.2798519]))
+        assert torch.allclose(log_prob_approx, torch.Tensor([-0.2798185]))
         del dist
 
     def test_tanh_normal_expand(self):
@@ -71,3 +71,14 @@ class TestBenchmarkTanhNormalDistribution:
         std = torch.ones(1)
         dist = TanhNormal(mean, std)
         assert repr(dist) == 'TanhNormal'
+
+    def test_tanh_normal_log_prob_of_clipped_action(self):
+        """Verify that clipped actions still have a valid log probability."""
+        mean = torch.zeros(2)
+        std = torch.ones(2)
+        dist = TanhNormal(mean, std)
+        action = torch.Tensor([[1., -1.]])
+        log_prob_approx = dist.log_prob(action)
+        assert torch.isfinite(log_prob_approx)
+        assert log_prob_approx < -20
+        del dist


### PR DESCRIPTION
TanhNormal uses an `epsilon` value to handle numerical instabilities. In very rare circumstances (which I've encountered about once after running about 10^8 steps), an action can get sampled at the very edge of the action space (i.e. one dimension is exactly 1.0 or -1.0).
This change makes it so that such actions are only considered exceptionally unlikely, instead of making the log probability negative infinity.

This also means that actions taken by an expert, then clipped into the action space always have a valid log probability.
I believe this formulation changes the rest of the tanh normal distribution as little as is practical. Essentially, when computing the pre-tanh value, instead of using the inverse of tanh, it uses the inverse of an equivalent shaped sigmoid from -1 - epsilon to 1 + epsilon (where epsilon=1e-6 by default).