### PR TITLE
Resolve conflicts between mujoco-py and gym temporarily

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN python -m virtualenv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 
 # Prevent pip from complaining about available upgrades inside virtualenv
-RUN pip install --upgrade pip setuptools wheel && \
+RUN pip install "pip<20.3" && pip install --upgrade setuptools wheel && \
   rm -r $HOME/.cache/pip
 
 # We need a MuJoCo key to install mujoco_py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,7 +178,7 @@ RUN git init && \
   rm -r $HOME/.cache/pip
 
 # Install deps (but not the code)
-RUN pip install --upgrade pip setuptools wheel && \
+RUN pip install "pip<=20.2.4" && pip install --upgrade setuptools wheel && \
   pip install .[all,dev] && \
   rm $MJKEY_PATH && \
   rm -r $HOME/.cache/pip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN python -m virtualenv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 
 # Prevent pip from complaining about available upgrades inside virtualenv
-RUN pip install "pip<20.3" && pip install --upgrade setuptools wheel && \
+RUN pip install "pip<=20.2.4" && pip install --upgrade setuptools wheel && \
   rm -r $HOME/.cache/pip
 
 # We need a MuJoCo key to install mujoco_py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN python -m virtualenv $VIRTUAL_ENV
 ENV PATH "$VIRTUAL_ENV/bin:$PATH"
 
 # Prevent pip from complaining about available upgrades inside virtualenv
-RUN pip install "pip<=20.2.4" && pip install --upgrade setuptools wheel && \
+RUN pip install --upgrade pip setuptools wheel && \
   rm -r $HOME/.cache/pip
 
 # We need a MuJoCo key to install mujoco_py
@@ -178,7 +178,7 @@ RUN git init && \
   rm -r $HOME/.cache/pip
 
 # Install deps (but not the code)
-RUN pip install "pip<=20.2.4" && pip install --upgrade setuptools wheel && \
+RUN pip install --upgrade pip setuptools wheel && \
   pip install .[all,dev] && \
   rm $MJKEY_PATH && \
   rm -r $HOME/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ EXTRAS['gym'] = [
 
 EXTRAS['mujoco'] = [
     'mujoco-py>=2.0,<=2.0.2.8',
+    # Currently gym is not compatible with mujoco 2.0 because of poor
+    # performance. So here we just install imageio to meet the dependency
+    # requirement of gym's mujoco extra.
     'imageio',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ EXTRAS['gym'] = [
 
 EXTRAS['mujoco'] = [
     'mujoco-py>=2.0,<=2.0.2.8',
-    f'gym[all]=={GYM_VERSION}',
+    'imageio',
 ]
 
 EXTRAS['dm_control'] = [


### PR DESCRIPTION
Pip release [20.3](https://github.com/pypa/pip/releases) today, which makes the CI build failed. Here is the [log](https://github.com/rlworkgroup/garage/runs/1476748450?check_suite_focus=true), and the related [issue](https://github.com/pypa/pip/issues/9011).