### PR TITLE
Construct sampler in the launcher

### DIFF
--- a/docs/user/experiments.rst
+++ b/docs/user/experiments.rst
@@ -35,6 +35,7 @@ simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
   from garage.envs import GymEnv
   from garage.experiment.deterministic import set_seed
   from garage.np.baselines import LinearFeatureBaseline
+  from garage.sampler import RaySampler
   from garage.tf.algos import TRPO
   from garage.tf.policies import CategoricalMLPPolicy
   from garage.trainer import TFTrainer
@@ -61,9 +62,15 @@ simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
 
           baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+          sampler = RaySampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
+
           algo = TRPO(env_spec=env.spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=0.99,
                       max_kl_step=0.01)
 

--- a/examples/np/cem_cartpole.py
+++ b/examples/np/cem_cartpole.py
@@ -11,6 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.algos import CEM
+from garage.sampler import LocalSampler
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
 
@@ -36,8 +37,14 @@ def cem_cartpole(ctxt=None, seed=1):
 
         n_samples = 20
 
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
+
         algo = CEM(env_spec=env.spec,
                    policy=policy,
+                   sampler=sampler,
                    best_frac=0.05,
                    n_samples=n_samples)
 

--- a/examples/np/cma_es_cartpole.py
+++ b/examples/np/cma_es_cartpole.py
@@ -12,6 +12,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.algos import CMAES
+from garage.sampler import LocalSampler
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
 
@@ -37,7 +38,15 @@ def cma_es_cartpole(ctxt=None, seed=1):
 
         n_samples = 20
 
-        algo = CMAES(env_spec=env.spec, policy=policy, n_samples=n_samples)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
+
+        algo = CMAES(env_spec=env.spec,
+                     policy=policy,
+                     sampler=sampler,
+                     n_samples=n_samples)
 
         trainer.setup(algo, env)
         trainer.train(n_epochs=100, batch_size=1000)

--- a/examples/np/tutorial_cem.py
+++ b/examples/np/tutorial_cem.py
@@ -18,13 +18,14 @@ class SimpleCEM:
     Args:
         env_spec (EnvSpec): Environment specification.
         policy (Policy): Action policy.
+        sampler (garage.sampler.Sampler): Sampler.
 
     """
-    sampler_cls = LocalSampler
 
-    def __init__(self, env_spec, policy):
+    def __init__(self, env_spec, policy, sampler):
         self.env_spec = env_spec
         self.policy = policy
+        self.sampler = sampler
         self.max_episode_length = env_spec.max_episode_length
         self._discount = 0.99
         self._extra_std = 1
@@ -117,7 +118,11 @@ def tutorial_cem(ctxt=None):
     with TFTrainer(ctxt) as trainer:
         env = GymEnv('CartPole-v1')
         policy = CategoricalMLPPolicy(env.spec)
-        algo = SimpleCEM(env.spec, policy)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
+        algo = SimpleCEM(env.spec, policy, sampler)
         trainer.setup(algo, env)
         trainer.train(n_epochs=100, batch_size=1000)
 

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -15,6 +15,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -51,12 +52,21 @@ def ddpg_pendulum(ctxt=None, seed=1):
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,
                     policy_lr=1e-4,
                     qf_lr=1e-3,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    sampler=sampler,
                     steps_per_epoch=20,
                     target_update_tau=1e-2,
                     n_train_steps=50,

--- a/examples/tf/ddpg_pendulum.py
+++ b/examples/tf/ddpg_pendulum.py
@@ -15,7 +15,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -52,13 +52,11 @@ def ddpg_pendulum(ctxt=None, seed=1):
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
 
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -8,6 +8,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteMLPQFunction
@@ -41,11 +42,21 @@ def dqn_cartpole(ctxt=None, seed=1):
                                                  max_epsilon=1.0,
                                                  min_epsilon=0.02,
                                                  decay_ratio=0.1)
+
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         algo = DQN(env_spec=env.spec,
                    policy=policy,
                    qf=qf,
                    exploration_policy=exploration_policy,
                    replay_buffer=replay_buffer,
+                   sampler=sampler,
                    steps_per_epoch=steps_per_epoch,
                    qf_lr=1e-4,
                    discount=1.0,

--- a/examples/tf/dqn_cartpole.py
+++ b/examples/tf/dqn_cartpole.py
@@ -8,7 +8,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteMLPQFunction
@@ -43,13 +43,11 @@ def dqn_cartpole(ctxt=None, seed=1):
                                                  min_epsilon=0.02,
                                                  decay_ratio=0.1)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
 
         algo = DQN(env_spec=env.spec,
                    policy=policy,

--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -19,6 +19,7 @@ from garage.envs.wrappers.stack_frames import StackFrames
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteCNNQFunction
@@ -83,11 +84,20 @@ def dqn_pong(ctxt=None, seed=1, buffer_size=int(5e4), max_episode_length=500):
                                                  min_epsilon=0.02,
                                                  decay_ratio=0.1)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         algo = DQN(env_spec=env.spec,
                    policy=policy,
                    qf=qf,
                    exploration_policy=exploration_policy,
                    replay_buffer=replay_buffer,
+                   sampler=sampler,
                    qf_lr=1e-4,
                    discount=0.99,
                    min_buffer_size=int(1e4),

--- a/examples/tf/dqn_pong.py
+++ b/examples/tf/dqn_pong.py
@@ -19,7 +19,7 @@ from garage.envs.wrappers.stack_frames import StackFrames
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteCNNQFunction
@@ -84,13 +84,11 @@ def dqn_pong(ctxt=None, seed=1, buffer_size=int(5e4), max_episode_length=500):
                                                  min_epsilon=0.02,
                                                  decay_ratio=0.1)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
 
         algo = DQN(env_spec=env.spec,
                    policy=policy,

--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -11,7 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import ERWR
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -38,11 +38,10 @@ def erwr_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = ERWR(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/erwr_cartpole.py
+++ b/examples/tf/erwr_cartpole.py
@@ -11,6 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import ERWR
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -37,9 +38,16 @@ def erwr_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = ERWR(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99)
 
         trainer.setup(algo=algo, env=env)

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -10,7 +10,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import HERReplayBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -57,13 +57,11 @@ def her_ddpg_fetchreach(ctxt=None, seed=1):
                                         reward_fn=env.compute_reward,
                                         env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
 
         ddpg = DDPG(
             env_spec=env.spec,

--- a/examples/tf/her_ddpg_fetchreach.py
+++ b/examples/tf/her_ddpg_fetchreach.py
@@ -10,6 +10,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import HERReplayBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -56,6 +57,14 @@ def her_ddpg_fetchreach(ctxt=None, seed=1):
                                         reward_fn=env.compute_reward,
                                         env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         ddpg = DDPG(
             env_spec=env.spec,
             policy=policy,
@@ -63,6 +72,7 @@ def her_ddpg_fetchreach(ctxt=None, seed=1):
             qf_lr=1e-3,
             qf=qf,
             replay_buffer=replay_buffer,
+            sampler=sampler,
             target_update_tau=0.01,
             steps_per_epoch=50,
             n_train_steps=40,

--- a/examples/tf/multi_env_ppo.py
+++ b/examples/tf/multi_env_ppo.py
@@ -7,7 +7,7 @@ from garage.envs import GymEnv, normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -37,11 +37,10 @@ def multi_env_ppo(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = PPO(env_spec=env.spec,
                    policy=policy,

--- a/examples/tf/multi_env_ppo.py
+++ b/examples/tf/multi_env_ppo.py
@@ -7,6 +7,7 @@ from garage.envs import GymEnv, normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import PPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -36,9 +37,16 @@ def multi_env_ppo(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = PPO(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    gae_lambda=0.95,
                    lr_clip_range=0.2,

--- a/examples/tf/multi_env_trpo.py
+++ b/examples/tf/multi_env_trpo.py
@@ -5,7 +5,7 @@ from garage.envs import normalize, PointEnv
 from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -32,11 +32,10 @@ def multi_env_trpo(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/multi_env_trpo.py
+++ b/examples/tf/multi_env_trpo.py
@@ -5,6 +5,7 @@ from garage.envs import normalize, PointEnv
 from garage.envs.multi_env_wrapper import MultiEnvWrapper
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -31,9 +32,16 @@ def multi_env_trpo(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     gae_lambda=0.95,
                     lr_clip_range=0.2,

--- a/examples/tf/ppo_memorize_digits.py
+++ b/examples/tf/ppo_memorize_digits.py
@@ -8,6 +8,7 @@ import click
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -61,9 +62,16 @@ def ppo_memorize_digits(ctxt=None,
             hidden_sizes=(256, ),
             use_trust_region=True)  # yapf: disable
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = PPO(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    gae_lambda=0.95,
                    lr_clip_range=0.2,

--- a/examples/tf/ppo_memorize_digits.py
+++ b/examples/tf/ppo_memorize_digits.py
@@ -8,7 +8,7 @@ import click
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -62,11 +62,10 @@ def ppo_memorize_digits(ctxt=None,
             hidden_sizes=(256, ),
             use_trust_region=True)  # yapf: disable
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = PPO(env_spec=env.spec,
                    policy=policy,

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -14,6 +14,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.policies import GaussianMLPPolicy
@@ -48,6 +49,12 @@ def ppo_pendulum(ctxt=None, seed=1):
             use_trust_region=True,
         )
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         # NOTE: make sure when setting entropy_method to 'max', set
         # center_adv to False and turn off policy gradient. See
         # tf.algos.NPO for detailed documentation.
@@ -55,6 +62,7 @@ def ppo_pendulum(ctxt=None, seed=1):
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,

--- a/examples/tf/ppo_pendulum.py
+++ b/examples/tf/ppo_pendulum.py
@@ -14,7 +14,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.policies import GaussianMLPPolicy
@@ -49,11 +49,10 @@ def ppo_pendulum(ctxt=None, seed=1):
             use_trust_region=True,
         )
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         # NOTE: make sure when setting entropy_method to 'max', set
         # center_adv to False and turn off policy gradient. See

--- a/examples/tf/reps_gym_cartpole.py
+++ b/examples/tf/reps_gym_cartpole.py
@@ -13,6 +13,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import REPS
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -37,9 +38,16 @@ def reps_gym_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = REPS(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99)
 
         trainer.setup(algo, env)

--- a/examples/tf/reps_gym_cartpole.py
+++ b/examples/tf/reps_gym_cartpole.py
@@ -13,7 +13,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import REPS
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -38,11 +38,10 @@ def reps_gym_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = REPS(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/rl2_ppo_halfcheetah.py
+++ b/examples/tf/rl2_ppo_halfcheetah.py
@@ -9,7 +9,7 @@ from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 from garage.experiment import task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -55,11 +55,23 @@ def rl2_ppo_halfcheetah(ctxt, seed, max_episode_length, meta_batch_size,
 
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
+        envs = tasks.sample(meta_batch_size)
+        worker_factory = WorkerFactory(
+            max_episode_length=env_spec.max_episode_length,
+            is_tf_worker=True,
+            n_workers=meta_batch_size,
+            worker_class=RL2Worker,
+            worker_args=dict(n_episodes_per_trial=episode_per_task))
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=envs)
+
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,
                       env_spec=env_spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       episodes_per_trial=episode_per_task,
                       discount=0.99,
                       gae_lambda=0.95,
@@ -73,12 +85,7 @@ def rl2_ppo_halfcheetah(ctxt, seed, max_episode_length, meta_batch_size,
                       policy_ent_coeff=0.02,
                       center_adv=False)
 
-        trainer.setup(algo,
-                      tasks.sample(meta_batch_size),
-                      sampler_cls=LocalSampler,
-                      n_workers=meta_batch_size,
-                      worker_class=RL2Worker,
-                      worker_args=dict(n_episodes_per_trial=episode_per_task))
+        trainer.setup(algo, envs)
 
         trainer.train(n_epochs=n_epochs,
                       batch_size=episode_per_task * max_episode_length *

--- a/examples/tf/rl2_ppo_halfcheetah.py
+++ b/examples/tf/rl2_ppo_halfcheetah.py
@@ -9,7 +9,7 @@ from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 from garage.experiment import task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -56,15 +56,14 @@ def rl2_ppo_halfcheetah(ctxt, seed, max_episode_length, meta_batch_size,
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
         envs = tasks.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,

--- a/examples/tf/rl2_ppo_halfcheetah_meta_test.py
+++ b/examples/tf/rl2_ppo_halfcheetah_meta_test.py
@@ -10,7 +10,7 @@ from garage.experiment import task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.experiment.meta_evaluator import MetaEvaluator
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -60,11 +60,23 @@ def rl2_ppo_halfcheetah_meta_test(ctxt, seed, meta_batch_size, n_epochs,
                                        n_test_episodes=10,
                                        n_test_tasks=5)
 
+        envs = tasks.sample(meta_batch_size)
+        worker_factory = WorkerFactory(
+            max_episode_length=env_spec.max_episode_length,
+            is_tf_worker=True,
+            n_workers=meta_batch_size,
+            worker_class=RL2Worker,
+            worker_args=dict(n_episodes_per_trial=episode_per_task))
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=envs)
+
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,
                       env_spec=env_spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
@@ -80,12 +92,7 @@ def rl2_ppo_halfcheetah_meta_test(ctxt, seed, meta_batch_size, n_epochs,
                       meta_evaluator=meta_evaluator,
                       n_epochs_per_eval=10)
 
-        trainer.setup(algo,
-                      tasks.sample(meta_batch_size),
-                      sampler_cls=LocalSampler,
-                      n_workers=meta_batch_size,
-                      worker_class=RL2Worker,
-                      worker_args=dict(n_episodes_per_trial=episode_per_task))
+        trainer.setup(algo, envs)
 
         trainer.train(n_epochs=n_epochs,
                       batch_size=episode_per_task * max_episode_length *

--- a/examples/tf/rl2_ppo_halfcheetah_meta_test.py
+++ b/examples/tf/rl2_ppo_halfcheetah_meta_test.py
@@ -10,7 +10,7 @@ from garage.experiment import task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.experiment.meta_evaluator import MetaEvaluator
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -61,15 +61,14 @@ def rl2_ppo_halfcheetah_meta_test(ctxt, seed, meta_batch_size, n_epochs,
                                        n_test_tasks=5)
 
         envs = tasks.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,

--- a/examples/tf/rl2_ppo_metaworld_ml10.py
+++ b/examples/tf/rl2_ppo_metaworld_ml10.py
@@ -11,7 +11,7 @@ from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -62,15 +62,14 @@ def rl2_ppo_metaworld_ml10(ctxt, seed, meta_batch_size, n_epochs,
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
         envs = tasks.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,

--- a/examples/tf/rl2_ppo_metaworld_ml1_push.py
+++ b/examples/tf/rl2_ppo_metaworld_ml1_push.py
@@ -11,7 +11,7 @@ from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -62,15 +62,14 @@ def rl2_ppo_metaworld_ml1_push(ctxt, seed, meta_batch_size, n_epochs,
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
         envs = task_sampler.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=task_sampler,

--- a/examples/tf/rl2_ppo_metaworld_ml1_push.py
+++ b/examples/tf/rl2_ppo_metaworld_ml1_push.py
@@ -11,7 +11,7 @@ from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -61,11 +61,23 @@ def rl2_ppo_metaworld_ml1_push(ctxt, seed, meta_batch_size, n_epochs,
 
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
+        envs = task_sampler.sample(meta_batch_size)
+        worker_factory = WorkerFactory(
+            max_episode_length=env_spec.max_episode_length,
+            is_tf_worker=True,
+            n_workers=meta_batch_size,
+            worker_class=RL2Worker,
+            worker_args=dict(n_episodes_per_trial=episode_per_task))
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=envs)
+
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=task_sampler,
                       env_spec=env_spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
@@ -78,12 +90,7 @@ def rl2_ppo_metaworld_ml1_push(ctxt, seed, meta_batch_size, n_epochs,
                       meta_evaluator=meta_evaluator,
                       episodes_per_trial=episode_per_task)
 
-        trainer.setup(algo,
-                      task_sampler.sample(meta_batch_size),
-                      sampler_cls=LocalSampler,
-                      n_workers=meta_batch_size,
-                      worker_class=RL2Worker,
-                      worker_args=dict(n_episodes_per_trial=episode_per_task))
+        trainer.setup(algo, envs)
 
         trainer.train(n_epochs=n_epochs,
                       batch_size=episode_per_task *

--- a/examples/tf/rl2_ppo_metaworld_ml45.py
+++ b/examples/tf/rl2_ppo_metaworld_ml45.py
@@ -11,7 +11,7 @@ from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -63,11 +63,23 @@ def rl2_ppo_metaworld_ml45(ctxt, seed, meta_batch_size, n_epochs,
                                        n_test_episodes=10,
                                        n_test_tasks=5)
 
+        envs = tasks.sample(meta_batch_size)
+        worker_factory = WorkerFactory(
+            max_episode_length=env_spec.max_episode_length,
+            is_tf_worker=True,
+            n_workers=meta_batch_size,
+            worker_class=RL2Worker,
+            worker_args=dict(n_episodes_per_trial=episode_per_task))
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=envs)
+
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,
                       env_spec=env_spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=0.99,
                       gae_lambda=0.95,
                       lr_clip_range=0.2,
@@ -79,12 +91,7 @@ def rl2_ppo_metaworld_ml45(ctxt, seed, meta_batch_size, n_epochs,
                       meta_evaluator=meta_evaluator,
                       episodes_per_trial=10)
 
-        trainer.setup(algo,
-                      tasks.sample(meta_batch_size),
-                      sampler_cls=LocalSampler,
-                      n_workers=meta_batch_size,
-                      worker_class=RL2Worker,
-                      worker_args=dict(n_episodes_per_trial=episode_per_task))
+        trainer.setup(algo, envs)
 
         trainer.train(n_epochs=n_epochs,
                       batch_size=episode_per_task *

--- a/examples/tf/rl2_ppo_metaworld_ml45.py
+++ b/examples/tf/rl2_ppo_metaworld_ml45.py
@@ -11,7 +11,7 @@ from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2PPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.policies import GaussianGRUPolicy
@@ -64,15 +64,14 @@ def rl2_ppo_metaworld_ml45(ctxt, seed, meta_batch_size, n_epochs,
                                        n_test_tasks=5)
 
         envs = tasks.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2PPO(meta_batch_size=meta_batch_size,
                       task_sampler=tasks,

--- a/examples/tf/rl2_trpo_halfcheetah.py
+++ b/examples/tf/rl2_trpo_halfcheetah.py
@@ -9,7 +9,7 @@ from garage.envs.mujoco.half_cheetah_vel_env import HalfCheetahVelEnv
 from garage.experiment import task_sampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2TRPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
@@ -59,15 +59,14 @@ def rl2_trpo_halfcheetah(ctxt, seed, max_episode_length, meta_batch_size,
         baseline = LinearFeatureBaseline(env_spec=env_spec)
 
         envs = tasks.sample(meta_batch_size)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=policy,
+            envs=envs,
             max_episode_length=env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=meta_batch_size,
             worker_class=RL2Worker,
             worker_args=dict(n_episodes_per_trial=episode_per_task))
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=envs)
 
         algo = RL2TRPO(meta_batch_size=meta_batch_size,
                        task_sampler=tasks,

--- a/examples/tf/td3_pendulum.py
+++ b/examples/tf/td3_pendulum.py
@@ -15,7 +15,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import TD3
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -67,13 +67,11 @@ def td3_pendulum(ctxt=None, seed=1):
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
 
         td3 = TD3(env_spec=env.spec,
                   policy=policy,

--- a/examples/tf/te_ppo_metaworld_mt10.py
+++ b/examples/tf/te_ppo_metaworld_mt10.py
@@ -11,7 +11,7 @@ from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -109,9 +109,18 @@ def te_ppo_mt10(ctxt, seed, n_epochs, batch_size_per_task, n_tasks):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=TaskEmbeddingWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=env)
+
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,
                      baseline=baseline,
+                     sampler=sampler,
                      inference=inference,
                      discount=0.99,
                      lr_clip_range=0.2,
@@ -131,11 +140,7 @@ def te_ppo_mt10(ctxt, seed, n_epochs, batch_size_per_task, n_tasks):
                      center_adv=True,
                      stop_ce_gradient=True)
 
-        trainer.setup(algo,
-                      env,
-                      sampler_cls=LocalSampler,
-                      sampler_args=None,
-                      worker_class=TaskEmbeddingWorker)
+        trainer.setup(algo, env)
         trainer.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
 
 

--- a/examples/tf/te_ppo_metaworld_mt10.py
+++ b/examples/tf/te_ppo_metaworld_mt10.py
@@ -11,7 +11,7 @@ from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -109,13 +109,11 @@ def te_ppo_mt10(ctxt, seed, n_epochs, batch_size_per_task, n_tasks):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=TaskEmbeddingWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=TaskEmbeddingWorker)
 
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,

--- a/examples/tf/te_ppo_metaworld_mt1_push.py
+++ b/examples/tf/te_ppo_metaworld_mt1_push.py
@@ -11,7 +11,7 @@ from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -106,13 +106,11 @@ def te_ppo_mt1_push(ctxt, seed, n_epochs, batch_size_per_task):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=TaskEmbeddingWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=TaskEmbeddingWorker)
 
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,

--- a/examples/tf/te_ppo_metaworld_mt1_push.py
+++ b/examples/tf/te_ppo_metaworld_mt1_push.py
@@ -11,7 +11,7 @@ from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -106,9 +106,18 @@ def te_ppo_mt1_push(ctxt, seed, n_epochs, batch_size_per_task):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=TaskEmbeddingWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=env)
+
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,
                      baseline=baseline,
+                     sampler=sampler,
                      inference=inference,
                      discount=0.99,
                      lr_clip_range=0.2,
@@ -128,11 +137,7 @@ def te_ppo_mt1_push(ctxt, seed, n_epochs, batch_size_per_task):
                      center_adv=True,
                      stop_ce_gradient=True)
 
-        trainer.setup(algo,
-                      env,
-                      sampler_cls=LocalSampler,
-                      sampler_args=None,
-                      worker_class=TaskEmbeddingWorker)
+        trainer.setup(algo, env)
         trainer.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
 
 

--- a/examples/tf/te_ppo_metaworld_mt50.py
+++ b/examples/tf/te_ppo_metaworld_mt50.py
@@ -11,7 +11,7 @@ from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -109,13 +109,11 @@ def te_ppo_mt50(ctxt, seed, n_epochs, batch_size_per_task, n_tasks):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=TaskEmbeddingWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=TaskEmbeddingWorker)
 
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,

--- a/examples/tf/te_ppo_point.py
+++ b/examples/tf/te_ppo_point.py
@@ -10,7 +10,7 @@ from garage.envs import PointEnv
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -137,9 +137,18 @@ def te_ppo_pointenv(ctxt, seed, n_epochs, batch_size_per_task):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            is_tf_worker=True,
+            worker_class=TaskEmbeddingWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=env)
+
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,
                      baseline=baseline,
+                     sampler=sampler,
                      inference=inference,
                      discount=0.99,
                      lr_clip_range=0.2,
@@ -160,11 +169,7 @@ def te_ppo_pointenv(ctxt, seed, n_epochs, batch_size_per_task):
                      center_adv=True,
                      stop_ce_gradient=True)
 
-        trainer.setup(algo,
-                      env,
-                      sampler_cls=LocalSampler,
-                      sampler_args=None,
-                      worker_class=TaskEmbeddingWorker)
+        trainer.setup(algo, env)
         trainer.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
 
 

--- a/examples/tf/te_ppo_point.py
+++ b/examples/tf/te_ppo_point.py
@@ -10,7 +10,7 @@ from garage.envs import PointEnv
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -137,13 +137,11 @@ def te_ppo_pointenv(ctxt, seed, n_epochs, batch_size_per_task):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            is_tf_worker=True,
-            worker_class=TaskEmbeddingWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=TaskEmbeddingWorker)
 
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -11,7 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -38,11 +38,10 @@ def trpo_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -11,6 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -37,9 +38,16 @@ def trpo_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     max_kl_step=0.01)
 

--- a/examples/tf/trpo_cartpole_bullet.py
+++ b/examples/tf/trpo_cartpole_bullet.py
@@ -10,7 +10,7 @@ from garage import wrap_experiment
 from garage.envs.bullet import BulletEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -40,11 +40,10 @@ def trpo_cartpole_bullet(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/trpo_cartpole_bullet.py
+++ b/examples/tf/trpo_cartpole_bullet.py
@@ -10,6 +10,7 @@ from garage import wrap_experiment
 from garage.envs.bullet import BulletEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -39,9 +40,16 @@ def trpo_cartpole_bullet(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     max_kl_step=0.01)
 

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -16,6 +16,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
                                   FiniteDifferenceHVP)
@@ -50,9 +51,16 @@ def trpo_cartpole_recurrent(ctxt, seed, n_epochs, batch_size, plot):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     max_kl_step=0.01,
                     optimizer=ConjugateGradientOptimizer,

--- a/examples/tf/trpo_cartpole_recurrent.py
+++ b/examples/tf/trpo_cartpole_recurrent.py
@@ -16,7 +16,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
                                   FiniteDifferenceHVP)
@@ -51,11 +51,10 @@ def trpo_cartpole_recurrent(ctxt, seed, n_epochs, batch_size, plot):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/trpo_cubecrash.py
+++ b/examples/tf/trpo_cubecrash.py
@@ -8,7 +8,7 @@ import click
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -48,11 +48,10 @@ def trpo_cubecrash(ctxt=None, seed=1, max_episode_length=5, batch_size=4000):
                                        hidden_sizes=(32, 32),
                                        use_trust_region=True)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/trpo_cubecrash.py
+++ b/examples/tf/trpo_cubecrash.py
@@ -8,6 +8,7 @@ import click
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -47,9 +48,16 @@ def trpo_cubecrash(ctxt=None, seed=1, max_episode_length=5, batch_size=4000):
                                        hidden_sizes=(32, 32),
                                        use_trust_region=True)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     gae_lambda=0.95,
                     lr_clip_range=0.2,

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -4,7 +4,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -31,11 +31,10 @@ def trpo_gym_tf_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(
             env_spec=env.spec,

--- a/examples/tf/trpo_gym_tf_cartpole.py
+++ b/examples/tf/trpo_gym_tf_cartpole.py
@@ -4,6 +4,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -30,10 +31,17 @@ def trpo_gym_tf_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             max_kl_step=0.01,
         )

--- a/examples/tf/trpo_gym_tf_cartpole_pretrained.py
+++ b/examples/tf/trpo_gym_tf_cartpole_pretrained.py
@@ -6,7 +6,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -33,11 +33,10 @@ def trpo_gym_tf_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(
             env_spec=env.spec,

--- a/examples/tf/trpo_gym_tf_cartpole_pretrained.py
+++ b/examples/tf/trpo_gym_tf_cartpole_pretrained.py
@@ -6,6 +6,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -32,10 +33,17 @@ def trpo_gym_tf_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             max_kl_step=0.01,
         )

--- a/examples/tf/trpo_swimmer.py
+++ b/examples/tf/trpo_swimmer.py
@@ -4,6 +4,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -29,9 +30,16 @@ def trpo_swimmer(ctxt=None, seed=1, batch_size=4000):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=0.99,
                     max_kl_step=0.01)
 

--- a/examples/tf/trpo_swimmer.py
+++ b/examples/tf/trpo_swimmer.py
@@ -4,7 +4,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -30,11 +30,10 @@ def trpo_swimmer(ctxt=None, seed=1, batch_size=4000):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/trpo_swimmer_ray_sampler.py
+++ b/examples/tf/trpo_swimmer_ray_sampler.py
@@ -11,7 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -44,11 +44,10 @@ def trpo_swimmer_ray_sampler(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/tf/tutorial_vpg.py
+++ b/examples/tf/tutorial_vpg.py
@@ -7,7 +7,7 @@ from garage import EpisodeBatch, log_performance, wrap_experiment
 from garage.envs import PointEnv
 from garage.experiment.deterministic import set_seed
 from garage.np import discount_cumsum
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
 
@@ -128,11 +128,10 @@ def tutorial_vpg(ctxt=None):
     with TFTrainer(ctxt) as trainer:
         env = PointEnv(max_episode_length=200)
         policy = GaussianMLPPolicy(env.spec)
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
         algo = SimpleVPG(env.spec, policy, sampler)
         trainer.setup(algo, env)
         trainer.train(n_epochs=200, batch_size=4000)

--- a/examples/tf/tutorial_vpg.py
+++ b/examples/tf/tutorial_vpg.py
@@ -7,7 +7,7 @@ from garage import EpisodeBatch, log_performance, wrap_experiment
 from garage.envs import PointEnv
 from garage.experiment.deterministic import set_seed
 from garage.np import discount_cumsum
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
 
@@ -18,13 +18,14 @@ class SimpleVPG:
     Args:
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
+        sampler (garage.sampler.Sampler): Sampler.
 
     """
-    sampler_cls = LocalSampler
 
-    def __init__(self, env_spec, policy):
+    def __init__(self, env_spec, policy, sampler):
         self.env_spec = env_spec
         self.policy = policy
+        self.sampler = sampler
         self.max_episode_length = env_spec.max_episode_length
         self._discount = 0.99
         self.init_opt()
@@ -127,7 +128,12 @@ def tutorial_vpg(ctxt=None):
     with TFTrainer(ctxt) as trainer:
         env = PointEnv(max_episode_length=200)
         policy = GaussianMLPPolicy(env.spec)
-        algo = SimpleVPG(env.spec, policy)
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=policy,
+                                                   envs=env)
+        algo = SimpleVPG(env.spec, policy, sampler)
         trainer.setup(algo, env)
         trainer.train(n_epochs=200, batch_size=4000)
 

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -11,7 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.tf.algos import VPG
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -38,11 +38,10 @@ def vpg_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
-        sampler = RaySampler.from_worker_factory(worker_factory,
-                                                 agents=policy,
-                                                 envs=env)
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
 
         algo = VPG(env_spec=env.spec,
                    policy=policy,

--- a/examples/tf/vpg_cartpole.py
+++ b/examples/tf/vpg_cartpole.py
@@ -11,6 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler, WorkerFactory
 from garage.tf.algos import VPG
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -37,9 +38,16 @@ def vpg_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length, is_tf_worker=True)
+        sampler = RaySampler.from_worker_factory(worker_factory,
+                                                 agents=policy,
+                                                 envs=env)
+
         algo = VPG(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    optimizer_args=dict(learning_rate=0.01, ))
 

--- a/examples/torch/bc_point.py
+++ b/examples/torch/bc_point.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from garage import wrap_experiment
 from garage.envs import PointEnv
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import BC
 from garage.torch.policies import GaussianMLPPolicy, Policy
 from garage.trainer import Trainer
@@ -81,11 +81,9 @@ def bc_point(ctxt=None, loss='log_prob'):
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = GaussianMLPPolicy(env.spec, [8, 8])
     batch_size = 1000
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length, )
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=expert,
-                                             envs=env)
+    sampler = RaySampler(agents=expert,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,

--- a/examples/torch/bc_point.py
+++ b/examples/torch/bc_point.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from garage import wrap_experiment
 from garage.envs import PointEnv
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import BC
 from garage.torch.policies import GaussianMLPPolicy, Policy
 from garage.trainer import Trainer
@@ -80,10 +81,16 @@ def bc_point(ctxt=None, loss='log_prob'):
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = GaussianMLPPolicy(env.spec, [8, 8])
     batch_size = 1000
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length, )
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=expert,
+                                             envs=env)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,
               source=expert,
+              sampler=sampler,
               policy_lr=1e-2,
               loss=loss)
     trainer.setup(algo, env)

--- a/examples/torch/bc_point_deterministic_policy.py
+++ b/examples/torch/bc_point_deterministic_policy.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from garage import wrap_experiment
 from garage.envs import PointEnv
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import BC
 from garage.torch.policies import DeterministicMLPPolicy, Policy
 from garage.trainer import Trainer
@@ -76,10 +77,16 @@ def bc_point(ctxt=None):
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = DeterministicMLPPolicy(env.spec, hidden_sizes=[8, 8])
     batch_size = 1000
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length, )
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=expert,
+                                             envs=env)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,
               source=expert,
+              sampler=sampler,
               policy_lr=1e-2,
               loss='mse')
     trainer.setup(algo, env)

--- a/examples/torch/bc_point_deterministic_policy.py
+++ b/examples/torch/bc_point_deterministic_policy.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from garage import wrap_experiment
 from garage.envs import PointEnv
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import BC
 from garage.torch.policies import DeterministicMLPPolicy, Policy
 from garage.trainer import Trainer
@@ -77,11 +77,9 @@ def bc_point(ctxt=None):
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = DeterministicMLPPolicy(env.spec, hidden_sizes=[8, 8])
     batch_size = 1000
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length, )
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=expert,
-                                             envs=env)
+    sampler = RaySampler(agents=expert,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,

--- a/examples/torch/ddpg_pendulum.py
+++ b/examples/torch/ddpg_pendulum.py
@@ -13,7 +13,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch.algos import DDPG
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -51,12 +51,10 @@ def ddpg_pendulum(ctxt=None, seed=1, lr=1e-4):
 
     policy_optimizer = (torch.optim.Adagrad, {'lr': lr, 'lr_decay': 0.99})
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
 
     ddpg = DDPG(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/dqn_atari.py
+++ b/examples/torch/dqn_atari.py
@@ -24,7 +24,7 @@ from garage.envs.wrappers.stack_frames import StackFrames
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import DQN
 from garage.torch.policies import DiscreteQFArgmaxPolicy
@@ -169,13 +169,11 @@ def dqn_atari(ctxt=None,
         min_epsilon=hyperparams['min_epsilon'],
         decay_ratio=hyperparams['decay_ratio'])
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker,
-        n_workers=n_workers)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker,
+                           n_workers=n_workers)
 
     algo = DQN(env_spec=env.spec,
                policy=policy,

--- a/examples/torch/dqn_cartpole.py
+++ b/examples/torch/dqn_cartpole.py
@@ -10,7 +10,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch.algos import DQN
 from garage.torch.policies import DiscreteQFArgmaxPolicy
 from garage.torch.q_functions import DiscreteMLPQFunction
@@ -46,12 +46,10 @@ def dqn_cartpole(ctxt=None, seed=24):
                                              max_epsilon=1.0,
                                              min_epsilon=0.01,
                                              decay_ratio=0.4)
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     algo = DQN(env_spec=env.spec,
                policy=policy,
                qf=qf,

--- a/examples/torch/dqn_cartpole.py
+++ b/examples/torch/dqn_cartpole.py
@@ -10,7 +10,7 @@ from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch.algos import DQN
 from garage.torch.policies import DiscreteQFArgmaxPolicy
 from garage.torch.q_functions import DiscreteMLPQFunction
@@ -46,11 +46,18 @@ def dqn_cartpole(ctxt=None, seed=24):
                                              max_epsilon=1.0,
                                              min_epsilon=0.01,
                                              decay_ratio=0.4)
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=exploration_policy,
+                                               envs=env)
     algo = DQN(env_spec=env.spec,
                policy=policy,
                qf=qf,
                exploration_policy=exploration_policy,
                replay_buffer=replay_buffer,
+               sampler=sampler,
                steps_per_epoch=steps_per_epoch,
                qf_lr=5e-5,
                discount=0.9,
@@ -59,7 +66,7 @@ def dqn_cartpole(ctxt=None, seed=24):
                target_update_freq=30,
                buffer_batch_size=64)
 
-    runner.setup(algo, env, sampler_cls=LocalSampler)
+    runner.setup(algo, env)
     runner.train(n_epochs=n_epochs, batch_size=sampler_batch_size)
 
     env.close()

--- a/examples/torch/maml_ppo_half_cheetah_dir.py
+++ b/examples/torch/maml_ppo_half_cheetah_dir.py
@@ -10,7 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLPPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -68,11 +68,9 @@ def maml_ppo_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
 
     trainer = Trainer(ctxt)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = MAMLPPO(env=env,
                    policy=policy,

--- a/examples/torch/maml_ppo_half_cheetah_dir.py
+++ b/examples/torch/maml_ppo_half_cheetah_dir.py
@@ -10,6 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLPPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -66,8 +67,16 @@ def maml_ppo_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
                                    n_test_episodes=10)
 
     trainer = Trainer(ctxt)
+
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = MAMLPPO(env=env,
                    policy=policy,
+                   sampler=sampler,
                    task_sampler=task_sampler,
                    value_function=value_function,
                    meta_batch_size=meta_batch_size,

--- a/examples/torch/maml_trpo_half_cheetah_dir.py
+++ b/examples/torch/maml_trpo_half_cheetah_dir.py
@@ -10,6 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -66,8 +67,16 @@ def maml_trpo_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
                                    n_test_episodes=10)
 
     trainer = Trainer(ctxt)
+
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = MAMLTRPO(env=env,
                     policy=policy,
+                    sampler=sampler,
                     task_sampler=task_sampler,
                     value_function=value_function,
                     meta_batch_size=meta_batch_size,

--- a/examples/torch/maml_trpo_half_cheetah_dir.py
+++ b/examples/torch/maml_trpo_half_cheetah_dir.py
@@ -10,7 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -68,11 +68,9 @@ def maml_trpo_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
 
     trainer = Trainer(ctxt)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = MAMLTRPO(env=env,
                     policy=policy,

--- a/examples/torch/maml_trpo_metaworld_ml10.py
+++ b/examples/torch/maml_trpo_metaworld_ml10.py
@@ -11,6 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -61,9 +62,17 @@ def maml_trpo_metaworld_ml10(ctxt, seed, epochs, episodes_per_task,
 
     meta_evaluator = MetaEvaluator(test_task_sampler=test_sampler)
 
+    worker_factory = WorkerFactory(
+        n_workers=meta_batch_size,
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,
                     policy=policy,
+                    sampler=sampler,
                     task_sampler=tasks,
                     value_function=value_function,
                     meta_batch_size=meta_batch_size,
@@ -73,7 +82,7 @@ def maml_trpo_metaworld_ml10(ctxt, seed, epochs, episodes_per_task,
                     num_grad_updates=1,
                     meta_evaluator=meta_evaluator)
 
-    trainer.setup(algo, env, n_workers=meta_batch_size)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs,
                   batch_size=episodes_per_task * env.spec.max_episode_length)
 

--- a/examples/torch/maml_trpo_metaworld_ml10.py
+++ b/examples/torch/maml_trpo_metaworld_ml10.py
@@ -11,7 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -62,12 +62,10 @@ def maml_trpo_metaworld_ml10(ctxt, seed, epochs, episodes_per_task,
 
     meta_evaluator = MetaEvaluator(test_task_sampler=test_sampler)
 
-    worker_factory = WorkerFactory(
-        n_workers=meta_batch_size,
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=meta_batch_size)
 
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,

--- a/examples/torch/maml_trpo_metaworld_ml1_push.py
+++ b/examples/torch/maml_trpo_metaworld_ml1_push.py
@@ -11,7 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -65,12 +65,10 @@ def maml_trpo_metaworld_ml1_push(ctxt, seed, epochs, rollouts_per_task,
                                    n_test_tasks=1,
                                    n_exploration_eps=rollouts_per_task)
 
-    worker_factory = WorkerFactory(
-        n_workers=meta_batch_size,
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=meta_batch_size)
 
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,

--- a/examples/torch/maml_trpo_metaworld_ml1_push.py
+++ b/examples/torch/maml_trpo_metaworld_ml1_push.py
@@ -11,6 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -64,9 +65,17 @@ def maml_trpo_metaworld_ml1_push(ctxt, seed, epochs, rollouts_per_task,
                                    n_test_tasks=1,
                                    n_exploration_eps=rollouts_per_task)
 
+    worker_factory = WorkerFactory(
+        n_workers=meta_batch_size,
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,
                     policy=policy,
+                    sampler=sampler,
                     task_sampler=tasks,
                     value_function=value_function,
                     meta_batch_size=meta_batch_size,
@@ -76,7 +85,7 @@ def maml_trpo_metaworld_ml1_push(ctxt, seed, epochs, rollouts_per_task,
                     num_grad_updates=1,
                     meta_evaluator=meta_evaluator)
 
-    trainer.setup(algo, env, n_workers=meta_batch_size)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs,
                   batch_size=rollouts_per_task * env.spec.max_episode_length)
 

--- a/examples/torch/maml_trpo_metaworld_ml45.py
+++ b/examples/torch/maml_trpo_metaworld_ml45.py
@@ -11,7 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -69,12 +69,10 @@ def maml_trpo_metaworld_ml45(ctxt, seed, epochs, episodes_per_task,
 
     meta_evaluator = MetaEvaluator(test_task_sampler=test_task_sampler)
 
-    worker_factory = WorkerFactory(
-        n_workers=meta_batch_size,
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=meta_batch_size)
 
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,

--- a/examples/torch/maml_trpo_metaworld_ml45.py
+++ b/examples/torch/maml_trpo_metaworld_ml45.py
@@ -11,6 +11,7 @@ from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment import (MetaEvaluator, MetaWorldTaskSampler,
                                SetTaskSampler)
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -68,10 +69,18 @@ def maml_trpo_metaworld_ml45(ctxt, seed, epochs, episodes_per_task,
 
     meta_evaluator = MetaEvaluator(test_task_sampler=test_task_sampler)
 
+    worker_factory = WorkerFactory(
+        n_workers=meta_batch_size,
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     trainer = Trainer(ctxt)
     algo = MAMLTRPO(env=env,
                     task_sampler=train_task_sampler,
                     policy=policy,
+                    sampler=sampler,
                     value_function=value_function,
                     meta_batch_size=meta_batch_size,
                     discount=0.99,
@@ -80,7 +89,7 @@ def maml_trpo_metaworld_ml45(ctxt, seed, epochs, episodes_per_task,
                     num_grad_updates=1,
                     meta_evaluator=meta_evaluator)
 
-    trainer.setup(algo, env, n_workers=meta_batch_size)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs,
                   batch_size=episodes_per_task * env.spec.max_episode_length)
 

--- a/examples/torch/maml_vpg_half_cheetah_dir.py
+++ b/examples/torch/maml_vpg_half_cheetah_dir.py
@@ -10,7 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import MAMLVPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -66,11 +66,9 @@ def maml_vpg_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
                                    n_test_tasks=1,
                                    n_test_episodes=10)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     trainer = Trainer(ctxt)
     algo = MAMLVPG(env=env,

--- a/examples/torch/maml_vpg_half_cheetah_dir.py
+++ b/examples/torch/maml_vpg_half_cheetah_dir.py
@@ -10,6 +10,7 @@ from garage.envs.mujoco import HalfCheetahDirEnv
 from garage.experiment import MetaEvaluator
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import MAMLVPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -65,9 +66,16 @@ def maml_vpg_half_cheetah_dir(ctxt, seed, epochs, episodes_per_task,
                                    n_test_tasks=1,
                                    n_test_episodes=10)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     trainer = Trainer(ctxt)
     algo = MAMLVPG(env=env,
                    policy=policy,
+                   sampler=sampler,
                    task_sampler=task_sampler,
                    value_function=value_function,
                    meta_batch_size=meta_batch_size,

--- a/examples/torch/mtppo_metaworld_mt10.py
+++ b/examples/torch/mtppo_metaworld_mt10.py
@@ -11,7 +11,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -64,11 +64,10 @@ def mtppo_metaworld_mt10(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=n_workers)
 
     algo = PPO(env_spec=env.spec,
                policy=policy,

--- a/examples/torch/mtppo_metaworld_mt10.py
+++ b/examples/torch/mtppo_metaworld_mt10.py
@@ -11,6 +11,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -63,16 +64,23 @@ def mtppo_metaworld_mt10(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = PPO(env_spec=env.spec,
                policy=policy,
                value_function=value_function,
+               sampler=sampler,
                discount=0.99,
                gae_lambda=0.95,
                center_adv=True,
                lr_clip_range=0.2)
 
     trainer = Trainer(ctxt)
-    trainer.setup(algo, env, n_workers=n_workers)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs, batch_size=batch_size)
 
 

--- a/examples/torch/mtppo_metaworld_mt1_push.py
+++ b/examples/torch/mtppo_metaworld_mt1_push.py
@@ -10,6 +10,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -53,9 +54,16 @@ def mtppo_metaworld_mt1_push(ctxt, seed, epochs, batch_size):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = PPO(env_spec=env.spec,
                policy=policy,
                value_function=value_function,
+               sampler=sampler,
                discount=0.99,
                gae_lambda=0.95,
                center_adv=True,

--- a/examples/torch/mtppo_metaworld_mt1_push.py
+++ b/examples/torch/mtppo_metaworld_mt1_push.py
@@ -10,7 +10,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -54,11 +54,9 @@ def mtppo_metaworld_mt1_push(ctxt, seed, epochs, batch_size):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = PPO(env_spec=env.spec,
                policy=policy,

--- a/examples/torch/mtppo_metaworld_mt50.py
+++ b/examples/torch/mtppo_metaworld_mt50.py
@@ -11,6 +11,7 @@ from garage.envs import MultiEnvWrapper, normalize
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -63,16 +64,23 @@ def mtppo_metaworld_mt50(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = PPO(env_spec=env.spec,
                policy=policy,
                value_function=value_function,
+               sampler=sampler,
                discount=0.99,
                gae_lambda=0.95,
                center_adv=True,
                lr_clip_range=0.2)
 
     trainer = Trainer(ctxt)
-    trainer.setup(algo, env, n_workers=n_workers)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs, batch_size=batch_size)
 
 

--- a/examples/torch/mtppo_metaworld_mt50.py
+++ b/examples/torch/mtppo_metaworld_mt50.py
@@ -11,7 +11,7 @@ from garage.envs import MultiEnvWrapper, normalize
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment import MetaWorldTaskSampler
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -64,11 +64,10 @@ def mtppo_metaworld_mt50(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=n_workers)
 
     algo = PPO(env_spec=env.spec,
                policy=policy,

--- a/examples/torch/mtsac_metaworld_mt10.py
+++ b/examples/torch/mtsac_metaworld_mt10.py
@@ -14,7 +14,7 @@ from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment.task_sampler import MetaWorldTaskSampler
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import MTSAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -83,10 +83,12 @@ def mtsac_metaworld_mt10(ctxt=None, *, seed, _gpu, n_tasks, timesteps):
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     meta_batch_size = 10
 
-    worker_factory = WorkerFactory(
+    sampler = LocalSampler(
+        agents=policy,
+        envs=mt10_train_envs,
+        max_episode_length=env.spec.max_episode_length,
         # 1 sampler worker for each environment
         n_workers=meta_batch_size,
-        max_episode_length=env.spec.max_episode_length,
         worker_class=FragmentWorker,
         # increasing n_envs increases the vectorization of a sampler worker
         # which improves runtime performance, but you will need to adjust this
@@ -96,9 +98,6 @@ def mtsac_metaworld_mt10(ctxt=None, *, seed, _gpu, n_tasks, timesteps):
         # users want to be able to run multiple seeds on 1 machine, so I have
         # reduced this to n_envs = 2 for 2 copies in the meantime.
         worker_args=dict(n_envs=2))
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=mt10_train_envs)
 
     batch_size = int(env.spec.max_episode_length * meta_batch_size)
     num_evaluation_points = 500

--- a/examples/torch/mtsac_metaworld_mt10.py
+++ b/examples/torch/mtsac_metaworld_mt10.py
@@ -14,7 +14,7 @@ from garage.envs import normalize
 from garage.experiment import deterministic
 from garage.experiment.task_sampler import MetaWorldTaskSampler
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import MTSAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -83,6 +83,23 @@ def mtsac_metaworld_mt10(ctxt=None, *, seed, _gpu, n_tasks, timesteps):
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     meta_batch_size = 10
 
+    worker_factory = WorkerFactory(
+        # 1 sampler worker for each environment
+        n_workers=meta_batch_size,
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker,
+        # increasing n_envs increases the vectorization of a sampler worker
+        # which improves runtime performance, but you will need to adjust this
+        # depending on your memory constraints. For reference, each worker by
+        # default uses n_envs=8. Each environment is approximately ~50mb large
+        # so creating 50 envs with 8 copies comes out to 20gb of memory. Many
+        # users want to be able to run multiple seeds on 1 machine, so I have
+        # reduced this to n_envs = 2 for 2 copies in the meantime.
+        worker_args=dict(n_envs=2))
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=policy,
+                                               envs=mt10_train_envs)
+
     batch_size = int(env.spec.max_episode_length * meta_batch_size)
     num_evaluation_points = 500
     epochs = timesteps // batch_size
@@ -91,6 +108,7 @@ def mtsac_metaworld_mt10(ctxt=None, *, seed, _gpu, n_tasks, timesteps):
     mtsac = MTSAC(policy=policy,
                   qf1=qf1,
                   qf2=qf2,
+                  sampler=sampler,
                   gradient_steps_per_itr=env.spec.max_episode_length,
                   eval_env=mt10_test_envs,
                   env_spec=env.spec,
@@ -104,20 +122,7 @@ def mtsac_metaworld_mt10(ctxt=None, *, seed, _gpu, n_tasks, timesteps):
     if _gpu is not None:
         set_gpu_mode(True, _gpu)
     mtsac.to()
-    trainer.setup(
-        algo=mtsac,
-        env=mt10_train_envs,
-        sampler_cls=LocalSampler,
-        # 1 sampler worker for each environment
-        n_workers=meta_batch_size,
-        # increasing n_envs increases the vectorization of a sampler worker
-        # which improves runtime performance, but you will need to adjust this
-        # depending on your memory constraints. For reference, each worker by
-        # default uses n_envs=8. Each environment is approximately ~50mb large
-        # so creating 10 envs with 8 copies comes out to 20gb of memory. Many
-        # users want to be able to run multiple seeds on 1 machine, so I have
-        # reduced this to n_envs = 2 for 2 copies in the meantime.
-        worker_args=dict(n_envs=2))
+    trainer.setup(algo=mtsac, env=mt10_train_envs)
     trainer.train(n_epochs=epochs, batch_size=batch_size)
 
 

--- a/examples/torch/mtsac_metaworld_mt1_pick_place.py
+++ b/examples/torch/mtsac_metaworld_mt1_pick_place.py
@@ -16,7 +16,7 @@ from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic, MetaWorldTaskSampler
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import MTSAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -73,14 +73,11 @@ def mtsac_metaworld_mt1_pick_place(ctxt=None, *, seed, timesteps, _gpu):
                                  hidden_nonlinearity=F.relu)
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
 
-    worker_factory = WorkerFactory(
-        n_workers=n_tasks,
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker,
-    )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=train_envs)
+    sampler = LocalSampler(agents=policy,
+                           envs=train_envs,
+                           max_episode_length=env.spec.max_episode_length,
+                           n_workers=n_tasks,
+                           worker_class=FragmentWorker)
 
     batch_size = int(env.spec.max_episode_length * n_tasks)
     num_evaluation_points = 500

--- a/examples/torch/mtsac_metaworld_mt1_pick_place.py
+++ b/examples/torch/mtsac_metaworld_mt1_pick_place.py
@@ -16,7 +16,7 @@ from garage import wrap_experiment
 from garage.envs import normalize
 from garage.experiment import deterministic, MetaWorldTaskSampler
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import MTSAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -73,6 +73,15 @@ def mtsac_metaworld_mt1_pick_place(ctxt=None, *, seed, timesteps, _gpu):
                                  hidden_nonlinearity=F.relu)
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
 
+    worker_factory = WorkerFactory(
+        n_workers=n_tasks,
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker,
+    )
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=policy,
+                                               envs=train_envs)
+
     batch_size = int(env.spec.max_episode_length * n_tasks)
     num_evaluation_points = 500
     epochs = timesteps // batch_size
@@ -81,6 +90,7 @@ def mtsac_metaworld_mt1_pick_place(ctxt=None, *, seed, timesteps, _gpu):
     mtsac = MTSAC(policy=policy,
                   qf1=qf1,
                   qf2=qf2,
+                  sampler=sampler,
                   gradient_steps_per_itr=150,
                   eval_env=test_envs,
                   env_spec=env.spec,
@@ -94,10 +104,7 @@ def mtsac_metaworld_mt1_pick_place(ctxt=None, *, seed, timesteps, _gpu):
     if _gpu is not None:
         set_gpu_mode(True, _gpu)
     mtsac.to()
-    trainer.setup(algo=mtsac,
-                  env=train_envs,
-                  sampler_cls=LocalSampler,
-                  n_workers=n_tasks)
+    trainer.setup(algo=mtsac, env=train_envs)
     trainer.train(n_epochs=epochs, batch_size=batch_size)
 
 

--- a/examples/torch/mttrpo_metaworld_mt10.py
+++ b/examples/torch/mttrpo_metaworld_mt10.py
@@ -11,7 +11,7 @@ from garage.envs import MultiEnvWrapper, normalize
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -64,11 +64,10 @@ def mttrpo_metaworld_mt10(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=n_workers)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/mttrpo_metaworld_mt10.py
+++ b/examples/torch/mttrpo_metaworld_mt10.py
@@ -11,6 +11,7 @@ from garage.envs import MultiEnvWrapper, normalize
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -63,14 +64,21 @@ def mttrpo_metaworld_mt10(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = TRPO(env_spec=env.spec,
                 policy=policy,
                 value_function=value_function,
+                sampler=sampler,
                 discount=0.99,
                 gae_lambda=0.95)
 
     trainer = Trainer(ctxt)
-    trainer.setup(algo, env, n_workers=n_workers)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=epochs, batch_size=batch_size)
 
 

--- a/examples/torch/mttrpo_metaworld_mt1_push.py
+++ b/examples/torch/mttrpo_metaworld_mt1_push.py
@@ -10,6 +10,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -55,9 +56,16 @@ def mttrpo_metaworld_mt1_push(ctxt, seed, epochs, batch_size):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = TRPO(env_spec=env.spec,
                 policy=policy,
                 value_function=value_function,
+                sampler=sampler,
                 discount=0.99,
                 gae_lambda=0.95)
 

--- a/examples/torch/mttrpo_metaworld_mt1_push.py
+++ b/examples/torch/mttrpo_metaworld_mt1_push.py
@@ -10,7 +10,7 @@ from garage.envs import normalize
 from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -56,11 +56,9 @@ def mttrpo_metaworld_mt1_push(ctxt, seed, epochs, batch_size):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/mttrpo_metaworld_mt50.py
+++ b/examples/torch/mttrpo_metaworld_mt50.py
@@ -11,7 +11,7 @@ from garage.envs import MultiEnvWrapper, normalize
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import MetaWorldTaskSampler
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -64,11 +64,10 @@ def mttrpo_metaworld_mt50(ctxt, seed, epochs, batch_size, n_workers, n_tasks):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        n_workers=n_workers, max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length,
+                         n_workers=n_workers)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/pearl_half_cheetah_vel.py
+++ b/examples/torch/pearl_half_cheetah_vel.py
@@ -7,7 +7,7 @@ from garage.envs import GymEnv, normalize
 from garage.envs.mujoco import HalfCheetahVelEnv
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -117,13 +117,11 @@ def pearl_half_cheetah_vel(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env[0]().spec.max_episode_length,
-        n_workers=1,
-        worker_class=PEARLWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=None,
-                                               envs=env[0]())
+    sampler = LocalSampler(agents=None,
+                           envs=env[0](),
+                           max_episode_length=env[0]().spec.max_episode_length,
+                           n_workers=1,
+                           worker_class=PEARLWorker)
 
     pearl = PEARL(
         env=env,

--- a/examples/torch/pearl_metaworld_ml10.py
+++ b/examples/torch/pearl_metaworld_ml10.py
@@ -8,7 +8,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,6 +112,14 @@ def pearl_metaworld_ml10(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env[0]().spec.max_episode_length,
+        n_workers=1,
+        worker_class=PEARLWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=None,
+                                               envs=env[0]())
+
     pearl = PEARL(
         env=env,
         policy_class=ContextConditionedPolicy,
@@ -119,6 +127,7 @@ def pearl_metaworld_ml10(ctxt=None,
         inner_policy=inner_policy,
         qf=qf,
         vf=vf,
+        sampler=sampler,
         num_train_tasks=num_train_tasks,
         latent_dim=latent_size,
         encoder_hidden_sizes=encoder_hidden_sizes,
@@ -139,11 +148,7 @@ def pearl_metaworld_ml10(ctxt=None,
     if use_gpu:
         pearl.to()
 
-    trainer.setup(algo=pearl,
-                  env=env[0](),
-                  sampler_cls=LocalSampler,
-                  n_workers=1,
-                  worker_class=PEARLWorker)
+    trainer.setup(algo=pearl, env=env[0]())
 
     trainer.train(n_epochs=num_epochs, batch_size=batch_size)
 

--- a/examples/torch/pearl_metaworld_ml10.py
+++ b/examples/torch/pearl_metaworld_ml10.py
@@ -8,7 +8,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,13 +112,11 @@ def pearl_metaworld_ml10(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env[0]().spec.max_episode_length,
-        n_workers=1,
-        worker_class=PEARLWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=None,
-                                               envs=env[0]())
+    sampler = LocalSampler(agents=None,
+                           envs=env[0](),
+                           max_episode_length=env[0]().spec.max_episode_length,
+                           n_workers=1,
+                           worker_class=PEARLWorker)
 
     pearl = PEARL(
         env=env,

--- a/examples/torch/pearl_metaworld_ml1_push.py
+++ b/examples/torch/pearl_metaworld_ml1_push.py
@@ -7,7 +7,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,13 +112,11 @@ def pearl_metaworld_ml1_push(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env[0]().spec.max_episode_length,
-        n_workers=1,
-        worker_class=PEARLWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=None,
-                                               envs=env[0]())
+    sampler = LocalSampler(agents=None,
+                           envs=env[0](),
+                           max_episode_length=env[0]().spec.max_episode_length,
+                           n_workers=1,
+                           worker_class=PEARLWorker)
 
     pearl = PEARL(
         env=env,

--- a/examples/torch/pearl_metaworld_ml1_push.py
+++ b/examples/torch/pearl_metaworld_ml1_push.py
@@ -7,7 +7,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,6 +112,14 @@ def pearl_metaworld_ml1_push(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env[0]().spec.max_episode_length,
+        n_workers=1,
+        worker_class=PEARLWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=None,
+                                               envs=env[0]())
+
     pearl = PEARL(
         env=env,
         policy_class=ContextConditionedPolicy,
@@ -119,6 +127,7 @@ def pearl_metaworld_ml1_push(ctxt=None,
         inner_policy=inner_policy,
         qf=qf,
         vf=vf,
+        sampler=sampler,
         num_train_tasks=num_train_tasks,
         latent_dim=latent_size,
         encoder_hidden_sizes=encoder_hidden_sizes,
@@ -139,11 +148,7 @@ def pearl_metaworld_ml1_push(ctxt=None,
     if use_gpu:
         pearl.to()
 
-    trainer.setup(algo=pearl,
-                  env=env[0](),
-                  sampler_cls=LocalSampler,
-                  n_workers=1,
-                  worker_class=PEARLWorker)
+    trainer.setup(algo=pearl, env=env[0]())
 
     trainer.train(n_epochs=num_epochs, batch_size=batch_size)
 

--- a/examples/torch/pearl_metaworld_ml45.py
+++ b/examples/torch/pearl_metaworld_ml45.py
@@ -8,7 +8,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,6 +112,14 @@ def pearl_metaworld_ml45(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env[0]().spec.max_episode_length,
+        n_workers=1,
+        worker_class=PEARLWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=None,
+                                               envs=env[0]())
+
     pearl = PEARL(
         env=env,
         policy_class=ContextConditionedPolicy,
@@ -119,6 +127,7 @@ def pearl_metaworld_ml45(ctxt=None,
         inner_policy=inner_policy,
         qf=qf,
         vf=vf,
+        sampler=sampler,
         num_train_tasks=num_train_tasks,
         latent_dim=latent_size,
         encoder_hidden_sizes=encoder_hidden_sizes,
@@ -139,11 +148,7 @@ def pearl_metaworld_ml45(ctxt=None,
     if use_gpu:
         pearl.to()
 
-    trainer.setup(algo=pearl,
-                  env=env[0](),
-                  sampler_cls=LocalSampler,
-                  n_workers=1,
-                  worker_class=PEARLWorker)
+    trainer.setup(algo=pearl, env=env[0]())
 
     trainer.train(n_epochs=num_epochs, batch_size=batch_size)
 

--- a/examples/torch/pearl_metaworld_ml45.py
+++ b/examples/torch/pearl_metaworld_ml45.py
@@ -8,7 +8,7 @@ from garage import wrap_experiment
 from garage.envs import MetaWorldSetTaskEnv, normalize
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -112,13 +112,11 @@ def pearl_metaworld_ml45(ctxt=None,
     inner_policy = TanhGaussianMLPPolicy(
         env_spec=augmented_env, hidden_sizes=[net_size, net_size, net_size])
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env[0]().spec.max_episode_length,
-        n_workers=1,
-        worker_class=PEARLWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=None,
-                                               envs=env[0]())
+    sampler = LocalSampler(agents=None,
+                           envs=env[0](),
+                           max_episode_length=env[0]().spec.max_episode_length,
+                           n_workers=1,
+                           worker_class=PEARLWorker)
 
     pearl = PEARL(
         env=env,

--- a/examples/torch/ppo_pendulum.py
+++ b/examples/torch/ppo_pendulum.py
@@ -8,7 +8,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -41,11 +41,9 @@ def ppo_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = PPO(env_spec=env.spec,
                policy=policy,

--- a/examples/torch/ppo_pendulum.py
+++ b/examples/torch/ppo_pendulum.py
@@ -8,6 +8,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -40,9 +41,16 @@ def ppo_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = PPO(env_spec=env.spec,
                policy=policy,
                value_function=value_function,
+               sampler=sampler,
                discount=0.99,
                center_adv=False)
 

--- a/examples/torch/sac_half_cheetah_batch.py
+++ b/examples/torch/sac_half_cheetah_batch.py
@@ -9,7 +9,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import SAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -51,10 +51,18 @@ def sac_half_cheetah_batch(ctxt=None, seed=1):
 
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=policy,
+                                               envs=env)
+
     sac = SAC(env_spec=env.spec,
               policy=policy,
               qf1=qf1,
               qf2=qf2,
+              sampler=sampler,
               gradient_steps_per_itr=1000,
               max_episode_length_eval=1000,
               replay_buffer=replay_buffer,
@@ -70,7 +78,7 @@ def sac_half_cheetah_batch(ctxt=None, seed=1):
     else:
         set_gpu_mode(False)
     sac.to()
-    trainer.setup(algo=sac, env=env, sampler_cls=LocalSampler)
+    trainer.setup(algo=sac, env=env)
     trainer.train(n_epochs=1000, batch_size=1000)
 
 

--- a/examples/torch/sac_half_cheetah_batch.py
+++ b/examples/torch/sac_half_cheetah_batch.py
@@ -9,7 +9,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import SAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -51,12 +51,10 @@ def sac_half_cheetah_batch(ctxt=None, seed=1):
 
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
 
     sac = SAC(env_spec=env.spec,
               policy=policy,

--- a/examples/torch/td3_halfcheetah.py
+++ b/examples/torch/td3_halfcheetah.py
@@ -10,7 +10,7 @@ from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.np.policies import UniformRandomPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch.algos import TD3
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -60,12 +60,10 @@ def td3_half_cheetah(ctxt=None, seed=1):
 
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
 
     td3 = TD3(env_spec=env.spec,
               policy=policy,

--- a/examples/torch/td3_halfcheetah.py
+++ b/examples/torch/td3_halfcheetah.py
@@ -10,6 +10,7 @@ from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.np.policies import UniformRandomPolicy
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch.algos import TD3
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -59,11 +60,19 @@ def td3_half_cheetah(ctxt=None, seed=1):
 
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=exploration_policy,
+                                               envs=env)
+
     td3 = TD3(env_spec=env.spec,
               policy=policy,
               qf1=qf1,
               qf2=qf2,
               replay_buffer=replay_buffer,
+              sampler=sampler,
               policy_optimizer=torch.optim.Adam,
               qf_optimizer=torch.optim.Adam,
               exploration_policy=exploration_policy,

--- a/examples/torch/td3_pendulum.py
+++ b/examples/torch/td3_pendulum.py
@@ -9,7 +9,7 @@ from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.np.policies import UniformRandomPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import prefer_gpu
 from garage.torch.algos import TD3
 from garage.torch.policies import DeterministicMLPPolicy
@@ -60,12 +60,10 @@ def td3_pendulum(ctxt=None, seed=1):
 
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
 
     td3 = TD3(env_spec=env.spec,
               policy=policy,

--- a/examples/torch/trpo_pendulum.py
+++ b/examples/torch/trpo_pendulum.py
@@ -8,6 +8,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -40,9 +41,16 @@ def trpo_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = TRPO(env_spec=env.spec,
                 policy=policy,
                 value_function=value_function,
+                sampler=sampler,
                 discount=0.99,
                 center_adv=False)
 

--- a/examples/torch/trpo_pendulum.py
+++ b/examples/torch/trpo_pendulum.py
@@ -8,7 +8,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -41,11 +41,9 @@ def trpo_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -11,7 +11,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment import deterministic
-from garage.sampler import RaySampler
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -51,13 +51,20 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = TRPO(env_spec=env.spec,
                 policy=policy,
                 value_function=value_function,
+                sampler=sampler,
                 discount=0.99,
                 center_adv=False)
 
-    trainer.setup(algo, env, sampler_cls=RaySampler)
+    trainer.setup(algo, env)
     trainer.train(n_epochs=100, batch_size=1024)
 
 

--- a/examples/torch/trpo_pendulum_ray_sampler.py
+++ b/examples/torch/trpo_pendulum_ray_sampler.py
@@ -11,7 +11,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment import deterministic
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -51,11 +51,9 @@ def trpo_pendulum_ray_sampler(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,

--- a/examples/torch/tutorial_vpg.py
+++ b/examples/torch/tutorial_vpg.py
@@ -7,7 +7,7 @@ from garage import EpisodeBatch, log_performance, wrap_experiment
 from garage.envs import PointEnv
 from garage.experiment.deterministic import set_seed
 from garage.np import discount_cumsum
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.policies import GaussianMLPPolicy
 from garage.trainer import Trainer
 
@@ -85,11 +85,9 @@ def tutorial_vpg(ctxt=None):
     trainer = Trainer(ctxt)
     env = PointEnv()
     policy = GaussianMLPPolicy(env.spec)
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length, )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
     algo = SimpleVPG(env.spec, policy, sampler)
     trainer.setup(algo, env)
     trainer.train(n_epochs=200, batch_size=4000)

--- a/examples/torch/vpg_pendulum.py
+++ b/examples/torch/vpg_pendulum.py
@@ -11,6 +11,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
+from garage.sampler import RaySampler, WorkerFactory
 from garage.torch.algos import VPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -43,9 +44,16 @@ def vpg_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length)
+    sampler = RaySampler.from_worker_factory(worker_factory,
+                                             agents=policy,
+                                             envs=env)
+
     algo = VPG(env_spec=env.spec,
                policy=policy,
                value_function=value_function,
+               sampler=sampler,
                discount=0.99,
                center_adv=False)
 

--- a/examples/torch/vpg_pendulum.py
+++ b/examples/torch/vpg_pendulum.py
@@ -11,7 +11,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler, WorkerFactory
+from garage.sampler import RaySampler
 from garage.torch.algos import VPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -44,11 +44,9 @@ def vpg_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = RaySampler.from_worker_factory(worker_factory,
-                                             agents=policy,
-                                             envs=env)
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
 
     algo = VPG(env_spec=env.spec,
                policy=policy,

--- a/src/garage/np/algos/cem.py
+++ b/src/garage/np/algos/cem.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from garage import log_performance
 from garage.np.algos.rl_algorithm import RLAlgorithm
-from garage.sampler import RaySampler
 
 
 class CEM(RLAlgorithm):
@@ -24,6 +23,7 @@ class CEM(RLAlgorithm):
     Args:
         env_spec (EnvSpec): Environment specification.
         policy (garage.np.policies.Policy): Action policy.
+        sampler (garage.sampler.Sampler): Sampler.
         n_samples (int): Number of policies sampled in one epoch.
         discount (float): Environment reward discount.
         best_frac (float): The best fraction.
@@ -36,6 +36,7 @@ class CEM(RLAlgorithm):
     def __init__(self,
                  env_spec,
                  policy,
+                 sampler,
                  n_samples,
                  discount=0.99,
                  init_std=1,
@@ -45,7 +46,7 @@ class CEM(RLAlgorithm):
         self.policy = policy
         self.max_episode_length = env_spec.max_episode_length
 
-        self.sampler_cls = RaySampler
+        self.sampler = sampler
 
         self._best_frac = best_frac
         self._init_std = init_std

--- a/src/garage/np/algos/cma_es.py
+++ b/src/garage/np/algos/cma_es.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from garage import log_performance
 from garage.np.algos.rl_algorithm import RLAlgorithm
-from garage.sampler import RaySampler
 
 
 class CMAES(RLAlgorithm):
@@ -21,16 +20,23 @@ class CMAES(RLAlgorithm):
     Args:
         env_spec (EnvSpec): Environment specification.
         policy (garage.np.policies.Policy): Action policy.
+        sampler (garage.sampler.Sampler): Sampler.
         n_samples (int): Number of policies sampled in one epoch.
         discount (float): Environment reward discount.
         sigma0 (float): Initial std for param distribution.
 
     """
 
-    def __init__(self, env_spec, policy, n_samples, discount=0.99, sigma0=1.):
+    def __init__(self,
+                 env_spec,
+                 policy,
+                 sampler,
+                 n_samples,
+                 discount=0.99,
+                 sigma0=1.):
         self.policy = policy
         self.max_episode_length = env_spec.max_episode_length
-        self.sampler_cls = RaySampler
+        self.sampler = sampler
 
         self._env_spec = env_spec
         self._discount = discount

--- a/src/garage/sampler/local_sampler.py
+++ b/src/garage/sampler/local_sampler.py
@@ -60,8 +60,7 @@ class LocalSampler(Sampler):
             worker_class=DefaultWorker,
             worker_args=None):
         # pylint: disable=super-init-not-called
-        if not isinstance(worker_factory, WorkerFactory) and not isinstance(
-                max_episode_length, int):
+        if worker_factory is None and max_episode_length is None:
             raise TypeError('Must construct a sampler from WorkerFactory or'
                             'parameters (at least max_episode_length)')
         if isinstance(worker_factory, WorkerFactory):

--- a/src/garage/sampler/multiprocessing_sampler.py
+++ b/src/garage/sampler/multiprocessing_sampler.py
@@ -62,8 +62,7 @@ class MultiprocessingSampler(Sampler):
             worker_class=DefaultWorker,
             worker_args=None):
         # pylint: disable=super-init-not-called
-        if not isinstance(worker_factory, WorkerFactory) and not isinstance(
-                max_episode_length, int):
+        if worker_factory is None and max_episode_length is None:
             raise TypeError('Must construct a sampler from WorkerFactory or'
                             'parameters (at least max_episode_length)')
         if isinstance(worker_factory, WorkerFactory):

--- a/src/garage/sampler/multiprocessing_sampler.py
+++ b/src/garage/sampler/multiprocessing_sampler.py
@@ -6,20 +6,24 @@ import queue
 
 import click
 import cloudpickle
+import psutil
 import setproctitle
 
 from garage import EpisodeBatch
+from garage.experiment.deterministic import get_seed
+from garage.sampler.default_worker import DefaultWorker
 from garage.sampler.sampler import Sampler
+from garage.sampler.worker_factory import WorkerFactory
 
 
 class MultiprocessingSampler(Sampler):
     """Sampler that uses multiprocessing to distribute workers.
 
+    The sampler need to be created either from a worker factory or from
+    parameters which can construct a worker factory. See the __init__ method
+    of WorkerFactory for the detail of these parameters.
+
     Args:
-        worker_factory (WorkerFactory): Pickleable factory for creating
-            workers. Should be transmitted to other processes / nodes where
-            work needs to be done, then workers should be constructed
-            there.
         agents (Policy or List[Policy]): Agent(s) to use to sample episodes.
             If a list is passed in, it must have length exactly
             `worker_factory.n_workers`, and will be spread across the
@@ -28,12 +32,51 @@ class MultiprocessingSampler(Sampler):
             episodes are sampled. If a list is passed in, it must have length
             exactly `worker_factory.n_workers`, and will be spread across the
             workers.
+        worker_factory (WorkerFactory): Pickleable factory for creating
+            workers. Should be transmitted to other processes / nodes where
+            work needs to be done, then workers should be constructed
+            there. Either this param or params after this are required to
+            construct a sampler.
+        max_episode_length(int): Params used to construct a worker factory.
+            The maximum length episodes which will be sampled.
+        is_tf_worker (bool): Whether it is workers for TFTrainer.
+        seed(int): The seed to use to initialize random number generators.
+        n_workers(int): The number of workers to use.
+        worker_class(type): Class of the workers. Instances should implement
+            the Worker interface.
+        worker_args (dict or None): Additional arguments that should be passed
+            to the worker.
 
     """
 
-    def __init__(self, worker_factory, agents, envs):
+    def __init__(
+            self,
+            agents,
+            envs,
+            *,  # After this require passing by keyword.
+            worker_factory=None,
+            max_episode_length=None,
+            is_tf_worker=False,
+            seed=get_seed(),
+            n_workers=psutil.cpu_count(logical=False),
+            worker_class=DefaultWorker,
+            worker_args=None):
         # pylint: disable=super-init-not-called
-        self._factory = worker_factory
+        if not isinstance(worker_factory, WorkerFactory) and not isinstance(
+                max_episode_length, int):
+            raise TypeError('Must construct a sampler from WorkerFactory or'
+                            'parameters (at least max_episode_length)')
+        if isinstance(worker_factory, WorkerFactory):
+            self._factory = worker_factory
+        else:
+            self._factory = WorkerFactory(
+                max_episode_length=max_episode_length,
+                is_tf_worker=is_tf_worker,
+                seed=seed,
+                n_workers=n_workers,
+                worker_class=worker_class,
+                worker_args=worker_args)
+
         self._agents = self._factory.prepare_worker_messages(
             agents, cloudpickle.dumps)
         self._envs = self._factory.prepare_worker_messages(envs)
@@ -85,7 +128,7 @@ class MultiprocessingSampler(Sampler):
             Sampler: An instance of `cls`.
 
         """
-        return cls(worker_factory, agents, envs)
+        return cls(agents, envs, worker_factory=worker_factory)
 
     def _push_updates(self, updated_workers, agent_updates, env_updates):
         """Apply updates to the workers and (re)start them.
@@ -304,7 +347,9 @@ class MultiprocessingSampler(Sampler):
             state (dict): Unpickled state.
 
         """
-        self.__init__(state['factory'], state['agents'], state['envs'])
+        self.__init__(state['agents'],
+                      state['envs'],
+                      worker_factory=state['factory'])
 
 
 def run_worker(factory, to_worker, to_sampler, worker_number, agent, env):

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -58,8 +58,7 @@ class RaySampler(Sampler):
             worker_class=DefaultWorker,
             worker_args=None):
         # pylint: disable=super-init-not-called
-        if not isinstance(worker_factory, WorkerFactory) and not isinstance(
-                max_episode_length, int):
+        if worker_factory is None and max_episode_length is None:
             raise TypeError('Must construct a sampler from WorkerFactory or'
                             'parameters (at least max_episode_length)')
         if isinstance(worker_factory, WorkerFactory):

--- a/src/garage/sampler/ray_sampler.py
+++ b/src/garage/sampler/ray_sampler.py
@@ -11,28 +11,70 @@ import itertools
 
 import click
 import cloudpickle
+import psutil
 import ray
 
 from garage import EpisodeBatch
+from garage.experiment.deterministic import get_seed
+from garage.sampler.default_worker import DefaultWorker
 from garage.sampler.sampler import Sampler
+from garage.sampler.worker_factory import WorkerFactory
 
 
 class RaySampler(Sampler):
     """Samples episodes in a data-parallel fashion using a Ray cluster.
 
+    The sampler need to be created either from a worker factory or from
+    parameters which can construct a worker factory. See the __init__ method
+    of WorkerFactory for the detail of these parameters.
+
     Args:
-        worker_factory (WorkerFactory): Used for worker behavior.
         agents (list[Policy]): Agents to distribute across workers.
         envs (list[Environment]): Environments to distribute across workers.
+        worker_factory (WorkerFactory): Used for worker behavior. Either this
+            param or params after this are required to construct a sampler.
+        max_episode_length(int): Params used to construct a worker factory.
+            The maximum length episodes which will be sampled.
+        is_tf_worker (bool): Whether it is workers for TFTrainer.
+        seed(int): The seed to use to initialize random number generators.
+        n_workers(int): The number of workers to use.
+        worker_class(type): Class of the workers. Instances should implement
+            the Worker interface.
+        worker_args (dict or None): Additional arguments that should be passed
+            to the worker.
 
     """
 
-    def __init__(self, worker_factory, agents, envs):
+    def __init__(
+            self,
+            agents,
+            envs,
+            *,  # After this require passing by keyword.
+            worker_factory=None,
+            max_episode_length=None,
+            is_tf_worker=False,
+            seed=get_seed(),
+            n_workers=psutil.cpu_count(logical=False),
+            worker_class=DefaultWorker,
+            worker_args=None):
         # pylint: disable=super-init-not-called
+        if not isinstance(worker_factory, WorkerFactory) and not isinstance(
+                max_episode_length, int):
+            raise TypeError('Must construct a sampler from WorkerFactory or'
+                            'parameters (at least max_episode_length)')
+        if isinstance(worker_factory, WorkerFactory):
+            self._worker_factory = worker_factory
+        else:
+            self._worker_factory = WorkerFactory(
+                max_episode_length=max_episode_length,
+                is_tf_worker=is_tf_worker,
+                seed=seed,
+                n_workers=n_workers,
+                worker_class=worker_class,
+                worker_args=worker_args)
         if not ray.is_initialized():
             ray.init(log_to_driver=False, ignore_reinit_error=True)
         self._sampler_worker = ray.remote(SamplerWorker)
-        self._worker_factory = worker_factory
         self._agents = agents
         self._envs = self._worker_factory.prepare_worker_messages(envs)
         self._all_workers = defaultdict(None)
@@ -62,7 +104,7 @@ class RaySampler(Sampler):
             Sampler: An instance of `cls`.
 
         """
-        return cls(worker_factory, agents, envs)
+        return cls(agents, envs, worker_factory=worker_factory)
 
     def start_worker(self):
         """Initialize a new ray worker."""

--- a/src/garage/tf/algos/_rl2npo.py
+++ b/src/garage/tf/algos/_rl2npo.py
@@ -16,6 +16,7 @@ class RL2NPO(NPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -7,7 +7,6 @@ import tensorflow as tf
 from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes)
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf import compile_function, get_target_ops
 
 # yapf: enable
@@ -30,6 +29,7 @@ class DDPG(RLAlgorithm):
         policy (Policy): Policy.
         qf (object): The q value network.
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         steps_per_epoch (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         buffer_batch_size (int): Batch size of replay buffer.
@@ -66,6 +66,7 @@ class DDPG(RLAlgorithm):
             policy,
             qf,
             replay_buffer,
+            sampler,
             *,  # Everything after this is numbers.
             steps_per_epoch=20,
             n_train_steps=50,
@@ -127,8 +128,7 @@ class DDPG(RLAlgorithm):
         self.policy = policy
         self.exploration_policy = exploration_policy
 
-        self.sampler_cls = LocalSampler
-        self.worker_cls = FragmentWorker
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -7,7 +7,6 @@ import tensorflow as tf
 
 from garage import log_performance, make_optimizer, obtain_evaluation_episodes
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf import compile_function, get_target_ops
 
 # yapf: enable
@@ -27,6 +26,7 @@ class DQN(RLAlgorithm):
         policy (Policy): Policy.
         qf (object): The q value network.
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         exploration_policy (ExplorationPolicy): Exploration strategy.
         steps_per_epoch (int): Number of train_once calls per epoch.
         min_buffer_size (int): The minimum buffer size for replay buffer.
@@ -55,6 +55,7 @@ class DQN(RLAlgorithm):
                  policy,
                  qf,
                  replay_buffer,
+                 sampler,
                  exploration_policy=None,
                  steps_per_epoch=20,
                  min_buffer_size=int(1e4),
@@ -99,8 +100,7 @@ class DQN(RLAlgorithm):
         self.policy = policy
         self.exploration_policy = exploration_policy
 
-        self.sampler_cls = LocalSampler
-        self.worker_cls = FragmentWorker
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/erwr.py
+++ b/src/garage/tf/algos/erwr.py
@@ -23,6 +23,7 @@ class ERWR(VPG):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -65,6 +66,7 @@ class ERWR(VPG):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=1,
@@ -88,6 +90,7 @@ class ERWR(VPG):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -10,7 +10,6 @@ import tensorflow as tf
 from garage import log_performance, make_optimizer
 from garage.np import explained_variance_1d, pad_batch_array
 from garage.np.algos import RLAlgorithm
-from garage.sampler import RaySampler
 from garage.tf import (center_advs, compile_function, compute_advantages,
                        discounted_returns, flatten_inputs, graph_inputs,
                        positive_advs)
@@ -26,6 +25,7 @@ class NPO(RLAlgorithm):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -81,6 +81,7 @@ class NPO(RLAlgorithm):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=1,
@@ -141,7 +142,8 @@ class NPO(RLAlgorithm):
         self._old_policy_network = None
 
         self._episode_reward_mean = collections.deque(maxlen=100)
-        self.sampler_cls = RaySampler
+
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/ppo.py
+++ b/src/garage/tf/algos/ppo.py
@@ -12,6 +12,7 @@ class PPO(NPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -54,6 +55,7 @@ class PPO(NPO):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=1,
@@ -77,6 +79,7 @@ class PPO(NPO):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -10,7 +10,6 @@ import tensorflow as tf
 from garage import _Default, log_performance, make_optimizer
 from garage.np import pad_batch_array
 from garage.np.algos import RLAlgorithm
-from garage.sampler import RaySampler
 from garage.tf import (compile_function, flatten_inputs, graph_inputs,
                        new_tensor)
 from garage.tf.optimizers import LBFGSOptimizer
@@ -34,6 +33,7 @@ class REPS(RLAlgorithm):  # noqa: D416
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -64,6 +64,7 @@ class REPS(RLAlgorithm):  # noqa: D416
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  discount=0.99,
                  gae_lambda=1,
                  center_adv=True,
@@ -112,7 +113,7 @@ class REPS(RLAlgorithm):  # noqa: D416
         self._l2_reg_loss = float(l2_reg_loss)
 
         self._episode_reward_mean = collections.deque(maxlen=100)
-        self.sampler_cls = RaySampler
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/rl2.py
+++ b/src/garage/tf/algos/rl2.py
@@ -320,6 +320,7 @@ class RL2(MetaRLAlgorithm, abc.ABC):
         self._meta_batch_size = meta_batch_size
         self._task_sampler = task_sampler
         self._meta_evaluator = meta_evaluator
+        self.sampler = self._inner_algo.sampler
 
     def train(self, trainer):
         """Obtain samplers and start actual training for each epoch.

--- a/src/garage/tf/algos/rl2ppo.py
+++ b/src/garage/tf/algos/rl2ppo.py
@@ -14,6 +14,7 @@ class RL2PPO(RL2):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         episodes_per_trial (int): Used to calculate the max episode length for
             the inner algorithm.
         scope (str): Scope for identifying the algorithm.
@@ -62,6 +63,7 @@ class RL2PPO(RL2):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  episodes_per_trial,
                  scope=None,
                  discount=0.99,
@@ -87,6 +89,7 @@ class RL2PPO(RL2):
                          env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          episodes_per_trial=episodes_per_trial,
                          scope=scope,
                          discount=discount,

--- a/src/garage/tf/algos/rl2trpo.py
+++ b/src/garage/tf/algos/rl2trpo.py
@@ -15,6 +15,7 @@ class RL2TRPO(RL2):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -65,6 +66,7 @@ class RL2TRPO(RL2):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  episodes_per_trial,
                  scope=None,
                  discount=0.99,
@@ -101,6 +103,7 @@ class RL2TRPO(RL2):
                          env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          episodes_per_trial=episodes_per_trial,
                          scope=scope,
                          discount=discount,

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -12,7 +12,6 @@ import tensorflow as tf
 from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes)
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf import compile_function, get_target_ops
 
 # yapf: enable
@@ -32,6 +31,7 @@ class TD3(RLAlgorithm):
         qf (garage.tf.q_functions.QFunction): Q-function.
         qf2 (garage.tf.q_functions.QFunction): Q function to use
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         target_update_tau (float): Interpolation parameter for doing the
             soft target update.
         policy_lr (float): Learning rate for training policy network.
@@ -73,6 +73,7 @@ class TD3(RLAlgorithm):
             qf,
             qf2,
             replay_buffer,
+            sampler,
             *,  # Everything after this is numbers.
             target_update_tau=0.01,
             policy_weight_decay=0,
@@ -147,8 +148,7 @@ class TD3(RLAlgorithm):
         self.policy = policy
         self.exploration_policy = exploration_policy
 
-        self.sampler_cls = LocalSampler
-        self.worker_cls = FragmentWorker
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/te_npo.py
+++ b/src/garage/tf/algos/te_npo.py
@@ -12,7 +12,6 @@ from garage.experiment import deterministic
 from garage.np import (discount_cumsum, explained_variance_1d, pad_batch_array,
                        rrse, sliding_window)
 from garage.np.algos import RLAlgorithm
-from garage.sampler import LocalSampler
 from garage.tf import (center_advs, compile_function, compute_advantages,
                        concat_tensor_list, discounted_returns, flatten_inputs,
                        graph_inputs, pad_tensor_dict, positive_advs,
@@ -34,6 +33,7 @@ class TENPO(RLAlgorithm):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.TaskEmbeddingPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -80,6 +80,7 @@ class TENPO(RLAlgorithm):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=1,
@@ -153,7 +154,7 @@ class TENPO(RLAlgorithm):
         self._infer_network = None
         self._old_infer_network = None
 
-        self.sampler_cls = LocalSampler
+        self.sampler = sampler
 
         self._init_opt()
 

--- a/src/garage/tf/algos/te_ppo.py
+++ b/src/garage/tf/algos/te_ppo.py
@@ -13,6 +13,7 @@ class TEPPO(TENPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.TaskEmbeddingPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -59,6 +60,7 @@ class TEPPO(TENPO):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=0.98,
@@ -90,6 +92,7 @@ class TEPPO(TENPO):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/algos/tnpg.py
+++ b/src/garage/tf/algos/tnpg.py
@@ -12,6 +12,7 @@ class TNPG(NPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -54,6 +55,7 @@ class TNPG(NPO):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=0.98,
@@ -80,6 +82,7 @@ class TNPG(NPO):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/algos/trpo.py
+++ b/src/garage/tf/algos/trpo.py
@@ -13,6 +13,7 @@ class TRPO(NPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -56,6 +57,7 @@ class TRPO(NPO):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=0.98,
@@ -87,6 +89,7 @@ class TRPO(NPO):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/algos/vpg.py
+++ b/src/garage/tf/algos/vpg.py
@@ -10,6 +10,7 @@ class VPG(NPO):
         env_spec (EnvSpec): Environment specification.
         policy (garage.tf.policies.StochasticPolicy): Policy.
         baseline (garage.tf.baselines.Baseline): The baseline.
+        sampler (garage.sampler.Sampler): Sampler.
         scope (str): Scope for identifying the algorithm.
             Must be specified if running multiple algorithms
             simultaneously, each using different environments
@@ -52,6 +53,7 @@ class VPG(NPO):
                  env_spec,
                  policy,
                  baseline,
+                 sampler,
                  scope=None,
                  discount=0.99,
                  gae_lambda=1,
@@ -81,6 +83,7 @@ class VPG(NPO):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          baseline=baseline,
+                         sampler=sampler,
                          scope=scope,
                          discount=discount,
                          gae_lambda=gae_lambda,

--- a/src/garage/tf/samplers/worker.py
+++ b/src/garage/tf/samplers/worker.py
@@ -1,7 +1,7 @@
 """Default TensorFlow sampler Worker."""
 import tensorflow as tf
 
-from garage.sampler import Worker
+from garage.sampler.worker import Worker
 
 
 class TFWorkerClassWrapper:

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -9,7 +9,6 @@ import torch
 from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes)
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import dict_np_to_torch, torch_to_np
 
 # yapf: enable
@@ -29,6 +28,7 @@ class DDPG(RLAlgorithm):
         policy (garage.torch.policies.Policy): Policy.
         qf (object): Q-value network.
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         steps_per_epoch (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         buffer_batch_size (int): Batch size of replay buffer.
@@ -71,6 +71,7 @@ class DDPG(RLAlgorithm):
             policy,
             qf,
             replay_buffer,
+            sampler,
             *,  # Everything after this is numbers.
             steps_per_epoch=20,
             n_train_steps=50,
@@ -135,8 +136,7 @@ class DDPG(RLAlgorithm):
                                             module=self._qf,
                                             lr=qf_lr)
         self._eval_env = None
-        self.sampler_cls = LocalSampler
-        self.worker_cls = FragmentWorker
+        self.sampler = sampler
 
     def train(self, trainer):
         """Obtain samplers and start actual training for each epoch.

--- a/src/garage/torch/algos/dqn.py
+++ b/src/garage/torch/algos/dqn.py
@@ -10,7 +10,6 @@ import torch.nn.functional as F
 from garage import _Default, log_performance, make_optimizer
 from garage._functions import obtain_evaluation_episodes
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker
 from garage.torch import global_device, np_to_torch
 
 
@@ -28,6 +27,7 @@ class DQN(RLAlgorithm):
             policy that performs the action that yields the highest Q value.
         qf (nn.Module): Q-value network.
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         steps_per_epoch (int): Number of train_once calls per epoch.
         n_train_steps (int): Training steps.
         eval_env (Environment): Evaluation environment. If None, a copy of the
@@ -59,7 +59,6 @@ class DQN(RLAlgorithm):
             gradient are not clipped. Defaults to 10.
         reward_scale (float): Reward scale.
     """
-    worker_cls = FragmentWorker
 
     def __init__(
             self,
@@ -67,6 +66,7 @@ class DQN(RLAlgorithm):
             policy,
             qf,
             replay_buffer,
+            sampler,
             exploration_policy=None,
             eval_env=None,
             double_q=True,
@@ -123,6 +123,8 @@ class DQN(RLAlgorithm):
                                             module=self._qf,
                                             lr=qf_lr)
         self._eval_env = eval_env
+
+        self.sampler = sampler
 
     def train(self, trainer):
         """Obtain samplers and start actual training for each epoch.

--- a/src/garage/torch/algos/maml.py
+++ b/src/garage/torch/algos/maml.py
@@ -10,7 +10,6 @@ import torch
 from garage import (_Default, EpisodeBatch, log_multitask_performance,
                     make_optimizer)
 from garage.np import discount_cumsum
-from garage.sampler import RaySampler
 from garage.torch import update_module_params
 from garage.torch.optimizers import (ConjugateGradientOptimizer,
                                      DifferentiableSGD)
@@ -26,6 +25,7 @@ class MAML:
             computing loss.
         env (Environment): An environment.
         policy (garage.torch.policies.Policy): Policy.
+        sampler (garage.sampler.Sampler): Sampler.
         task_sampler (garage.experiment.TaskSampler): Task sampler.
         meta_optimizer (Union[torch.optim.Optimizer, tuple]):
             Type of optimizer.
@@ -46,6 +46,7 @@ class MAML:
                  inner_algo,
                  env,
                  policy,
+                 sampler,
                  task_sampler,
                  meta_optimizer,
                  meta_batch_size=40,
@@ -54,7 +55,7 @@ class MAML:
                  num_grad_updates=1,
                  meta_evaluator=None,
                  evaluate_every_n_epochs=1):
-        self.sampler_cls = RaySampler
+        self.sampler = sampler
 
         self.max_episode_length = inner_algo.max_episode_length
 

--- a/src/garage/torch/algos/maml_ppo.py
+++ b/src/garage/torch/algos/maml_ppo.py
@@ -14,6 +14,7 @@ class MAMLPPO(MAML):
         env (Environment): A multi-task environment.
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.np.baselines.Baseline): The value function.
+        sampler (garage.sampler.Sampler): Sampler.
         task_sampler (garage.experiment.TaskSampler): Task sampler.
         inner_lr (float): Adaptation learning rate.
         outer_lr (float): Meta policy learning rate.
@@ -51,6 +52,7 @@ class MAMLPPO(MAML):
                  env,
                  policy,
                  value_function,
+                 sampler,
                  task_sampler,
                  inner_lr=_Default(1e-1),
                  outer_lr=1e-3,
@@ -76,6 +78,7 @@ class MAMLPPO(MAML):
         inner_algo = PPO(env.spec,
                          policy,
                          value_function,
+                         None,
                          policy_optimizer=policy_optimizer,
                          vf_optimizer=vf_optimizer,
                          lr_clip_range=lr_clip_range,
@@ -92,6 +95,7 @@ class MAMLPPO(MAML):
         super().__init__(inner_algo=inner_algo,
                          env=env,
                          policy=policy,
+                         sampler=sampler,
                          task_sampler=task_sampler,
                          meta_optimizer=torch.optim.Adam,
                          meta_batch_size=meta_batch_size,

--- a/src/garage/torch/algos/maml_trpo.py
+++ b/src/garage/torch/algos/maml_trpo.py
@@ -15,6 +15,7 @@ class MAMLTRPO(MAML):
         env (Environment): A multi-task environment.
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.np.baselines.Baseline): The value function.
+        sampler (garage.sampler.Sampler): Sampler.
         task_sampler (garage.experiment.TaskSampler): Task sampler.
         inner_lr (float): Adaptation learning rate.
         outer_lr (float): Meta policy learning rate.
@@ -52,6 +53,7 @@ class MAMLTRPO(MAML):
                  env,
                  policy,
                  value_function,
+                 sampler,
                  task_sampler,
                  inner_lr=_Default(1e-2),
                  outer_lr=1e-3,
@@ -77,6 +79,7 @@ class MAMLTRPO(MAML):
         inner_algo = VPG(env.spec,
                          policy,
                          value_function,
+                         None,
                          policy_optimizer=policy_optimizer,
                          vf_optimizer=vf_optimizer,
                          num_train_per_epoch=1,
@@ -95,6 +98,7 @@ class MAMLTRPO(MAML):
         super().__init__(inner_algo=inner_algo,
                          env=env,
                          policy=policy,
+                         sampler=sampler,
                          task_sampler=task_sampler,
                          meta_optimizer=meta_optimizer,
                          meta_batch_size=meta_batch_size,

--- a/src/garage/torch/algos/maml_vpg.py
+++ b/src/garage/torch/algos/maml_vpg.py
@@ -14,6 +14,7 @@ class MAMLVPG(MAML):
         env (Environment): A multi-task environment.
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.np.baselines.Baseline): The value function.
+        sampler (garage.sampler.Sampler): Sampler.
         task_sampler (garage.experiment.TaskSampler): Task sampler.
         inner_lr (float): Adaptation learning rate.
         outer_lr (float): Meta policy learning rate.
@@ -49,6 +50,7 @@ class MAMLVPG(MAML):
                  env,
                  policy,
                  value_function,
+                 sampler,
                  task_sampler,
                  inner_lr=_Default(1e-1),
                  outer_lr=1e-3,
@@ -72,6 +74,7 @@ class MAMLVPG(MAML):
         inner_algo = VPG(env.spec,
                          policy,
                          value_function,
+                         None,
                          policy_optimizer=policy_optimizer,
                          vf_optimizer=vf_optimizer,
                          num_train_per_epoch=1,
@@ -87,6 +90,7 @@ class MAMLVPG(MAML):
         super().__init__(inner_algo=inner_algo,
                          env=env,
                          policy=policy,
+                         sampler=sampler,
                          task_sampler=task_sampler,
                          meta_optimizer=torch.optim.Adam,
                          meta_batch_size=meta_batch_size,

--- a/src/garage/torch/algos/mtsac.py
+++ b/src/garage/torch/algos/mtsac.py
@@ -34,6 +34,7 @@ class MTSAC(SAC):
             collected by the sampler.
         env_spec (EnvSpec): The env_spec attribute of the environment that the
             agent is being trained in.
+        sampler (garage.sampler.Sampler): Sampler.
         num_tasks (int): The number of tasks being learned.
         max_episode_length_eval (int or None): Maximum length of episodes used
             for off-policy evaluation. If None, defaults to
@@ -82,6 +83,7 @@ class MTSAC(SAC):
         qf2,
         replay_buffer,
         env_spec,
+        sampler,
         *,
         num_tasks,
         eval_env,
@@ -108,6 +110,7 @@ class MTSAC(SAC):
             qf1=qf1,
             qf2=qf2,
             replay_buffer=replay_buffer,
+            sampler=sampler,
             env_spec=env_spec,
             max_episode_length_eval=max_episode_length_eval,
             gradient_steps_per_itr=gradient_steps_per_itr,

--- a/src/garage/torch/algos/pearl.py
+++ b/src/garage/torch/algos/pearl.py
@@ -41,6 +41,7 @@ class PEARL(MetaRLAlgorithm):
         inner_policy (garage.torch.policies.Policy): Policy.
         qf (torch.nn.Module): Q-function.
         vf (torch.nn.Module): Value function.
+        sampler (garage.sampler.Sampler): Sampler.
         num_train_tasks (int): Number of tasks for training.
         num_test_tasks (int or None): Number of tasks for testing.
         latent_dim (int): Size of latent context vector.
@@ -96,6 +97,7 @@ class PEARL(MetaRLAlgorithm):
             inner_policy,
             qf,
             vf,
+            sampler,
             *,  # Mostly numbers after here.
             num_train_tasks,
             num_test_tasks=None,
@@ -163,6 +165,8 @@ class PEARL(MetaRLAlgorithm):
         self._task_idx = None
         self._single_env = env[0]()
         self.max_episode_length = self._single_env.spec.max_episode_length
+
+        self.sampler = sampler
 
         self._is_resuming = False
 

--- a/src/garage/torch/algos/ppo.py
+++ b/src/garage/torch/algos/ppo.py
@@ -13,6 +13,7 @@ class PPO(VPG):
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.torch.value_functions.ValueFunction): The value
             function.
+        sampler (garage.sampler.Sampler): Sampler.
         policy_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer
             for policy.
         vf_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer for
@@ -47,6 +48,7 @@ class PPO(VPG):
                  env_spec,
                  policy,
                  value_function,
+                 sampler,
                  policy_optimizer=None,
                  vf_optimizer=None,
                  lr_clip_range=2e-1,
@@ -76,6 +78,7 @@ class PPO(VPG):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          value_function=value_function,
+                         sampler=sampler,
                          policy_optimizer=policy_optimizer,
                          vf_optimizer=vf_optimizer,
                          num_train_per_epoch=num_train_per_epoch,

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -10,7 +10,6 @@ import torch.nn.functional as F
 
 from garage import log_performance, obtain_evaluation_episodes, StepType
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, RaySampler
 from garage.torch import dict_np_to_torch, global_device
 
 # yapf: enable
@@ -43,6 +42,7 @@ class SAC(RLAlgorithm):
             Applications.
         replay_buffer (ReplayBuffer): Stores transitions that are previously
             collected by the sampler.
+        sampler (garage.sampler.Sampler): Sampler.
         env_spec (EnvSpec): The env_spec attribute of the environment that the
             agent is being trained in.
         max_episode_length_eval (int or None): Maximum length of episodes used
@@ -93,6 +93,7 @@ class SAC(RLAlgorithm):
             qf1,
             qf2,
             replay_buffer,
+            sampler,
             *,  # Everything after this is numbers.
             max_episode_length_eval=None,
             gradient_steps_per_itr,
@@ -140,8 +141,7 @@ class SAC(RLAlgorithm):
         self.env_spec = env_spec
         self.replay_buffer = replay_buffer
 
-        self.sampler_cls = RaySampler
-        self.worker_cls = FragmentWorker
+        self.sampler = sampler
 
         self._reward_scale = reward_scale
         # use 2 target q networks

--- a/src/garage/torch/algos/td3.py
+++ b/src/garage/torch/algos/td3.py
@@ -9,7 +9,6 @@ import torch.nn.functional as F
 from garage import (_Default, log_performance, make_optimizer,
                     obtain_evaluation_episodes)
 from garage.np.algos import RLAlgorithm
-from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import (dict_np_to_torch, global_device, soft_update_model,
                           torch_to_np)
 
@@ -25,6 +24,7 @@ class TD3(RLAlgorithm):
         qf1 (garage.torch.q_functions.QFunction): Q function (critic network).
         qf2 (garage.torch.q_functions.QFunction): Q function (critic network).
         replay_buffer (ReplayBuffer): Replay buffer.
+        sampler (garage.sampler.Sampler): Sampler.
         replay_buffer_size (int): Size of the replay buffer
         exploration_policy (garage.np.exploration_policies.ExplorationPolicy):
                 Exploration strategy.
@@ -81,6 +81,7 @@ class TD3(RLAlgorithm):
             qf1,
             qf2,
             replay_buffer,
+            sampler,
             *,  # Everything after this is numbers.
             max_episode_length_eval=None,
             grad_steps_per_env_step,
@@ -142,8 +143,7 @@ class TD3(RLAlgorithm):
         self._eval_env = None
         self.exploration_policy = exploration_policy
         self._uniform_random_policy = uniform_random_policy
-        self.worker_cls = FragmentWorker
-        self.sampler_cls = LocalSampler
+        self.sampler = sampler
 
         self._replay_buffer = replay_buffer
         self.policy = policy

--- a/src/garage/torch/algos/trpo.py
+++ b/src/garage/torch/algos/trpo.py
@@ -14,6 +14,7 @@ class TRPO(VPG):
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.torch.value_functions.ValueFunction): The value
             function.
+        sampler (garage.sampler.Sampler): Sampler.
         policy_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer
             for policy.
         vf_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer for
@@ -46,6 +47,7 @@ class TRPO(VPG):
                  env_spec,
                  policy,
                  value_function,
+                 sampler,
                  policy_optimizer=None,
                  vf_optimizer=None,
                  num_train_per_epoch=1,
@@ -72,6 +74,7 @@ class TRPO(VPG):
         super().__init__(env_spec=env_spec,
                          policy=policy,
                          value_function=value_function,
+                         sampler=sampler,
                          policy_optimizer=policy_optimizer,
                          vf_optimizer=vf_optimizer,
                          num_train_per_epoch=num_train_per_epoch,

--- a/src/garage/torch/algos/vpg.py
+++ b/src/garage/torch/algos/vpg.py
@@ -10,7 +10,6 @@ import torch.nn.functional as F
 from garage import log_performance
 from garage.np import discount_cumsum
 from garage.np.algos import RLAlgorithm
-from garage.sampler import RaySampler
 from garage.torch import compute_advantages, filter_valids
 from garage.torch.optimizers import OptimizerWrapper
 
@@ -25,6 +24,7 @@ class VPG(RLAlgorithm):
         policy (garage.torch.policies.Policy): Policy.
         value_function (garage.torch.value_functions.ValueFunction): The value
             function.
+        sampler (garage.sampler.Sampler): Sampler.
         policy_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer
             for policy.
         vf_optimizer (garage.torch.optimizer.OptimizerWrapper): Optimizer for
@@ -58,6 +58,7 @@ class VPG(RLAlgorithm):
         env_spec,
         policy,
         value_function,
+        sampler,
         policy_optimizer=None,
         vf_optimizer=None,
         num_train_per_epoch=1,
@@ -91,7 +92,7 @@ class VPG(RLAlgorithm):
                                           stop_entropy_gradient,
                                           policy_ent_coeff)
         self._episode_reward_mean = collections.deque(maxlen=100)
-        self.sampler_cls = RaySampler
+        self.sampler = sampler
 
         if policy_optimizer:
             self._policy_optimizer = policy_optimizer

--- a/tests/fixtures/experiment/fixture_experiment.py
+++ b/tests/fixtures/experiment/fixture_experiment.py
@@ -32,13 +32,18 @@ def fixture_exp(snapshot_config, sess):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length)
+
         algo = VPG(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    optimizer_args=dict(learning_rate=0.01, ))
 
-        trainer.setup(algo, env, sampler_cls=LocalSampler)
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=100)
 
         return policy.get_param_values()

--- a/tests/garage/envs/dm_control/test_dm_control_tf_policy.py
+++ b/tests/garage/envs/dm_control/test_dm_control_tf_policy.py
@@ -27,15 +27,22 @@ class TestDmControlTfPolicy(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+
             algo = TRPO(
                 env_spec=env.spec,
                 policy=policy,
                 baseline=baseline,
+                sampler=sampler,
                 discount=0.99,
                 max_kl_step=0.01,
             )
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             trainer.train(n_epochs=1, batch_size=10)
 
             env.close()

--- a/tests/garage/experiment/test_meta_evaluator.py
+++ b/tests/garage/experiment/test_meta_evaluator.py
@@ -45,12 +45,13 @@ class SingleActionPolicy:
 
 class OptimalActionInference(MetaRLAlgorithm):
 
-    sampler_cls = LocalSampler
-
     def __init__(self, env, max_episode_length):
         self.env = env
         self.policy = RandomPolicy(self.env.spec.action_space)
         self.max_episode_length = max_episode_length
+        self.sampler = LocalSampler(agents=self.policy,
+                                    envs=self.env,
+                                    max_episode_length=self.max_episode_length)
 
     def train(self, trainer):
         del trainer
@@ -108,8 +109,6 @@ def test_meta_evaluator():
 
 class MockAlgo:
 
-    sampler_cls = LocalSampler
-
     def __init__(self, env, policy, max_episode_length, n_exploration_eps,
                  meta_eval):
         self.env = env
@@ -117,6 +116,9 @@ class MockAlgo:
         self.max_episode_length = max_episode_length
         self.n_exploration_eps = n_exploration_eps
         self.meta_eval = meta_eval
+        self.sampler = LocalSampler(agents=self.policy,
+                                    envs=self.env,
+                                    max_episode_length=self.max_episode_length)
 
     def train(self, trainer):
         for step in trainer.step_epochs():

--- a/tests/garage/experiment/test_trainer.py
+++ b/tests/garage/experiment/test_trainer.py
@@ -4,7 +4,7 @@ import torch
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.plotter import Plotter
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -27,12 +27,11 @@ class TestTrainer:
         )
         self.value_function = GaussianMLPValueFunction(env_spec=self.env.spec)
         deterministic.set_seed(0)
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length,
             is_tf_worker=True)
-        self.sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                        agents=self.policy,
-                                                        envs=self.env)
 
     def teardown_method(self):
         """Teardown method which is called after every test."""

--- a/tests/garage/np/algos/test_cem.py
+++ b/tests/garage/np/algos/test_cem.py
@@ -23,12 +23,19 @@ class TestCEM(TfGraphTestCase):
 
             n_samples = 10
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+
             algo = CEM(env_spec=env.spec,
                        policy=policy,
+                       sampler=sampler,
                        best_frac=0.1,
                        n_samples=n_samples)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             rtn = trainer.train(n_epochs=10, batch_size=2048)
             assert rtn > 40
 

--- a/tests/garage/np/algos/test_cma_es.py
+++ b/tests/garage/np/algos/test_cma_es.py
@@ -20,9 +20,18 @@ class TestCMAES(TfGraphTestCase):
 
             n_samples = 20
 
-            algo = CMAES(env_spec=env.spec, policy=policy, n_samples=n_samples)
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            algo = CMAES(env_spec=env.spec,
+                         policy=policy,
+                         sampler=sampler,
+                         n_samples=n_samples)
+
+            trainer.setup(algo, env)
             trainer.train(n_epochs=1, batch_size=1000)
             # No assertion on return because CMAES is not stable.
 

--- a/tests/garage/sampler/test_local_sampler.py
+++ b/tests/garage/sampler/test_local_sampler.py
@@ -3,7 +3,7 @@ import pytest
 
 from garage.envs import PointEnv
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.np.policies import FixedPolicy, ScriptedPolicy
+from garage.np.policies import FixedPolicy
 from garage.sampler import LocalSampler, WorkerFactory
 
 
@@ -103,3 +103,24 @@ def test_no_seed():
     sampler = LocalSampler.from_worker_factory(workers, policy, env)
     episodes = sampler.obtain_samples(0, 160, policy)
     assert sum(episodes.lengths) >= 160
+
+
+def test_init_without_worker_factory():
+    max_episode_length = 16
+    env = PointEnv()
+    policy = FixedPolicy(env.spec,
+                         scripted_actions=[
+                             env.action_space.sample()
+                             for _ in range(max_episode_length)
+                         ])
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           seed=100,
+                           max_episode_length=max_episode_length)
+    worker_factory = WorkerFactory(seed=100,
+                                   max_episode_length=max_episode_length)
+    assert sampler._factory._seed == worker_factory._seed
+    assert (sampler._factory._max_episode_length ==
+            worker_factory._max_episode_length)
+    with pytest.raises(TypeError, match='Must construct a sampler from'):
+        LocalSampler(agents=policy, envs=env)

--- a/tests/garage/sampler/test_multiprocessing_sampler.py
+++ b/tests/garage/sampler/test_multiprocessing_sampler.py
@@ -205,6 +205,7 @@ def test_pickle():
     env.close()
 
 
+@pytest.mark.timeout(10)
 def test_init_without_worker_factory():
     max_episode_length = 16
     env = PointEnv()
@@ -224,3 +225,5 @@ def test_init_without_worker_factory():
             worker_factory._max_episode_length)
     with pytest.raises(TypeError, match='Must construct a sampler from'):
         MultiprocessingSampler(agents=policy, envs=env)
+    sampler.shutdown_worker()
+    env.close()

--- a/tests/garage/sampler/test_multiprocessing_sampler.py
+++ b/tests/garage/sampler/test_multiprocessing_sampler.py
@@ -203,3 +203,24 @@ def test_pickle():
     assert np.var(goals) > 0
     sampler2.shutdown_worker()
     env.close()
+
+
+def test_init_without_worker_factory():
+    max_episode_length = 16
+    env = PointEnv()
+    policy = FixedPolicy(env.spec,
+                         scripted_actions=[
+                             env.action_space.sample()
+                             for _ in range(max_episode_length)
+                         ])
+    sampler = MultiprocessingSampler(agents=policy,
+                                     envs=env,
+                                     seed=100,
+                                     max_episode_length=max_episode_length)
+    worker_factory = WorkerFactory(seed=100,
+                                   max_episode_length=max_episode_length)
+    assert sampler._factory._seed == worker_factory._seed
+    assert (sampler._factory._max_episode_length ==
+            worker_factory._max_episode_length)
+    with pytest.raises(TypeError, match='Must construct a sampler from'):
+        MultiprocessingSampler(agents=policy, envs=env)

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -138,7 +138,9 @@ def test_init_with_env_updates(ray_local_session_fixture):
     assert sum(episodes.lengths) >= 160
 
 
-def test_init_without_worker_factory():
+def test_init_without_worker_factory(ray_local_session_fixture):
+    del ray_local_session_fixture
+    assert ray.is_initialized()
     max_episode_length = 16
     env = PointEnv()
     policy = FixedPolicy(env.spec,

--- a/tests/garage/sampler/test_ray_batched_sampler.py
+++ b/tests/garage/sampler/test_ray_batched_sampler.py
@@ -136,3 +136,24 @@ def test_init_with_env_updates(ray_local_session_fixture):
                                              envs=tasks.sample(n_workers))
     episodes = sampler.obtain_samples(0, 160, policy)
     assert sum(episodes.lengths) >= 160
+
+
+def test_init_without_worker_factory():
+    max_episode_length = 16
+    env = PointEnv()
+    policy = FixedPolicy(env.spec,
+                         scripted_actions=[
+                             env.action_space.sample()
+                             for _ in range(max_episode_length)
+                         ])
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         seed=100,
+                         max_episode_length=max_episode_length)
+    worker_factory = WorkerFactory(seed=100,
+                                   max_episode_length=max_episode_length)
+    assert sampler._worker_factory._seed == worker_factory._seed
+    assert (sampler._worker_factory._max_episode_length ==
+            worker_factory._max_episode_length)
+    with pytest.raises(TypeError, match='Must construct a sampler from'):
+        RaySampler(agents=policy, envs=env)

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -8,7 +8,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment.deterministic import get_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -36,12 +36,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e5))
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=exploration_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -83,12 +83,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=exploration_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -130,12 +130,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=exploration_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,

--- a/tests/garage/tf/algos/test_ddpg.py
+++ b/tests/garage/tf/algos/test_ddpg.py
@@ -5,8 +5,10 @@ import pytest
 import tensorflow as tf
 
 from garage.envs import GymEnv, normalize
+from garage.experiment.deterministic import get_seed
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -34,6 +36,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e5))
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -41,6 +49,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                sampler=sampler,
                 steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,
@@ -74,7 +83,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
-
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -82,6 +96,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                sampler=sampler,
                 steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,
@@ -115,6 +130,12 @@ class TestDDPG(TfGraphTestCase):
                                         hidden_sizes=[64, 64],
                                         hidden_nonlinearity=tf.nn.relu)
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=exploration_policy, envs=env)
             algo = DDPG(
                 env_spec=env.spec,
                 policy=policy,
@@ -122,6 +143,7 @@ class TestDDPG(TfGraphTestCase):
                 qf_lr=1e-3,
                 qf=qf,
                 replay_buffer=replay_buffer,
+                sampler=sampler,
                 steps_per_epoch=20,
                 target_update_tau=1e-2,
                 n_train_steps=50,

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -12,7 +12,7 @@ from garage.envs import GymEnv
 from garage.experiment import deterministic
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteMLPQFunction
@@ -43,12 +43,12 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=epilson_greedy_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
@@ -91,12 +91,12 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=epilson_greedy_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
@@ -139,12 +139,12 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=epilson_greedy_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
@@ -187,12 +187,12 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=epilson_greedy_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,

--- a/tests/garage/tf/algos/test_dqn.py
+++ b/tests/garage/tf/algos/test_dqn.py
@@ -12,6 +12,7 @@ from garage.envs import GymEnv
 from garage.experiment import deterministic
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import DQN
 from garage.tf.policies import DiscreteQFArgmaxPolicy
 from garage.tf.q_functions import DiscreteMLPQFunction
@@ -42,11 +43,18 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
                        exploration_policy=epilson_greedy_policy,
                        replay_buffer=replay_buffer,
+                       sampler=sampler,
                        qf_lr=1e-4,
                        discount=1.0,
                        min_buffer_size=int(1e3),
@@ -83,11 +91,18 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
                        exploration_policy=epilson_greedy_policy,
                        replay_buffer=replay_buffer,
+                       sampler=sampler,
                        qf_lr=1e-4,
                        discount=1.0,
                        min_buffer_size=int(1e3),
@@ -124,11 +139,18 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
                        exploration_policy=epilson_greedy_policy,
                        replay_buffer=replay_buffer,
+                       sampler=sampler,
                        qf_lr=1e-4,
                        discount=1.0,
                        min_buffer_size=int(1e3),
@@ -165,11 +187,18 @@ class TestDQN(TfGraphTestCase):
                 max_epsilon=1.0,
                 min_epsilon=0.02,
                 decay_ratio=0.1)
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=epilson_greedy_policy, envs=env)
             algo = DQN(env_spec=env.spec,
                        policy=policy,
                        qf=qf,
                        exploration_policy=epilson_greedy_policy,
                        replay_buffer=replay_buffer,
+                       sampler=sampler,
                        qf_lr=1e-4,
                        discount=1.0,
                        min_buffer_size=int(1e3),

--- a/tests/garage/tf/algos/test_erwr.py
+++ b/tests/garage/tf/algos/test_erwr.py
@@ -3,7 +3,7 @@ import pytest
 from garage.envs import GymEnv
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import ERWR
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -27,12 +27,20 @@ class TestERWR(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = ERWR(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
 
             last_avg_ret = trainer.train(n_epochs=10, batch_size=10000)
             assert last_avg_ret > 60

--- a/tests/garage/tf/algos/test_erwr.py
+++ b/tests/garage/tf/algos/test_erwr.py
@@ -3,7 +3,7 @@ import pytest
 from garage.envs import GymEnv
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import ERWR
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -27,12 +27,11 @@ class TestERWR(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = ERWR(env_spec=env.spec,
                         policy=policy,

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -6,7 +6,7 @@ import pytest
 import tensorflow as tf
 
 from garage.envs import GymEnv, normalize
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import NPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.policies import GaussianMLPPolicy
@@ -31,6 +31,12 @@ class TestNPO(TfGraphTestCase):
             env_spec=self.env.spec,
             hidden_sizes=(32, 32),
         )
+        worker_factory = WorkerFactory(
+            max_episode_length=self.env.spec.max_episode_length,
+            is_tf_worker=True)
+        self.sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                        agents=self.policy,
+                                                        envs=self.env)
 
     @pytest.mark.flaky
     @pytest.mark.mujoco
@@ -40,10 +46,11 @@ class TestNPO(TfGraphTestCase):
             algo = NPO(env_spec=self.env.spec,
                        policy=self.policy,
                        baseline=self.baseline,
+                       sampler=self.sampler,
                        discount=0.99,
                        gae_lambda=0.98,
                        policy_ent_coeff=0.0)
-            trainer.setup(algo, self.env, sampler_cls=LocalSampler)
+            trainer.setup(algo, self.env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 20
 
@@ -55,6 +62,7 @@ class TestNPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 pg_loss='random pg_loss',
             )
 
@@ -66,6 +74,7 @@ class TestNPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 entropy_method=None,
             )
 
@@ -77,6 +86,7 @@ class TestNPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 entropy_method='max',
                 center_adv=True,
             )
@@ -89,6 +99,7 @@ class TestNPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 entropy_method='max',
                 stop_entropy_gradient=False,
             )
@@ -101,6 +112,7 @@ class TestNPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 entropy_method='no_entropy',
                 policy_ent_coeff=0.02,
             )

--- a/tests/garage/tf/algos/test_npo.py
+++ b/tests/garage/tf/algos/test_npo.py
@@ -6,7 +6,7 @@ import pytest
 import tensorflow as tf
 
 from garage.envs import GymEnv, normalize
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import NPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.policies import GaussianMLPPolicy
@@ -31,12 +31,11 @@ class TestNPO(TfGraphTestCase):
             env_spec=self.env.spec,
             hidden_sizes=(32, 32),
         )
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length,
             is_tf_worker=True)
-        self.sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                        agents=self.policy,
-                                                        envs=self.env)
 
     @pytest.mark.flaky
     @pytest.mark.mujoco

--- a/tests/garage/tf/algos/test_ppo.py
+++ b/tests/garage/tf/algos/test_ppo.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 # yapf: disable
 from garage.envs import GymEnv, normalize
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import ContinuousMLPBaseline, GaussianMLPBaseline
 from garage.tf.policies import (CategoricalMLPPolicy, GaussianGRUPolicy,
@@ -41,12 +41,11 @@ class TestPPO(TfGraphTestCase):
             env_spec=self.env.spec,
             hidden_sizes=(32, 32),
         )
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length,
             is_tf_worker=True)
-        self.sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                        agents=self.policy,
-                                                        envs=self.env)
 
     @pytest.mark.mujoco
     def test_ppo_pendulum(self):
@@ -175,12 +174,11 @@ class TestPPOContinuousBaseline(TfGraphTestCase):
                 env_spec=env.spec,
                 hidden_sizes=(32, 32),
             )
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
             algo = PPO(
                 env_spec=env.spec,
                 policy=policy,
@@ -215,12 +213,11 @@ class TestPPOContinuousBaseline(TfGraphTestCase):
                 env_spec=env.spec,
                 hidden_sizes=(32, 32),
             )
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
             algo = PPO(
                 env_spec=env.spec,
                 policy=policy,
@@ -258,12 +255,11 @@ class TestPPOPendulumLSTM(TfGraphTestCase):
                 env_spec=env.spec,
                 hidden_sizes=(32, 32),
             )
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=lstm_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=lstm_policy,
-                                                       envs=env)
             algo = PPO(
                 env_spec=env.spec,
                 policy=lstm_policy,
@@ -299,12 +295,11 @@ class TestPPOPendulumGRU(TfGraphTestCase):
                 env_spec=env.spec,
                 hidden_sizes=(32, 32),
             )
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=gru_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=gru_policy,
-                                                       envs=env)
             algo = PPO(
                 env_spec=env.spec,
                 policy=gru_policy,

--- a/tests/garage/tf/algos/test_reps.py
+++ b/tests/garage/tf/algos/test_reps.py
@@ -6,7 +6,7 @@ import pytest
 
 from garage.envs import GymEnv
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import REPS
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -27,12 +27,20 @@ class TestREPS(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = REPS(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
 
             last_avg_ret = trainer.train(n_epochs=10, batch_size=4000)
             assert last_avg_ret > 5

--- a/tests/garage/tf/algos/test_reps.py
+++ b/tests/garage/tf/algos/test_reps.py
@@ -6,7 +6,7 @@ import pytest
 
 from garage.envs import GymEnv
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import REPS
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -27,12 +27,11 @@ class TestREPS(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = REPS(env_spec=env.spec,
                         policy=policy,

--- a/tests/garage/tf/algos/test_rl2trpo.py
+++ b/tests/garage/tf/algos/test_rl2trpo.py
@@ -8,7 +8,7 @@ import pytest
 from garage.envs import GymEnv, normalize
 from garage.experiment import task_sampler
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import RL2TRPO
 from garage.tf.algos.rl2 import RL2Env, RL2Worker
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
@@ -58,15 +58,13 @@ class TestRL2TRPO(TfGraphTestCase):
                                         hidden_dim=64,
                                         state_include_action=False)
         self.baseline = LinearFeatureBaseline(env_spec=self.env_spec)
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.tasks.sample(self.meta_batch_size),
             max_episode_length=self.env_spec.max_episode_length,
             is_tf_worker=True,
             n_workers=self.meta_batch_size,
             worker_class=RL2Worker)
-        self.sampler = LocalSampler.from_worker_factory(
-            worker_factory,
-            agents=self.policy,
-            envs=self.tasks.sample(self.meta_batch_size))
 
     def test_rl2_trpo_pendulum(self):
         with TFTrainer(snapshot_config, sess=self.sess) as trainer:

--- a/tests/garage/tf/algos/test_td3.py
+++ b/tests/garage/tf/algos/test_td3.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.tf.algos import TD3
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -55,6 +55,13 @@ class TestTD3(TfGraphTestCase):
 
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True,
+                worker_class=FragmentWorker)
+            sampler = LocalSampler.from_worker_factory(
+                worker_factory, agents=exploration_policy, envs=env)
+
             algo = TD3(env_spec=env.spec,
                        policy=policy,
                        policy_lr=1e-3,
@@ -62,6 +69,7 @@ class TestTD3(TfGraphTestCase):
                        qf=qf,
                        qf2=qf2,
                        replay_buffer=replay_buffer,
+                       sampler=sampler,
                        steps_per_epoch=steps_per_epoch,
                        target_update_tau=0.005,
                        n_train_steps=50,
@@ -74,7 +82,7 @@ class TestTD3(TfGraphTestCase):
                        policy_optimizer=tf.compat.v1.train.AdamOptimizer,
                        qf_optimizer=tf.compat.v1.train.AdamOptimizer)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             last_avg_ret = trainer.train(n_epochs=n_epochs,
                                          batch_size=sampler_batch_size)
             assert last_avg_ret > 200

--- a/tests/garage/tf/algos/test_td3.py
+++ b/tests/garage/tf/algos/test_td3.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 from garage.envs import GymEnv
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import TD3
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -55,12 +55,12 @@ class TestTD3(TfGraphTestCase):
 
             replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=exploration_policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=FragmentWorker)
-            sampler = LocalSampler.from_worker_factory(
-                worker_factory, agents=exploration_policy, envs=env)
 
             algo = TD3(env_spec=env.spec,
                        policy=policy,

--- a/tests/garage/tf/algos/test_te.py
+++ b/tests/garage/tf/algos/test_te.py
@@ -7,7 +7,7 @@ from garage import InOutSpec
 from garage.envs import MultiEnvWrapper, PointEnv
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TEPPO
 from garage.tf.algos.te import TaskEmbeddingWorker
 from garage.tf.embeddings import GaussianMLPEncoder
@@ -143,13 +143,12 @@ class TestTE(TfGraphTestCase):
 
     def test_te_ppo(self):
         with TFTrainer(snapshot_config, sess=self.sess) as trainer:
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=self.policy,
+                envs=self.env,
                 max_episode_length=self.env.spec.max_episode_length,
                 is_tf_worker=True,
                 worker_class=TaskEmbeddingWorker)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=self.policy,
-                                                       envs=self.env)
             algo = TEPPO(env_spec=self.env.spec,
                          policy=self.policy,
                          baseline=self.baseline,

--- a/tests/garage/tf/algos/test_tnpg.py
+++ b/tests/garage/tf/algos/test_tnpg.py
@@ -2,7 +2,7 @@ import pytest
 
 from garage.envs import GymEnv, normalize
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import TNPG
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -24,13 +24,21 @@ class TestTNPG(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = TNPG(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99,
                         optimizer_args=dict(reg_coeff=5e-1))
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
 
             last_avg_ret = trainer.train(n_epochs=10, batch_size=10000)
             assert last_avg_ret > 15

--- a/tests/garage/tf/algos/test_tnpg.py
+++ b/tests/garage/tf/algos/test_tnpg.py
@@ -2,7 +2,7 @@ import pytest
 
 from garage.envs import GymEnv, normalize
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TNPG
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -24,12 +24,11 @@ class TestTNPG(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = TNPG(env_spec=env.spec,
                         policy=policy,

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -10,14 +10,12 @@ import tensorflow as tf
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic, snapshotter
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianCNNBaseline, GaussianMLPBaseline
 from garage.tf.optimizers import FiniteDifferenceHVP
-from garage.tf.policies import (CategoricalCNNPolicy,
-                                CategoricalGRUPolicy,
-                                CategoricalLSTMPolicy,
-                                GaussianMLPPolicy)
+from garage.tf.policies import (CategoricalCNNPolicy, CategoricalGRUPolicy,
+                                CategoricalLSTMPolicy, GaussianMLPPolicy)
 from garage.trainer import TFTrainer
 
 from tests.fixtures import snapshot_config, TfGraphTestCase
@@ -41,6 +39,12 @@ class TestTRPO(TfGraphTestCase):
             env_spec=self.env.spec,
             hidden_sizes=(32, 32),
         )
+        worker_factory = WorkerFactory(
+            max_episode_length=self.env.spec.max_episode_length,
+            is_tf_worker=True)
+        self.sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                        agents=self.policy,
+                                                        envs=self.env)
 
     @pytest.mark.mujoco_long
     def test_trpo_pendulum(self):
@@ -49,10 +53,11 @@ class TestTRPO(TfGraphTestCase):
             algo = TRPO(env_spec=self.env.spec,
                         policy=self.policy,
                         baseline=self.baseline,
+                        sampler=self.sampler,
                         discount=0.99,
                         gae_lambda=0.98,
                         policy_ent_coeff=0.0)
-            trainer.setup(algo, self.env, sampler_cls=LocalSampler)
+            trainer.setup(algo, self.env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
@@ -64,6 +69,7 @@ class TestTRPO(TfGraphTestCase):
                 env_spec=self.env.spec,
                 policy=self.policy,
                 baseline=self.baseline,
+                sampler=self.sampler,
                 discount=0.99,
                 gae_lambda=0.98,
                 policy_ent_coeff=0.0,
@@ -77,11 +83,12 @@ class TestTRPO(TfGraphTestCase):
             algo = TRPO(env_spec=self.env.spec,
                         policy=self.policy,
                         baseline=self.baseline,
+                        sampler=self.sampler,
                         discount=0.99,
                         gae_lambda=0.98,
                         policy_ent_coeff=0.0,
                         kl_constraint='soft')
-            trainer.setup(algo, self.env, sampler_cls=LocalSampler)
+            trainer.setup(algo, self.env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 45
 
@@ -94,16 +101,24 @@ class TestTRPO(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99,
                         max_kl_step=0.01,
                         optimizer_args=dict(hvp_approach=FiniteDifferenceHVP(
                             base_eps=1e-5)))
 
             snapshotter.snapshot_dir = './'
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 60
 
@@ -119,15 +134,23 @@ class TestTRPO(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99,
                         max_kl_step=0.01,
                         optimizer_args=dict(hvp_approach=FiniteDifferenceHVP(
                             base_eps=1e-5)))
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > 40
 
@@ -159,15 +182,23 @@ class TestTRPOCNNCubeCrash(TfGraphTestCase):
                                            hidden_sizes=(32, 32),
                                            use_trust_region=True)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99,
                         gae_lambda=0.98,
                         max_kl_step=0.01,
                         policy_ent_coeff=0.0)
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             last_avg_ret = trainer.train(n_epochs=10, batch_size=2048)
             assert last_avg_ret > -1.5
 

--- a/tests/garage/tf/algos/test_trpo.py
+++ b/tests/garage/tf/algos/test_trpo.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic, snapshotter
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import TRPO
 from garage.tf.baselines import GaussianCNNBaseline, GaussianMLPBaseline
 from garage.tf.optimizers import FiniteDifferenceHVP
@@ -39,12 +39,11 @@ class TestTRPO(TfGraphTestCase):
             env_spec=self.env.spec,
             hidden_sizes=(32, 32),
         )
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length,
             is_tf_worker=True)
-        self.sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                        agents=self.policy,
-                                                        envs=self.env)
 
     @pytest.mark.mujoco_long
     def test_trpo_pendulum(self):
@@ -101,12 +100,11 @@ class TestTRPO(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
@@ -134,12 +132,11 @@ class TestTRPO(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
@@ -182,12 +179,11 @@ class TestTRPOCNNCubeCrash(TfGraphTestCase):
                                            hidden_sizes=(32, 32),
                                            use_trust_region=True)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = TRPO(env_spec=env.spec,
                         policy=policy,

--- a/tests/garage/tf/algos/test_vpg.py
+++ b/tests/garage/tf/algos/test_vpg.py
@@ -2,7 +2,7 @@ import pytest
 
 from garage.envs import GymEnv
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.tf.algos import VPG
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -24,12 +24,11 @@ class TestVPG(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-            worker_factory = WorkerFactory(
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
                 max_episode_length=env.spec.max_episode_length,
                 is_tf_worker=True)
-            sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                       agents=policy,
-                                                       envs=env)
 
             algo = VPG(env_spec=env.spec,
                        policy=policy,

--- a/tests/garage/tf/algos/test_vpg.py
+++ b/tests/garage/tf/algos/test_vpg.py
@@ -2,7 +2,7 @@ import pytest
 
 from garage.envs import GymEnv
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.tf.algos import VPG
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -24,13 +24,21 @@ class TestVPG(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            worker_factory = WorkerFactory(
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+            sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                       agents=policy,
+                                                       envs=env)
+
             algo = VPG(env_spec=env.spec,
                        policy=policy,
                        baseline=baseline,
+                       sampler=sampler,
                        discount=0.99,
                        optimizer_args=dict(learning_rate=0.01, ))
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
 
             last_avg_ret = trainer.train(n_epochs=10, batch_size=10000)
             assert last_avg_ret > 90

--- a/tests/garage/tf/policies/test_categorical_policies.py
+++ b/tests/garage/tf/policies/test_categorical_policies.py
@@ -11,8 +11,7 @@ from garage.sampler import LocalSampler
 from garage.tf.algos import TRPO
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
                                   FiniteDifferenceHVP)
-from garage.tf.policies import (CategoricalGRUPolicy,
-                                CategoricalLSTMPolicy,
+from garage.tf.policies import (CategoricalGRUPolicy, CategoricalLSTMPolicy,
                                 CategoricalMLPPolicy)
 from garage.trainer import TFTrainer
 
@@ -34,10 +33,17 @@ class TestCategoricalPolicies(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+
             algo = TRPO(
                 env_spec=env.spec,
                 policy=policy,
                 baseline=baseline,
+                sampler=sampler,
                 discount=0.99,
                 max_kl_step=0.01,
                 optimizer=ConjugateGradientOptimizer,
@@ -45,7 +51,7 @@ class TestCategoricalPolicies(TfGraphTestCase):
                     base_eps=1e-5)),
             )
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             trainer.train(n_epochs=1, batch_size=4000)
 
             env.close()

--- a/tests/garage/tf/policies/test_gaussian_policies.py
+++ b/tests/garage/tf/policies/test_gaussian_policies.py
@@ -7,8 +7,7 @@ from garage.sampler import LocalSampler
 from garage.tf.algos import TRPO
 from garage.tf.optimizers import (ConjugateGradientOptimizer,
                                   FiniteDifferenceHVP)
-from garage.tf.policies import (GaussianGRUPolicy,
-                                GaussianLSTMPolicy,
+from garage.tf.policies import (GaussianGRUPolicy, GaussianLSTMPolicy,
                                 GaussianMLPPolicy)
 from garage.trainer import TFTrainer
 
@@ -30,10 +29,17 @@ class TestGaussianPolicies(TfGraphTestCase):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+
             algo = TRPO(
                 env_spec=env.spec,
                 policy=policy,
                 baseline=baseline,
+                sampler=sampler,
                 discount=0.99,
                 max_kl_step=0.01,
                 optimizer=ConjugateGradientOptimizer,
@@ -41,6 +47,6 @@ class TestGaussianPolicies(TfGraphTestCase):
                     base_eps=1e-5)),
             )
 
-            trainer.setup(algo, env, sampler_cls=LocalSampler)
+            trainer.setup(algo, env)
             trainer.train(n_epochs=1, batch_size=4000)
             env.close()

--- a/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
+++ b/tests/garage/tf/samplers/test_ray_batched_sampler_tf.py
@@ -56,6 +56,6 @@ class TestRaySamplerTF():
         assert ray.is_initialized()
         workers = WorkerFactory(
             seed=100, max_episode_length=self.algo.max_episode_length)
-        sampler1 = RaySampler(workers, self.policy, self.env)
+        sampler1 = RaySampler(self.policy, self.env, worker_factory=workers)
         sampler1.start_worker()
         sampler1.shutdown_worker()

--- a/tests/garage/torch/algos/test_bc.py
+++ b/tests/garage/torch/algos/test_bc.py
@@ -89,10 +89,16 @@ def test_bc_point_deterministic(ray_local_session_fixture):  # NOQA
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = DeterministicMLPPolicy(env.spec, hidden_sizes=[8, 8])
     batch_size = 600
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length, )
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=expert,
+                                               envs=env)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,
               source=expert,
+              sampler=sampler,
               policy_lr=1e-2,
               loss='mse')
     trainer.setup(algo, env)
@@ -109,10 +115,16 @@ def test_bc_point(ray_local_session_fixture):  # NOQA
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = GaussianMLPPolicy(env.spec, [4])
     batch_size = 400
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length, )
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=expert,
+                                               envs=env)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,
               source=expert,
+              sampler=sampler,
               policy_lr=1e-2,
               loss='log_prob')
     trainer.setup(algo, env)

--- a/tests/garage/torch/algos/test_bc.py
+++ b/tests/garage/torch/algos/test_bc.py
@@ -89,11 +89,9 @@ def test_bc_point_deterministic(ray_local_session_fixture):  # NOQA
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = DeterministicMLPPolicy(env.spec, hidden_sizes=[8, 8])
     batch_size = 600
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length, )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=expert,
-                                               envs=env)
+    sampler = LocalSampler(agents=expert,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,
@@ -115,11 +113,9 @@ def test_bc_point(ray_local_session_fixture):  # NOQA
     expert = OptimalPolicy(env.spec, goal=goal)
     policy = GaussianMLPPolicy(env.spec, [4])
     batch_size = 400
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length, )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=expert,
-                                               envs=env)
+    sampler = LocalSampler(agents=expert,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
     algo = BC(env.spec,
               policy,
               batch_size=batch_size,

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -7,6 +7,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch.algos import DDPG
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -39,10 +40,18 @@ class TestDDPG:
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         algo = DDPG(env_spec=env.spec,
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    sampler=sampler,
                     steps_per_epoch=20,
                     n_train_steps=50,
                     min_buffer_size=int(1e4),
@@ -81,10 +90,18 @@ class TestDDPG:
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env.spec.max_episode_length,
+            worker_class=FragmentWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=exploration_policy,
+                                                   envs=env)
+
         algo = DDPG(env_spec=env.spec,
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    sampler=sampler,
                     steps_per_epoch=20,
                     n_train_steps=50,
                     min_buffer_size=int(1e4),

--- a/tests/garage/torch/algos/test_ddpg.py
+++ b/tests/garage/torch/algos/test_ddpg.py
@@ -7,7 +7,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch.algos import DDPG
 from garage.torch.policies import DeterministicMLPPolicy
 from garage.torch.q_functions import ContinuousMLPQFunction
@@ -40,12 +40,10 @@ class TestDDPG:
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               worker_class=FragmentWorker)
 
         algo = DDPG(env_spec=env.spec,
                     policy=policy,
@@ -90,12 +88,10 @@ class TestDDPG:
 
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
 
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               worker_class=FragmentWorker)
 
         algo = DDPG(env_spec=env.spec,
                     policy=policy,

--- a/tests/garage/torch/algos/test_dqn.py
+++ b/tests/garage/torch/algos/test_dqn.py
@@ -12,7 +12,7 @@ from garage.experiment import SnapshotConfig
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import np_to_torch
 from garage.torch.algos import DQN
 from garage.torch.policies import DiscreteQFArgmaxPolicy
@@ -42,12 +42,10 @@ def setup():
                                              max_epsilon=1.0,
                                              min_epsilon=0.01,
                                              decay_ratio=0.4)
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=exploration_policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=exploration_policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     algo = DQN(env_spec=env.spec,
                policy=policy,
                qf=qf,

--- a/tests/garage/torch/algos/test_dqn.py
+++ b/tests/garage/torch/algos/test_dqn.py
@@ -12,7 +12,7 @@ from garage.experiment import SnapshotConfig
 from garage.experiment.deterministic import set_seed
 from garage.np.exploration_policies import EpsilonGreedyPolicy
 from garage.replay_buffer import PathBuffer
-from garage.sampler import LocalSampler
+from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
 from garage.torch import np_to_torch
 from garage.torch.algos import DQN
 from garage.torch.policies import DiscreteQFArgmaxPolicy
@@ -42,11 +42,18 @@ def setup():
                                              max_epsilon=1.0,
                                              min_epsilon=0.01,
                                              decay_ratio=0.4)
+    worker_factory = WorkerFactory(
+        max_episode_length=env.spec.max_episode_length,
+        worker_class=FragmentWorker)
+    sampler = LocalSampler.from_worker_factory(worker_factory,
+                                               agents=exploration_policy,
+                                               envs=env)
     algo = DQN(env_spec=env.spec,
                policy=policy,
                qf=qf,
                exploration_policy=exploration_policy,
                replay_buffer=replay_buffer,
+               sampler=sampler,
                steps_per_epoch=steps_per_epoch,
                qf_lr=5e-5,
                double_q=False,
@@ -68,7 +75,7 @@ def test_dqn_cartpole(setup):
 
     trainer = Trainer(config)
     algo, env, _, n_epochs, batch_size = setup
-    trainer.setup(algo, env, sampler_cls=LocalSampler)
+    trainer.setup(algo, env)
     last_avg_return = trainer.train(n_epochs=n_epochs, batch_size=batch_size)
     assert last_avg_return > 10
     env.close()
@@ -82,7 +89,7 @@ def test_dqn_loss(setup):
     algo, env, buff, _, batch_size = setup
 
     trainer = Trainer(snapshot_config)
-    trainer.setup(algo, env, sampler_cls=LocalSampler)
+    trainer.setup(algo, env)
 
     paths = trainer.obtain_episodes(0, batch_size=batch_size)
     buff.add_episode_batch(paths)
@@ -126,7 +133,7 @@ def test_double_dqn_loss(setup):
 
     algo._double_q = True
     trainer = Trainer(snapshot_config)
-    trainer.setup(algo, env, sampler_cls=LocalSampler)
+    trainer.setup(algo, env)
 
     paths = trainer.obtain_episodes(0, batch_size=batch_size)
     buff.add_episode_batch(paths)

--- a/tests/garage/torch/algos/test_maml.py
+++ b/tests/garage/torch/algos/test_maml.py
@@ -47,6 +47,7 @@ class TestMAML:
                                                        hidden_sizes=(32, 32))
         self.algo = MAMLPPO(env=self.env,
                             policy=self.policy,
+                            sampler=None,
                             task_sampler=task_sampler,
                             value_function=self.value_function,
                             meta_batch_size=5,

--- a/tests/garage/torch/algos/test_maml_ppo.py
+++ b/tests/garage/torch/algos/test_maml_ppo.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic, SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import MAMLPPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -49,11 +49,10 @@ class TestMAMLPPO:
         )
         self.value_function = GaussianMLPValueFunction(env_spec=self.env.spec,
                                                        hidden_sizes=(32, 32))
-        worker_factory = WorkerFactory(
+        self.sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length)
-        self.sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                        agents=self.policy,
-                                                        envs=self.env)
 
     def teardown_method(self):
         """Teardown method which is called after every test."""

--- a/tests/garage/torch/algos/test_maml_trpo.py
+++ b/tests/garage/torch/algos/test_maml_trpo.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import MAMLTRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -51,11 +51,9 @@ def test_maml_trpo_pendulum():
             env, max_episode_length=max_episode_length),
                                          expected_action_scale=10.))
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
 
     trainer = Trainer(snapshot_config)
     algo = MAMLTRPO(env=env,
@@ -99,11 +97,9 @@ def test_maml_trpo_dummy_named_env():
     episodes_per_task = 2
     max_episode_length = env.spec.max_episode_length
 
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
 
     trainer = Trainer(snapshot_config)
     algo = MAMLTRPO(env=env,

--- a/tests/garage/torch/algos/test_maml_vpg.py
+++ b/tests/garage/torch/algos/test_maml_vpg.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic, MetaEvaluator, SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import MAMLVPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -71,11 +71,10 @@ class TestMAMLVPG:
         meta_evaluator = MetaEvaluator(test_task_sampler=task_sampler,
                                        n_test_tasks=1,
                                        n_test_episodes=10)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=self.policy,
-                                                   envs=self.env)
         trainer = Trainer(snapshot_config)
         algo = MAMLVPG(env=self.env,
                        policy=self.policy,

--- a/tests/garage/torch/algos/test_mtsac.py
+++ b/tests/garage/torch/algos/test_mtsac.py
@@ -8,7 +8,7 @@ from garage.envs import GymEnv, MultiEnvWrapper
 from garage.envs.multi_env_wrapper import round_robin_strategy
 from garage.experiment import deterministic
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import global_device, set_gpu_mode
 from garage.torch.algos import MTSAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -155,13 +155,10 @@ def test_mtsac_inverted_double_pendulum():
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     num_tasks = 2
     buffer_batch_size = 128
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker,
-    )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     mtsac = MTSAC(policy=policy,
                   qf1=qf1,
                   qf2=qf2,
@@ -270,13 +267,10 @@ def test_fixed_alpha():
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     num_tasks = 2
     buffer_batch_size = 128
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker,
-    )
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     mtsac = MTSAC(policy=policy,
                   qf1=qf1,
                   qf2=qf2,

--- a/tests/garage/torch/algos/test_pearl.py
+++ b/tests/garage/torch/algos/test_pearl.py
@@ -6,7 +6,7 @@ import pytest
 from garage.envs import MetaWorldSetTaskEnv, normalize, PointEnv
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -88,13 +88,12 @@ class TestPEARL:
             env_spec=augmented_env,
             hidden_sizes=[net_size, net_size, net_size])
 
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=None,
+            envs=env[0](),
             max_episode_length=env[0]().spec.max_episode_length,
             n_workers=1,
             worker_class=PEARLWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=None,
-                                                   envs=env[0]())
 
         pearl = PEARL(
             env=env,

--- a/tests/garage/torch/algos/test_pearl.py
+++ b/tests/garage/torch/algos/test_pearl.py
@@ -6,7 +6,7 @@ import pytest
 from garage.envs import MetaWorldSetTaskEnv, normalize, PointEnv
 from garage.experiment.deterministic import set_seed
 from garage.experiment.task_sampler import SetTaskSampler
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch import set_gpu_mode
 from garage.torch.algos import PEARL
 from garage.torch.algos.pearl import PEARLWorker
@@ -88,6 +88,14 @@ class TestPEARL:
             env_spec=augmented_env,
             hidden_sizes=[net_size, net_size, net_size])
 
+        worker_factory = WorkerFactory(
+            max_episode_length=env[0]().spec.max_episode_length,
+            n_workers=1,
+            worker_class=PEARLWorker)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=None,
+                                                   envs=env[0]())
+
         pearl = PEARL(
             env=env,
             policy_class=ContextConditionedPolicy,
@@ -95,6 +103,7 @@ class TestPEARL:
             inner_policy=inner_policy,
             qf=qf,
             vf=vf,
+            sampler=sampler,
             num_train_tasks=params['num_train_tasks'],
             latent_dim=params['latent_size'],
             encoder_hidden_sizes=params['encoder_hidden_sizes'],
@@ -117,11 +126,7 @@ class TestPEARL:
             pearl.to()
 
         trainer = Trainer(snapshot_config)
-        trainer.setup(algo=pearl,
-                      env=env[0](),
-                      sampler_cls=LocalSampler,
-                      n_workers=1,
-                      worker_class=PEARLWorker)
+        trainer.setup(algo=pearl, env=env[0]())
 
         trainer.train(n_epochs=params['num_epochs'],
                       batch_size=params['batch_size'])
@@ -151,6 +156,7 @@ class TestPEARL:
                       inner_policy=inner_policy,
                       qf=qf,
                       vf=vf,
+                      sampler=None,
                       num_train_tasks=5,
                       num_test_tasks=5,
                       latent_dim=5,

--- a/tests/garage/torch/algos/test_ppo.py
+++ b/tests/garage/torch/algos/test_ppo.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import PPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -36,11 +36,10 @@ class TestPPO:
     def test_ppo_pendulum(self):
         """Test PPO with Pendulum environment."""
         deterministic.set_seed(0)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=self.policy,
-                                                   envs=self.env)
         trainer = Trainer(snapshot_config)
         algo = PPO(env_spec=self.env.spec,
                    policy=self.policy,

--- a/tests/garage/torch/algos/test_sac.py
+++ b/tests/garage/torch/algos/test_sac.py
@@ -9,7 +9,7 @@ from torch.nn import functional as F
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import set_gpu_mode
 from garage.torch.algos import SAC
 from garage.torch.policies import TanhGaussianMLPPolicy
@@ -202,12 +202,10 @@ def test_sac_inverted_double_pendulum():
                                  hidden_nonlinearity=F.relu)
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     trainer = Trainer(snapshot_config=snapshot_config)
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     sac = SAC(env_spec=env.spec,
               policy=policy,
               qf1=qf1,
@@ -263,12 +261,10 @@ def test_fixed_alpha():
                                  hidden_nonlinearity=F.relu)
     replay_buffer = PathBuffer(capacity_in_transitions=int(1e6), )
     trainer = Trainer(snapshot_config=snapshot_config)
-    worker_factory = WorkerFactory(
-        max_episode_length=env.spec.max_episode_length,
-        worker_class=FragmentWorker)
-    sampler = LocalSampler.from_worker_factory(worker_factory,
-                                               agents=policy,
-                                               envs=env)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=FragmentWorker)
     sac = SAC(env_spec=env.spec,
               policy=policy,
               qf1=qf1,

--- a/tests/garage/torch/algos/test_td3.py
+++ b/tests/garage/torch/algos/test_td3.py
@@ -8,7 +8,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.replay_buffer import PathBuffer
-from garage.sampler import FragmentWorker, LocalSampler, WorkerFactory
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.torch import prefer_gpu
 from garage.torch.algos import TD3
 from garage.torch.policies import DeterministicMLPPolicy
@@ -47,12 +47,10 @@ class TestTD3(TfGraphTestCase):
                                      hidden_sizes=[256, 256],
                                      hidden_nonlinearity=F.relu)
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               worker_class=FragmentWorker)
         td3 = TD3(env_spec=env.spec,
                   policy=policy,
                   qf1=qf1,
@@ -97,12 +95,10 @@ class TestTD3(TfGraphTestCase):
                                      hidden_sizes=[256, 256],
                                      hidden_nonlinearity=F.relu)
         replay_buffer = PathBuffer(capacity_in_transitions=int(1e6))
-        worker_factory = WorkerFactory(
-            max_episode_length=env.spec.max_episode_length,
-            worker_class=FragmentWorker)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=exploration_policy,
-                                                   envs=env)
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               worker_class=FragmentWorker)
         td3 = TD3(env_spec=env.spec,
                   policy=policy,
                   qf1=qf1,

--- a/tests/garage/torch/algos/test_trpo.py
+++ b/tests/garage/torch/algos/test_trpo.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -36,14 +36,19 @@ class TestTRPO:
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
         deterministic.set_seed(0)
-
+        worker_factory = WorkerFactory(
+            max_episode_length=self.env.spec.max_episode_length)
+        sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                   agents=self.policy,
+                                                   envs=self.env)
         trainer = Trainer(snapshot_config)
         algo = TRPO(env_spec=self.env.spec,
                     policy=self.policy,
                     value_function=self.value_function,
+                    sampler=sampler,
                     discount=0.99,
                     gae_lambda=0.98)
 
-        trainer.setup(algo, self.env, sampler_cls=LocalSampler)
+        trainer.setup(algo, self.env)
         last_avg_ret = trainer.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 0

--- a/tests/garage/torch/algos/test_trpo.py
+++ b/tests/garage/torch/algos/test_trpo.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -36,11 +36,10 @@ class TestTRPO:
     def test_trpo_pendulum(self):
         """Test TRPO with Pendulum environment."""
         deterministic.set_seed(0)
-        worker_factory = WorkerFactory(
+        sampler = LocalSampler(
+            agents=self.policy,
+            envs=self.env,
             max_episode_length=self.env.spec.max_episode_length)
-        sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                   agents=self.policy,
-                                                   envs=self.env)
         trainer = Trainer(snapshot_config)
         algo = TRPO(env_spec=self.env.spec,
                     policy=self.policy,

--- a/tests/garage/torch/algos/test_vpg.py
+++ b/tests/garage/torch/algos/test_vpg.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv
 from garage.experiment import deterministic
-from garage.sampler import LocalSampler
+from garage.sampler import LocalSampler, WorkerFactory
 from garage.torch.algos import VPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -47,11 +47,17 @@ class TestVPG:
                                          hidden_sizes=[64, 64],
                                          hidden_nonlinearity=torch.tanh,
                                          output_nonlinearity=None)
+        worker_factory = WorkerFactory(
+            max_episode_length=self._env.spec.max_episode_length)
+        self._sampler = LocalSampler.from_worker_factory(worker_factory,
+                                                         agents=self._policy,
+                                                         envs=self._env)
         self._params = {
             'env_spec': self._env.spec,
             'policy': self._policy,
             'value_function':
             GaussianMLPValueFunction(env_spec=self._env.spec),
+            'sampler': self._sampler,
             'discount': 0.99,
         }
 
@@ -66,7 +72,7 @@ class TestVPG:
         self._params['use_softplus_entropy'] = True
 
         algo = VPG(**self._params)
-        self._trainer.setup(algo, self._env, sampler_cls=LocalSampler)
+        self._trainer.setup(algo, self._env)
         last_avg_ret = self._trainer.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 0
 
@@ -78,7 +84,7 @@ class TestVPG:
         self._params['entropy_method'] = 'max'
 
         algo = VPG(**self._params)
-        self._trainer.setup(algo, self._env, sampler_cls=LocalSampler)
+        self._trainer.setup(algo, self._env)
         last_avg_ret = self._trainer.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 0
 
@@ -88,7 +94,7 @@ class TestVPG:
         self._params['entropy_method'] = 'regularized'
 
         algo = VPG(**self._params)
-        self._trainer.setup(algo, self._env, sampler_cls=LocalSampler)
+        self._trainer.setup(algo, self._env)
         last_avg_ret = self._trainer.train(n_epochs=10, batch_size=100)
         assert last_avg_ret > 0
 

--- a/tests/garage/torch/algos/test_vpg.py
+++ b/tests/garage/torch/algos/test_vpg.py
@@ -4,7 +4,7 @@ import torch
 
 from garage.envs import GymEnv
 from garage.experiment import deterministic
-from garage.sampler import LocalSampler, WorkerFactory
+from garage.sampler import LocalSampler
 from garage.torch.algos import VPG
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -47,11 +47,10 @@ class TestVPG:
                                          hidden_sizes=[64, 64],
                                          hidden_nonlinearity=torch.tanh,
                                          output_nonlinearity=None)
-        worker_factory = WorkerFactory(
+        self._sampler = LocalSampler(
+            agents=self._policy,
+            envs=self._env,
             max_episode_length=self._env.spec.max_episode_length)
-        self._sampler = LocalSampler.from_worker_factory(worker_factory,
-                                                         agents=self._policy,
-                                                         envs=self._env)
         self._params = {
             'env_spec': self._env.spec,
             'policy': self._policy,


### PR DESCRIPTION
This PR moves the construction of sampler into the launcher instead of the trainer. And algorithms will have a `sampler` field. 

This should close https://github.com/rlworkgroup/garage/issues/1756.