### PR TITLE
Remove include_dashboard arg so that doctests pass

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
+sphinx-autoapi
+sphinxcontrib-bibtex
+
 akro
 click
 cloudpickle
@@ -5,6 +8,7 @@ cma==2.7.0
 dm_env
 dowel==0.0.3
 gym[atari, box2d, classic_control]==0.17.2
+matplotlib
 psutil
 pyprind
 python-dateutil
@@ -13,11 +17,3 @@ scipy
 setproctitle
 tensorflow
 tensorflow-probability
-
-# dev dependencies
-matplotlib
-recommonmark
-sphinx
-sphinx-autoapi>=1.4.0
-sphinx_rtd_theme
-sphinxcontrib-bibtex

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -30,9 +30,7 @@ class RaySampler(Sampler):
     def __init__(self, worker_factory, agents, envs):
         # pylint: disable=super-init-not-called
         if not ray.is_initialized():
-            ray.init(log_to_driver=False,
-                     ignore_reinit_error=True,
-                     include_dashboard=False)
+            ray.init(log_to_driver=False, ignore_reinit_error=True)
         self._sampler_worker = ray.remote(SamplerWorker)
         self._worker_factory = worker_factory
         self._agents = agents


### PR DESCRIPTION
I also updated docs/requirements.txt so that it works with pip's new dependency resolver, which is enabled on readthedocs (with no apparent way to disable it)