### PR TITLE
Fix SetTaskEnvUpdate when new env is a supertype

### DIFF
--- a/src/garage/sampler/env_update.py
+++ b/src/garage/sampler/env_update.py
@@ -107,10 +107,11 @@ class SetTaskUpdate(EnvUpdate):
             Environment: The new, updated environment.
 
         """
+        # We need exact type equality, not just a subtype
+        # pylint: disable=unidiomatic-typecheck
         if old_env is None:
             return self._make_env()
-        elif not isinstance(getattr(old_env, 'unwrapped', old_env),
-                            self._env_type):
+        elif type(getattr(old_env, 'unwrapped', old_env)) != self._env_type:
             warnings.warn('SetTaskEnvUpdate is closing an environment. This '
                           'may indicate a very slow TaskSampler setup.')
             old_env.close()

--- a/tests/garage/sampler/test_env_update.py
+++ b/tests/garage/sampler/test_env_update.py
@@ -1,0 +1,24 @@
+from garage.sampler import SetTaskUpdate
+
+from tests.fixtures.envs.dummy import DummyBoxEnv
+
+TEST_TASK = ['test_task']
+
+
+class MTDummyEnv(DummyBoxEnv):
+
+    def set_task(self, task):
+        assert task == TEST_TASK
+
+
+class MTDummyEnvSubtype(MTDummyEnv):
+    pass
+
+
+def test_set_task_update_with_subtype():
+    old_env = MTDummyEnvSubtype()
+    env_update = SetTaskUpdate(MTDummyEnv, TEST_TASK, None)
+    new_env = env_update(old_env)
+    assert new_env is not old_env
+    assert new_env is not None
+    assert old_env is not None


### PR DESCRIPTION
Before, if the new environment was a subtype of the existing environment, the environment was not changed, even though it should be.