### PR TITLE
Fix CI failing on commit re-runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           for i in {1..5}; do
               bash <(curl -s https://codecov.io/bash --retry 5) -Z && break
               if [ $i == 5 ]; then
-                  exit 1
+                  exit 0
               else
                   echo "Retry ${i}..."
                   sleep 30
@@ -234,7 +234,7 @@ jobs:
           for i in {1..5}; do
               bash <(curl -s https://codecov.io/bash --retry 5) -Z && break
               if [ $i == 5 ]; then
-                  exit 1
+                  exit 0
               else
                   echo "Retry ${i}..."
                   sleep 30
@@ -278,7 +278,7 @@ jobs:
           for i in {1..5}; do
               bash <(curl -s https://codecov.io/bash --retry 5) -Z && break
               if [ $i == 5 ]; then
-                  exit 1
+                  exit 0
               else
                   echo "Retry ${i}..."
                   sleep 30
@@ -322,7 +322,7 @@ jobs:
           for i in {1..5}; do
               bash <(curl -s https://codecov.io/bash --retry 5) -Z && break
               if [ $i == 5 ]; then
-                  exit 1
+                  exit 0
               else
                   echo "Retry ${i}..."
                   sleep 30

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,9 +24,8 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge queue for master (maintainers)
     conditions:
@@ -45,9 +44,8 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge for master (docs only)
     conditions:
@@ -62,9 +60,8 @@ pull_request_rules:
       - -files~=\.(?!md|rst|png|bib|html|css)
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge for master (docs only, maintainers)
     conditions:
@@ -79,9 +76,8 @@ pull_request_rules:
       - -files~=\.(?!md|rst|png|bib|html|css)
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge queue for release-2019.10
     conditions:
@@ -94,9 +90,8 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge queue for release-2019.10 (automatic backports)
     conditions:
@@ -108,9 +103,8 @@ pull_request_rules:
       - status-success="codecov/patch"
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge queue for release-2020.06
     conditions:
@@ -123,9 +117,8 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Merge queue for release-2020.06 (automatic backports)
     conditions:
@@ -137,9 +130,8 @@ pull_request_rules:
       - status-success="codecov/patch"
     actions:
       merge:
-        strict: smart
-        strict_method: rebase
         method: squash
+        rebase_fallback: none
       delete_head_branch: {}
   - name: Create backports for v2019.10
     conditions:


### PR DESCRIPTION
If the same commit gets tested multiple times, CodeCov throws an error back, which causes the CI to fail.
The easy way to fix this is just to ignore CodeCov uploads failing.