### PR TITLE
Update docs and benchmarks to fit with #2182

### DIFF
--- a/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ddpg_garage_tf.py
@@ -6,6 +6,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -60,10 +61,17 @@ def ddpg_garage_tf(ctxt, env_id, seed):
         replay_buffer = PathBuffer(
             capacity_in_transitions=hyper_parameters['replay_buffer_size'])
 
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
+
         algo = DDPG(env_spec=env.spec,
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    sampler=sampler,
                     steps_per_epoch=hyper_parameters['steps_per_epoch'],
                     policy_lr=hyper_parameters['policy_lr'],
                     qf_lr=hyper_parameters['qf_lr'],

--- a/benchmarks/src/garage_benchmarks/experiments/algos/her_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/her_garage_tf.py
@@ -6,6 +6,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import HERReplayBuffer
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -66,11 +67,18 @@ def her_garage_tf(ctxt, env_id, seed):
             reward_fn=env.compute_reward,
         )
 
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
+
         algo = DDPG(
             env_spec=env.spec,
             policy=policy,
             qf=qf,
             replay_buffer=replay_buffer,
+            sampler=sampler,
             steps_per_epoch=hyper_parameters['steps_per_epoch'],
             policy_lr=hyper_parameters['policy_lr'],
             qf_lr=hyper_parameters['qf_lr'],

--- a/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_pytorch.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_pytorch.py
@@ -4,6 +4,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.torch.algos import PPO as PyTorch_PPO
 from garage.torch.optimizers import OptimizerWrapper
 from garage.torch.policies import GaussianMLPPolicy as PyTorch_GMP
@@ -54,9 +55,14 @@ def ppo_garage_pytorch(ctxt, env_id, seed):
                                     max_optimization_epochs=10,
                                     minibatch_size=64)
 
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
+
     algo = PyTorch_PPO(env_spec=env.spec,
                        policy=policy,
                        value_function=value_function,
+                       sampler=sampler,
                        policy_optimizer=policy_optimizer,
                        vf_optimizer=vf_optimizer,
                        discount=0.99,

--- a/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/ppo_garage_tf.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO as TF_PPO
 from garage.tf.baselines import GaussianMLPBaseline as TF_GMB
 from garage.tf.optimizers import FirstOrderOptimizer
@@ -52,9 +53,15 @@ def ppo_garage_tf(ctxt, env_id, seed):
             ),
         )
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = TF_PPO(env_spec=env.spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=0.99,
                       gae_lambda=0.95,
                       center_adv=True,

--- a/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/td3_garage_tf.py
@@ -6,6 +6,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddGaussianNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import TD3
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -79,11 +80,18 @@ def td3_garage_tf(ctxt, env_id, seed):
         replay_buffer = PathBuffer(
             capacity_in_transitions=hyper_parameters['replay_buffer_size'])
 
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
+
         td3 = TD3(env.spec,
                   policy=policy,
                   qf=qf,
                   qf2=qf2,
                   replay_buffer=replay_buffer,
+                  sampler=sampler,
                   steps_per_epoch=hyper_parameters['steps_per_epoch'],
                   policy_lr=hyper_parameters['policy_lr'],
                   qf_lr=hyper_parameters['qf_lr'],

--- a/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_pytorch.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_pytorch.py
@@ -4,6 +4,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import LocalSampler
 from garage.torch.algos import TRPO as PyTorch_TRPO
 from garage.torch.policies import GaussianMLPPolicy as PyTorch_GMP
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -47,9 +48,14 @@ def trpo_garage_pytorch(ctxt, env_id, seed):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
+
     algo = PyTorch_TRPO(env_spec=env.spec,
                         policy=policy,
                         value_function=value_function,
+                        sampler=sampler,
                         discount=hyper_parameters['discount'],
                         gae_lambda=hyper_parameters['gae_lambda'])
 

--- a/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_tf.py
@@ -5,6 +5,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import GaussianMLPPolicy
 from garage.trainer import TFTrainer
@@ -45,9 +46,15 @@ def trpo_garage_tf(ctxt, env_id, seed):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = TRPO(env_spec=env.spec,
                     policy=policy,
                     baseline=baseline,
+                    sampler=sampler,
                     discount=hyper_parameters['discount'],
                     gae_lambda=hyper_parameters['gae_lambda'],
                     max_kl_step=hyper_parameters['max_kl'])

--- a/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_pytorch.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_pytorch.py
@@ -4,6 +4,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.torch.algos import VPG as PyTorch_VPG
 from garage.torch.optimizers import OptimizerWrapper
 from garage.torch.policies import GaussianMLPPolicy as PyTorch_GMP
@@ -57,9 +58,14 @@ def vpg_garage_pytorch(ctxt, env_id, seed):
                                     max_optimization_epochs=10,
                                     minibatch_size=64)
 
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         max_episode_length=env.spec.max_episode_length)
+
     algo = PyTorch_VPG(env_spec=env.spec,
                        policy=policy,
                        value_function=value_function,
+                       sampler=sampler,
                        policy_optimizer=policy_optimizer,
                        vf_optimizer=vf_optimizer,
                        discount=hyper_parameters['discount'],

--- a/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_tf.py
+++ b/benchmarks/src/garage_benchmarks/experiments/algos/vpg_garage_tf.py
@@ -5,6 +5,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler
 from garage.tf.algos import VPG as TF_VPG
 from garage.tf.policies import GaussianMLPPolicy as TF_GMP
 from garage.trainer import TFTrainer
@@ -45,9 +46,15 @@ def vpg_garage_tf(ctxt, env_id, seed):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = TF_VPG(env_spec=env.spec,
                       policy=policy,
                       baseline=baseline,
+                      sampler=sampler,
                       discount=hyper_parameters['discount'],
                       center_adv=hyper_parameters['center_adv'],
                       optimizer_args=dict(

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_cnn_baseline.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_cnn_baseline.py
@@ -2,6 +2,7 @@
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -53,10 +54,16 @@ def gaussian_cnn_baseline(ctxt, env_id, seed):
             hidden_sizes=params['hidden_sizes'],
             use_trust_region=params['use_trust_region'])
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,

--- a/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_mlp_baseline.py
+++ b/benchmarks/src/garage_benchmarks/experiments/baselines/gaussian_mlp_baseline.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.optimizers import FirstOrderOptimizer
@@ -47,10 +48,16 @@ def gaussian_mlp_baseline(ctxt, env_id, seed):
             ),
         )
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -61,5 +68,5 @@ def gaussian_mlp_baseline(ctxt, env_id, seed):
                 learning_rate=1e-3,
             ),
         )
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_cnn_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_cnn_policy.py
@@ -2,6 +2,7 @@
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianCNNBaseline
 from garage.tf.policies import CategoricalCNNPolicy
@@ -54,9 +55,15 @@ def categorical_cnn_policy(ctxt, env_id, seed):
             hidden_sizes=hyper_params['hidden_sizes'],
             use_trust_region=hyper_params['use_trust_region'])
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    gae_lambda=0.95,
                    lr_clip_range=0.2,

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_gru_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_gru_policy.py
@@ -5,6 +5,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import LocalSampler
 from garage.tf.algos import PPO
 from garage.tf.policies import CategoricalGRUPolicy
 from garage.trainer import TFTrainer
@@ -35,10 +36,15 @@ def categorical_gru_policy(ctxt, env_id, seed):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -50,5 +56,5 @@ def categorical_gru_policy(ctxt, env_id, seed):
             ),
         )
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=488, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_lstm_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_lstm_policy.py
@@ -5,6 +5,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.policies import CategoricalLSTMPolicy
 from garage.trainer import TFTrainer
@@ -35,10 +36,16 @@ def categorical_lstm_policy(ctxt, env_id, seed):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -50,5 +57,5 @@ def categorical_lstm_policy(ctxt, env_id, seed):
             ),
         )
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=488, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/categorical_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/categorical_mlp_policy.py
@@ -5,6 +5,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.baselines import LinearFeatureBaseline
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -34,9 +35,15 @@ def categorical_mlp_policy(ctxt, env_id, seed):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(env_spec=env.spec,
                    policy=policy,
                    baseline=baseline,
+                   sampler=sampler,
                    discount=0.99,
                    gae_lambda=0.95,
                    lr_clip_range=0.2,
@@ -48,5 +55,5 @@ def categorical_mlp_policy(ctxt, env_id, seed):
                    ),
                    name='CategoricalMLPPolicyBenchmark')
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/continuous_mlp_policy.py
@@ -6,6 +6,7 @@ from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
 from garage.np.exploration_policies import AddOrnsteinUhlenbeckNoise
 from garage.replay_buffer import PathBuffer
+from garage.sampler import FragmentWorker, LocalSampler
 from garage.tf.algos import DDPG
 from garage.tf.policies import ContinuousMLPPolicy
 from garage.tf.q_functions import ContinuousMLPQFunction
@@ -62,10 +63,17 @@ def continuous_mlp_policy(ctxt, env_id, seed):
         replay_buffer = PathBuffer(
             capacity_in_transitions=hyper_params['replay_buffer_size'])
 
+        sampler = LocalSampler(agents=exploration_policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=FragmentWorker)
+
         ddpg = DDPG(env_spec=env.spec,
                     policy=policy,
                     qf=qf,
                     replay_buffer=replay_buffer,
+                    sampler=sampler,
                     steps_per_epoch=hyper_params['steps_per_epoch'],
                     policy_lr=hyper_params['policy_lr'],
                     qf_lr=hyper_params['qf_lr'],
@@ -77,6 +85,6 @@ def continuous_mlp_policy(ctxt, env_id, seed):
                     policy_optimizer=tf.compat.v1.train.AdamOptimizer,
                     qf_optimizer=tf.compat.v1.train.AdamOptimizer)
 
-        trainer.setup(ddpg, env, sampler_args=dict(n_envs=12))
+        trainer.setup(ddpg, env)
         trainer.train(n_epochs=hyper_params['n_epochs'],
                       batch_size=hyper_params['n_exploration_steps'])

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_gru_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_gru_policy.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.optimizers import FirstOrderOptimizer
@@ -47,10 +48,16 @@ def gaussian_gru_policy(ctxt, env_id, seed):
             ),
         )
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -62,5 +69,5 @@ def gaussian_gru_policy(ctxt, env_id, seed):
             ),
         )
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_lstm_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_lstm_policy.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.optimizers import FirstOrderOptimizer
@@ -47,10 +48,16 @@ def gaussian_lstm_policy(ctxt, env_id, seed):
             ),
         )
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -62,5 +69,5 @@ def gaussian_lstm_policy(ctxt, env_id, seed):
             ),
         )
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=2048)

--- a/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_mlp_policy.py
+++ b/benchmarks/src/garage_benchmarks/experiments/policies/gaussian_mlp_policy.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from garage import wrap_experiment
 from garage.envs import GymEnv, normalize
 from garage.experiment import deterministic
+from garage.sampler import RaySampler
 from garage.tf.algos import PPO
 from garage.tf.baselines import GaussianMLPBaseline
 from garage.tf.optimizers import FirstOrderOptimizer
@@ -47,10 +48,16 @@ def gaussian_mlp_policy(ctxt, env_id, seed):
             ),
         )
 
+        sampler = RaySampler(agents=policy,
+                             envs=env,
+                             max_episode_length=env.spec.max_episode_length,
+                             is_tf_worker=True)
+
         algo = PPO(
             env_spec=env.spec,
             policy=policy,
             baseline=baseline,
+            sampler=sampler,
             discount=0.99,
             gae_lambda=0.95,
             lr_clip_range=0.2,
@@ -62,5 +69,5 @@ def gaussian_mlp_policy(ctxt, env_id, seed):
             ),
         )
 
-        trainer.setup(algo, env, sampler_args=dict(n_envs=12))
+        trainer.setup(algo, env)
         trainer.train(n_epochs=5, batch_size=2048)

--- a/docs/user/custom_worker.md
+++ b/docs/user/custom_worker.md
@@ -7,7 +7,7 @@ we will implement a custom worker to meet the requirements of the RL2 algorithm
 resets the RNN policy state at the beginning of a trail.
 ```
 
-## `Worker` interface and `DefaultWorker`
+## Worker interface and DefaultWorker
 
 In Garage, all `Worker`s need to implement the [`Worker` interface](https://garage.readthedocs.io/en/latest/_autoapi/garage/sampler/index.html#garage.sampler.Worker).
 Garage provides a [`DefaultWorker`](https://garage.readthedocs.io/en/latest/_autoapi/garage/sampler/index.html#garage.sampler.DefaultWorker)

--- a/docs/user/ensure_your_experiments_are_reproducible.md
+++ b/docs/user/ensure_your_experiments_are_reproducible.md
@@ -22,6 +22,7 @@ def experiment(ctxt=None, seed):
     # Initialize algorithm dependencies (policy, Q-functions,
     # replay buffers, etc.)
     policy = ...
+    sampler = ...
     algo = ...
 
     trainer.setup(algo=algo, env=env)
@@ -82,8 +83,7 @@ algorithm, logger, and snapshotter.
 
 To setup the `Trainer` use the function
 `Trainer.setup(algo, env, ...)`. It takes your algorithm and environment as
-required parameters. You can also control the sampling process you would like
-to use by specifying information such as the `sampler_cls`, `worker_cls`, etc.
+required parameters.
 Lastly, to trigger the training process of your experiment, use the function
 `Trainer.train(n_epochs, batch_size, ...)`. The required parameter
 `n_epochs` is used for specifying the number of training epochs that your

--- a/docs/user/experiments.rst
+++ b/docs/user/experiments.rst
@@ -19,9 +19,10 @@ experiment.
 Within the decorated experiment function, experiment launchers then construct
 the important objects involved in running an experiment, such as the following:
 
- - The :code:`Trainer`, which sets up important state (such as a TensorFlow Session) for running the algorithm in the experiment.
+ - The :code:`trainer`, which sets up important state (such as a TensorFlow Session) for running the algorithm in the experiment.
  - The :code:`environment` object, which is the environment in which reinforcement learning is being done.
  - The :code:`policy` object, which is trained to optimize for maximal reward in the :code:`environment`.
+ - The :code:`sampler` object, which make samples for the :code:`algorithm` when training.
  - The :code:`algorithm`, which trains the :code:`policy`.
 
 Finally, the launcher calls :code:`trainer.setup` and :code:`trainer.train` which co-ordinate running the algorithm.
@@ -29,61 +30,7 @@ Finally, the launcher calls :code:`trainer.setup` and :code:`trainer.train` whic
 The garage repository contains several example experiment launchers. A fairly
 simple one, :code:`examples/tf/trpo_cartpole.py`, is also pasted below:
 
-.. testcode::
-
-  from garage import wrap_experiment
-  from garage.envs import GymEnv
-  from garage.experiment.deterministic import set_seed
-  from garage.np.baselines import LinearFeatureBaseline
-  from garage.sampler import RaySampler
-  from garage.tf.algos import TRPO
-  from garage.tf.policies import CategoricalMLPPolicy
-  from garage.trainer import TFTrainer
-
-
-  @wrap_experiment
-  def trpo_cartpole(ctxt=None, seed=1):
-      """Train TRPO with CartPole-v1 environment.
-
-      Args:
-          ctxt (garage.experiment.ExperimentContext): The experiment
-              configuration used by Trainer to create the snapshotter.
-          seed (int): Used to seed the random number generator to produce
-              determinism.
-
-      """
-      set_seed(seed)
-      with TFTrainer(ctxt) as trainer:
-          env = GymEnv('CartPole-v1')
-
-          policy = CategoricalMLPPolicy(name='policy',
-                                        env_spec=env.spec,
-                                        hidden_sizes=(32, 32))
-
-          baseline = LinearFeatureBaseline(env_spec=env.spec)
-
-          sampler = RaySampler(agents=policy,
-                               envs=env,
-                               max_episode_length=env.spec.max_episode_length,
-                               is_tf_worker=True)
-
-          algo = TRPO(env_spec=env.spec,
-                      policy=policy,
-                      baseline=baseline,
-                      sampler=sampler,
-                      discount=0.99,
-                      max_kl_step=0.01)
-
-          trainer.setup(algo, env)
-          trainer.train(n_epochs=100, batch_size=4000)
-
-
-  trpo_cartpole()
-
-.. testoutput::
-   :hide:
-
-   ...
+.. literalinclude:: ../../examples/tf/trpo_cartpole.py
 
 Running the above should produce output like:
 

--- a/docs/user/get_started.md
+++ b/docs/user/get_started.md
@@ -111,12 +111,16 @@ They are organized in the [github repository](https://github.com/rlworkgroup/gar
 
 Note: clickable links represents the directory of algorithms.
 
-A simple pytorch example to import `TRPO` algorithm, as well as, the policy `GaussianMLPPolicy` and value function `GaussianMLPValueFunction` in garage is shown below:
+A simple pytorch example to import `TRPO` algorithm, as well as, the policy
+`GaussianMLPPolicy`, value function `GaussianMLPValueFunction` and sampler
+`LocalSampler` in garage is shown below:
+
 ```py
 import gym
 import torch
 
 from garage.envs import GarageEnv, normalize
+from garage.sampler import LocalSampler
 from garage.torch.algos import TRPO as PyTorch_TRPO
 from garage.torch.policies import GaussianMLPPolicy as PyTorch_GMP
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -135,11 +139,15 @@ def trpo_garage_pytorch():
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
+
     algo = PyTorch_TRPO(
         env_spec=env.spec,
         policy=policy,
         value_function=value_function,
-        max_episode_length=100,
+        sampler=sampler,
         discount=0.99,
         gae_lambda=0.97)
 
@@ -157,48 +165,10 @@ In garage, experiments are run using the "experiment launcher" `wrap_experiment`
 from garage import wrap_experiment
 ```
 
-Moreover, objects, such as `trainer`, `environment`, `policy` e.t.c are commonly used when constructing experiments in garage.
+Moreover, objects, such as `trainer`, `environment`, `policy`, `sampler` e.t.c are commonly used when constructing experiments in garage.
 
-```py
-import gym
-import torch
-
-from garage import wrap_experiment
-from garage.envs import GarageEnv, normalize
-from garage.experiment import deterministic, LocalRunner
-from garage.torch.algos import TRPO as PyTorch_TRPO
-from garage.torch.policies import GaussianMLPPolicy as PyTorch_GMP
-from garage.torch.value_functions import GaussianMLPValueFunction
-
-@wrap_experiment
-def trpo_garage_pytorch(ctxt, env_id, seed):
-    deterministic.set_seed(seed)
-
-    runner = LocalRunner(ctxt)
-
-    env = GarageEnv(normalize(gym.make(env_id)))
-
-    policy = PyTorch_GMP(env.spec,
-                         hidden_sizes=[32, 32],
-                         hidden_nonlinearity=torch.tanh,
-                         output_nonlinearity=None)
-
-    value_function = GaussianMLPValueFunction(env_spec=env.spec,
-                                              hidden_sizes=(32, 32),
-                                              hidden_nonlinearity=torch.tanh,
-                                              output_nonlinearity=None)
-
-    algo = PyTorch_TRPO(
-        env_spec=env.spec,
-        policy=policy,
-        value_function=value_function,
-        max_episode_length=100,
-        discount=0.99,
-        gae_lambda=0.97)
-
-    runner.setup(algo, env)
-    runner.train(n_epochs=999,
-                 batch_size=1024)
+```eval_rst
+.. literalinclude:: ../../benchmarks/src/garage_benchmarks/experiments/algos/trpo_garage_pytorch.py
 ```
 
 [This page](https://garage.readthedocs.io/en/latest/user/experiments.html) will give you more insight into running experiments.
@@ -239,6 +209,7 @@ Experiment results will, by default, output to the same directory as the garage 
 During an experiment, garage extensively use `logger` from [`Dowel`](https://github.com/rlworkgroup/dowel) for logging outputs to StdOutput, and/ or TextOutput, and/or CsvOutput. For details, you can check [this](https://github.com/rlworkgroup/dowel/blob/master/src/dowel/logger.py).
 
 ## Open Source Support
+
 Since October 2018, garage is active in the open-source community contributing to RL researches and developments. Any [contributions](https://garage.readthedocs.io/en/latest/user/preparing_a_pr.html) from the community is more than welcomed.
 
 ## Resources

--- a/docs/user/implement_env.rst
+++ b/docs/user/implement_env.rst
@@ -8,7 +8,7 @@ Garage uses an environment API based on the very popular OpenAI Gym interface. T
 :code:`akro` to describe input and output spaces, which are an extension of the :code:`gym.Space` API.
 
 If you have an OpenAI Gym compatible environment, you can wrap it in :code:`garage.envs.GymEnv` to use it with
-garage. You can also provide its environment name id (see the example below), and let `:code:`GymEnv` creates
+garage. You can also provide its environment name id (see the example below), and let :code:`GymEnv` creates
 the environment for you.
 
 .. code-block:: python
@@ -175,6 +175,7 @@ stub mode):
     from garage.envs import normalize
     from garage.experiment.deterministic import set_seed
     from garage.np.baselines import LinearFeatureBaseline
+    from garage.sampler import LocalSampler
     from garage.tf.algos import TRPO
     from garage.tf.policies import CategoricalMLPPolicy
     from garage.trainer import TFTrainer
@@ -192,9 +193,16 @@ stub mode):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length,
+                is_tf_worker=True)
+
             algo = TRPO(env_spec=env.spec,
                         policy=policy,
                         baseline=baseline,
+                        sampler=sampler,
                         discount=0.99,
                         max_kl_step=0.01)
 

--- a/docs/user/max_resource_usage.md
+++ b/docs/user/max_resource_usage.md
@@ -23,7 +23,15 @@ sampler will run workers in the same process.
 from garage.sampler import LocalSampler, DefaultWorker
 
     ...
-    trainer.setup(algo, env, sampler_cls=LocalSampler, worker_class=DefaultWorker)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           # below is the params for constructing worker factory
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_cls=DefaultWorker)
+
+    algo = TRPO(...
+                sampler=sampler,
+                ...)
     ...
 ```
 
@@ -47,12 +55,12 @@ environments simulated in one step), just set `n_envs` in `worker_args`.
 from garage.sampler import LocalSampler, VecWorker
 
     ...
-    trainer.setup(
-        algo=algo,
-        env=env,
-        worker_class=VecWorker,
-        worker_args=dict(n_envs=12)
-    )
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           # below is the params for constructing worker factory
+                           max_episode_length=env.spec.max_episode_length,
+                           worker_class=VecWorker,
+                           worker_args=dict(n_envs=12))
     ...
 ```
 
@@ -76,13 +84,12 @@ on the local machine.
 from garage.sampler import RaySampler, VecWorker
 
     ...
-    trainer.setup(
-        algo=algo,
-        env=env,
-        sampler_cls=RaySampler,
-        worker_class=VecWorker,
-        worker_args=dict(n_envs=12)
-    )
+    sampler = RaySampler(agents=policy,
+                         envs=env,
+                         # below is the params for constructing worker factory
+                         max_episode_length=env.spec.max_episode_length,
+                         worker_class=VecWorker,
+                         worker_args=dict(n_envs=12))
     ...
 ```
 
@@ -123,6 +130,7 @@ def trpo_pendulum(ctxt=None, seed=1):
     algo = TRPO(env_spec=env.spec,
                 policy=policy,
                 value_function=value_function,
+                sampler=sampler,
                 discount=0.99,
                 center_adv=False)
 

--- a/docs/user/meta_multi_task_rl_exp.md
+++ b/docs/user/meta_multi_task_rl_exp.md
@@ -120,6 +120,12 @@ def te_ppo_ml1_push(ctxt, seed, n_epochs, batch_size_per_task):
         baseline = LinearMultiFeatureBaseline(
             env_spec=env.spec, features=['observations', 'tasks', 'latents'])
 
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True,
+                               worker_class=TaskEmbeddingWorker)
+
         algo = TEPPO(env_spec=env.spec,
                      policy=policy,
                      baseline=baseline,
@@ -143,11 +149,7 @@ def te_ppo_ml1_push(ctxt, seed, n_epochs, batch_size_per_task):
                      center_adv=True,
                      stop_ce_gradient=True)
 
-        trainer.setup(algo,
-                     env,
-                     sampler_cls=LocalSampler,
-                     sampler_args=None,
-                     worker_class=TaskEmbeddingWorker)
+        trainer.setup(algo, env)
         trainer.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
 
 
@@ -164,140 +166,8 @@ In this example, we assume one-hot task id is appened to observation and to excl
 
 When performing a multi-task RL experiment, we can use multi-task learning environment such as `MT50`, `MT10` etc. We will take a look at `te_ppo_metaworld_mt50.py` as below:
 
-```py
-import metaworld
-
-from garage import wrap_experiment
-from garage.envs import GymEnv, normalize
-from garage.envs.multi_env_wrapper import MultiEnvWrapper, round_robin_strategy
-from garage.experiment import TFTrainer
-from garage.experiment.deterministic import set_seed
-from garage.np.baselines import LinearMultiFeatureBaseline
-from garage.sampler import LocalSampler
-from garage.tf.algos import TEPPO
-from garage.tf.algos.te import TaskEmbeddingWorker
-from garage.tf.embeddings import GaussianMLPEncoder
-from garage.tf.policies import GaussianMLPTaskEmbeddingPolicy
-
-@wrap_experiment
-def te_ppo_mt50(ctxt, seed, n_epochs, batch_size_per_task, n_tasks):
-    """Train Task Embedding PPO with PointEnv.
-
-    Args:
-        ctxt (garage.experiment.ExperimentContext): The experiment
-            configuration used by Trainer to create the snapshotter.
-        seed (int): Used to seed the random number generator to produce
-            determinism.
-        n_epochs (int): Total number of epochs for training.
-        batch_size_per_task (int): Batch size of samples for each task.
-        n_tasks (int): Number of tasks to use. Should be a multiple of 50.
-
-    """
-    set_seed(seed)
-    mt50 = metaworld.MT50()
-    task_sampler = MetaWorldTaskSampler(mt50,
-                                        'train',
-                                        lambda env, _: normalize(env),
-                                        add_env_onehot=False)
-    assert n_tasks % 50 == 0
-    assert n_tasks <= 2500
-    envs = [env_up() for env_up in task_sampler.sample(n_tasks)]
-    env = MultiEnvWrapper(envs,
-                          sample_strategy=round_robin_strategy,
-                          mode='vanilla')
-
-    latent_length = 6
-    inference_window = 6
-    batch_size = batch_size_per_task * n_tasks
-    policy_ent_coeff = 2e-2
-    encoder_ent_coeff = 2e-4
-    inference_ce_coeff = 5e-2
-    max_episode_length = 100
-    embedding_init_std = 0.1
-    embedding_max_std = 0.2
-    embedding_min_std = 1e-6
-    policy_init_std = 1.0
-    policy_max_std = None
-    policy_min_std = None
-
-    with TFTrainer(snapshot_config=ctxt) as trainer:
-
-        task_embed_spec = TEPPO.get_encoder_spec(env.task_space,
-                                                 latent_dim=latent_length)
-
-        task_encoder = GaussianMLPEncoder(
-            name='embedding',
-            embedding_spec=task_embed_spec,
-            hidden_sizes=(20, 20),
-            std_share_network=True,
-            init_std=embedding_init_std,
-            max_std=embedding_max_std,
-            output_nonlinearity=tf.nn.tanh,
-            min_std=embedding_min_std,
-        )
-
-        traj_embed_spec = TEPPO.get_infer_spec(
-            env.spec,
-            latent_dim=latent_length,
-            inference_window_size=inference_window)
-
-        inference = GaussianMLPEncoder(
-            name='inference',
-            embedding_spec=traj_embed_spec,
-            hidden_sizes=(20, 10),
-            std_share_network=True,
-            init_std=2.0,
-            output_nonlinearity=tf.nn.tanh,
-            min_std=embedding_min_std,
-        )
-
-        policy = GaussianMLPTaskEmbeddingPolicy(
-            name='policy',
-            env_spec=env.spec,
-            encoder=task_encoder,
-            hidden_sizes=(32, 16),
-            std_share_network=True,
-            max_std=policy_max_std,
-            init_std=policy_init_std,
-            min_std=policy_min_std,
-        )
-
-        baseline = LinearMultiFeatureBaseline(
-            env_spec=env.spec, features=['observations', 'tasks', 'latents'])
-
-        algo = TEPPO(env_spec=env.spec,
-                     policy=policy,
-                     baseline=baseline,
-                     inference=inference,
-                     max_episode_length=max_episode_length,
-                     discount=0.99,
-                     lr_clip_range=0.2,
-                     policy_ent_coeff=policy_ent_coeff,
-                     encoder_ent_coeff=encoder_ent_coeff,
-                     inference_ce_coeff=inference_ce_coeff,
-                     use_softplus_entropy=True,
-                     optimizer_args=dict(
-                         batch_size=32,
-                         max_optimization_epochs=10,
-                         learning_rate=1e-3,
-                     ),
-                     inference_optimizer_args=dict(
-                         batch_size=32,
-                         max_optimization_epochs=10,
-                     ),
-                     center_adv=True,
-                     stop_ce_gradient=True)
-
-        trainer.setup(algo,
-                     env,
-                     sampler_cls=LocalSampler,
-                     sampler_args=None,
-                     worker_class=TaskEmbeddingWorker)
-        trainer.train(n_epochs=n_epochs, batch_size=batch_size, plot=False)
-
-
-te_ppo_mt50()
-
+```eval_rst
+.. literalinclude:: ../../examples/tf/te_ppo_metaworld_mt50.py
 ```
 
 In this example, to sample tasks from `MT50` environments in a round robin fashion, the call to `MultiEnvWrapper` becomes `MultiEnvWrapper(envs , sample_strategy=round_robin_strategy, mode='del-onehot')`.
@@ -318,9 +188,7 @@ Garage benchmarks the following meta-/ multi RL experiements:
 
 ```py
 *ML_ENV_SET = ['ML1-push-v1' ,  'ML1-reach-v1' ,  'ML1-pick-place-v1' ,  'ML10' ,  'ML45']
-
-*MT
-_ENV_SET = ['ML1-push-v1' ,  'ML1-reach-v1' ,  'ML1-pick-place-v1' ,  'MT10' ,  'MT50' ]
+*MT_ENV_SET = ['ML1-push-v1' ,  'ML1-reach-v1' ,  'ML1-pick-place-v1' ,  'MT10' ,  'MT50' ]
 ```
 
 See [`docs/benchmarking.md`](https://garage.readthedocs.io/en/latest/user/benchmarking.html) for a more detailed explaination on garage's benchmarking.

--- a/docs/user/testing.md
+++ b/docs/user/testing.md
@@ -117,9 +117,16 @@ class TestVPG(...):
 
             baseline = LinearFeatureBaseline(env_spec=env.spec)
 
+            sampler = LocalSampler(
+                agents=policy,
+                envs=env,
+                max_episode_length=env.spec.max_episode_length.
+                is_tf_worker=True)
+
             algo = VPG(env_spec=env.spec,
                        policy=policy,
                        baseline=baseline,
+                       sampler=sampler,
                        discount=0.99,
                        optimizer_args=dict(learning_rate=0.01, ))
 

--- a/examples/tf/trpo_cartpole.py
+++ b/examples/tf/trpo_cartpole.py
@@ -11,7 +11,7 @@ from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
 from garage.np.baselines import LinearFeatureBaseline
-from garage.sampler import RaySampler
+from garage.sampler import LocalSampler
 from garage.tf.algos import TRPO
 from garage.tf.policies import CategoricalMLPPolicy
 from garage.trainer import TFTrainer
@@ -38,10 +38,10 @@ def trpo_cartpole(ctxt=None, seed=1):
 
         baseline = LinearFeatureBaseline(env_spec=env.spec)
 
-        sampler = RaySampler(agents=policy,
-                             envs=env,
-                             max_episode_length=env.spec.max_episode_length,
-                             is_tf_worker=True)
+        sampler = LocalSampler(agents=policy,
+                               envs=env,
+                               max_episode_length=env.spec.max_episode_length,
+                               is_tf_worker=True)
 
         algo = TRPO(env_spec=env.spec,
                     policy=policy,

--- a/examples/torch/trpo_pendulum.py
+++ b/examples/torch/trpo_pendulum.py
@@ -8,7 +8,7 @@ import torch
 from garage import wrap_experiment
 from garage.envs import GymEnv
 from garage.experiment.deterministic import set_seed
-from garage.sampler import RaySampler
+from garage.sampler import LocalSampler
 from garage.torch.algos import TRPO
 from garage.torch.policies import GaussianMLPPolicy
 from garage.torch.value_functions import GaussianMLPValueFunction
@@ -41,9 +41,9 @@ def trpo_pendulum(ctxt=None, seed=1):
                                               hidden_nonlinearity=torch.tanh,
                                               output_nonlinearity=None)
 
-    sampler = RaySampler(agents=policy,
-                         envs=env,
-                         max_episode_length=env.spec.max_episode_length)
+    sampler = LocalSampler(agents=policy,
+                           envs=env,
+                           max_episode_length=env.spec.max_episode_length)
 
     algo = TRPO(env_spec=env.spec,
                 policy=policy,


### PR DESCRIPTION
Update docs and benchmarks to fit with the new way of constructing the sampler. See https://github.com/rlworkgroup/garage/pull/2182.