### PR TITLE
Add python 3.8 in metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Except for an issue with mocking, which shouldn't affect usability, everything else seems to work fine. 

https://github.com/rlworkgroup/garage/actions/runs/336779170