### PR TITLE
Prevent broken tf-prob installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ REQUIRED = [
     'scipy',
     'setproctitle>=1.0',
     'tensorflow>=1.14,!=2.5.0',
-    'tensorflow-probability>=0.11.0',
+    'tensorflow-probability>=0.11.0,<=0.12.2',
     'torch>=1.0.0,!=1.5.0,<1.8.0',
     'torchvision>=0.2.1,<=0.8.2',
 ]


### PR DESCRIPTION
The latest version of tensorflow-probability (0.13.0) requires
tensorflow 2.5.0.  However, we do not allow 2.5.0, since it depends on
keras-nightly, which several of our packaging systems can't support.
Unfortunately, tensorflow-probability 0.13.0 fails to declare this
dependency, and fails at runtime instead.  This results in broken
installs.

This change should prevent those broken installs and fix the CI.  It can
probably be rolled back once tensorflow doesn't depend on keras-nightly
(hopefully 2.5.1).