### PR TITLE
Fix scheduled release CI dependency bug

### DIFF
--- a/.github/workflows/ci-release-2020.06.yml
+++ b/.github/workflows/ci-release-2020.06.yml
@@ -82,7 +82,7 @@ jobs:
   large_test:
     name: Large Tests
     runs-on: ubuntu-latest
-    needs: check_pre_commit
+    needs: build_docker_container
 
     steps:
     - name: Login to GitHub Package Registry
@@ -118,7 +118,7 @@ jobs:
   mujoco_test:
     name: MuJoCo-Based Tests
     runs-on: ubuntu-latest
-    needs: check_pre_commit
+    needs: build_docker_container
 
     steps:
     - name: Login to GitHub Package Registry
@@ -154,7 +154,7 @@ jobs:
   mujoco_test_long:
     name: Large MuJoCo-Based Tests
     runs-on: ubuntu-latest
-    needs: check_pre_commit
+    needs: build_docker_container
 
     steps:
     - name: Login to GitHub Package Registry


### PR DESCRIPTION
It seems like I didn't change all the pre-commit dependencies on the CI when I removed  the job, so this change should make the workflow valid again