### PR TITLE
Unpin cloudpickle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ REQUIRED = [
     # Please keep alphabetized
     'akro',
     'click>=2.0',
-    'cloudpickle==1.3',
+    'cloudpickle',
     'cma==2.7.0',
     'dowel==0.0.3',
     'numpy>=1.14.5',


### PR DESCRIPTION
closes #1882

tensorflow/probability 0.11.1 is out which allows
compatibility with cloudpickle >= 1.3, so we don't
need to pin it anymore