### PR TITLE
Add gpu pickleable module to torch

### DIFF
--- a/src/garage/torch/__init__.py
+++ b/src/garage/torch/__init__.py
@@ -3,7 +3,7 @@
 from garage.torch._functions import (as_torch_dict, compute_advantages,
                                      expand_var, filter_valids, flatten_batch,
                                      flatten_to_single_vector, global_device,
-                                     NonLinearity, np_to_torch,
+                                     Module, NonLinearity, np_to_torch,
                                      output_height_2d, output_width_2d,
                                      pad_to_last, prefer_gpu,
                                      product_of_gaussians, set_gpu_mode,
@@ -31,4 +31,5 @@ __all__ = [
     'state_dict_to',
     'torch_to_np',
     'update_module_params',
+    'Module',
 ]

--- a/src/garage/torch/policies/policy.py
+++ b/src/garage/torch/policies/policy.py
@@ -1,12 +1,11 @@
 """Base Policy."""
 import abc
 
-import torch
-
 from garage.np.policies import Policy as BasePolicy
+from garage.torch import Module
 
 
-class Policy(torch.nn.Module, BasePolicy, abc.ABC):
+class Policy(Module, BasePolicy, abc.ABC):
     """Policy base class.
 
     Args:


### PR DESCRIPTION
A potential fix for #2079, by creating an garage.torch.Module wrapper class which implements pickling with moving to cpu on pickle and back to original device on unpickle if the device exists. 