### PR TITLE
Pin atari-py to last release with packaged ROMs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ EXTRAS = {}
 
 EXTRAS['gym'] = [
     f'gym[atari,box2d,classic_control]=={GYM_VERSION}',
+    'atari-py<0.2.7',
 ]
 
 EXTRAS['mujoco'] = [


### PR DESCRIPTION
This is a temporary fix. atari-py releases starting 0.2.7
don't install ROMs by default. While there are instructions
given for how to install ROMs on their github, it is still
incovenient for a garage user and adds an extra step in
installation.

A better fix would be to figure out if it's possible to
install ROMs as a post install step in setup.py