### PR TITLE
render_modes compatability with gym>0.17.3

### DIFF
--- a/src/garage/envs/gym_env.py
+++ b/src/garage/envs/gym_env.py
@@ -144,7 +144,10 @@ class GymEnv(Environment):
         self._max_episode_length = _get_time_limit(self._env,
                                                    max_episode_length)
 
-        self._render_modes = self._env.metadata['render.modes']
+        try:
+            self._render_modes = self._env.metadata['render_modes']
+        except KeyError:
+            self._render_modes = self._env.metadata['render.modes']
 
         self._step_cnt = None
         self._visualize = False


### PR DESCRIPTION
As of gym==0.18.0, the metadata key `render.modes` has been renamed to `render_modes`.  As a result, defining a [GymEnv](https://github.com/rlworkgroup/garage/blob/master/src/garage/envs/gym_env.py#L62-L390) fails with newer versions of gym [here](https://github.com/rlworkgroup/garage/blob/master/src/garage/envs/gym_env.py#L147). 

This change supports new versions of gym while retaining support for older version. 