### PR TITLE
Pin dm_env for compatibility with Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ EXTRAS['dm_control'] = [
     # command again and the install succeeds because absl-py has been
     # installed. This is stupid, but harmless.
     'dm_control==0.0.300771433',
+    # dm_env version 1.4 requires python 3.6
+    'dm_env<1.4'
 ]
 
 EXTRAS['all'] = list(set(sum(EXTRAS.values(), [])))


### PR DESCRIPTION
dm_env just updated to version 1.4 which requires python 3.6 or higher 