### PR TITLE
[WiP] Deterministic on- and off-policy sampling

### DIFF
--- a/src/garage/_environment.py
+++ b/src/garage/_environment.py
@@ -159,6 +159,8 @@ class Environment(abc.ABC):
     +-----------------------+
     | visualize()           |
     +-----------------------+
+    | seed()                |
+    +-----------------------+
     | close()               |
     +-----------------------+
 
@@ -350,6 +352,16 @@ class Environment(abc.ABC):
                              'got render mode {} instead.'.format(
                                  self.render_modes, mode))
 
+    @abc.abstractmethod
+    def seed(self, seed):
+        """Sets environment seeds.
+
+        This method should set all seeds specific to the environment library.
+
+        Args:
+            seed (int): The seed value to set
+        """
+
     def __del__(self):
         """Environment destructor."""
         self.close()
@@ -451,6 +463,13 @@ class Wrapper(Environment):
     def visualize(self):
         """Creates a visualization of the wrapped environment."""
         self._env.visualize()
+
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+        """
 
     def close(self):
         """Close the wrapped env."""

--- a/src/garage/envs/dm_control/dm_control_env.py
+++ b/src/garage/envs/dm_control/dm_control_env.py
@@ -184,6 +184,13 @@ class DMControlEnv(Environment):
             self._viewer = DmControlViewer(title=title)
             self._viewer.launch(self._env)
 
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+        """
+
     def close(self):
         """Close the environment."""
         if self._viewer:

--- a/src/garage/envs/grid_world_env.py
+++ b/src/garage/envs/grid_world_env.py
@@ -184,6 +184,13 @@ class GridWorldEnv(Environment):
     def visualize(self):
         """Creates a visualization of the environment."""
 
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+        """
+
     def close(self):
         """Close the env."""
 

--- a/src/garage/envs/gym_env.py
+++ b/src/garage/envs/gym_env.py
@@ -288,6 +288,13 @@ class GymEnv(Environment):
         self._env.render(mode='human')
         self._visualize = True
 
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+        """
+
     def close(self):
         """Close the wrapped env."""
         self._close_viewer_window()

--- a/src/garage/envs/gym_env.py
+++ b/src/garage/envs/gym_env.py
@@ -294,6 +294,8 @@ class GymEnv(Environment):
         Args:
             seed (int): The seed value to set
         """
+        self._env.seed(seed)
+        self.action_space.seed(seed)
 
     def close(self):
         """Close the wrapped env."""

--- a/src/garage/envs/metaworld_set_task_env.py
+++ b/src/garage/envs/metaworld_set_task_env.py
@@ -251,6 +251,13 @@ class MetaWorldSetTaskEnv(Environment):
         """Creates a visualization of the wrapped environment."""
         self._current_env.visualize()
 
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+        """
+
     def close(self):
         """Close the wrapped env."""
         for env in self._envs.values():

--- a/src/garage/envs/point_env.py
+++ b/src/garage/envs/point_env.py
@@ -182,6 +182,14 @@ class PointEnv(Environment):
     def close(self):
         """Close the env."""
 
+    def seed(self, seed):
+        """Sets all environment seeds.
+
+        Args:
+            seed (int): The seed value to set
+
+        """
+
     # pylint: disable=no-self-use
     def sample_tasks(self, num_tasks):
         """Sample a list of `num_tasks` tasks.

--- a/src/garage/sampler/_functions.py
+++ b/src/garage/sampler/_functions.py
@@ -1,5 +1,6 @@
 """Functions used by multiple Samplers or Workers."""
 from garage import Environment
+from garage.experiment import deterministic
 from garage.sampler.env_update import EnvUpdate
 
 
@@ -33,6 +34,7 @@ def _apply_env_update(old_env, env_update):
         elif isinstance(env_update, Environment):
             if old_env is not None:
                 old_env.close()
+            env_update.seed(deterministic.get_seed())
             return env_update, True
         else:
             raise TypeError('Unknown environment update type.')


### PR DESCRIPTION
Extend the `Environment` API to support setting environment library specific seeds.

Tasks:
- [ ] Extend interface
- [ ] Set seeds for Gym envs
- [ ] Set seeds for dm_control envs
- [ ] Set seeds for grid_world envs
- [ ] Set seeds for point envs
- [ ] Set seeds for metaworld envs

Open Questions:
- How to ensure determinism of off-policy algorithms?