### PR TITLE
Don't use TF 2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRED = [
     'scikit-image',
     'scipy',
     'setproctitle>=1.0',
-    'tensorflow>=1.14',
+    'tensorflow>=1.14,!=2.5.0',
     'tensorflow-probability>=0.11.0',
     'torch>=1.0.0,!=1.5.0,<1.8.0',
     'torchvision>=0.2.1,<=0.8.2',


### PR DESCRIPTION
Currently breaks normal tests and pipenv. Also, it depends on keras-nightly (probably because of Google I/O rush). Hopefully, 2.5.1+ fixes it.