### PR TITLE
Add command for running CI on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ env:
   DOCKER_CACHE_REPO: "garage-ci"
   MJKEY: ${{ secrets.MJKEY }}
   CI_USER: rlworkgroupbot
+  IS_PR_FROM_FORK: ${{ github.event.client_payload.pull_request.head.repo.fork }}
 
 on:
   schedule:
@@ -21,17 +22,50 @@ on:
   pull_request:
     branches:
       - master
+  repository_dispatch:
+    types: [ ok-to-test-command ]
 
 jobs:
+  comment_link_to_output_on_fork_pr:
+    name: Post link to CI output for fork PRs
+    runs-on: ubuntu-latest
+    # can't use env.IS_PR_FROM_FORK here because env is not available here
+    if: github.event.client_payload.pull_request.head.repo.fork
+    steps:
+      - name: Dump the client payload context
+        env:
+          PAYLOAD_CONTEXT: ${{ toJson(github.event.client_payload) }}
+        run: echo "$PAYLOAD_CONTEXT"
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CI_REGISTRY_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            [Command run output][1] for ${{ github.event.client_payload.pull_request.html_url }}/commits/${{ github.event.client_payload.pull_request.head.sha }}
+
+            [1]: ${{ steps.vars.outputs.run-url }}
+
   build_docker_container:
     name: Build Docker Container
     runs-on: ubuntu-latest
-
+    if: ${{ !(github.event.pull_request.head.repo.fork && github.event_name == 'pull_request') }}
     steps:
       - name: Docker info
         run: docker version
       - uses: actions/checkout@v2
+        if: ${{ !env.IS_PR_FROM_FORK }}
         with:
+          fetch-depth: 0
+      - uses: actions/checkout@v2
+        if: env.IS_PR_FROM_FORK
+        with:
+          ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
           fetch-depth: 0
       - name: Login to GitHub Package Registry
         run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -47,6 +81,14 @@ jobs:
         run: |
           docker tag "${DOCKER_TAG}" "docker.pkg.github.com/${OWNER}/${DOCKER_CACHE_REPO}/${DOCKER_TAG}"
           docker push "docker.pkg.github.com/${OWNER}/${DOCKER_CACHE_REPO}/${DOCKER_TAG}"
+      - name: Update check status for PRs from forks
+        uses: LouisBrunner/checks-action@v1.1.1
+        if: always() && env.IS_PR_FROM_FORK
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Build Docker Container
+          sha: ${{ github.event.client_payload.pull_request.head.sha }}
+          conclusion: ${{ job.status }}
 
 
   check_pre_commit:
@@ -56,8 +98,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request'
+      if: ${{ github.event_name == 'pull_request' && !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       if: github.event_name == 'pull_request'
@@ -77,6 +124,14 @@ jobs:
           --memory 6500m \
           --memory-swap 6500m \
           "${DOCKER_TAG}" scripts/travisci/check_precommit.sh
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Check pre-commit
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   doctest:
@@ -86,7 +141,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -103,6 +164,14 @@ jobs:
           "${DOCKER_TAG}" \
           /bin/bash -c \
           'pushd docs && make doctest clean && popd'
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Run Doctest
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   normal_test:
@@ -112,7 +181,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -145,6 +220,14 @@ jobs:
                   sleep 30
               fi
           done'
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Normal Tests
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   large_test:
@@ -154,7 +237,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -186,6 +275,14 @@ jobs:
                   sleep 30
               fi
           done'
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Large Tests
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   mujoco_test:
@@ -195,7 +292,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -226,6 +329,14 @@ jobs:
                   sleep 30
               fi
           done'
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: MuJoCo-Based Tests
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   mujoco_test_long:
@@ -235,7 +346,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ !env.IS_PR_FROM_FORK }}
       with:
+        fetch-depth: 0
+    - uses: actions/checkout@v2
+      if: env.IS_PR_FROM_FORK
+      with:
+        ref: ${{ github.event.client_payload.pull_request.merge_commit_sha }}
         fetch-depth: 0
     - name: Login to GitHub Package Registry
       run: echo ${{ secrets.CI_REGISTRY_TOKEN }} | docker login docker.pkg.github.com -u ${CI_USER} --password-stdin
@@ -266,6 +383,14 @@ jobs:
                   sleep 30
               fi
           done'
+    - name: Update check status for PRs from forks
+      uses: LouisBrunner/checks-action@v1.1.1
+      if: env.IS_PR_FROM_FORK && always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: Large MuJoCo-Based Tests
+        sha: ${{ github.event.client_payload.pull_request.head.sha }}
+        conclusion: ${{ job.status }}
 
 
   nightly_test:
@@ -408,8 +533,8 @@ jobs:
   delete_docker_container:
     name: Delete Docker Container
     runs-on: ubuntu-latest
-    needs: [normal_test, large_test, mujoco_test, mujoco_test_long, nightly_test, verify_envs_conda, verify_envs_pipenv]
-    if: always()
+    needs: [build_docker_container, normal_test, large_test, mujoco_test, mujoco_test_long, nightly_test, verify_envs_conda, verify_envs_pipenv]
+    if: ${{ always() && needs.build_docker_container.result == 'success' }}
 
     steps:
       - uses: actions/delete-package-versions@v1

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,26 @@
+# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+name: Ok To Test
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  ok-to-test:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get PR details
+      id: pr_details
+      run: |
+        pr_details=$(curl -v -H "Accept: application/vnd.github.sailor-v-preview+json" -u ${{ secrets.CI_REGISTRY_TOKEN }} ${{ github.event.issue.pull_request.url }})
+        echo "::set-output name=is_from_fork::$(echo $pr_details | jq '.head.repo.fork')"
+        echo "::set-output name=base_ref::$(echo $pr_details | jq '.base.ref' | sed 's/\"//g')"
+    - name: Slash Command Dispatch
+      uses: peter-evans/slash-command-dispatch@v1
+      if: ${{ steps.pr_details.outputs.is_from_fork && steps.pr_details.outputs.base_ref == 'master' }}
+      with:
+        token: ${{ secrets.CI_REGISTRY_TOKEN }}
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-type: pull-request
+        commands: ok-to-test
+        named-args: true
+        permission: write


### PR DESCRIPTION
Secret variable are not accessible to the CI if the
pull request repo head is a fork, so that a random
fork can't access the secrets by logging them in
the CI output. `pull_request_target` event has similar
security issues.

This commit adds a workflow that allows somebody with
write access to the repo to trigger the CI workflow with
access to secrets, against the PR, by commenting `/ok-to-test`
on that PR, after reviewing the code to make sure it is safe.

By default, it runs the workflow against the merge commit of
the head of the PR and the target branch. Newer commits have to
be tested by issuing the slash command again. It is also
possible to test a specific commit using
`/ok-to-test sha=<commit_sha>`.