### PR TITLE
Decrease BC eval steps

### DIFF
--- a/src/garage/_functions.py
+++ b/src/garage/_functions.py
@@ -1,6 +1,7 @@
 """Functions exposed directly in the garage namespace."""
 from collections import defaultdict
 
+import click
 from dowel import tabular
 import numpy as np
 
@@ -160,12 +161,13 @@ def obtain_evaluation_episodes(policy,
     episodes = []
     # Use a finite length rollout for evaluation.
 
-    for _ in range(num_eps):
-        eps = rollout(env,
-                      policy,
-                      max_episode_length=max_episode_length,
-                      deterministic=deterministic)
-        episodes.append(eps)
+    with click.progressbar(range(num_eps), label='Evaluating') as bar:
+        for _ in bar:
+            eps = rollout(env,
+                          policy,
+                          max_episode_length=max_episode_length,
+                          deterministic=deterministic)
+            episodes.append(eps)
     return EpisodeBatch.from_list(env.spec, episodes)
 
 

--- a/src/garage/experiment/experiment.py
+++ b/src/garage/experiment/experiment.py
@@ -161,6 +161,7 @@ class ExperimentTemplate:
             the function definition.
         use_existing_dir (bool): If true, (re)use the directory for this
             experiment, even if it already contains data.
+        x_axis (str): Key to use for x axis of plots.
 
 
 
@@ -170,7 +171,7 @@ class ExperimentTemplate:
 
     def __init__(self, *, function, log_dir, name, prefix, snapshot_mode,
                  snapshot_gap, archive_launch_repo, name_parameters,
-                 use_existing_dir):
+                 use_existing_dir, x_axis):
         self.function = function
         self.log_dir = log_dir
         self.name = name
@@ -180,6 +181,7 @@ class ExperimentTemplate:
         self.archive_launch_repo = archive_launch_repo
         self.name_parameters = name_parameters
         self.use_existing_dir = use_existing_dir
+        self.x_axis = x_axis
         if self.function is not None:
             self._update_wrap_params()
 
@@ -263,6 +265,7 @@ class ExperimentTemplate:
                        snapshot_gap=self.snapshot_gap,
                        snapshot_mode=self.snapshot_mode,
                        use_existing_dir=self.use_existing_dir,
+                       x_axis=self.x_axis,
                        signature=self.__signature__)
         if args:
             if len(args) == 1 and isinstance(args[0], dict):
@@ -321,7 +324,7 @@ class ExperimentTemplate:
         logger.add_output(dowel.TextOutput(text_log_file))
         logger.add_output(dowel.CsvOutput(tabular_log_file))
         logger.add_output(
-            dowel.TensorBoardOutput(log_dir, x_axis='TotalEnvSteps'))
+            dowel.TensorBoardOutput(log_dir, x_axis=options['x_axis']))
         logger.add_output(dowel.StdOutput())
 
         logger.push_prefix('[{}] '.format(name))
@@ -377,7 +380,8 @@ def wrap_experiment(function=None,
                     snapshot_gap=1,
                     archive_launch_repo=True,
                     name_parameters=None,
-                    use_existing_dir=False):
+                    use_existing_dir=False,
+                    x_axis='TotalEnvSteps'):
     """Decorate a function to turn it into an ExperimentTemplate.
 
     When invoked, the wrapped function will receive an ExperimentContext, which
@@ -424,6 +428,7 @@ def wrap_experiment(function=None,
             the function definition.
         use_existing_dir (bool): If true, (re)use the directory for this
             experiment, even if it already contains data.
+        x_axis (str): Key to use for x axis of plots.
 
     Returns:
         callable: The wrapped function.
@@ -437,7 +442,8 @@ def wrap_experiment(function=None,
                               snapshot_gap=snapshot_gap,
                               archive_launch_repo=archive_launch_repo,
                               name_parameters=name_parameters,
-                              use_existing_dir=use_existing_dir)
+                              use_existing_dir=use_existing_dir,
+                              x_axis=x_axis)
 
 
 def dump_json(filename, data):

--- a/src/garage/torch/algos/bc.py
+++ b/src/garage/torch/algos/bc.py
@@ -76,13 +76,17 @@ class BC(RLAlgorithm):
         self._batch_size = batch_size
         self._name = name
 
+        # For plotting
+        self.policy = self.learner
+
         # Public fields for sampling.
         self._env_spec = env_spec
+        self.exploration_policy = None
         self.policy = None
         self.max_episode_length = env_spec.max_episode_length
         self.sampler_cls = None
         if isinstance(self._source, Policy):
-            self.policy = self._source
+            self.exploration_policy = self._source
             self.sampler_cls = RaySampler
             self._source = source
         else:

--- a/src/garage/torch/algos/bc.py
+++ b/src/garage/torch/algos/bc.py
@@ -106,7 +106,8 @@ class BC(RLAlgorithm):
             if self._eval_env is not None:
                 log_performance(epoch,
                                 obtain_evaluation_episodes(
-                                    self.learner, self._eval_env),
+                                    self.learner, self._eval_env,
+                                    num_eps=10),
                                 discount=1.0)
             losses = self._train_once(trainer, epoch)
             with tabular.prefix(self._name + '/'):

--- a/src/garage/torch/distributions/tanh_normal.py
+++ b/src/garage/torch/distributions/tanh_normal.py
@@ -49,7 +49,7 @@ class TanhNormal(torch.distributions.Distribution):
         """
         # pylint: disable=arguments-differ
         if pre_tanh_value is None:
-            pre_tanh_value = torch.log((1 + value) / (1 - value)) / 2
+            pre_tanh_value = torch.log((1 + epsilon + value) / (1 + epsilon - value)) / 2
         norm_lp = self._normal.log_prob(pre_tanh_value)
         ret = (norm_lp - torch.sum(
             torch.log(self._clip_but_pass_gradient((1. - value**2)) + epsilon),


### PR DESCRIPTION
Behavioral cloning doesn't normally need to sample, making it practical to run a very large number of iterations. However, right now we still use 100 evaluation episodes in BC, which makes it much slower to run. This decreases the number of evaluations to 10.