### PR TITLE
Add build hook for garage-base docker image

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -9,7 +9,15 @@ echo DOCKERFILE_PATH="$DOCKERFILE_PATH"
 echo DOCKER_REPO="$DOCKER_REPO"
 echo IMAGE_NAME="$IMAGE_NAME"
 
-if [[ "$DOCKER_REPO" = *"rlworkgroup/garage" ]]; then
+if [[ "$DOCKER_REPO" = *"rlworkgroup/garage-base" ]]; then
+  echo "Building target garage-base"
+  docker build \
+		-f "../$DOCKERFILE_PATH" \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--target garage-base \
+		-t "$IMAGE_NAME" \
+		..
+elif [[ "$DOCKER_REPO" = *"rlworkgroup/garage" ]]; then
   echo "Building target garage"
   docker build \
 		-f "../$DOCKERFILE_PATH" \


### PR DESCRIPTION
This image can then be used as the parent image for metaworld-ci docker image, instead of garage-headless as of now, which we discontinued in end of Jan 2021.