### PR TITLE
Fix #2131

### DIFF
--- a/tests/garage/envs/test_normalized_gym.py
+++ b/tests/garage/envs/test_normalized_gym.py
@@ -4,7 +4,7 @@ from garage.envs import GymEnv, normalize
 class TestNormalizedGym:
 
     def setup_method(self):
-        self.env = normalize(GymEnv('Pendulum-v0'),
+        self.env = normalize(GymEnv('CartPole-v1'),
                              normalize_reward=True,
                              normalize_obs=True,
                              flatten_obs=True)


### PR DESCRIPTION
There's something specifically wrong with an image used
in rendering pendulum-v0, causing visualize to fail.

I swapped it out with CartPole-v1 for the purposes of
the tests and that was a fix.