### PR TITLE
Fix saving episodes

### DIFF
--- a/src/garage/np/algos/cem.py
+++ b/src/garage/np/algos/cem.py
@@ -111,9 +111,10 @@ class CEM(RLAlgorithm):
 
         for _ in trainer.step_epochs():
             for _ in range(self._n_samples):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 last_return = self._train_once(trainer.step_itr,
-                                               trainer.step_path)
+                                               trainer.step_episode)
                 trainer.step_itr += 1
 
         return last_return

--- a/src/garage/np/algos/cma_es.py
+++ b/src/garage/np/algos/cma_es.py
@@ -83,9 +83,10 @@ class CMAES(RLAlgorithm):
 
         for _ in trainer.step_epochs():
             for _ in range(self._n_samples):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 last_return = self._train_once(trainer.step_itr,
-                                               trainer.step_path)
+                                               trainer.step_episode)
                 trainer.step_itr += 1
 
         return last_return

--- a/src/garage/tf/algos/ddpg.py
+++ b/src/garage/tf/algos/ddpg.py
@@ -284,10 +284,11 @@ class DDPG(RLAlgorithm):
 
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 if hasattr(self.exploration_policy, 'update'):
-                    self.exploration_policy.update(trainer.step_path)
-                self._train_once(trainer.step_itr, trainer.step_path)
+                    self.exploration_policy.update(trainer.step_episode)
+                self._train_once(trainer.step_itr, trainer.step_episode)
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):
                     trainer.enable_logging = True

--- a/src/garage/tf/algos/dqn.py
+++ b/src/garage/tf/algos/dqn.py
@@ -209,11 +209,12 @@ class DQN(RLAlgorithm):
         qf_losses = []
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 if hasattr(self.exploration_policy, 'update'):
-                    self.exploration_policy.update(trainer.step_path)
+                    self.exploration_policy.update(trainer.step_episode)
                 qf_losses.extend(
-                    self._train_once(trainer.step_itr, trainer.step_path))
+                    self._train_once(trainer.step_itr, trainer.step_episode))
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):
                     trainer.enable_logging = True

--- a/src/garage/tf/algos/npo.py
+++ b/src/garage/tf/algos/npo.py
@@ -174,8 +174,9 @@ class NPO(RLAlgorithm):
         last_return = None
 
         for _ in trainer.step_epochs():
-            trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
-            last_return = self._train_once(trainer.step_itr, trainer.step_path)
+            trainer.step_episode = trainer.obtain_episodes(trainer.step_itr)
+            last_return = self._train_once(trainer.step_itr,
+                                           trainer.step_episode)
             trainer.step_itr += 1
 
         return last_return

--- a/src/garage/tf/algos/reps.py
+++ b/src/garage/tf/algos/reps.py
@@ -143,8 +143,9 @@ class REPS(RLAlgorithm):  # noqa: D416
         last_return = None
 
         for _ in trainer.step_epochs():
-            trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
-            last_return = self._train_once(trainer.step_itr, trainer.step_path)
+            trainer.step_episode = trainer.obtain_episodes(trainer.step_itr)
+            last_return = self._train_once(trainer.step_itr,
+                                           trainer.step_episode)
             trainer.step_itr += 1
 
         return last_return

--- a/src/garage/tf/algos/td3.py
+++ b/src/garage/tf/algos/td3.py
@@ -301,10 +301,11 @@ class TD3(RLAlgorithm):
 
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 if hasattr(self.exploration_policy, 'update'):
-                    self.exploration_policy.update(trainer.step_path)
-                self._train_once(trainer.step_itr, trainer.step_path)
+                    self.exploration_policy.update(trainer.step_episode)
+                self._train_once(trainer.step_itr, trainer.step_episode)
                 if (cycle == 0 and self._replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):
                     trainer.enable_logging = True

--- a/src/garage/tf/algos/te_npo.py
+++ b/src/garage/tf/algos/te_npo.py
@@ -203,8 +203,9 @@ class TENPO(RLAlgorithm):
         last_return = None
 
         for _ in trainer.step_epochs():
-            trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
-            last_return = self._train_once(trainer.step_itr, trainer.step_path)
+            trainer.step_episode = trainer.obtain_episodes(trainer.step_itr)
+            last_return = self._train_once(trainer.step_itr,
+                                           trainer.step_episode)
             trainer.step_itr += 1
 
         return last_return

--- a/src/garage/torch/algos/ddpg.py
+++ b/src/garage/torch/algos/ddpg.py
@@ -155,10 +155,11 @@ class DDPG(RLAlgorithm):
 
         for _ in trainer.step_epochs():
             for cycle in range(self._steps_per_epoch):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 if hasattr(self.exploration_policy, 'update'):
-                    self.exploration_policy.update(trainer.step_path)
-                self.train_once(trainer.step_itr, trainer.step_path)
+                    self.exploration_policy.update(trainer.step_episode)
+                self.train_once(trainer.step_itr, trainer.step_episode)
                 if (cycle == 0 and self.replay_buffer.n_transitions_stored >=
                         self._min_buffer_size):
                     trainer.enable_logging = True

--- a/src/garage/torch/algos/dqn.py
+++ b/src/garage/torch/algos/dqn.py
@@ -170,11 +170,12 @@ class DQN(RLAlgorithm):
                                np.mean(self._episode_reward_mean))
 
             for _ in range(self._steps_per_epoch):
-                trainer.step_path = trainer.obtain_episodes(trainer.step_itr)
+                trainer.step_episode = trainer.obtain_episodes(
+                    trainer.step_itr)
                 if hasattr(self.exploration_policy, 'update'):
-                    self.exploration_policy.update(trainer.step_path)
+                    self.exploration_policy.update(trainer.step_episode)
 
-                self._train_once(trainer.step_itr, trainer.step_path)
+                self._train_once(trainer.step_itr, trainer.step_episode)
                 trainer.step_itr += 1
 
         return np.mean(last_returns)

--- a/src/garage/torch/algos/sac.py
+++ b/src/garage/torch/algos/sac.py
@@ -192,10 +192,10 @@ class SAC(RLAlgorithm):
                     batch_size = int(self._min_buffer_size)
                 else:
                     batch_size = None
-                trainer.step_path = trainer.obtain_samples(
+                trainer.step_episode = trainer.obtain_samples(
                     trainer.step_itr, batch_size)
                 path_returns = []
-                for path in trainer.step_path:
+                for path in trainer.step_episode:
                     self.replay_buffer.add_path(
                         dict(observation=path['observations'],
                              action=path['actions'],
@@ -206,7 +206,7 @@ class SAC(RLAlgorithm):
                                  for step_type in path['step_types']
                              ]).reshape(-1, 1)))
                     path_returns.append(sum(path['rewards']))
-                assert len(path_returns) == len(trainer.step_path)
+                assert len(path_returns) == len(trainer.step_episode)
                 self.episode_rewards.append(np.mean(path_returns))
                 for _ in range(self._gradient_steps):
                     policy_loss, qf1_loss, qf2_loss = self.train_once()

--- a/src/garage/torch/algos/td3.py
+++ b/src/garage/torch/algos/td3.py
@@ -198,13 +198,13 @@ class TD3(RLAlgorithm):
                 # Afterwards, get action from policy.
                 if self._uniform_random_policy and \
                         trainer.step_itr < self._start_steps:
-                    trainer.step_path = trainer.obtain_episodes(
+                    trainer.step_episode = trainer.obtain_episodes(
                         trainer.step_itr,
                         agent_update=self._uniform_random_policy)
                 else:
-                    trainer.step_path = trainer.obtain_episodes(
+                    trainer.step_episode = trainer.obtain_episodes(
                         trainer.step_itr, agent_update=self.exploration_policy)
-                self._replay_buffer.add_episode_batch(trainer.step_path)
+                self._replay_buffer.add_episode_batch(trainer.step_episode)
 
                 # Update after warm-up steps.
                 if trainer.total_env_steps >= self._update_after:
@@ -215,7 +215,7 @@ class TD3(RLAlgorithm):
                         self._min_buffer_size):
                     trainer.enable_logging = True
                     eval_eps = self._evaluate_policy()
-                    log_performance(trainer.step_path,
+                    log_performance(trainer.step_episode,
                                     eval_eps,
                                     discount=self._discount,
                                     prefix='Training')


### PR DESCRIPTION
When we renamed `trainer.step_episodes` to `trainer.step_path`, another related refactor still used `step_path`, resulting in most algorithms failing to save episodes. This change fixes those algorithms.