### PR TITLE
Add default docker container; Update docker docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           docker build . \
             -f docker/Dockerfile \
-            --target garage-dev-18.04 \
+            --target garage-dev \
             -t "${DOCKER_TAG}" \
             --build-arg GARAGE_GH_TOKEN \
             --cache-from="docker.pkg.github.com/${OWNER}/${DOCKER_CACHE_REPO}/${DOCKER_TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
       - name: Build Docker container
         run: |
-          docker build . \
+          DOCKER_BUILDKIT=1 docker build . \
             -f docker/Dockerfile \
             --target garage-dev \
             -t "${DOCKER_TAG}" \

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ build-ci: TAG ?= rlworkgroup/garage-ci:latest
 build-ci: assert-docker-version docker/Dockerfile
 	docker build \
 		--cache-from rlworkgroup/garage-ci:latest \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		-f docker/Dockerfile \
 		--target garage-dev \
 		-t ${TAG} \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 SHELL := /bin/bash
 
-.PHONY: help test check docs ci-job-normal ci-job-large ci-job-nightly \
-	ci-job-verify-envs ci-verify-envs-conda ci-verify-envs-pipenv build-ci \
-	build-headless build-nvidia run-ci run-headless run-nvidia assert-docker
+.PHONY: help test build-test check docs ci-job-precommit ci-job-normal \
+	ci-job-large ci-job-mujoco ci-job-mujoco-long ci-job-nightly ci-job-verify-envs \
+	ci-verify-envs-conda ci-verify-envs-pipenv ci-deploy-docker build-ci build-dev \
+	build-dev-nvidia run-ci run-dev run-dev-nvidia run-dev-nvidia-headless \
+	assert-docker assert-travis ensure-data-path-exists assert-docker-version
 
 .DEFAULT_GOAL := help
 
@@ -170,9 +172,9 @@ build-dev: assert-docker-version docker/Dockerfile
 		-t ${TAG} \
 		${BUILD_ARGS} .
 
-build-nvidia-dev: TAG ?= rlworkgroup/garage-dev-nvidia:latest
-build-nvidia-dev: PARENT_IMAGE ?= nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
-build-nvidia-dev: assert-docker-version docker/Dockerfile
+build-dev-nvidia: TAG ?= rlworkgroup/garage-dev-nvidia:latest
+build-dev-nvidia: PARENT_IMAGE ?= nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+build-dev-nvidia: assert-docker-version docker/Dockerfile
 	docker build \
 		-f docker/Dockerfile \
 		--cache-from rlworkgroup/garage-dev-nvidia:latest \
@@ -218,7 +220,7 @@ run-dev-nvidia: ## Requires https://github.com/NVIDIA/nvidia-container-runtime a
 run-dev-nvidia: CONTAINER_NAME ?= ''
 run-dev-nvidia: user ?= $$USER
 run-dev-nvidia: GPUS ?= "all"
-run-dev-nvidia: ensure-data-path-exists build-nvidia-dev
+run-dev-nvidia: ensure-data-path-exists build-dev-nvidia
 	xhost +local:docker
 	docker run \
 		-it \
@@ -238,7 +240,7 @@ run-dev-nvidia-headless: ## Requires https://github.com/NVIDIA/nvidia-container-
 run-dev-nvidia-headless: CONTAINER_NAME ?= ''
 run-dev-nvidia-headless: user ?= $$USER
 run-dev-nvidia-headless: GPUS ?= "all"
-run-dev-nvidia-headless: ensure-data-path-exists build-nvidia-dev
+run-dev-nvidia-headless: ensure-data-path-exists build-dev-nvidia
 	docker run \
 		-it \
 		--rm \

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ build-dev: assert-docker-version docker/Dockerfile
 		${BUILD_ARGS} .
 
 build-dev-nvidia: TAG ?= rlworkgroup/garage-dev-nvidia:latest
-build-dev-nvidia: PARENT_IMAGE ?= nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04
+build-dev-nvidia: PARENT_IMAGE ?= nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04
 build-dev-nvidia: assert-docker-version docker/Dockerfile
 	docker build \
 		-f docker/Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,12 @@ build-test: assert-docker-version docker/Dockerfile
 		-f docker/Dockerfile \
 		--cache-from rlworkgroup/garage-test:latest \
 		--cache-from rlworkgroup/garage:latest \
-		--target garage-test-18.04 \
+		--target garage-test \
 		-t ${TAG} \
 		${BUILD_ARGS} \
 		.
 
-test:  ## Run the garage-test-18.04 docker target
+test:  ## Run the garage-test docker target that runs all tests except huge and flaky
 test: RUN_ARGS = --memory 7500m --memory-swap 7500m
 test: TAG ?= rlworkgroup/garage-test
 test: CONTAINER_NAME ?= ''
@@ -153,7 +153,7 @@ build-ci: assert-docker-version docker/Dockerfile
 	docker build \
 		--cache-from rlworkgroup/garage-ci:latest \
 		-f docker/Dockerfile \
-		--target garage-dev-18.04 \
+		--target garage-dev \
 		-t ${TAG} \
 		${BUILD_ARGS} .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG PARENT_IMAGE=ubuntu:18.04
 
 # Garage base target ###########################################################
-FROM $PARENT_IMAGE AS garage-18.04
+FROM $PARENT_IMAGE AS garage-base
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
@@ -66,8 +66,8 @@ ENV PATH_NO_VENV $PATH
 WORKDIR $HOME
 
 RUN curl https://pyenv.run | bash && \
-  pyenv install 3.6.10 && \
-  pyenv global 3.6.10 && \
+  pyenv install 3.6.12 && \
+  pyenv global 3.6.12 && \
   pip install virtualenv && \
   rm -r $HOME/.cache/pip
 
@@ -106,11 +106,7 @@ RUN pip install --upgrade pip setuptools wheel && \
 ENV MJKEY_PATH $HOME/.mujoco/mjkey.txt
 RUN touch $MJKEY_PATH
 
-COPY --chown=$user:$user docker/entrypoint-runtime.sh $HOME/code/garage/docker/entrypoint-runtime.sh
-ENTRYPOINT ["code/garage/docker/entrypoint-runtime.sh"]
-
-# Headless machine with xvfb, i.e. so rendering works ##########################
-FROM garage-18.04 AS garage-headless-18.04
+# xvfb, so that rendering works
 USER root
 RUN \
   apt-get -y -q update && \
@@ -132,10 +128,24 @@ USER $user
 COPY --chown=$user:$user docker/entrypoint-headless.sh $HOME/code/garage/docker/entrypoint-headless.sh
 ENTRYPOINT ["code/garage/docker/entrypoint-headless.sh"]
 
+# Garage target for latest release from pypi ###################################
+FROM garage-base AS garage
+
+RUN pip install --upgrade pip setuptools wheel && \
+  pip install garage[all] && \
+  rm -r $HOME/.cache/pip
+
+COPY --chown=$user:$user ./examples $HOME/examples
+
+# Nvidia target ################################################################
+FROM garage AS garage-nvidia
+COPY --chown=$user:$user docker/entrypoint-runtime.sh $HOME/code/garage/docker/entrypoint-runtime.sh
+ENTRYPOINT ["code/garage/docker/entrypoint-runtime.sh"]
+
 
 # Special setup for garage developers, which installs garage from source #######
 # Assumes $PWD is the garage repository.
-FROM garage-headless-18.04 AS garage-dev-18.04
+FROM garage-base AS garage-dev
 
 # apt dependencies
 USER root
@@ -197,10 +207,10 @@ RUN cd benchmarks && python setup.py sdist && \
 
 ENTRYPOINT ["docker/entrypoint-headless.sh"]
 
-# Nvidia target ################################################################
-FROM garage-dev-18.04 AS garage-nvidia-18.04
+# Nvidia Dev target ############################################################
+FROM garage-dev AS garage-dev-nvidia
 ENTRYPOINT ["docker/entrypoint-runtime.sh"]
 
 # Test target ##################################################################
-FROM garage-dev-18.04 AS garage-test-18.04
+FROM garage-dev AS garage-test
 CMD nice -n 11 pytest -v -n auto -m 'not huge and not flaky' --durations=20

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.1.7-experimental
 ARG PARENT_IMAGE=ubuntu:18.04
 
 # Garage base target ###########################################################
@@ -133,9 +134,9 @@ FROM garage-base AS garage
 
 RUN pip install --upgrade pip setuptools wheel && \
   pip install garage[all] && \
-  rm -r $HOME/.cache/pip
-
-COPY --chown=$user:$user ./examples $HOME/examples
+  rm -r $HOME/.cache/pip && \
+  (python -c 'import mujoco_py' || true) && \
+  rm $MJKEY_PATH
 
 # Nvidia target ################################################################
 FROM garage AS garage-nvidia
@@ -190,6 +191,7 @@ RUN git init && \
 # Install deps (but not the code)
 RUN pip install --upgrade pip setuptools wheel && \
   pip install .[all,dev] && \
+  (python -c 'import mujoco_py' || true) && \
   rm $MJKEY_PATH && \
   rm -r $HOME/.cache/pip
 

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -9,18 +9,18 @@ echo DOCKERFILE_PATH="$DOCKERFILE_PATH"
 echo DOCKER_REPO="$DOCKER_REPO"
 echo IMAGE_NAME="$IMAGE_NAME"
 
-if [[ "$DOCKER_REPO" = *"rlworkgroup/garage-headless" ]]; then
-  echo "Building target garage-dev-18.04"
+if [[ "$DOCKER_REPO" = *"rlworkgroup/garage" ]]; then
+  echo "Building target garage"
   docker build \
 		-f "../$DOCKERFILE_PATH" \
-		--target garage-dev-18.04 \
+		--target garage \
 		-t "$IMAGE_NAME" \
 		..
 elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage-nvidia" ]]; then
-  echo "Building target garage-nvidia-18.04"
+  echo "Building target garage-nvidia"
   docker build \
 		-f "../$DOCKERFILE_PATH" \
-		--target garage-nvidia-18.04 \
+		--target garage-nvidia \
 		-t "$IMAGE_NAME" \
 		--build-arg PARENT_IMAGE="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04" \
 		..

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -24,6 +24,6 @@ elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage-nvidia" ]]; then
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--target garage-nvidia \
 		-t "$IMAGE_NAME" \
-		--build-arg PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04" \
+		--build-arg PARENT_IMAGE="nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04" \
 		..
 fi

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -24,6 +24,6 @@ elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage-nvidia" ]]; then
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--target garage-nvidia \
 		-t "$IMAGE_NAME" \
-		--build-arg PARENT_IMAGE="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04" \
+		--build-arg PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04" \
 		..
 fi

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -13,6 +13,7 @@ if [[ "$DOCKER_REPO" = *"rlworkgroup/garage" ]]; then
   echo "Building target garage"
   docker build \
 		-f "../$DOCKERFILE_PATH" \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--target garage \
 		-t "$IMAGE_NAME" \
 		..
@@ -20,6 +21,7 @@ elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage-nvidia" ]]; then
   echo "Building target garage-nvidia"
   docker build \
 		-f "../$DOCKERFILE_PATH" \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--target garage-nvidia \
 		-t "$IMAGE_NAME" \
 		--build-arg PARENT_IMAGE="nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04" \

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ and how to implement new MDPs and new algorithms.
    user/writing_documentation
    user/git_workflow
    user/preparing_a_pr
+   user/docker_dev
 
 .. toctree::
    :caption: API Reference

--- a/docs/user/docker.md
+++ b/docs/user/docker.md
@@ -7,7 +7,7 @@ Currently there are two types of garage images available on Docker Hub:
  NVIDIA graphics card.
 
 If you want to compile a new image using the the source, proceed to the document
-[Building garage docker image from source](docker_dev.md) instead.
+[Building garage Docker image from source](docker_dev.md) instead.
 
 # `garage` image
 
@@ -18,9 +18,9 @@ Be aware of the following prerequisites to run the image.
 - Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce)
   version 19.03 or higher. Tested on version 19.03.
 
-Tested on Ubuntu 16.04, 18.04 & 20.04.
+Tested on Ubuntu 16.04, 18.04 and 20.04.
 
-### Running the `garage` docker image
+### Running the `garage` Docker image
 
 The garage container comes bundled with the examples available in the garage
 repo. To run an example launcher in the container, execute:
@@ -83,7 +83,7 @@ docker run \
   python examples/tf/trpo_cartpole.py
 ```
 
-Similarly, if you want to run your own code inside the docker container, you can
+Similarly, if you want to run your own code inside the Docker container, you can
 mount the directory containing your files as a volume, by using the `-v` option
 with `docker run`. If your code is in a file called `launcher.py` in the
 directory, say, `/home/user/my_garage_experiment_dir`, then you can mount it at
@@ -115,7 +115,8 @@ docker run \
 
 ## `garage-nvidia` image
 
-The garage NVIDIA images come with CUDA 10.2 and cuDNN (required for tensorflow).
+The garage NVIDIA images come with CUDA 10.2 and cuDNN 7.6 (required for
+TensorFlow).
 
 ### Prerequisites for `garage-nvidia` image
 
@@ -127,7 +128,7 @@ Additional to the prerequisites for the headless image, make sure to have:
    version](#using-a-different-driver-version)
 - [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
 
-Tested on Ubuntu 18.04 & 20.04.
+Tested on Ubuntu 18.04 and 20.04.
 
 ### Running the `garage-nvidia` image
 
@@ -147,13 +148,13 @@ docker run \
 
 ### Enabling environment visualization
 
-Allow the docker container to access the X server on your machine by running:
+Allow the Docker container to access the X server on your machine by running:
 
 ```bash
 xhost +local:docker
 ```
 
-and while running the docker container, add the following arguments to
+and while running the Docker container, add the following arguments to
 `docker run`:
 
 ```bash
@@ -181,7 +182,7 @@ docker run \
 
 By default, `garage-nvidia` uses all of your gpus. If you want to customize
 which GPUs are used and/or want to set the GPU capabilities exposed, as
-described in official docker documentation
+described in official Docker documentation
 [here](https://docs.docker.com/config/containers/resource_constraints/#gpu),
 you can pass the desired values to `--gpus` option as follows:
 
@@ -197,12 +198,14 @@ docker run \
 
 ### Using a different driver version
 
-The `garage-nvidia` docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
+The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime
+-ubuntu18.04`
 as the parent image which requires NVIDIA driver version 440.33+. If you need
 to use garage with a different driver version, you might be able to build the
 garage-nvidia image using a different parent image by following the guide at
-[Building garage docker image from source](docker_dev.md)
+[Building garage Docker image from source](docker_dev.md)
 
 ----
 
-This page was authored by Gitanshu Sardana ([@gitanshu](https://github.com/gitanshu>)).
+**This page was authored by Gitanshu Sardana ([@gitanshu](https://github.com
+/gitanshu>)).**

--- a/docs/user/docker.md
+++ b/docs/user/docker.md
@@ -3,13 +3,13 @@
 Currently there are two types of garage images available on Docker Hub:
 
 - `garage`: garage without environment visualization.
-- `garage-nvidia`: garage with environment visualization capability using an
- NVIDIA graphics card.
+- `garage-nvidia`: garage with GPU support, CUDA, and environment visualization
+  capability using NVIDIA graphics cards.
 
 If you want to compile a new image using the the source, proceed to the document
 [Building garage Docker image from source](docker_dev.md) instead.
 
-# `garage` image
+## `garage` image
 
 ### Prerequisites
 
@@ -52,23 +52,23 @@ written to `/home/garage-user/data`.
 For example, if the path of the directory on your computer where you want
 the results to be stored is `/home/user/data`, make sure the directory exists.
 
-Additionally, if you are on linux, make sure that this directory is writeable by
-the container user `garage-user` by either making it accessible by running:
+```eval_rst
+.. note::
 
-```bash
-setfacl -m u:999:rwx /home/user/data
-```
+    Additionally, if you are on linux, make sure that this directory is
+    writeable by the container user ``garage-user``, by either making it
+    accessible by running:
 
-or making it writable to all other users by running:
+    ``setfacl -m u:999:rwx /home/user/data``
 
-```bash
-chmod 777 /home/user/data
-```
+    or making it writable to all other users by running:
 
-or giving ownership of the directory to `garage-user` through:
+    ``chmod 777 /home/user/data``
 
-```bash
-chown -R 999:docker /home/user/data
+    or giving ownership of the directory to ``garage-user`` through:
+
+    ``chown -R 999:docker /home/user/data``
+
 ```
 
 Then, if the path of the directory on your computer is `/home/user/data`,
@@ -137,7 +137,7 @@ image, except that the image name is `rlworkgroup/garage-nvidia`.
 
 For example, to execute a launcher file:
 
-```
+```bash
 docker run \
   -it \
   --rm \
@@ -186,7 +186,7 @@ described in official Docker documentation
 [here](https://docs.docker.com/config/containers/resource_constraints/#gpu),
 you can pass the desired values to `--gpus` option as follows:
 
-```
+```bash
 docker run \
   -it \
   --rm \
@@ -198,14 +198,13 @@ docker run \
 
 ### Using a different driver version
 
-The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime
--ubuntu18.04`
+The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
 as the parent image which requires NVIDIA driver version 440.33+. If you need
 to use garage with a different driver version, you might be able to build the
 garage-nvidia image using a different parent image by following the guide at
 [Building garage Docker image from source](docker_dev.md)
 
-----
+---
 
-**This page was authored by Gitanshu Sardana ([@gitanshu](https://github.com
-/gitanshu>)).**
+**This page was authored by Gitanshu Sardana
+([@gitanshu](https://github.com/gitanshu>)).**

--- a/docs/user/docker.md
+++ b/docs/user/docker.md
@@ -115,16 +115,16 @@ docker run \
 
 ## `garage-nvidia` image
 
-The garage NVIDIA images come with CUDA 10.1 and cuDNN 7.6 (required for
-TensorFlow >= 2.1.0).
+The garage NVIDIA images come with CUDA 11.0 and cuDNN 8.0 (required for
+TensorFlow >= 2.4.0).
 
 ### Prerequisites for `garage-nvidia` image
 
 Additional to the prerequisites for the headless image, make sure to have:
 
 - [Install the latest NVIDIA driver](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/),
-  tested on nvidia driver version 440.100. CUDA 10.1 requires a minimum of
-  version 418.39.
+  tested on nvidia driver version 455.45.01. CUDA 11.0 requires a minimum of
+  version 450.36.06.
 - [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
 
 Tested on Ubuntu 18.04 and 20.04.
@@ -197,8 +197,8 @@ docker run \
 
 ### Using a different CUDA version
 
-The `garage-nvidia` Docker image uses `nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04`
-as the parent image since TensorFlow requires CUDA 10.1 & cuDNN 7.6. If you
+The `garage-nvidia` Docker image uses `nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04`
+as the parent image since TensorFlow requires CUDA 11.0 & cuDNN 8.0. If you
 need to use garage with a different CUDA version, you might be able to build
 the garage-nvidia image using a different parent image by following the guide
 at [Building garage Docker image from source](docker_dev.md)

--- a/docs/user/docker.md
+++ b/docs/user/docker.md
@@ -115,17 +115,16 @@ docker run \
 
 ## `garage-nvidia` image
 
-The garage NVIDIA images come with CUDA 10.2 and cuDNN 7.6 (required for
-TensorFlow).
+The garage NVIDIA images come with CUDA 10.1 and cuDNN 7.6 (required for
+TensorFlow >= 2.1.0).
 
 ### Prerequisites for `garage-nvidia` image
 
 Additional to the prerequisites for the headless image, make sure to have:
 
 - [Install the latest NVIDIA driver](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/),
-  tested on nvidia driver version 440.100. CUDA 10.2 requires a minimum of
-  version 440.33. For older driver versions, see [Using a different driver
-   version](#using-a-different-driver-version)
+  tested on nvidia driver version 440.100. CUDA 10.1 requires a minimum of
+  version 418.39.
 - [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
 
 Tested on Ubuntu 18.04 and 20.04.
@@ -196,13 +195,13 @@ docker run \
   python examples/tf/trpo_cartpole.py
 ```
 
-### Using a different driver version
+### Using a different CUDA version
 
-The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
-as the parent image which requires NVIDIA driver version 440.33+. If you need
-to use garage with a different driver version, you might be able to build the
-garage-nvidia image using a different parent image by following the guide at
-[Building garage Docker image from source](docker_dev.md)
+The `garage-nvidia` Docker image uses `nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04`
+as the parent image since TensorFlow requires CUDA 10.1 & cuDNN 7.6. If you
+need to use garage with a different CUDA version, you might be able to build
+the garage-nvidia image using a different parent image by following the guide
+at [Building garage Docker image from source](docker_dev.md)
 
 ---
 

--- a/docs/user/docker_dev.md
+++ b/docs/user/docker_dev.md
@@ -1,0 +1,137 @@
+# Build garage docker image from source
+
+Garage source comes with a Makefile that contains recipes for building
+different garage docker images.
+
+Garage uses multi-stage docker builds with the Docker BuildKit backend. The
+BuildKit backend is opt-in and needs to be enabled by setting environment
+variable `DOCKER_BUILDKIT=1` in your shell. The Makefile takes care of that
+for you.
+
+The important docker related `make` targets are:
+
+- `run-dev`: builds and runs the docker image with your copy of garage source
+ installed. This builds the `garage-dev` target in Dockerfile and the
+ resulting image is tagged as `rlworkgroup/garage-dev`
+- `run-dev-nvidia`: same as `run-dev` with CUDA 10.2 and cuDNN for taking
+ advantage of NVIDIA GPUs and also supports environment visualization. The
+ build target is `garage-dev-nvidia` and the resulting image is tagged as
+ `rlworkgroup/garage-dev-nvidia`
+- `run-dev-nvidia-headless`: same as `run-dev-nvidia` but without support for
+ environment visualization. Suitable for running in headless mode for
+ machines without a display.
+
+
+## Prerequisites
+
+Be aware of the following prerequisites to build the image.
+
+- Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce)
+  version 19.03 or higher. Tested on version 19.03.12.
+
+Tested on Ubuntu 16.04, 18.04 & 20.04.
+
+### Build and run the `garage-dev` image
+
+To build and run the headless image, first clone the garage repository,
+move to the root folder of your local repository and then execute;
+
+```
+make run-dev RUN_CMD="python examples/tf/trpo_cartpole.py"
+```
+
+Where RUN_CMD specifies the executable to run in the container.
+
+The previous command adds a volume from the `data` folder inside your cloned
+garage repository to the `data` folder in the garage container, so any
+experiment results ran in the container will be saved in the `data` folder
+inside your cloned repository. The Makefile uses the same username and uid as
+your current local account to create the default user in the docker images.
+This keeps things simple by allowing the docker user to write to the data
+directory without giving explicit permission.
+
+
+By default, docker generates random names for containers. If you want to specify
+a name for the container, you can do so with the variable `CONTAINER_NAME`. As a
+side effect, this will output the results in `data/$CONTAINER_NAME` directory
+instead of the `data` directory.
+
+```
+make run-dev RUN_CMD="..." CONTAINER_NAME="my_container_123"
+```
+
+This will output results in `data/my_container_123` directory.
+
+If you need to use MuJoCo, you need to place your key at `~/.mujoco/mjkey.txt`
+or specify the corresponding path through the MJKEY_PATH variable:
+
+```
+make run-dev RUN_CMD="..." MJKEY_PATH="/home/user/mjkey.txt"
+```
+
+If you require to pass additional arguments to docker build and run commands,
+you can use the variables BUILD_ARGS and RUN_ARGS, for example:
+
+```
+make run-dev BUILD_ARGS="--build-arg MY_VAR=123" RUN_ARGS="-e MY_VAR=123"
+```
+
+### Prerequisites for NVIDIA image
+
+Additional to the prerequisites for the `garage` image, make sure to have:
+
+- [Install the latest NVIDIA driver](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/),
+  tested on nvidia driver version 440.100. CUDA 10.2 requires a minimum of
+  version 440.33. For older driver versions, see [Using a different driver
+   version](#using-a-different-driver-version)
+- [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
+
+Tested on Ubuntu 18.04 & 20.04.
+
+### Build and run the NVIDIA image
+
+The same rules for the headless image apply here, except that the target name
+is:
+
+```
+make run-dev-nvidia ...
+```
+
+This make command builds the NVIDIA image and runs it in a non-headless mode.
+It will not work on headless machines. You can run the NVIDIA in a headless
+state using the following target:
+
+```
+make run-dev-nvidia-headless ...
+```
+
+### Expose GPUs for use
+
+By default, `garage-nvidia` uses all of your gpus. If you want to customize
+which GPUs are used and/or want to set the GPU capabilities exposed, as
+described in official docker documentation
+[here](https://docs.docker.com/config/containers/resource_constraints/#gpu),
+you can pass the desired values to `--gpus` option using the variable GPUS. For
+example:
+
+```
+make run-nvidia GPUS="device=0,2"
+```
+
+### Using a different NVIDIA driver version
+
+The garage-nvidia docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
+as the parent image which requires NVIDIA driver version 440.33+. If you need
+to use garage with a different driver version, you might be able to build the
+`garage-nvidia` image from scratch using a different parent image using the
+variable `PARENT_IMAGE`.
+
+```
+make run-nvidia PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04" ...
+```
+
+You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub.docker.com/r/nvidia/cuda/tags)
+
+----
+
+This page was authored by Angel Ivan Gonzalez ([@gonzaiva](https://github.com/gonzaiva)), with contributions from Gitanshu Sardana ([@gitanshu](https://github.com/gitanshu>)).

--- a/docs/user/docker_dev.md
+++ b/docs/user/docker_dev.md
@@ -1,16 +1,16 @@
-# Build garage docker image from source
+# Build garage Docker image from source
 
-Garage source comes with a Makefile that contains recipes for building
-different garage docker images.
+Garage source comes with a Makefile that contains recipes for building and
+running different Docker configurations for garage
 
-Garage uses multi-stage docker builds with the Docker BuildKit backend. The
+Garage uses multi-stage Docker builds with the Docker BuildKit backend. The
 BuildKit backend is opt-in and needs to be enabled by setting environment
 variable `DOCKER_BUILDKIT=1` in your shell. The Makefile takes care of that
 for you.
 
-The important docker related `make` targets are:
+The important Docker related `make` targets are:
 
-- `run-dev`: builds and runs the docker image with your copy of garage source
+- `run-dev`: builds and runs the Docker image with your copy of garage source
  installed. This builds the `garage-dev` target in Dockerfile and the
  resulting image is tagged as `rlworkgroup/garage-dev`
 - `run-dev-nvidia`: same as `run-dev` with CUDA 10.2 and cuDNN for taking
@@ -46,12 +46,12 @@ The previous command adds a volume from the `data` folder inside your cloned
 garage repository to the `data` folder in the garage container, so any
 experiment results ran in the container will be saved in the `data` folder
 inside your cloned repository. The Makefile uses the same username and uid as
-your current local account to create the default user in the docker images.
-This keeps things simple by allowing the docker user to write to the data
+your current local account to create the default user in the Docker images.
+This keeps things simple by allowing the Docker user to write to the data
 directory without giving explicit permission.
 
 
-By default, docker generates random names for containers. If you want to specify
+By default, Docker generates random names for containers. If you want to specify
 a name for the container, you can do so with the variable `CONTAINER_NAME`. As a
 side effect, this will output the results in `data/$CONTAINER_NAME` directory
 instead of the `data` directory.
@@ -109,18 +109,18 @@ make run-dev-nvidia-headless ...
 
 By default, `garage-nvidia` uses all of your gpus. If you want to customize
 which GPUs are used and/or want to set the GPU capabilities exposed, as
-described in official docker documentation
+described in official Docker documentation
 [here](https://docs.docker.com/config/containers/resource_constraints/#gpu),
 you can pass the desired values to `--gpus` option using the variable GPUS. For
 example:
 
 ```
-make run-nvidia GPUS="device=0,2"
+make run-nvidia GPUS="device=0,2" ...
 ```
 
 ### Using a different NVIDIA driver version
 
-The garage-nvidia docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
+The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
 as the parent image which requires NVIDIA driver version 440.33+. If you need
 to use garage with a different driver version, you might be able to build the
 `garage-nvidia` image from scratch using a different parent image using the
@@ -134,4 +134,6 @@ You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub
 
 ----
 
-This page was authored by Angel Ivan Gonzalez ([@gonzaiva](https://github.com/gonzaiva)), with contributions from Gitanshu Sardana ([@gitanshu](https://github.com/gitanshu>)).
+**This page was authored by Gitanshu Sardana ([@gitanshu](https://github.com
+/gitanshu>)), with contributions from Angel Ivan Gonzalez ([@gonzaiva](https://github
+.com/gonzaiva))**

--- a/docs/user/docker_dev.md
+++ b/docs/user/docker_dev.md
@@ -13,7 +13,7 @@ The important Docker related `make` targets are:
 - `run-dev`: builds and runs the Docker image with your copy of garage source
  installed. This builds the `garage-dev` target in Dockerfile and the
  resulting image is tagged as `rlworkgroup/garage-dev`
-- `run-dev-nvidia`: same as `run-dev` with CUDA 10.1 and cuDNN 7.6 for taking
+- `run-dev-nvidia`: same as `run-dev` with CUDA 11.0 and cuDNN 8.0 for taking
  advantage of NVIDIA GPUs and also supports environment visualization. The
  build target is `garage-dev-nvidia` and the resulting image is tagged as
  `rlworkgroup/garage-dev-nvidia`
@@ -81,8 +81,8 @@ make run-dev BUILD_ARGS="--build-arg MY_VAR=123" RUN_ARGS="-e MY_VAR=123"
 Additional to the prerequisites for the `garage` image, make sure to have:
 
 - [Install the latest NVIDIA driver](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/),
-  tested on nvidia driver version 440.100. CUDA 10.1 requires a minimum of
-  version 418.39. If you need a different CUDA version, see
+  tested on nvidia driver version 455.45.01. CUDA 11.0 requires a minimum of
+  version 450.36.06. If you need a different CUDA version, see
   [Using a different CUDA version](#using-a-different-cuda-version)
 - [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
 
@@ -120,14 +120,14 @@ make run-dev-nvidia GPUS="device=0,2" ...
 
 ### Using a different CUDA version
 
-The `garage-nvidia` Docker image uses `nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04`
-as the parent image which requires NVIDIA driver version 418.39+. If you need
+The `garage-nvidia` Docker image uses `nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04`
+as the parent image which requires NVIDIA driver version 450.36.06+. If you need
 to use garage with a different CUDA version, you might be able to build the
 `garage-nvidia` image from scratch using a different parent image using the
 variable `PARENT_IMAGE`.
 
 ```bash
-make run-dev-nvidia PARENT_IMAGE="nvidia/cuda:11.1-cudnn8-runtime-ubuntu18.04" ...
+make run-dev-nvidia PARENT_IMAGE="nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04" ...
 ```
 
 You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub.docker.com/r/nvidia/cuda/tags)

--- a/docs/user/docker_dev.md
+++ b/docs/user/docker_dev.md
@@ -1,6 +1,6 @@
 # Build garage Docker image from source
 
-Garage source comes with a Makefile that contains recipes for building and
+G~~~~arage source comes with a Makefile that contains recipes for building and
 running different Docker configurations for garage
 
 Garage uses multi-stage Docker builds with the Docker BuildKit backend. The
@@ -22,25 +22,25 @@ The important Docker related `make` targets are:
  machines without a display.
 
 
-## Prerequisites
+### Prerequisites
 
 Be aware of the following prerequisites to build the image.
 
 - Install [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-docker-ce)
-  version 19.03 or higher. Tested on version 19.03.12.
+  version 19.03 or higher. Tested on version 19.03.
 
-Tested on Ubuntu 16.04, 18.04 & 20.04.
+Tested on Ubuntu 16.04, 18.04 and 20.04.
 
 ### Build and run the `garage-dev` image
 
 To build and run the headless image, first clone the garage repository,
 move to the root folder of your local repository and then execute;
 
-```
+```bash
 make run-dev RUN_CMD="python examples/tf/trpo_cartpole.py"
 ```
 
-Where RUN_CMD specifies the executable to run in the container.
+Where `RUN_CMD` specifies the executable to run in the container.
 
 The previous command adds a volume from the `data` folder inside your cloned
 garage repository to the `data` folder in the garage container, so any
@@ -56,7 +56,7 @@ a name for the container, you can do so with the variable `CONTAINER_NAME`. As a
 side effect, this will output the results in `data/$CONTAINER_NAME` directory
 instead of the `data` directory.
 
-```
+```bash
 make run-dev RUN_CMD="..." CONTAINER_NAME="my_container_123"
 ```
 
@@ -65,14 +65,14 @@ This will output results in `data/my_container_123` directory.
 If you need to use MuJoCo, you need to place your key at `~/.mujoco/mjkey.txt`
 or specify the corresponding path through the MJKEY_PATH variable:
 
-```
+```bash
 make run-dev RUN_CMD="..." MJKEY_PATH="/home/user/mjkey.txt"
 ```
 
 If you require to pass additional arguments to docker build and run commands,
 you can use the variables BUILD_ARGS and RUN_ARGS, for example:
 
-```
+```bash
 make run-dev BUILD_ARGS="--build-arg MY_VAR=123" RUN_ARGS="-e MY_VAR=123"
 ```
 
@@ -93,7 +93,7 @@ Tested on Ubuntu 18.04 & 20.04.
 The same rules for the headless image apply here, except that the target name
 is:
 
-```
+```bash
 make run-dev-nvidia ...
 ```
 
@@ -101,7 +101,7 @@ This make command builds the NVIDIA image and runs it in a non-headless mode.
 It will not work on headless machines. You can run the NVIDIA in a headless
 state using the following target:
 
-```
+```bash
 make run-dev-nvidia-headless ...
 ```
 
@@ -114,7 +114,7 @@ described in official Docker documentation
 you can pass the desired values to `--gpus` option using the variable GPUS. For
 example:
 
-```
+```bash
 make run-nvidia GPUS="device=0,2" ...
 ```
 
@@ -126,14 +126,15 @@ to use garage with a different driver version, you might be able to build the
 `garage-nvidia` image from scratch using a different parent image using the
 variable `PARENT_IMAGE`.
 
-```
+```bash
 make run-nvidia PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04" ...
 ```
 
 You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub.docker.com/r/nvidia/cuda/tags)
 
-----
+---
 
-**This page was authored by Gitanshu Sardana ([@gitanshu](https://github.com
-/gitanshu>)), with contributions from Angel Ivan Gonzalez ([@gonzaiva](https://github
-.com/gonzaiva))**
+**This page was authored by Gitanshu Sardana
+([@gitanshu](https://github.com/gitanshu>)),
+with contributions from Angel Ivan Gonzalez
+([@gonzaiva](https://github.com/gonzaiva))**

--- a/docs/user/docker_dev.md
+++ b/docs/user/docker_dev.md
@@ -1,6 +1,6 @@
 # Build garage Docker image from source
 
-G~~~~arage source comes with a Makefile that contains recipes for building and
+Garage source comes with a Makefile that contains recipes for building and
 running different Docker configurations for garage
 
 Garage uses multi-stage Docker builds with the Docker BuildKit backend. The
@@ -13,7 +13,7 @@ The important Docker related `make` targets are:
 - `run-dev`: builds and runs the Docker image with your copy of garage source
  installed. This builds the `garage-dev` target in Dockerfile and the
  resulting image is tagged as `rlworkgroup/garage-dev`
-- `run-dev-nvidia`: same as `run-dev` with CUDA 10.2 and cuDNN for taking
+- `run-dev-nvidia`: same as `run-dev` with CUDA 10.1 and cuDNN 7.6 for taking
  advantage of NVIDIA GPUs and also supports environment visualization. The
  build target is `garage-dev-nvidia` and the resulting image is tagged as
  `rlworkgroup/garage-dev-nvidia`
@@ -81,9 +81,9 @@ make run-dev BUILD_ARGS="--build-arg MY_VAR=123" RUN_ARGS="-e MY_VAR=123"
 Additional to the prerequisites for the `garage` image, make sure to have:
 
 - [Install the latest NVIDIA driver](https://tecadmin.net/install-latest-nvidia-drivers-ubuntu/),
-  tested on nvidia driver version 440.100. CUDA 10.2 requires a minimum of
-  version 440.33. For older driver versions, see [Using a different driver
-   version](#using-a-different-driver-version)
+  tested on nvidia driver version 440.100. CUDA 10.1 requires a minimum of
+  version 418.39. If you need a different CUDA version, see
+  [Using a different CUDA version](#using-a-different-cuda-version)
 - [Install nvidia-container-runtime](https://github.com/NVIDIA/nvidia-container-runtime#installation)
 
 Tested on Ubuntu 18.04 & 20.04.
@@ -115,19 +115,19 @@ you can pass the desired values to `--gpus` option using the variable GPUS. For
 example:
 
 ```bash
-make run-nvidia GPUS="device=0,2" ...
+make run-dev-nvidia GPUS="device=0,2" ...
 ```
 
-### Using a different NVIDIA driver version
+### Using a different CUDA version
 
-The `garage-nvidia` Docker image uses `nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04`
-as the parent image which requires NVIDIA driver version 440.33+. If you need
-to use garage with a different driver version, you might be able to build the
+The `garage-nvidia` Docker image uses `nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04`
+as the parent image which requires NVIDIA driver version 418.39+. If you need
+to use garage with a different CUDA version, you might be able to build the
 `garage-nvidia` image from scratch using a different parent image using the
 variable `PARENT_IMAGE`.
 
 ```bash
-make run-nvidia PARENT_IMAGE="nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04" ...
+make run-dev-nvidia PARENT_IMAGE="nvidia/cuda:11.1-cudnn8-runtime-ubuntu18.04" ...
 ```
 
 You can find the required parent images at [NVIDIA CUDA's DockerHub](https://hub.docker.com/r/nvidia/cuda/tags)


### PR DESCRIPTION
closes #1833, closes #1830 , closes #1805, closes #1863 

What this PR does?
- Create a docker target that installs latest garage release from pypi called `garage` and the corresponding tag would be `rlworkgroup/garage`. No more `garage-headless`
- Remove suffix `-18.04` from Dockerfile targets because they don't really provide any relevance. The way Dockerfile is setup, if we wanted to switch from 18.04 to 20.04, we either hardcode it in Dockerfile, or pass it using the `PARENT_IMAGE` variable, so hardcoded suffixes don't make much sense to me.
- Splits docker docs into user and dev docs. User docs assumes you are working with garage images directly from docker hub and not building from source. Dev docs assume you want to build the images from source.
- Correspondingly, this PR updates the Makefile to expose targets `run-dev`, `run-dev-nvidia`, `run-dev-nvidia-headless` instead of `run-headless`, `run-nvidia` and `run-nvidia-headless`.

Definitely looking for feedback on the target naming. Also, I feel the dev docs could've been better but I don't wanna sit on this anymore, so opening it for feedback. Nitpicking also appreciated. 

