### PR TITLE
Blacklist KellyCoinflip from nightly build GymEnv tests

### DIFF
--- a/tests/garage/tf/envs/test_gym_base.py
+++ b/tests/garage/tf/envs/test_gym_base.py
@@ -19,6 +19,9 @@ class TestGymEnv:
         if spec._env_name.startswith('CarRacing'):
             pytest.skip(
                 'CarRacing-* envs bundled in atari-py 0.2.x don\'t load')
+        if spec._env_name.startswith('KellyCoinflip'):
+            pytest.skip(
+                'KellyCoinflip env has tuple observation, not np.array')
         if 'Kuka' in spec.id:
             # Kuka environments calls py_bullet.resetSimulation() in reset()
             # unconditionally, which globally resets other simulations. So


### PR DESCRIPTION
Fix for nightly build issue: https://github.com/rlworkgroup/garage/runs/1319831555?check_suite_focus=true

KellyCoinflipGeneralized env has tuple observation instead of np.array: https://github.com/openai/gym/blob/master/gym/envs/toy_text/kellycoinflip.py