### PR TITLE
Improve data types

### DIFF
--- a/examples/torch/dqn_atari.py
+++ b/examples/torch/dqn_atari.py
@@ -143,9 +143,6 @@ def dqn_atari(ctxt=None,
     set_seed(seed)
     trainer = Trainer(ctxt)
 
-    env.spec.observation_space = env.observation_space
-    env.spec.action_space = env.action_space
-
     n_epochs = hyperparams['n_epochs']
     steps_per_epoch = hyperparams['steps_per_epoch']
     sampler_batch_size = hyperparams['sampler_batch_size']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """setuptools based setup module."""
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -26,6 +27,9 @@ REQUIRED = [
     'torch>=1.0.0,!=1.5.0',
     'torchvision>=0.2.1',
 ]
+
+if sys.version_info < (3, 7):
+    REQUIRED.append('dataclasses==0.7')
 
 # Dependencies for optional features
 EXTRAS = {}

--- a/src/garage/__init__.py
+++ b/src/garage/__init__.py
@@ -1,8 +1,9 @@
 """Garage Base."""
 # yapf: disable
-from garage._dtypes import (EpisodeBatch, InOutSpec, StepType, TimeStep,
-                            TimeStepBatch)
-from garage._environment import Environment, EnvSpec, EnvStep, Wrapper
+
+from garage._dtypes import EpisodeBatch, TimeStep, TimeStepBatch
+from garage._environment import (Environment, EnvSpec, EnvStep, InOutSpec,
+                                 StepType, Wrapper)
 from garage._functions import (_Default, log_multitask_performance,
                                log_performance, make_optimizer,
                                obtain_evaluation_episodes, rollout)

--- a/src/garage/np/__init__.py
+++ b/src/garage/np/__init__.py
@@ -2,8 +2,9 @@
 # yapf: disable
 from garage.np._functions import (concat_tensor_dict_list, discount_cumsum,
                                   explained_variance_1d, flatten_tensors,
-                                  pad_tensor, pad_tensor_dict, pad_tensor_n,
-                                  rrse, slice_nested_dict, sliding_window,
+                                  pad_batch_array, pad_tensor, pad_tensor_dict,
+                                  pad_tensor_n, rrse, slice_nested_dict,
+                                  sliding_window,
                                   stack_and_pad_tensor_dict_list,
                                   stack_tensor_dict_list, truncate_tensor_dict,
                                   unflatten_tensors)
@@ -15,6 +16,7 @@ __all__ = [
     'explained_variance_1d',
     'flatten_tensors',
     'unflatten_tensors',
+    'pad_batch_array',
     'pad_tensor',
     'pad_tensor_n',
     'pad_tensor_dict',

--- a/src/garage/replay_buffer/path_buffer.py
+++ b/src/garage/replay_buffer/path_buffer.py
@@ -144,7 +144,7 @@ class PathBuffer:
                              episode_infos={},
                              observations=samples['observations'],
                              actions=samples['actions'],
-                             rewards=samples['rewards'],
+                             rewards=samples['rewards'].flatten(),
                              next_observations=samples['next_observations'],
                              step_types=step_types,
                              env_infos={},

--- a/src/garage/tf/algos/_rl2npo.py
+++ b/src/garage/tf/algos/_rl2npo.py
@@ -2,7 +2,7 @@
 from dowel import logger, tabular
 import numpy as np
 
-from garage.np import explained_variance_1d
+from garage.np import explained_variance_1d, pad_batch_array
 from garage.tf.algos import NPO
 
 
@@ -66,7 +66,7 @@ class RL2NPO(NPO):
 
         """
         # Baseline predictions with all zeros for feeding inputs of Tensorflow
-        baselines = np.zeros_like(episodes.padded_rewards)
+        baselines = np.zeros((len(episodes.lengths), max(episodes.lengths)))
 
         returns = self._fit_baseline_with_data(episodes, baselines)
         baselines = self._get_baseline_prediction(episodes)
@@ -113,4 +113,5 @@ class RL2NPO(NPO):
             self._baseline.predict({'observations': obs})
             for obs in episodes.observations_list
         ]
-        return episodes.pad_to_last(np.concatenate(obs))
+        return pad_batch_array(np.concatenate(obs), episodes.lengths,
+                               self.max_episode_length)

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -354,10 +354,10 @@ class DDPG(RLAlgorithm):
             self._buffer_batch_size)
 
         observations = timesteps.observations
-        rewards = timesteps.rewards
+        rewards = timesteps.rewards.reshape(-1, 1)
         actions = timesteps.actions
         next_observations = timesteps.next_observations
-        terminals = timesteps.terminals
+        terminals = timesteps.terminals.reshape(-1, 1)
 
         rewards *= self._reward_scale
 

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -262,10 +262,10 @@ class DQN(RLAlgorithm):
             self._buffer_batch_size)
 
         observations = timesteps.observations
-        rewards = timesteps.rewards
+        rewards = timesteps.rewards.reshape(-1, 1)
         actions = self._env_spec.action_space.unflatten_n(timesteps.actions)
         next_observations = timesteps.next_observations
-        dones = timesteps.terminals
+        dones = timesteps.terminals.reshape(-1, 1)
 
         if isinstance(self._env_spec.observation_space, akro.Image):
             if len(observations.shape[1:]) < len(

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorflow as tf
 
 from garage import log_performance, make_optimizer
-from garage.np import explained_variance_1d
+from garage.np import explained_variance_1d, pad_batch_array
 from garage.np.algos import RLAlgorithm
 from garage.sampler import RaySampler
 from garage.tf import (center_advs, compile_function, compute_advantages,
@@ -194,7 +194,8 @@ class NPO(RLAlgorithm):
             self._baseline.predict({'observations': obs})
             for obs in episodes.observations_list
         ]
-        baselines = episodes.pad_to_last(np.concatenate(obs))
+        baselines = pad_batch_array(np.concatenate(obs), episodes.lengths,
+                                    self.max_episode_length)
 
         # -- Stage: Run and calculate performance of the algorithm
         undiscounted_returns = log_performance(itr,
@@ -496,7 +497,9 @@ class NPO(RLAlgorithm):
             self._env_spec.action_space.flatten_n(act)
             for act in episodes.actions_list
         ]
-        padded_actions = episodes.pad_to_last(np.concatenate(actions))
+        padded_actions = pad_batch_array(np.concatenate(actions),
+                                         episodes.lengths,
+                                         self.max_episode_length)
 
         # pylint: disable=unexpected-keyword-arg
         policy_opt_input_values = self._policy_opt_inputs._replace(

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -8,6 +8,7 @@ import scipy.optimize
 import tensorflow as tf
 
 from garage import _Default, log_performance, make_optimizer
+from garage.np import pad_batch_array
 from garage.np.algos import RLAlgorithm
 from garage.sampler import RaySampler
 from garage.tf import (compile_function, flatten_inputs, graph_inputs,
@@ -498,7 +499,9 @@ class REPS(RLAlgorithm):  # noqa: D416
             self._env_spec.action_space.flatten_n(act)
             for act in episodes.actions_list
         ]
-        padded_actions = episodes.pad_to_last(np.concatenate(actions))
+        padded_actions = pad_batch_array(np.concatenate(actions),
+                                         episodes.lengths,
+                                         self.max_episode_length)
 
         # pylint: disable=unexpected-keyword-arg
         policy_opt_input_values = self._policy_opt_inputs._replace(

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -375,10 +375,10 @@ class TD3(RLAlgorithm):
             self._buffer_batch_size)
 
         observations = timesteps.observations
-        rewards = timesteps.rewards
+        rewards = timesteps.rewards.reshape(-1, 1)
         actions = timesteps.actions
         next_observations = timesteps.next_observations
-        terminals = timesteps.terminals
+        terminals = timesteps.terminals.reshape(-1, 1)
 
         rewards *= self._reward_scale
 

--- a/src/garage/torch/_functions.py
+++ b/src/garage/torch/_functions.py
@@ -10,13 +10,14 @@ This collection of functions can be used to manage the following:
     - Updating model parameters
 """
 import copy
+import dataclasses
 
 import akro
 import torch
 from torch import nn
 import torch.nn.functional as F
 
-from garage import Wrapper
+from garage import EnvSpec, Wrapper
 
 _USE_GPU = False
 _DEVICE = None
@@ -385,9 +386,7 @@ class TransposeImage(Wrapper):
     @property
     def spec(self):
         """EnvSpec: The environment specification."""
-        env_spec = copy.deepcopy(self._env.spec)
-        env_spec.observation_space = self.observation_space
-        return env_spec
+        return EnvSpec(self.observation_space, self._env.spec.action_space)
 
     def step(self, action):
         """Step the wrapped env.
@@ -401,4 +400,4 @@ class TransposeImage(Wrapper):
         """
         env_step = super().step(action)
         obs = env_step.observation.transpose(2, 0, 1)
-        return env_step._replace(observation=obs)
+        return dataclasses.replace(env_step, observation=obs)

--- a/src/garage/torch/algos/bc.py
+++ b/src/garage/torch/algos/bc.py
@@ -6,7 +6,7 @@ from dowel import tabular
 import numpy as np
 import torch
 
-from garage import (_Default, EpisodeBatch, log_performance, make_optimizer,
+from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes, TimeStepBatch)
 from garage.np.algos.rl_algorithm import RLAlgorithm
 from garage.np.policies import Policy
@@ -148,8 +148,7 @@ class BC(RLAlgorithm):
 
         """
         if isinstance(self._source, Policy):
-            batch = EpisodeBatch.from_list(self._env_spec,
-                                           trainer.obtain_samples(epoch))
+            batch = trainer.obtain_episodes(epoch)
             log_performance(epoch, batch, 1.0, prefix='Expert')
             return batch
         else:

--- a/tests/garage/experiment/test_task_sampler.py
+++ b/tests/garage/experiment/test_task_sampler.py
@@ -73,7 +73,7 @@ def test_set_task_task_sampler_ml10():
     for env in envs:
         env.reset()
     action = envs[0].action_space.sample()
-    rewards = [env.step(action)[1] for env in envs]
+    rewards = [env.step(action).reward for env in envs]
     assert np.var(rewards) > 0
     env = envs[0]
     env.close = unittest.mock.MagicMock(name='env.close')

--- a/tests/garage/np/test_functions.py
+++ b/tests/garage/np/test_functions.py
@@ -1,11 +1,11 @@
 # yapf: disable
+import warnings
+
 import numpy as np
 
-from garage.np import (concat_tensor_dict_list,
-                       explained_variance_1d,
-                       pad_tensor,
-                       stack_and_pad_tensor_dict_list,
-                       stack_tensor_dict_list)
+from garage.np import (concat_tensor_dict_list, explained_variance_1d,
+                       pad_batch_array, pad_tensor,
+                       stack_and_pad_tensor_dict_list, stack_tensor_dict_list)
 
 # yapf: enable
 
@@ -76,3 +76,13 @@ def test_stack_and_pad_tensor_dict_list():
                           np.array([[1, 1, 0, 0, 0], [1, 1, 0, 0, 0]]))
     assert np.array_equal(result['info']['baba'],
                           np.array([[2, 2, 0, 0, 0], [2, 2, 0, 0, 0]]))
+
+
+def test_pad_batch_array_warns_on_too_long():
+    with warnings.catch_warnings(record=True) as warns:
+        warnings.simplefilter('always')
+        result = pad_batch_array(np.ones(9), [5, 2, 2], 2)
+        assert len(warns) == 1
+        assert 'longer length than requested' in str(warns[0].message)
+    assert (result == np.asarray([[1., 1., 1., 1., 1.], [1., 1., 0., 0., 0.],
+                                  [1., 1., 0., 0., 0.]])).all()

--- a/tests/garage/torch/algos/test_bc.py
+++ b/tests/garage/torch/algos/test_bc.py
@@ -2,13 +2,11 @@
 import numpy as np
 import ray
 
-from garage import TimeStepBatch
 from garage.envs import PointEnv
 from garage.experiment import deterministic
 from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch.algos import BC
-from garage.torch.policies import (DeterministicMLPPolicy,
-                                   GaussianMLPPolicy,
+from garage.torch.policies import (DeterministicMLPPolicy, GaussianMLPPolicy,
                                    Policy)
 from garage.trainer import Trainer
 
@@ -127,7 +125,7 @@ def expert_source(env, goal, max_episode_length, n_eps):
     expert_sampler = LocalSampler.from_worker_factory(workers, expert, env)
     for _ in range(n_eps):
         eps_batch = expert_sampler.obtain_samples(0, max_episode_length, None)
-        yield TimeStepBatch.from_episode_batch(eps_batch)
+        yield eps_batch
 
 
 def test_bc_point_sample_batches():


### PR DESCRIPTION
This change converts all dtypes to use dataclass, and makes EpisodeBatch
a subclass of TimeStepBatch.

This required slightly changing some shapes, to make the types
completely consistent.

I also merged and re-wrote the checking code.
The error messages now have a more consistent pattern of "\<thing\> has
\<property\> but must have \<correct property\> to match \<ground truth\>".

All core dtypes have (including EnvSpec) have now also been made immutable.